### PR TITLE
Add Claude Opus 4.6 configs across providers

### DIFF
--- a/providers/anthropic/claude-opus-4-6-20251201.yaml
+++ b/providers/anthropic/claude-opus-4-6-20251201.yaml
@@ -1,0 +1,37 @@
+model: claude-opus-4-6-20251201
+costs:
+  input_cost_per_token: 0.000005
+  output_cost_per_token: 0.000025
+  cache_read_input_token_cost: 5.e-7
+  cache_creation_input_token_cost: 0.00000625
+limits:
+  max_input_tokens: 200000
+  max_output_tokens: 64000
+  tool_use_system_prompt_tokens: 159
+features: [function_calling, vision, chat, image]
+params:
+  - key: max_tokens
+    maxValue: 64000
+  - key: thinking
+    properties:
+      type:
+        type: string
+        enum:
+          - enabled
+          - disabled
+      budget_tokens:
+        type: number
+        minValue: 1024
+        maxValue: 128000
+    defaultValue: null
+    withdrawParams:
+      - top_k
+      - top_p
+    skipValues:
+      - disabled
+      - null
+removeParams:
+  - temperature
+  - top_p
+mode: chat
+original_provider: anthropic

--- a/providers/anthropic/claude-opus-4-6.yaml
+++ b/providers/anthropic/claude-opus-4-6.yaml
@@ -1,0 +1,37 @@
+model: claude-opus-4-6
+costs:
+  input_cost_per_token: 0.000005
+  output_cost_per_token: 0.000025
+  cache_read_input_token_cost: 5.e-7
+  cache_creation_input_token_cost: 0.00000625
+limits:
+  max_input_tokens: 200000
+  max_output_tokens: 64000
+  tool_use_system_prompt_tokens: 159
+features: [function_calling, vision, chat, image]
+params:
+  - key: max_tokens
+    maxValue: 64000
+  - key: thinking
+    properties:
+      type:
+        type: string
+        enum:
+          - enabled
+          - disabled
+      budget_tokens:
+        type: number
+        minValue: 1024
+        maxValue: 128000
+    defaultValue: null
+    withdrawParams:
+      - top_k
+      - top_p
+    skipValues:
+      - disabled
+      - null
+removeParams:
+  - temperature
+  - top_p
+mode: chat
+original_provider: anthropic

--- a/providers/aws-bedrock/anthropic.claude-opus-4-6-20251201-v1:0.yaml
+++ b/providers/aws-bedrock/anthropic.claude-opus-4-6-20251201-v1:0.yaml
@@ -1,0 +1,14 @@
+model: anthropic.claude-opus-4-6-20251201-v1:0
+costs:
+  input_cost_per_token: 0.000005
+  output_cost_per_token: 0.000025
+  cache_read_input_token_cost: 5.e-7
+  cache_creation_input_token_cost: 0.00000625
+limits:
+  max_tokens: 64000
+  max_input_tokens: 200000
+  max_output_tokens: 64000
+  tool_use_system_prompt_tokens: 159
+features: [function_calling, vision]
+mode: chat
+original_provider: bedrock_converse

--- a/providers/aws-bedrock/eu.anthropic.claude-opus-4-6-20251201-v1:0.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-opus-4-6-20251201-v1:0.yaml
@@ -1,0 +1,37 @@
+model: eu.anthropic.claude-opus-4-6-20251201-v1:0
+costs:
+  input_cost_per_token: 0.000005
+  output_cost_per_token: 0.000025
+  cache_read_input_token_cost: 5.e-7
+  cache_creation_input_token_cost: 0.00000625
+limits:
+  max_input_tokens: 200000
+  max_output_tokens: 64000
+  tool_use_system_prompt_tokens: 159
+features: [function_calling, vision, chat, image]
+params:
+  - key: max_tokens
+    maxValue: 64000
+  - key: thinking
+    properties:
+      type:
+        type: string
+        enum:
+          - enabled
+          - disabled
+      budget_tokens:
+        type: number
+        minValue: 1024
+        maxValue: 128000
+    defaultValue: null
+    withdrawParams:
+      - top_k
+      - top_p
+    skipValues:
+      - disabled
+      - null
+removeParams:
+  - temperature
+  - top_p
+mode: chat
+original_provider: bedrock_converse

--- a/providers/aws-bedrock/global.anthropic.claude-opus-4-6-20251201-v1:0.yaml
+++ b/providers/aws-bedrock/global.anthropic.claude-opus-4-6-20251201-v1:0.yaml
@@ -1,0 +1,37 @@
+model: global.anthropic.claude-opus-4-6-20251201-v1:0
+costs:
+  input_cost_per_token: 0.000005
+  output_cost_per_token: 0.000025
+  cache_read_input_token_cost: 5.e-7
+  cache_creation_input_token_cost: 0.00000625
+limits:
+  max_input_tokens: 200000
+  max_output_tokens: 64000
+  tool_use_system_prompt_tokens: 159
+features: [function_calling, vision, chat, image]
+params:
+  - key: max_tokens
+    maxValue: 64000
+  - key: thinking
+    properties:
+      type:
+        type: string
+        enum:
+          - enabled
+          - disabled
+      budget_tokens:
+        type: number
+        minValue: 1024
+        maxValue: 128000
+    defaultValue: null
+    withdrawParams:
+      - top_k
+      - top_p
+    skipValues:
+      - disabled
+      - null
+removeParams:
+  - temperature
+  - top_p
+mode: chat
+original_provider: bedrock_converse

--- a/providers/aws-bedrock/us.anthropic.claude-opus-4-6-20251201-v1:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-opus-4-6-20251201-v1:0.yaml
@@ -1,0 +1,37 @@
+model: us.anthropic.claude-opus-4-6-20251201-v1:0
+costs:
+  input_cost_per_token: 0.0000055
+  output_cost_per_token: 0.0000275
+  cache_read_input_token_cost: 5.5e-7
+  cache_creation_input_token_cost: 0.000006875
+limits:
+  max_input_tokens: 200000
+  max_output_tokens: 64000
+  tool_use_system_prompt_tokens: 159
+features: [function_calling, vision, chat, image]
+params:
+  - key: max_tokens
+    maxValue: 64000
+  - key: thinking
+    properties:
+      type:
+        type: string
+        enum:
+          - enabled
+          - disabled
+      budget_tokens:
+        type: number
+        minValue: 1024
+        maxValue: 128000
+    defaultValue: null
+    withdrawParams:
+      - top_k
+      - top_p
+    skipValues:
+      - disabled
+      - null
+removeParams:
+  - temperature
+  - top_p
+mode: chat
+original_provider: bedrock_converse

--- a/providers/azure-ai-foundry/claude-opus-4-6.yaml
+++ b/providers/azure-ai-foundry/claude-opus-4-6.yaml
@@ -1,0 +1,13 @@
+model: claude-opus-4-6
+costs:
+  input_cost_per_token: 0.000005
+  output_cost_per_token: 0.000025
+  cache_read_input_token_cost: 5.e-7
+  cache_creation_input_token_cost: 0.00000625
+limits:
+  max_tokens: 64000
+  max_input_tokens: 200000
+  max_output_tokens: 64000
+features: [function_calling, vision]
+mode: chat
+original_provider: azure_ai

--- a/providers/databricks/databricks-claude-opus-4-6.yaml
+++ b/providers/databricks/databricks-claude-opus-4-6.yaml
@@ -1,0 +1,11 @@
+model: databricks-claude-opus-4-6
+costs:
+  input_cost_per_token: 0.00000500003
+  output_cost_per_token: 0.000025000010000000002
+limits:
+  max_tokens: 64000
+  max_input_tokens: 200000
+  max_output_tokens: 64000
+features: [function_calling]
+mode: chat
+original_provider: databricks

--- a/providers/google-vertex/anthropic/claude-opus-4-6.yaml
+++ b/providers/google-vertex/anthropic/claude-opus-4-6.yaml
@@ -1,0 +1,14 @@
+model: anthropic/claude-opus-4-6
+costs:
+  input_cost_per_token: 0.000005
+  output_cost_per_token: 0.000025
+  cache_read_input_token_cost: 5.e-7
+  cache_creation_input_token_cost: 0.00000625
+limits:
+  max_tokens: 64000
+  max_input_tokens: 200000
+  max_output_tokens: 64000
+  tool_use_system_prompt_tokens: 159
+features: [function_calling, vision]
+mode: chat
+original_provider: vertex_ai-anthropic_models

--- a/providers/google-vertex/anthropic/claude-opus-4-6@20251201.yaml
+++ b/providers/google-vertex/anthropic/claude-opus-4-6@20251201.yaml
@@ -1,0 +1,14 @@
+model: anthropic/claude-opus-4-6@20251201
+costs:
+  input_cost_per_token: 0.000005
+  output_cost_per_token: 0.000025
+  cache_read_input_token_cost: 5.e-7
+  cache_creation_input_token_cost: 0.00000625
+limits:
+  max_tokens: 64000
+  max_input_tokens: 200000
+  max_output_tokens: 64000
+  tool_use_system_prompt_tokens: 159
+features: [function_calling, vision]
+mode: chat
+original_provider: vertex_ai-anthropic_models

--- a/providers/openrouter/anthropic/claude-opus-4.6.yaml
+++ b/providers/openrouter/anthropic/claude-opus-4.6.yaml
@@ -1,0 +1,14 @@
+model: anthropic/claude-opus-4.6
+costs:
+  input_cost_per_token: 0.000005
+  output_cost_per_token: 0.000025
+  cache_read_input_token_cost: 5.e-7
+  cache_creation_input_token_cost: 0.00000625
+limits:
+  max_tokens: 32000
+  max_input_tokens: 200000
+  max_output_tokens: 32000
+  tool_use_system_prompt_tokens: 159
+features: [function_calling, vision]
+mode: chat
+original_provider: openrouter


### PR DESCRIPTION
### Motivation
- Provide parity and availability of the Claude Opus 4.6 model across supported providers so the newer model variant can be selected consistently.
- Include dated `20251201` variants where provider naming conventions require explicit date suffixes.

### Description
- Add 11 new configuration files under `providers/` for Anthropic, AWS Bedrock (us, eu, global, anthropic), Azure AI Foundry, Databricks, Google Vertex (including `@20251201`), and OpenRouter with model names updated to `claude-opus-4-6` or provider-specific variants like `anthropic/claude-opus-4.6` and `anthropic.claude-opus-4-6-20251201-v1:0` (for example `providers/anthropic/claude-opus-4-6.yaml`, `providers/google-vertex/anthropic/claude-opus-4-6@20251201.yaml`, `providers/aws-bedrock/us.anthropic.claude-opus-4-6-20251201-v1:0.yaml`).
- The new files are copies of the existing 4-5 configs with version/date string updates and provider-specific field alignment (limits, features, and `original_provider` values) to match each provider's conventions.
- The change set adds approximately 265 insertions across 11 files.

### Testing
- No automated tests were executed because these are configuration-only additions.
- A local commit was created successfully and PR metadata was prepared; no CI runs were triggered as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6985291e0830832a849804f0283c5dc7)