### PR TITLE
Update AWS Bedrock model configurations with region-specific cost adjustments and new model additions.

### DIFF
--- a/providers/aws-bedrock/ai21.j2-mid-v1.yaml
+++ b/providers/aws-bedrock/ai21.j2-mid-v1.yaml
@@ -1,15 +1,20 @@
 model: ai21.j2-mid-v1
 costs:
-    - region: "*"
-      input_cost_per_token: 0.0000125
-      output_cost_per_token: 0.0000125
+    - region: us-west-2
+      input_cost_per_token: 1.25e-5
+      output_cost_per_token: 1.25e-5
+    - region: us-east-1
+      input_cost_per_token: 1.25e-5
+      output_cost_per_token: 1.25e-5
 limits:
     max_input_tokens: 8191
     max_output_tokens: 8191
-features: [chat]
+features:
+    - chat
 params:
-    - key: max_tokens
-      maxValue: 8192
+    -
+        key: max_tokens
+        maxValue: 8192
 removeParams:
     - stream
 mode: chat

--- a/providers/aws-bedrock/ai21.j2-mid-v1.yaml
+++ b/providers/aws-bedrock/ai21.j2-mid-v1.yaml
@@ -12,9 +12,8 @@ limits:
 features:
     - chat
 params:
-    -
-        key: max_tokens
-        maxValue: 8192
+    - key: max_tokens
+      maxValue: 8192
 removeParams:
     - stream
 mode: chat

--- a/providers/aws-bedrock/ai21.j2-ultra-v1.yaml
+++ b/providers/aws-bedrock/ai21.j2-ultra-v1.yaml
@@ -12,9 +12,8 @@ limits:
 features:
     - chat
 params:
-    -
-        key: max_tokens
-        maxValue: 8192
+    - key: max_tokens
+      maxValue: 8192
 removeParams:
     - stream
 mode: chat

--- a/providers/aws-bedrock/ai21.j2-ultra-v1.yaml
+++ b/providers/aws-bedrock/ai21.j2-ultra-v1.yaml
@@ -1,15 +1,20 @@
 model: ai21.j2-ultra-v1
 costs:
-    - region: "*"
-      input_cost_per_token: 0.0000188
-      output_cost_per_token: 0.0000188
+    - region: us-west-2
+      input_cost_per_token: 1.88e-5
+      output_cost_per_token: 1.88e-5
+    - region: us-east-1
+      input_cost_per_token: 1.88e-5
+      output_cost_per_token: 1.88e-5
 limits:
     max_input_tokens: 8191
     max_output_tokens: 8191
-features: [chat]
+features:
+    - chat
 params:
-    - key: max_tokens
-      maxValue: 8192
+    -
+        key: max_tokens
+        maxValue: 8192
 removeParams:
     - stream
 mode: chat

--- a/providers/aws-bedrock/ai21.jamba-1-5-mini-v1:0.yaml
+++ b/providers/aws-bedrock/ai21.jamba-1-5-mini-v1:0.yaml
@@ -10,5 +10,6 @@ limits:
     max_tokens: 4096
     max_input_tokens: 256000
     max_output_tokens: 256000
-features: [chat]
+features:
+    - chat
 mode: chat

--- a/providers/aws-bedrock/ai21.jamba-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/ai21.jamba-instruct-v1:0.yaml
@@ -1,8 +1,8 @@
 model: ai21.jamba-instruct-v1:0
 costs:
-    - region: "*"
-      input_cost_per_token: 5.e-7
-      output_cost_per_token: 7.e-7
+    - region: us-east-1
+      input_cost_per_token: 5e-7
+      output_cost_per_token: 7e-7
 limits:
     max_tokens: 4096
     max_input_tokens: 70000

--- a/providers/aws-bedrock/amazon.nova-2-multimodal-embeddings-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.nova-2-multimodal-embeddings-v1:0.yaml
@@ -1,13 +1,13 @@
 model: amazon.nova-2-multimodal-embeddings-v1:0
 costs:
     - region: us-east-1
-      input_cost_per_audio_token: 0.000112
-      input_cost_per_image: 0.00048
-      input_cost_per_second: 0.00056
-      input_cost_per_token: 6.75e-8
+      input_cost_per_image: 6e-4
+      input_cost_per_second: 1.4e-4
+      input_cost_per_token: 1.35e-7
 limits:
     max_tokens: 8172
     max_input_tokens: 8172
     output_vector_size: 3072
-features: [audio_input]
+features:
+    - audio_input
 mode: embedding

--- a/providers/aws-bedrock/amazon.nova-2-pro-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.nova-2-pro-v1:0.yaml
@@ -1,0 +1,102 @@
+model: amazon.nova-2-pro-v1:0
+costs:
+    - region: us-west-2
+      input_cost_per_audio_token: 1.25e-6
+      input_cost_per_token: 1.25e-6
+      output_cost_per_token: 1e-5
+    - region: us-west-1
+      input_cost_per_audio_token: 1.61e-6
+      input_cost_per_token: 1.61e-6
+      output_cost_per_token: 1.284e-5
+    - region: us-east-2
+      input_cost_per_audio_token: 1.375e-6
+      input_cost_per_token: 1.375e-6
+      output_cost_per_token: 1.1e-5
+    - region: us-east-1
+      input_cost_per_audio_token: 1.375e-6
+      input_cost_per_token: 1.375e-6
+      output_cost_per_token: 1.1e-5
+    - region: me-central-1
+      input_cost_per_audio_token: 1.25e-6
+      input_cost_per_token: 1.25e-6
+      output_cost_per_token: 1.002e-5
+    - region: il-central-1
+      input_cost_per_audio_token: 1.56e-6
+      input_cost_per_token: 1.56e-6
+      output_cost_per_token: 1.251e-5
+    - region: eu-west-3
+      input_cost_per_audio_token: 1.84e-6
+      input_cost_per_token: 1.84e-6
+      output_cost_per_token: 1.474e-5
+    - region: eu-west-2
+      input_cost_per_audio_token: 1.76e-6
+      input_cost_per_token: 1.76e-6
+      output_cost_per_token: 1.407e-5
+    - region: eu-west-1
+      input_cost_per_audio_token: 1.43e-6
+      input_cost_per_token: 1.43e-6
+      output_cost_per_token: 1.147e-5
+    - region: eu-south-2
+      input_cost_per_audio_token: 1.38e-6
+      input_cost_per_token: 1.38e-6
+      output_cost_per_token: 1.102e-5
+    - region: eu-south-1
+      input_cost_per_audio_token: 2.01e-6
+      input_cost_per_token: 2.01e-6
+      output_cost_per_token: 1.605e-5
+    - region: eu-north-1
+      input_cost_per_audio_token: 1.36e-6
+      input_cost_per_token: 1.36e-6
+      output_cost_per_token: 1.087e-5
+    - region: eu-central-1
+      input_cost_per_audio_token: 1.63e-6
+      input_cost_per_token: 1.63e-6
+      output_cost_per_token: 1.308e-5
+    - region: ca-west-1
+      input_cost_per_audio_token: 1.41e-6
+      input_cost_per_token: 1.41e-6
+      output_cost_per_token: 1.126e-5
+    - region: ca-central-1
+      input_cost_per_audio_token: 1.33e-6
+      input_cost_per_token: 1.33e-6
+      output_cost_per_token: 1.066e-5
+    - region: ap-southeast-7
+      input_cost_per_audio_token: 1.69e-6
+      input_cost_per_token: 1.69e-6
+      output_cost_per_token: 1.356e-5
+    - region: ap-southeast-5
+      input_cost_per_audio_token: 1.69e-6
+      input_cost_per_token: 1.69e-6
+      output_cost_per_token: 1.356e-5
+    - region: ap-southeast-4
+      input_cost_per_audio_token: 1.36e-6
+      input_cost_per_token: 1.36e-6
+      output_cost_per_token: 1.084e-5
+    - region: ap-southeast-3
+      input_cost_per_audio_token: 1.32e-6
+      input_cost_per_token: 1.32e-6
+      output_cost_per_token: 1.056e-5
+    - region: ap-southeast-2
+      input_cost_per_audio_token: 1.31e-6
+      input_cost_per_token: 1.31e-6
+      output_cost_per_token: 1.051e-5
+    - region: ap-southeast-1
+      input_cost_per_audio_token: 1.69e-6
+      input_cost_per_token: 1.69e-6
+      output_cost_per_token: 1.356e-5
+    - region: ap-south-1
+      input_cost_per_audio_token: 1.48e-6
+      input_cost_per_token: 1.48e-6
+      output_cost_per_token: 1.18e-5
+    - region: ap-northeast-2
+      input_cost_per_audio_token: 1.48e-6
+      input_cost_per_token: 1.48e-6
+      output_cost_per_token: 1.184e-5
+    - region: ap-northeast-1
+      input_cost_per_audio_token: 1.51e-6
+      input_cost_per_token: 1.51e-6
+      output_cost_per_token: 1.25e-5
+    - region: ap-east-2
+      input_cost_per_audio_token: 1.51e-6
+      input_cost_per_token: 1.51e-6
+      output_cost_per_token: 1.25e-5

--- a/providers/aws-bedrock/amazon.nova-2-pro-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.nova-2-pro-v1:0.yaml
@@ -100,3 +100,9 @@ costs:
       input_cost_per_audio_token: 1.51e-6
       input_cost_per_token: 1.51e-6
       output_cost_per_token: 1.25e-5
+limits:
+    max_tokens: 64000
+    max_input_tokens: 1000000
+    max_output_tokens: 64000
+features: [function_calling, vision]
+mode: chat

--- a/providers/aws-bedrock/amazon.nova-2-pro-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.nova-2-pro-v1:0.yaml
@@ -2,107 +2,159 @@ model: amazon.nova-2-pro-v1:0
 costs:
     - region: us-west-2
       input_cost_per_audio_token: 1.25e-6
+      input_cost_per_image_token: 1.25e-6
       input_cost_per_token: 1.25e-6
+      input_cost_per_video_token: 1.25e-6
       output_cost_per_token: 1e-5
     - region: us-west-1
       input_cost_per_audio_token: 1.61e-6
+      input_cost_per_image_token: 1.61e-6
       input_cost_per_token: 1.61e-6
+      input_cost_per_video_token: 1.61e-6
       output_cost_per_token: 1.284e-5
     - region: us-east-2
       input_cost_per_audio_token: 1.375e-6
+      input_cost_per_image_token: 1.375e-6
       input_cost_per_token: 1.375e-6
+      input_cost_per_video_token: 1.375e-6
       output_cost_per_token: 1.1e-5
     - region: us-east-1
       input_cost_per_audio_token: 1.375e-6
+      input_cost_per_image_token: 1.375e-6
       input_cost_per_token: 1.375e-6
+      input_cost_per_video_token: 1.375e-6
       output_cost_per_token: 1.1e-5
     - region: me-central-1
       input_cost_per_audio_token: 1.25e-6
+      input_cost_per_image_token: 1.25e-6
       input_cost_per_token: 1.25e-6
+      input_cost_per_video_token: 1.25e-6
       output_cost_per_token: 1.002e-5
     - region: il-central-1
       input_cost_per_audio_token: 1.56e-6
+      input_cost_per_image_token: 1.56e-6
       input_cost_per_token: 1.56e-6
+      input_cost_per_video_token: 1.56e-6
       output_cost_per_token: 1.251e-5
     - region: eu-west-3
       input_cost_per_audio_token: 1.84e-6
+      input_cost_per_image_token: 1.84e-6
       input_cost_per_token: 1.84e-6
+      input_cost_per_video_token: 1.84e-6
       output_cost_per_token: 1.474e-5
     - region: eu-west-2
       input_cost_per_audio_token: 1.76e-6
+      input_cost_per_image_token: 1.76e-6
       input_cost_per_token: 1.76e-6
+      input_cost_per_video_token: 1.76e-6
       output_cost_per_token: 1.407e-5
     - region: eu-west-1
       input_cost_per_audio_token: 1.43e-6
+      input_cost_per_image_token: 1.43e-6
       input_cost_per_token: 1.43e-6
+      input_cost_per_video_token: 1.43e-6
       output_cost_per_token: 1.147e-5
     - region: eu-south-2
       input_cost_per_audio_token: 1.38e-6
+      input_cost_per_image_token: 1.38e-6
       input_cost_per_token: 1.38e-6
+      input_cost_per_video_token: 1.38e-6
       output_cost_per_token: 1.102e-5
     - region: eu-south-1
       input_cost_per_audio_token: 2.01e-6
+      input_cost_per_image_token: 2.01e-6
       input_cost_per_token: 2.01e-6
+      input_cost_per_video_token: 2.01e-6
       output_cost_per_token: 1.605e-5
     - region: eu-north-1
       input_cost_per_audio_token: 1.36e-6
+      input_cost_per_image_token: 1.36e-6
       input_cost_per_token: 1.36e-6
+      input_cost_per_video_token: 1.36e-6
       output_cost_per_token: 1.087e-5
     - region: eu-central-1
       input_cost_per_audio_token: 1.63e-6
+      input_cost_per_image_token: 1.63e-6
       input_cost_per_token: 1.63e-6
+      input_cost_per_video_token: 1.63e-6
       output_cost_per_token: 1.308e-5
     - region: ca-west-1
       input_cost_per_audio_token: 1.41e-6
+      input_cost_per_image_token: 1.41e-6
       input_cost_per_token: 1.41e-6
+      input_cost_per_video_token: 1.41e-6
       output_cost_per_token: 1.126e-5
     - region: ca-central-1
       input_cost_per_audio_token: 1.33e-6
+      input_cost_per_image_token: 1.33e-6
       input_cost_per_token: 1.33e-6
+      input_cost_per_video_token: 1.33e-6
       output_cost_per_token: 1.066e-5
     - region: ap-southeast-7
       input_cost_per_audio_token: 1.69e-6
+      input_cost_per_image_token: 1.69e-6
       input_cost_per_token: 1.69e-6
+      input_cost_per_video_token: 1.69e-6
       output_cost_per_token: 1.356e-5
     - region: ap-southeast-5
       input_cost_per_audio_token: 1.69e-6
+      input_cost_per_image_token: 1.69e-6
       input_cost_per_token: 1.69e-6
+      input_cost_per_video_token: 1.69e-6
       output_cost_per_token: 1.356e-5
     - region: ap-southeast-4
       input_cost_per_audio_token: 1.36e-6
+      input_cost_per_image_token: 1.36e-6
       input_cost_per_token: 1.36e-6
+      input_cost_per_video_token: 1.36e-6
       output_cost_per_token: 1.084e-5
     - region: ap-southeast-3
       input_cost_per_audio_token: 1.32e-6
+      input_cost_per_image_token: 1.32e-6
       input_cost_per_token: 1.32e-6
+      input_cost_per_video_token: 1.32e-6
       output_cost_per_token: 1.056e-5
     - region: ap-southeast-2
       input_cost_per_audio_token: 1.31e-6
+      input_cost_per_image_token: 1.31e-6
       input_cost_per_token: 1.31e-6
+      input_cost_per_video_token: 1.31e-6
       output_cost_per_token: 1.051e-5
     - region: ap-southeast-1
       input_cost_per_audio_token: 1.69e-6
+      input_cost_per_image_token: 1.69e-6
       input_cost_per_token: 1.69e-6
+      input_cost_per_video_token: 1.69e-6
       output_cost_per_token: 1.356e-5
     - region: ap-south-1
       input_cost_per_audio_token: 1.48e-6
+      input_cost_per_image_token: 1.48e-6
       input_cost_per_token: 1.48e-6
+      input_cost_per_video_token: 1.48e-6
       output_cost_per_token: 1.18e-5
     - region: ap-northeast-2
       input_cost_per_audio_token: 1.48e-6
+      input_cost_per_image_token: 1.48e-6
       input_cost_per_token: 1.48e-6
+      input_cost_per_video_token: 1.48e-6
       output_cost_per_token: 1.184e-5
     - region: ap-northeast-1
       input_cost_per_audio_token: 1.51e-6
+      input_cost_per_image_token: 1.51e-6
       input_cost_per_token: 1.51e-6
+      input_cost_per_video_token: 1.51e-6
       output_cost_per_token: 1.25e-5
     - region: ap-east-2
       input_cost_per_audio_token: 1.51e-6
+      input_cost_per_image_token: 1.51e-6
       input_cost_per_token: 1.51e-6
+      input_cost_per_video_token: 1.51e-6
       output_cost_per_token: 1.25e-5
 limits:
     max_tokens: 64000
     max_input_tokens: 1000000
     max_output_tokens: 64000
-features: [function_calling, vision]
+features:
+    - function_calling
+    - vision
 mode: chat

--- a/providers/aws-bedrock/amazon.nova-2-sonic-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.nova-2-sonic-v1:0.yaml
@@ -104,3 +104,4 @@ costs:
       input_cost_per_audio_token: 1.1e-6
       input_cost_per_token: 3e-7
       output_cost_per_token: 2.8e-6
+mode: chat

--- a/providers/aws-bedrock/amazon.nova-2-sonic-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.nova-2-sonic-v1:0.yaml
@@ -2,106 +2,186 @@ model: amazon.nova-2-sonic-v1:0
 costs:
     - region: us-west-2
       input_cost_per_audio_token: 1.1e-6
+      input_cost_per_image_token: 3e-7
       input_cost_per_token: 3e-7
+      input_cost_per_video_token: 3e-7
+      output_cost_per_image_token: 4.4e-5
       output_cost_per_token: 2.8e-6
     - region: us-west-1
       input_cost_per_audio_token: 1.3e-6
+      input_cost_per_image_token: 4e-7
       input_cost_per_token: 4e-7
+      input_cost_per_video_token: 4e-7
+      output_cost_per_image_token: 5.2e-5
       output_cost_per_token: 3.2e-6
     - region: us-east-2
       input_cost_per_audio_token: 1.1e-6
+      input_cost_per_image_token: 3e-7
       input_cost_per_token: 3e-7
+      input_cost_per_video_token: 3e-7
+      output_cost_per_image_token: 4.4e-5
       output_cost_per_token: 2.8e-6
     - region: us-east-1
       input_cost_per_audio_token: 1e-6
+      input_cost_per_image_token: 3e-7
       input_cost_per_token: 3e-7
+      input_cost_per_video_token: 3e-7
+      output_cost_per_image_token: 4e-5
       output_cost_per_token: 2.5e-6
+    - region: mx-central-1
+      output_cost_per_image_token: 4e-5
     - region: me-south-1
       input_cost_per_audio_token: 1.1e-6
+      input_cost_per_image_token: 3e-7
       input_cost_per_token: 3e-7
+      input_cost_per_video_token: 3e-7
+      output_cost_per_image_token: 4.27e-5
       output_cost_per_token: 2.7e-6
     - region: me-central-1
       input_cost_per_audio_token: 1e-6
+      input_cost_per_image_token: 3e-7
       input_cost_per_token: 3e-7
+      input_cost_per_video_token: 3e-7
+      output_cost_per_image_token: 4e-5
       output_cost_per_token: 2.5e-6
     - region: il-central-1
       input_cost_per_audio_token: 1.3e-6
+      input_cost_per_image_token: 4e-7
       input_cost_per_token: 4e-7
+      input_cost_per_video_token: 4e-7
+      output_cost_per_image_token: 5.07e-5
       output_cost_per_token: 3.1e-6
     - region: eu-west-3
       input_cost_per_audio_token: 1.5e-6
+      input_cost_per_image_token: 4e-7
       input_cost_per_token: 4e-7
+      input_cost_per_video_token: 4e-7
+      output_cost_per_image_token: 5.87e-5
       output_cost_per_token: 3.7e-6
     - region: eu-west-2
       input_cost_per_audio_token: 1.4e-6
+      input_cost_per_image_token: 4e-7
       input_cost_per_token: 4e-7
+      input_cost_per_video_token: 4e-7
+      output_cost_per_image_token: 5.6e-5
       output_cost_per_token: 3.5e-6
     - region: eu-south-2
       input_cost_per_audio_token: 1.1e-6
+      input_cost_per_image_token: 3e-7
       input_cost_per_token: 3e-7
+      input_cost_per_video_token: 3e-7
+      output_cost_per_image_token: 4.4e-5
       output_cost_per_token: 2.8e-6
     - region: eu-south-1
       input_cost_per_audio_token: 1.6e-6
+      input_cost_per_image_token: 5e-7
       input_cost_per_token: 5e-7
+      input_cost_per_video_token: 5e-7
+      output_cost_per_image_token: 6.4e-5
       output_cost_per_token: 4e-6
     - region: eu-north-1
       input_cost_per_audio_token: 1.1e-6
+      input_cost_per_image_token: 3e-7
       input_cost_per_token: 3e-7
+      input_cost_per_video_token: 3e-7
+      output_cost_per_image_token: 4.4e-5
       output_cost_per_token: 2.7e-6
     - region: eu-central-1
       input_cost_per_audio_token: 1.3e-6
+      input_cost_per_image_token: 4e-7
       input_cost_per_token: 4e-7
+      input_cost_per_video_token: 4e-7
+      output_cost_per_image_token: 5.2e-5
       output_cost_per_token: 3.3e-6
     - region: ca-west-1
       input_cost_per_audio_token: 1.2e-6
+      input_cost_per_image_token: 4e-7
       input_cost_per_token: 4e-7
+      input_cost_per_video_token: 4e-7
+      output_cost_per_image_token: 4.98e-5
       output_cost_per_token: 3.1e-6
     - region: ca-central-1
       input_cost_per_audio_token: 1.2e-6
+      input_cost_per_image_token: 4e-7
       input_cost_per_token: 4e-7
+      input_cost_per_video_token: 4e-7
+      output_cost_per_image_token: 4.7e-5
       output_cost_per_token: 2.9e-6
     - region: ap-southeast-7
       input_cost_per_audio_token: 1.4e-6
+      input_cost_per_image_token: 4e-7
       input_cost_per_token: 4e-7
+      input_cost_per_video_token: 4e-7
+      output_cost_per_image_token: 5.47e-5
       output_cost_per_token: 3.4e-6
     - region: ap-southeast-5
       input_cost_per_audio_token: 1.4e-6
+      input_cost_per_image_token: 4e-7
       input_cost_per_token: 4e-7
+      input_cost_per_video_token: 4e-7
+      output_cost_per_image_token: 5.47e-5
       output_cost_per_token: 3.4e-6
     - region: ap-southeast-4
       input_cost_per_audio_token: 1.1e-6
+      input_cost_per_image_token: 3e-7
       input_cost_per_token: 3e-7
+      input_cost_per_video_token: 3e-7
+      output_cost_per_image_token: 4.4e-5
       output_cost_per_token: 2.7e-6
     - region: ap-southeast-3
       input_cost_per_audio_token: 1.1e-6
+      input_cost_per_image_token: 3e-7
       input_cost_per_token: 3e-7
+      input_cost_per_video_token: 3e-7
+      output_cost_per_image_token: 4.27e-5
       output_cost_per_token: 2.6e-6
     - region: ap-southeast-2
       input_cost_per_audio_token: 1.1e-6
+      input_cost_per_image_token: 3e-7
       input_cost_per_token: 3e-7
+      input_cost_per_video_token: 3e-7
+      output_cost_per_image_token: 4.27e-5
       output_cost_per_token: 2.6e-6
     - region: ap-southeast-1
       input_cost_per_audio_token: 1.4e-6
+      input_cost_per_image_token: 4e-7
       input_cost_per_token: 4e-7
+      input_cost_per_video_token: 4e-7
+      output_cost_per_image_token: 5.47e-5
       output_cost_per_token: 3.4e-6
     - region: ap-south-1
       input_cost_per_audio_token: 1.2e-6
+      input_cost_per_image_token: 4e-7
       input_cost_per_token: 4e-7
+      input_cost_per_video_token: 4e-7
+      output_cost_per_image_token: 4.67e-5
       output_cost_per_token: 3e-6
     - region: ap-northeast-2
       input_cost_per_audio_token: 1.2e-6
+      input_cost_per_image_token: 4e-7
       input_cost_per_token: 4e-7
+      input_cost_per_video_token: 4e-7
+      output_cost_per_image_token: 4.8e-5
       output_cost_per_token: 3e-6
     - region: ap-northeast-1
       input_cost_per_audio_token: 1.2e-6
+      input_cost_per_image_token: 4e-7
       input_cost_per_token: 4e-7
+      input_cost_per_video_token: 4e-7
+      output_cost_per_image_token: 4.8e-5
       output_cost_per_token: 3e-6
     - region: ap-east-2
       input_cost_per_audio_token: 1.2e-6
+      input_cost_per_image_token: 4e-7
       input_cost_per_token: 4e-7
+      input_cost_per_video_token: 4e-7
+      output_cost_per_image_token: 4.8e-5
       output_cost_per_token: 3e-6
     - region: af-south-1
       input_cost_per_audio_token: 1.1e-6
+      input_cost_per_image_token: 3e-7
       input_cost_per_token: 3e-7
+      input_cost_per_video_token: 3e-7
+      output_cost_per_image_token: 4.53e-5
       output_cost_per_token: 2.8e-6
 mode: chat

--- a/providers/aws-bedrock/amazon.nova-2-sonic-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.nova-2-sonic-v1:0.yaml
@@ -1,14 +1,106 @@
 model: amazon.nova-2-sonic-v1:0
 costs:
-    - region: us-east-1
-      input_cost_per_token: 3.3e-7
-      output_cost_per_token: 2.75e-6
-    - region: eu-north-1
-      input_cost_per_token: 3.63e-7
-      output_cost_per_token: 2.992e-6
-    - region: ap-northeast-1
-      input_cost_per_token: 3.96e-7
-      output_cost_per_token: 3.311e-6
     - region: us-west-2
-      input_cost_per_token: 3.19e-7
-      output_cost_per_token: 2.651e-6
+      input_cost_per_audio_token: 1.1e-6
+      input_cost_per_token: 3e-7
+      output_cost_per_token: 2.8e-6
+    - region: us-west-1
+      input_cost_per_audio_token: 1.3e-6
+      input_cost_per_token: 4e-7
+      output_cost_per_token: 3.2e-6
+    - region: us-east-2
+      input_cost_per_audio_token: 1.1e-6
+      input_cost_per_token: 3e-7
+      output_cost_per_token: 2.8e-6
+    - region: us-east-1
+      input_cost_per_audio_token: 1e-6
+      input_cost_per_token: 3e-7
+      output_cost_per_token: 2.5e-6
+    - region: me-south-1
+      input_cost_per_audio_token: 1.1e-6
+      input_cost_per_token: 3e-7
+      output_cost_per_token: 2.7e-6
+    - region: me-central-1
+      input_cost_per_audio_token: 1e-6
+      input_cost_per_token: 3e-7
+      output_cost_per_token: 2.5e-6
+    - region: il-central-1
+      input_cost_per_audio_token: 1.3e-6
+      input_cost_per_token: 4e-7
+      output_cost_per_token: 3.1e-6
+    - region: eu-west-3
+      input_cost_per_audio_token: 1.5e-6
+      input_cost_per_token: 4e-7
+      output_cost_per_token: 3.7e-6
+    - region: eu-west-2
+      input_cost_per_audio_token: 1.4e-6
+      input_cost_per_token: 4e-7
+      output_cost_per_token: 3.5e-6
+    - region: eu-south-2
+      input_cost_per_audio_token: 1.1e-6
+      input_cost_per_token: 3e-7
+      output_cost_per_token: 2.8e-6
+    - region: eu-south-1
+      input_cost_per_audio_token: 1.6e-6
+      input_cost_per_token: 5e-7
+      output_cost_per_token: 4e-6
+    - region: eu-north-1
+      input_cost_per_audio_token: 1.1e-6
+      input_cost_per_token: 3e-7
+      output_cost_per_token: 2.7e-6
+    - region: eu-central-1
+      input_cost_per_audio_token: 1.3e-6
+      input_cost_per_token: 4e-7
+      output_cost_per_token: 3.3e-6
+    - region: ca-west-1
+      input_cost_per_audio_token: 1.2e-6
+      input_cost_per_token: 4e-7
+      output_cost_per_token: 3.1e-6
+    - region: ca-central-1
+      input_cost_per_audio_token: 1.2e-6
+      input_cost_per_token: 4e-7
+      output_cost_per_token: 2.9e-6
+    - region: ap-southeast-7
+      input_cost_per_audio_token: 1.4e-6
+      input_cost_per_token: 4e-7
+      output_cost_per_token: 3.4e-6
+    - region: ap-southeast-5
+      input_cost_per_audio_token: 1.4e-6
+      input_cost_per_token: 4e-7
+      output_cost_per_token: 3.4e-6
+    - region: ap-southeast-4
+      input_cost_per_audio_token: 1.1e-6
+      input_cost_per_token: 3e-7
+      output_cost_per_token: 2.7e-6
+    - region: ap-southeast-3
+      input_cost_per_audio_token: 1.1e-6
+      input_cost_per_token: 3e-7
+      output_cost_per_token: 2.6e-6
+    - region: ap-southeast-2
+      input_cost_per_audio_token: 1.1e-6
+      input_cost_per_token: 3e-7
+      output_cost_per_token: 2.6e-6
+    - region: ap-southeast-1
+      input_cost_per_audio_token: 1.4e-6
+      input_cost_per_token: 4e-7
+      output_cost_per_token: 3.4e-6
+    - region: ap-south-1
+      input_cost_per_audio_token: 1.2e-6
+      input_cost_per_token: 4e-7
+      output_cost_per_token: 3e-6
+    - region: ap-northeast-2
+      input_cost_per_audio_token: 1.2e-6
+      input_cost_per_token: 4e-7
+      output_cost_per_token: 3e-6
+    - region: ap-northeast-1
+      input_cost_per_audio_token: 1.2e-6
+      input_cost_per_token: 4e-7
+      output_cost_per_token: 3e-6
+    - region: ap-east-2
+      input_cost_per_audio_token: 1.2e-6
+      input_cost_per_token: 4e-7
+      output_cost_per_token: 3e-6
+    - region: af-south-1
+      input_cost_per_audio_token: 1.1e-6
+      input_cost_per_token: 3e-7
+      output_cost_per_token: 2.8e-6

--- a/providers/aws-bedrock/amazon.nova-canvas-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.nova-canvas-v1:0.yaml
@@ -1,7 +1,11 @@
 model: amazon.nova-canvas-v1:0
 costs:
     - region: us-east-1
-      input_cost_per_image: 0.005
+      input_cost_per_image: 0.06
+    - region: eu-west-1
+      input_cost_per_image: 0.06
+    - region: ap-northeast-1
+      input_cost_per_image: 0.08
 limits:
     max_input_tokens: 2600
 mode: image

--- a/providers/aws-bedrock/amazon.nova-canvas-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.nova-canvas-v1:0.yaml
@@ -1,11 +1,11 @@
 model: amazon.nova-canvas-v1:0
 costs:
     - region: us-east-1
-      input_cost_per_image: 0.06
+      output_cost_per_image: 0.06
     - region: eu-west-1
-      input_cost_per_image: 0.06
+      output_cost_per_image: 0.06
     - region: ap-northeast-1
-      input_cost_per_image: 0.08
+      output_cost_per_image: 0.08
 limits:
     max_input_tokens: 2600
 mode: image

--- a/providers/aws-bedrock/amazon.nova-premier-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.nova-premier-v1:0.yaml
@@ -12,3 +12,9 @@ costs:
       input_cost_per_query: 0.03
       input_cost_per_token: 1.25e-6
       output_cost_per_token: 6.25e-6
+limits:
+    max_tokens: 10000
+    max_input_tokens: 300000
+    max_output_tokens: 10000
+features: [function_calling, vision]
+mode: chat

--- a/providers/aws-bedrock/amazon.nova-pro-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.nova-pro-v1:0.yaml
@@ -1,60 +1,102 @@
 model: amazon.nova-pro-v1:0
 costs:
     - region: us-west-2
+      cache_read_input_token_cost: 2e-7
+      input_cost_per_audio_token: 1.375e-6
       input_cost_per_token: 8e-7
       output_cost_per_token: 3.2e-6
     - region: us-west-1
+      input_cost_per_audio_token: 1.771e-6
       input_cost_per_token: 1.03e-6
       output_cost_per_token: 4.12e-6
+    - region: us-gov-west-1
+      cache_read_input_token_cost: 2.4e-7
+      input_cost_per_token: 9.6e-7
+      output_cost_per_token: 3.84e-6
     - region: us-east-2
+      cache_read_input_token_cost: 2e-7
+      input_cost_per_audio_token: 1.375e-6
       input_cost_per_token: 8e-7
       output_cost_per_token: 3.2e-6
     - region: us-east-1
       cache_read_input_token_cost: 2e-7
+      input_cost_per_audio_token: 1.375e-6
       input_cost_per_token: 8e-7
       output_cost_per_token: 3.2e-6
-    - region: eu-north-1
-      input_cost_per_token: 8.7e-7
-      output_cost_per_token: 3.48e-6
-    - region: eu-south-2
-      input_cost_per_token: 8.8e-7
-      output_cost_per_token: 3.52e-6
+    - region: me-central-1
+      cache_read_input_token_cost: 2e-7
+      input_cost_per_token: 8e-7
+      output_cost_per_token: 3.2e-6
+    - region: il-central-1
+      cache_read_input_token_cost: 2.5e-7
+      input_cost_per_token: 1e-6
+      output_cost_per_token: 4e-6
     - region: eu-west-3
+      cache_read_input_token_cost: 2.95e-7
       input_cost_per_token: 1.18e-6
       output_cost_per_token: 4.72e-6
-    - region: eu-south-1
-      input_cost_per_token: 1.28e-6
-      output_cost_per_token: 5.21e-6
-    - region: eu-west-1
-      input_cost_per_token: 9.2e-7
-      output_cost_per_token: 3.68e-6
-    - region: eu-central-1
-      input_cost_per_token: 1.05e-6
-      output_cost_per_token: 4.2e-6
-    - region: ap-northeast-1
-      input_cost_per_token: 9.6e-7
-      output_cost_per_token: 3.84e-6
     - region: eu-west-2
       input_cost_per_token: 1.13e-6
       output_cost_per_token: 4.52e-6
+    - region: eu-west-1
+      cache_read_input_token_cost: 2.3e-7
+      input_cost_per_token: 9.2e-7
+      output_cost_per_token: 3.68e-6
+    - region: eu-south-2
+      cache_read_input_token_cost: 2.2e-7
+      input_cost_per_token: 8.8e-7
+      output_cost_per_token: 3.52e-6
+    - region: eu-south-1
+      cache_read_input_token_cost: 3.2e-7
+      input_cost_per_token: 1.28e-6
+      output_cost_per_token: 5.21e-6
+    - region: eu-north-1
+      cache_read_input_token_cost: 2.175e-7
+      input_cost_per_token: 8.7e-7
+      output_cost_per_token: 3.48e-6
+    - region: eu-central-1
+      cache_read_input_token_cost: 2.625e-7
+      input_cost_per_token: 1.05e-6
+      output_cost_per_token: 4.2e-6
+    - region: ca-west-1
+      input_cost_per_audio_token: 1.551e-6
+      input_cost_per_token: 1.551e-6
+      output_cost_per_token: 1.2386e-5
+    - region: ca-central-1
+      input_cost_per_audio_token: 1.463e-6
+      input_cost_per_token: 1.463e-6
+      output_cost_per_token: 1.1726e-5
+    - region: ap-southeast-5
+      input_cost_per_token: 9.6e-7
+    - region: ap-southeast-4
+      cache_read_input_token_cost: 2.175e-7
+      input_cost_per_token: 8.7e-7
+      output_cost_per_token: 3.48e-6
     - region: ap-southeast-2
+      cache_read_input_token_cost: 2.1e-7
       input_cost_per_token: 8.4e-7
       output_cost_per_token: 3.36e-6
     - region: ap-southeast-1
+      cache_read_input_token_cost: 2.7e-7
       input_cost_per_token: 1.08e-6
       output_cost_per_token: 4.32e-6
-    - region: ap-northeast-2
-      input_cost_per_token: 9.5e-7
-      output_cost_per_token: 3.8e-6
     - region: ap-south-1
+      cache_read_input_token_cost: 2.35e-7
       input_cost_per_token: 9.4e-7
       output_cost_per_token: 3.76e-6
-    - region: us-gov-west-1
+    - region: ap-northeast-2
+      cache_read_input_token_cost: 2.375e-7
+      input_cost_per_token: 9.5e-7
+      output_cost_per_token: 3.8e-6
+    - region: ap-northeast-1
+      cache_read_input_token_cost: 2.4e-7
       input_cost_per_token: 9.6e-7
       output_cost_per_token: 3.84e-6
 limits:
     max_tokens: 10000
     max_input_tokens: 300000
     max_output_tokens: 10000
-features: [function_calling, vision]
+features:
+    - function_calling
+    - vision
 mode: chat

--- a/providers/aws-bedrock/amazon.nova-reel-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.nova-reel-v1:0.yaml
@@ -1,7 +1,7 @@
 model: amazon.nova-reel-v1:0
 costs:
     - region: us-east-1
-      input_cost_per_second: 0.08
+      output_cost_per_second: 0.08
     - region: ap-northeast-1
-      input_cost_per_second: 0.08
+      output_cost_per_second: 0.08
 mode: video

--- a/providers/aws-bedrock/amazon.nova-reel-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.nova-reel-v1:0.yaml
@@ -1,0 +1,6 @@
+model: amazon.nova-reel-v1:0
+costs:
+    - region: us-east-1
+      input_cost_per_second: 0.08
+    - region: ap-northeast-1
+      input_cost_per_second: 0.08

--- a/providers/aws-bedrock/amazon.nova-reel-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.nova-reel-v1:0.yaml
@@ -4,3 +4,4 @@ costs:
       input_cost_per_second: 0.08
     - region: ap-northeast-1
       input_cost_per_second: 0.08
+mode: video

--- a/providers/aws-bedrock/amazon.nova-reel-v1:1.yaml
+++ b/providers/aws-bedrock/amazon.nova-reel-v1:1.yaml
@@ -4,3 +4,4 @@ costs:
       output_cost_per_second: 0.08
     - region: ap-northeast-1
       output_cost_per_second: 0.08
+mode: video

--- a/providers/aws-bedrock/amazon.nova-sonic-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.nova-sonic-v1:0.yaml
@@ -12,3 +12,4 @@ costs:
     - region: ap-northeast-1
       input_cost_per_token: 3.63e-6
       output_cost_per_token: 1.452e-5
+mode: chat

--- a/providers/aws-bedrock/amazon.nova-sonic-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.nova-sonic-v1:0.yaml
@@ -1,11 +1,14 @@
 model: amazon.nova-sonic-v1:0
 costs:
+    - region: us-west-2
+      input_cost_per_token: 3.19e-7
+      output_cost_per_token: 1.2e-5
     - region: us-east-1
       input_cost_per_token: 6e-8
       output_cost_per_token: 2.4e-7
     - region: eu-north-1
       input_cost_per_token: 6.5e-8
-      output_cost_per_token: 2.6e-7
+      output_cost_per_token: 1.63e-5
     - region: ap-northeast-1
-      input_cost_per_token: 7.2e-8
-      output_cost_per_token: 2.88e-7
+      input_cost_per_token: 3.63e-6
+      output_cost_per_token: 1.452e-5

--- a/providers/aws-bedrock/amazon.rerank-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.rerank-v1:0.yaml
@@ -1,17 +1,18 @@
 model: amazon.rerank-v1:0
 costs:
     - region: us-west-2
-      input_cost_per_query: 0.001
+      input_cost_per_query: 1e-6
     - region: eu-central-1
-      input_cost_per_query: 0.001
+      input_cost_per_query: 1e-6
     - region: ca-central-1
-      input_cost_per_query: 0.001
+      input_cost_per_query: 1e-6
     - region: ap-northeast-1
-      input_cost_per_query: 0.001
+      input_cost_per_query: 1e-6
 limits:
     max_tokens: 4096
     max_input_tokens: 32000
     max_output_tokens: 32000
     max_query_tokens: 32000
-removeParams: [stream]
+removeParams:
+    - stream
 mode: rerank

--- a/providers/aws-bedrock/amazon.titan-embed-image-v1.yaml
+++ b/providers/aws-bedrock/amazon.titan-embed-image-v1.yaml
@@ -1,45 +1,32 @@
 model: amazon.titan-embed-image-v1
 costs:
     - region: us-west-2
-      input_cost_per_image: 0.0002
+      input_cost_per_image: 6e-5
       input_cost_per_token: 8e-7
-      input_cost_per_token_batches: 4e-7
     - region: us-east-1
-      input_cost_per_image: 0.0002
+      input_cost_per_image: 6e-5
       input_cost_per_token: 8e-7
-      input_cost_per_token_batches: 4e-7
     - region: sa-east-1
-      input_cost_per_image: 0.0001
       input_cost_per_token: 1.2e-6
-      input_cost_per_token_batches: 6e-7
     - region: eu-west-3
-      input_cost_per_image: 8e-05
+      input_cost_per_image: 8e-5
       input_cost_per_token: 1e-6
-      input_cost_per_token_batches: 5e-7
     - region: eu-west-2
-      input_cost_per_image: 0.0001
-      input_cost_per_token: 1e-6
-      input_cost_per_token_batches: 5e-7
+      input_cost_per_token: 1e-10
     - region: eu-west-1
-      input_cost_per_image: 7e-05
+      input_cost_per_image: 7e-5
       input_cost_per_token: 1e-6
-      input_cost_per_token_batches: 5e-7
     - region: eu-central-1
-      input_cost_per_image: 0.0001
+      input_cost_per_image: 1e-4
       input_cost_per_token: 1e-6
-      input_cost_per_token_batches: 5e-7
     - region: ca-central-1
-      input_cost_per_image: 0.0001
       input_cost_per_token: 9e-7
-      input_cost_per_token_batches: 4.5e-7
     - region: ap-southeast-2
-      input_cost_per_image: 8e-05
+      input_cost_per_image: 8e-5
       input_cost_per_token: 1e-6
-      input_cost_per_token_batches: 5e-7
     - region: ap-south-1
-      input_cost_per_image: 7e-05
+      input_cost_per_image: 7e-5
       input_cost_per_token: 1e-6
-      input_cost_per_token_batches: 5e-7
 limits:
     max_tokens: 4096
     max_input_tokens: 128

--- a/providers/aws-bedrock/amazon.titan-embed-text-v1.yaml
+++ b/providers/aws-bedrock/amazon.titan-embed-text-v1.yaml
@@ -1,15 +1,15 @@
 model: amazon.titan-embed-text-v1
 costs:
-    - region: us-east-1
-      input_cost_per_token: 1e-7
     - region: us-west-2
+      input_cost_per_token: 1e-7
+    - region: us-east-1
       input_cost_per_token: 1e-7
     - region: eu-west-1
       input_cost_per_token: 1e-7
-    - region: ap-south-1
-      input_cost_per_token: 1.2e-7
     - region: eu-central-1
       input_cost_per_token: 2e-7
+    - region: ap-south-1
+      input_cost_per_token: 1.2e-7
     - region: ap-northeast-1
       input_cost_per_token: 2e-7
 limits:

--- a/providers/aws-bedrock/amazon.titan-embed-text-v2:0.yaml
+++ b/providers/aws-bedrock/amazon.titan-embed-text-v2:0.yaml
@@ -1,7 +1,7 @@
 model: amazon.titan-embed-text-v2:0
 costs:
     - region: us-west-2
-      input_cost_per_token: 1e-7
+      input_cost_per_token: 2e-8
     - region: us-west-1
       input_cost_per_token: 2.4e-8
     - region: us-gov-west-1

--- a/providers/aws-bedrock/amazon.titan-embed-text-v2:0.yaml
+++ b/providers/aws-bedrock/amazon.titan-embed-text-v2:0.yaml
@@ -1,62 +1,51 @@
 model: amazon.titan-embed-text-v2:0
 costs:
+    - region: us-west-2
+      input_cost_per_token: 1e-7
+    - region: us-west-1
+      input_cost_per_token: 2.4e-8
+    - region: us-gov-west-1
+      input_cost_per_token: 1.1e-7
+    - region: us-gov-east-1
+      input_cost_per_token: 3e-8
+    - region: us-east-2
+      input_cost_per_token: 2e-8
     - region: us-east-1
       input_cost_per_token: 2e-8
-      input_cost_per_token_batches: 1e-8
-    - region: us-west-2
-      input_cost_per_token: 2e-8
-      input_cost_per_token_batches: 1e-8
     - region: sa-east-1
       input_cost_per_token: 2e-7
-      input_cost_per_token_batches: 1e-7
     - region: eu-west-3
       input_cost_per_token: 3e-8
     - region: eu-west-2
       input_cost_per_token: 1e-7
-      input_cost_per_token_batches: 5e-8
     - region: eu-west-1
-      input_cost_per_token: 2.6004e-8
-    - region: ca-central-1
-      input_cost_per_token: 1e-7
-      input_cost_per_token_batches: 5e-8
-    - region: ap-southeast-2
-      input_cost_per_token: 2.6004e-8
-    - region: ap-south-1
-      input_cost_per_token: 2.4e-8
-    - region: eu-central-1
-      input_cost_per_token: 2e-7
-      input_cost_per_token_batches: 1e-7
-    - region: ap-northeast-1
-      input_cost_per_token: 2.9e-8
-      input_cost_per_token_batches: 1.21e-8
-    - region: us-gov-west-1
-      input_cost_per_token: 1.1e-7
-    - region: us-west-1
-      input_cost_per_token: 2.4e-8
-    - region: us-east-2
-      input_cost_per_token: 2e-8
-    - region: eu-central-2
-      input_cost_per_token: 2.7e-8
-    - region: eu-north-1
-      input_cost_per_token: 2.1e-8
-      input_cost_per_token_batches: 1.05e-8
+      input_cost_per_token: 2.6e-8
     - region: eu-south-2
       input_cost_per_token: 2.1e-8
-      input_cost_per_token_batches: 1.05e-8
     - region: eu-south-1
       input_cost_per_token: 2.3e-8
-      input_cost_per_token_batches: 1.15e-8
+    - region: eu-north-1
+      input_cost_per_token: 2.1e-8
+    - region: eu-central-2
+      input_cost_per_token: 2.7e-8
+    - region: eu-central-1
+      input_cost_per_token: 2e-7
+    - region: ca-central-1
+      input_cost_per_token: 1e-7
+    - region: ap-southeast-2
+      input_cost_per_token: 2.6e-8
     - region: ap-southeast-1
       input_cost_per_token: 2.8e-8
-    - region: ap-northeast-2
-      input_cost_per_token: 2.4592e-8
-      input_cost_per_token_batches: 1.2296e-8
-    - region: ap-northeast-3
-      input_cost_per_token: 2.7e-8
     - region: ap-south-2
       input_cost_per_token: 2.7e-8
-    - region: us-gov-east-1
-      input_cost_per_token: 3e-8
+    - region: ap-south-1
+      input_cost_per_token: 2.4e-8
+    - region: ap-northeast-3
+      input_cost_per_token: 2.7e-8
+    - region: ap-northeast-2
+      input_cost_per_token: 2.46e-8
+    - region: ap-northeast-1
+      input_cost_per_token: 2.9e-8
 limits:
     max_tokens: 8192
     max_input_tokens: 8192

--- a/providers/aws-bedrock/amazon.titan-image-generator-v1.yaml
+++ b/providers/aws-bedrock/amazon.titan-image-generator-v1.yaml
@@ -3,7 +3,7 @@ costs:
     - region: us-west-2
       input_cost_per_image: 0.02
     - region: us-east-1
-      input_cost_per_image: 0.012
+      input_cost_per_image: 0.02
     - region: sa-east-1
       input_cost_per_image: 0.018
     - region: eu-west-2

--- a/providers/aws-bedrock/amazon.titan-image-generator-v1.yaml
+++ b/providers/aws-bedrock/amazon.titan-image-generator-v1.yaml
@@ -1,5 +1,18 @@
 model: amazon.titan-image-generator-v1
 costs:
-    - region: "*"
-      input_cost_per_image: 0
+    - region: us-west-2
+      input_cost_per_image: 0.02
+    - region: us-east-1
+      input_cost_per_image: 0.012
+    - region: sa-east-1
+      input_cost_per_image: 0.018
+    - region: eu-west-2
+      input_cost_per_image: 0.0101
+    - region: eu-west-1
+      input_cost_per_image: 0.013
+    - region: ca-central-1
+      input_cost_per_image: 0.0107
+    - region: ap-south-1
+      input_cost_per_image: 0.01
 mode: image
+isDeprecated: true

--- a/providers/aws-bedrock/amazon.titan-image-generator-v1.yaml
+++ b/providers/aws-bedrock/amazon.titan-image-generator-v1.yaml
@@ -1,18 +1,18 @@
 model: amazon.titan-image-generator-v1
 costs:
     - region: us-west-2
-      input_cost_per_image: 0.02
+      output_cost_per_image: 0.02
     - region: us-east-1
-      input_cost_per_image: 0.02
+      output_cost_per_image: 0.02
     - region: sa-east-1
-      input_cost_per_image: 0.018
+      output_cost_per_image: 0.018
     - region: eu-west-2
-      input_cost_per_image: 0.0101
+      output_cost_per_image: 0.0101
     - region: eu-west-1
-      input_cost_per_image: 0.013
+      output_cost_per_image: 0.013
     - region: ca-central-1
-      input_cost_per_image: 0.0107
+      output_cost_per_image: 0.0107
     - region: ap-south-1
-      input_cost_per_image: 0.01
+      output_cost_per_image: 0.01
 mode: image
 isDeprecated: true

--- a/providers/aws-bedrock/amazon.titan-image-generator-v2:0.yaml
+++ b/providers/aws-bedrock/amazon.titan-image-generator-v2:0.yaml
@@ -1,7 +1,7 @@
 model: amazon.titan-image-generator-v2:0
 costs:
     - region: us-west-2
-      input_cost_per_image: 0.012
+      output_cost_per_image: 0.012
     - region: us-east-1
-      input_cost_per_image: 0.012
+      output_cost_per_image: 0.012
 mode: image

--- a/providers/aws-bedrock/amazon.titan-image-generator-v2:0.yaml
+++ b/providers/aws-bedrock/amazon.titan-image-generator-v2:0.yaml
@@ -1,5 +1,7 @@
 model: amazon.titan-image-generator-v2:0
 costs:
-    - region: "*"
-      input_cost_per_image: 0
+    - region: us-west-2
+      input_cost_per_image: 0.012
+    - region: us-east-1
+      input_cost_per_image: 0.012
 mode: image

--- a/providers/aws-bedrock/amazon.titan-text-express-v1.yaml
+++ b/providers/aws-bedrock/amazon.titan-text-express-v1.yaml
@@ -1,0 +1,39 @@
+model: amazon.titan-text-express-v1
+costs:
+    - region: us-west-2
+      input_cost_per_token: 2e-7
+      output_cost_per_token: 6e-7
+    - region: us-gov-west-1
+      input_cost_per_token: 8e-7
+      output_cost_per_token: 1.6e-6
+    - region: us-east-1
+      input_cost_per_token: 2e-7
+      output_cost_per_token: 6e-7
+    - region: sa-east-1
+      input_cost_per_token: 4e-7
+      output_cost_per_token: 1.1e-6
+    - region: eu-west-3
+      input_cost_per_token: 2.5e-7
+      output_cost_per_token: 7.88e-7
+    - region: eu-west-2
+      input_cost_per_token: 3e-7
+      output_cost_per_token: 9e-7
+    - region: eu-west-1
+      input_cost_per_token: 1e-6
+      output_cost_per_token: 1.7e-6
+    - region: eu-central-1
+      input_cost_per_token: 3e-7
+      output_cost_per_token: 8.63e-7
+    - region: ca-central-1
+      input_cost_per_token: 3e-7
+      output_cost_per_token: 8e-7
+    - region: ap-southeast-2
+      input_cost_per_token: 2.5e-7
+      output_cost_per_token: 7.88e-7
+    - region: ap-south-1
+      input_cost_per_token: 1e-6
+      output_cost_per_token: 1.9e-6
+    - region: ap-northeast-1
+      input_cost_per_token: 2.75e-7
+      output_cost_per_token: 8.25e-7
+isDeprecated: true

--- a/providers/aws-bedrock/amazon.titan-text-lite-v1.yaml
+++ b/providers/aws-bedrock/amazon.titan-text-lite-v1.yaml
@@ -1,0 +1,30 @@
+model: amazon.titan-text-lite-v1
+costs:
+    - region: us-west-2
+      input_cost_per_token: 1.5e-7
+      output_cost_per_token: 2e-7
+    - region: us-east-1
+      input_cost_per_token: 1.5e-7
+      output_cost_per_token: 2e-7
+    - region: sa-east-1
+      input_cost_per_token: 3e-7
+      output_cost_per_token: 4e-7
+    - region: eu-west-3
+      input_cost_per_token: 2e-7
+      output_cost_per_token: 2.5e-7
+    - region: eu-west-2
+      input_cost_per_token: 2e-7
+      output_cost_per_token: 3e-7
+    - region: eu-west-1
+      input_cost_per_token: 3e-7
+      output_cost_per_token: 4e-7
+    - region: ca-central-1
+      input_cost_per_token: 2e-7
+      output_cost_per_token: 3e-7
+    - region: ap-southeast-2
+      input_cost_per_token: 2e-7
+      output_cost_per_token: 2.5e-7
+    - region: ap-south-1
+      input_cost_per_token: 4e-7
+      output_cost_per_token: 5e-7
+isDeprecated: true

--- a/providers/aws-bedrock/amazon.titan-text-premier-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.titan-text-premier-v1:0.yaml
@@ -1,10 +1,11 @@
 model: amazon.titan-text-premier-v1:0
 costs:
-    - region: "*"
-      input_cost_per_token: 5.e-7
-      output_cost_per_token: 0.0000015
+    - region: us-east-1
+      input_cost_per_token: 5e-7
+      output_cost_per_token: 1.5e-6
 limits:
     max_tokens: 32000
     max_input_tokens: 42000
     max_output_tokens: 32000
 mode: chat
+isDeprecated: true

--- a/providers/aws-bedrock/anthropic.claude-3-5-haiku-20241022-v1:0.yaml
+++ b/providers/aws-bedrock/anthropic.claude-3-5-haiku-20241022-v1:0.yaml
@@ -19,3 +19,9 @@ costs:
       input_cost_per_token_batches: 4e-7
       output_cost_per_token: 5e-6
       output_cost_per_token_batches: 2e-6
+limits:
+    max_tokens: 4096
+    max_input_tokens: 200000
+    max_output_tokens: 8192
+features: [function_calling, vision]
+mode: chat

--- a/providers/aws-bedrock/anthropic.claude-instant-v1.yaml
+++ b/providers/aws-bedrock/anthropic.claude-instant-v1.yaml
@@ -1,0 +1,18 @@
+model: anthropic.claude-instant-v1
+costs:
+    - region: us-west-2
+      input_cost_per_token: 3.26e-6
+      output_cost_per_token: 1.102e-5
+    - region: us-east-1
+      input_cost_per_token: 3.26e-6
+      output_cost_per_token: 1.102e-5
+    - region: eu-central-1
+      input_cost_per_token: 8e-7
+      output_cost_per_token: 2.4e-6
+    - region: ap-southeast-1
+      input_cost_per_token: 8e-7
+      output_cost_per_token: 2.4e-6
+    - region: ap-northeast-1
+      input_cost_per_token: 8e-7
+      output_cost_per_token: 2.4e-6
+isDeprecated: true

--- a/providers/aws-bedrock/anthropic.claude-sonnet-4-20250514-v1:0.yaml
+++ b/providers/aws-bedrock/anthropic.claude-sonnet-4-20250514-v1:0.yaml
@@ -105,3 +105,8 @@ costs:
       input_cost_per_token_batches: 1.5e-6
       output_cost_per_token: 1.5e-05
       output_cost_per_token_batches: 7.5e-6
+limits:
+    max_input_tokens: 200000
+    max_output_tokens: 64000
+features: [function_calling, vision]
+mode: chat

--- a/providers/aws-bedrock/anthropic.claude-v2.yaml
+++ b/providers/aws-bedrock/anthropic.claude-v2.yaml
@@ -1,0 +1,7 @@
+model: anthropic.claude-v2
+costs:
+    - region: us-west-2
+      input_cost_per_token: 8e-6
+    - region: us-east-1
+      input_cost_per_token: 8e-6
+isDeprecated: true

--- a/providers/aws-bedrock/anthropic.claude-v2:1.yaml
+++ b/providers/aws-bedrock/anthropic.claude-v2:1.yaml
@@ -1,10 +1,23 @@
 model: anthropic.claude-v2:1
 costs:
-    - region: "*"
-      input_cost_per_token: 0.000008
-      output_cost_per_token: 0.000024
+    - region: us-west-2
+      input_cost_per_token: 8e-6
+      output_cost_per_token: 6.536e-5
+    - region: us-east-1
+      input_cost_per_token: 8e-6
+      output_cost_per_token: 6.536e-5
+    - region: eu-central-1
+      input_cost_per_token: 8e-6
+      output_cost_per_token: 2.4e-5
+    - region: ap-southeast-1
+      input_cost_per_token: 8e-6
+      output_cost_per_token: 2.4e-5
+    - region: ap-northeast-1
+      input_cost_per_token: 8e-6
+      output_cost_per_token: 2.4e-5
 limits:
     max_tokens: 8191
     max_input_tokens: 100000
     max_output_tokens: 8191
 mode: chat
+isDeprecated: true

--- a/providers/aws-bedrock/apac.amazon.nova-lite-v1:0.yaml
+++ b/providers/aws-bedrock/apac.amazon.nova-lite-v1:0.yaml
@@ -1,23 +1,48 @@
 model: apac.amazon.nova-lite-v1:0
 costs:
-    - region: ap-northeast-1
+    - region: me-central-1
+      cache_read_input_token_cost: 1.5e-8
+      input_cost_per_token: 6e-8
+      output_cost_per_token: 2.4e-7
+    - region: ap-southeast-7
+      cache_read_input_token_cost: 1.8e-8
       input_cost_per_token: 7.2e-8
       output_cost_per_token: 2.88e-7
+    - region: ap-southeast-5
+      cache_read_input_token_cost: 1.8e-8
+      input_cost_per_token: 7.2e-8
+      output_cost_per_token: 2.88e-7
+    - region: ap-southeast-4
+      cache_read_input_token_cost: 1.62e-8
+      input_cost_per_token: 6.5e-8
+      output_cost_per_token: 2.6e-7
     - region: ap-southeast-2
+      cache_read_input_token_cost: 1.57e-8
       input_cost_per_token: 6.3e-8
       output_cost_per_token: 2.52e-7
     - region: ap-southeast-1
+      cache_read_input_token_cost: 2.02e-8
       input_cost_per_token: 8.1e-8
       output_cost_per_token: 3.24e-7
-    - region: ap-northeast-2
-      input_cost_per_token: 7.1e-8
-      output_cost_per_token: 2.84e-7
     - region: ap-south-1
+      cache_read_input_token_cost: 1.78e-8
       input_cost_per_token: 7.1e-8
       output_cost_per_token: 2.84e-7
+    - region: ap-northeast-2
+      cache_read_input_token_cost: 1.78e-8
+      input_cost_per_token: 7.1e-8
+      output_cost_per_token: 2.84e-7
+    - region: ap-northeast-1
+      cache_read_input_token_cost: 1.8e-8
+      input_cost_per_token: 7.2e-8
+      output_cost_per_token: 2.88e-7
+    - region: ap-east-2
+      input_cost_per_token: 7.2e-8
 limits:
     max_tokens: 10000
     max_input_tokens: 300000
     max_output_tokens: 10000
-features: [function_calling, vision]
+features:
+    - function_calling
+    - vision
 mode: chat

--- a/providers/aws-bedrock/apac.amazon.nova-micro-v1:0.yaml
+++ b/providers/aws-bedrock/apac.amazon.nova-micro-v1:0.yaml
@@ -1,23 +1,35 @@
 model: apac.amazon.nova-micro-v1:0
 costs:
-    - region: ap-northeast-1
+    - region: me-central-1
+      cache_read_input_token_cost: 8.7e-9
+      input_cost_per_token: 3.5e-8
+      output_cost_per_token: 1.4e-7
+    - region: ap-southeast-5
       input_cost_per_token: 4.2e-8
-      output_cost_per_token: 1.68e-7
     - region: ap-southeast-2
+      cache_read_input_token_cost: 9.3e-9
       input_cost_per_token: 3.7e-8
       output_cost_per_token: 1.48e-7
     - region: ap-southeast-1
+      cache_read_input_token_cost: 1.17e-8
       input_cost_per_token: 4.7e-8
       output_cost_per_token: 1.88e-7
-    - region: ap-northeast-2
-      input_cost_per_token: 4.1e-8
-      output_cost_per_token: 1.64e-7
     - region: ap-south-1
+      cache_read_input_token_cost: 1.03e-8
       input_cost_per_token: 4.1e-8
       output_cost_per_token: 1.64e-7
+    - region: ap-northeast-2
+      cache_read_input_token_cost: 1.03e-8
+      input_cost_per_token: 4.1e-8
+      output_cost_per_token: 1.64e-7
+    - region: ap-northeast-1
+      cache_read_input_token_cost: 1.05e-8
+      input_cost_per_token: 4.2e-8
+      output_cost_per_token: 1.68e-7
 limits:
     max_tokens: 10000
     max_input_tokens: 128000
     max_output_tokens: 10000
-features: [function_calling]
+features:
+    - function_calling
 mode: chat

--- a/providers/aws-bedrock/apac.amazon.nova-pro-v1:0.yaml
+++ b/providers/aws-bedrock/apac.amazon.nova-pro-v1:0.yaml
@@ -1,23 +1,54 @@
 model: apac.amazon.nova-pro-v1:0
 costs:
-    - region: ap-northeast-1
-      input_cost_per_token: 9.6e-7
-      output_cost_per_token: 3.84e-6
+    - region: me-central-1
+      input_cost_per_audio_token: 1.25e-6
+      input_cost_per_token: 1.25e-6
+      output_cost_per_token: 1.002e-5
+    - region: ap-southeast-7
+      input_cost_per_audio_token: 1.69e-6
+      input_cost_per_token: 1.69e-6
+      output_cost_per_token: 1.356e-5
+    - region: ap-southeast-5
+      input_cost_per_audio_token: 1.69e-6
+      input_cost_per_token: 1.69e-6
+      output_cost_per_token: 1.356e-5
+    - region: ap-southeast-4
+      input_cost_per_audio_token: 1.36e-6
+      input_cost_per_token: 1.36e-6
+      output_cost_per_token: 1.084e-5
+    - region: ap-southeast-3
+      input_cost_per_audio_token: 1.32e-6
+      input_cost_per_token: 1.32e-6
+      output_cost_per_token: 1.056e-5
     - region: ap-southeast-2
-      input_cost_per_token: 8.4e-7
-      output_cost_per_token: 3.36e-6
+      input_cost_per_audio_token: 1.31e-6
+      input_cost_per_token: 1.31e-6
+      output_cost_per_token: 1.051e-5
     - region: ap-southeast-1
-      input_cost_per_token: 1.08e-6
-      output_cost_per_token: 4.32e-6
-    - region: ap-northeast-2
-      input_cost_per_token: 9.5e-7
-      output_cost_per_token: 3.8e-6
+      input_cost_per_audio_token: 1.69e-6
+      input_cost_per_token: 1.69e-6
+      output_cost_per_token: 1.356e-5
     - region: ap-south-1
-      input_cost_per_token: 9.4e-7
-      output_cost_per_token: 3.76e-6
+      input_cost_per_audio_token: 1.48e-6
+      input_cost_per_token: 1.48e-6
+      output_cost_per_token: 1.18e-5
+    - region: ap-northeast-2
+      input_cost_per_audio_token: 1.48e-6
+      input_cost_per_token: 1.48e-6
+      output_cost_per_token: 1.184e-5
+    - region: ap-northeast-1
+      input_cost_per_audio_token: 1.51e-6
+      input_cost_per_token: 1.51e-6
+      output_cost_per_token: 1.25e-5
+    - region: ap-east-2
+      input_cost_per_audio_token: 1.51e-6
+      input_cost_per_token: 1.51e-6
+      output_cost_per_token: 1.25e-5
 limits:
     max_tokens: 10000
     max_input_tokens: 300000
     max_output_tokens: 10000
-features: [function_calling, vision]
+features:
+    - function_calling
+    - vision
 mode: chat

--- a/providers/aws-bedrock/apac.amazon.nova-pro-v1:0.yaml
+++ b/providers/aws-bedrock/apac.amazon.nova-pro-v1:0.yaml
@@ -1,49 +1,35 @@
 model: apac.amazon.nova-pro-v1:0
 costs:
     - region: me-central-1
-      input_cost_per_audio_token: 1.25e-6
-      input_cost_per_token: 1.25e-6
-      output_cost_per_token: 1.002e-5
-    - region: ap-southeast-7
-      input_cost_per_audio_token: 1.69e-6
-      input_cost_per_token: 1.69e-6
-      output_cost_per_token: 1.356e-5
+      cache_read_input_token_cost: 2e-7
+      input_cost_per_token: 8e-7
+      output_cost_per_token: 3.2e-6
     - region: ap-southeast-5
-      input_cost_per_audio_token: 1.69e-6
-      input_cost_per_token: 1.69e-6
-      output_cost_per_token: 1.356e-5
+      input_cost_per_token: 9.6e-7
     - region: ap-southeast-4
-      input_cost_per_audio_token: 1.36e-6
-      input_cost_per_token: 1.36e-6
-      output_cost_per_token: 1.084e-5
-    - region: ap-southeast-3
-      input_cost_per_audio_token: 1.32e-6
-      input_cost_per_token: 1.32e-6
-      output_cost_per_token: 1.056e-5
+      cache_read_input_token_cost: 2.175e-7
+      input_cost_per_token: 8.7e-7
+      output_cost_per_token: 3.48e-6
     - region: ap-southeast-2
-      input_cost_per_audio_token: 1.31e-6
-      input_cost_per_token: 1.31e-6
-      output_cost_per_token: 1.051e-5
+      cache_read_input_token_cost: 2.1e-7
+      input_cost_per_token: 8.4e-7
+      output_cost_per_token: 3.36e-6
     - region: ap-southeast-1
-      input_cost_per_audio_token: 1.69e-6
-      input_cost_per_token: 1.69e-6
-      output_cost_per_token: 1.356e-5
+      cache_read_input_token_cost: 2.7e-7
+      input_cost_per_token: 1.08e-6
+      output_cost_per_token: 4.32e-6
     - region: ap-south-1
-      input_cost_per_audio_token: 1.48e-6
-      input_cost_per_token: 1.48e-6
-      output_cost_per_token: 1.18e-5
+      cache_read_input_token_cost: 2.35e-7
+      input_cost_per_token: 9.4e-7
+      output_cost_per_token: 3.76e-6
     - region: ap-northeast-2
-      input_cost_per_audio_token: 1.48e-6
-      input_cost_per_token: 1.48e-6
-      output_cost_per_token: 1.184e-5
+      cache_read_input_token_cost: 2.375e-7
+      input_cost_per_token: 9.5e-7
+      output_cost_per_token: 3.8e-6
     - region: ap-northeast-1
-      input_cost_per_audio_token: 1.51e-6
-      input_cost_per_token: 1.51e-6
-      output_cost_per_token: 1.25e-5
-    - region: ap-east-2
-      input_cost_per_audio_token: 1.51e-6
-      input_cost_per_token: 1.51e-6
-      output_cost_per_token: 1.25e-5
+      cache_read_input_token_cost: 2.4e-7
+      input_cost_per_token: 9.6e-7
+      output_cost_per_token: 3.84e-6
 limits:
     max_tokens: 10000
     max_input_tokens: 300000

--- a/providers/aws-bedrock/apac.anthropic.claude-3-5-sonnet-20240620-v1:0.yaml
+++ b/providers/aws-bedrock/apac.anthropic.claude-3-5-sonnet-20240620-v1:0.yaml
@@ -1,11 +1,25 @@
 model: apac.anthropic.claude-3-5-sonnet-20240620-v1:0
 costs:
-    - region: "*"
-      input_cost_per_token: 0.000003
-      output_cost_per_token: 0.000015
+    - region: ap-southeast-2
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 1.5e-5
+    - region: ap-southeast-1
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 1.5e-5
+    - region: ap-south-1
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 1.5e-5
+    - region: ap-northeast-2
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 1.5e-5
+    - region: ap-northeast-1
+      input_cost_per_token: 1.5e-6
+      output_cost_per_token: 7.5e-6
 limits:
     max_tokens: 4096
     max_input_tokens: 200000
     max_output_tokens: 4096
-features: [function_calling, vision]
+features:
+    - function_calling
+    - vision
 mode: chat

--- a/providers/aws-bedrock/apac.anthropic.claude-3-5-sonnet-20241022-v2:0.yaml
+++ b/providers/aws-bedrock/apac.anthropic.claude-3-5-sonnet-20241022-v2:0.yaml
@@ -1,13 +1,31 @@
 model: apac.anthropic.claude-3-5-sonnet-20241022-v2:0
 costs:
-    - region: "*"
-      input_cost_per_token: 0.000003
-      output_cost_per_token: 0.000015
-      cache_read_input_token_cost: 3.e-7
-      cache_creation_input_token_cost: 0.00000375
+    - region: ap-southeast-2
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 1.5e-5
+    - region: ap-southeast-1
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 1.5e-5
+    - region: ap-south-2
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 1.5e-5
+    - region: ap-south-1
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 1.5e-5
+    - region: ap-northeast-3
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 1.5e-5
+    - region: ap-northeast-2
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 1.5e-5
+    - region: ap-northeast-1
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 1.5e-5
 limits:
     max_tokens: 8192
     max_input_tokens: 200000
     max_output_tokens: 8192
-features: [function_calling, vision]
+features:
+    - function_calling
+    - vision
 mode: chat

--- a/providers/aws-bedrock/apac.anthropic.claude-3-7-sonnet-20250219-v1:0.yaml
+++ b/providers/aws-bedrock/apac.anthropic.claude-3-7-sonnet-20250219-v1:0.yaml
@@ -35,3 +35,8 @@ costs:
       cache_read_input_token_cost: 3e-7
       input_cost_per_token: 3e-6
       output_cost_per_token: 1.5e-5
+limits:
+    max_input_tokens: 200000
+    max_output_tokens: 128000
+features: [function_calling, vision]
+mode: chat

--- a/providers/aws-bedrock/apac.anthropic.claude-3-7-sonnet-20250219-v1:0.yaml
+++ b/providers/aws-bedrock/apac.anthropic.claude-3-7-sonnet-20250219-v1:0.yaml
@@ -1,0 +1,37 @@
+model: apac.anthropic.claude-3-7-sonnet-20250219-v1:0
+costs:
+    - region: ap-southeast-2
+      cache_creation_input_token_cost: 3.75e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 1.5e-5
+    - region: ap-southeast-1
+      cache_creation_input_token_cost: 3.75e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 1.5e-5
+    - region: ap-south-2
+      cache_creation_input_token_cost: 3.75e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 1.5e-5
+    - region: ap-south-1
+      cache_creation_input_token_cost: 3.75e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 1.5e-5
+    - region: ap-northeast-3
+      cache_creation_input_token_cost: 3.75e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 1.5e-5
+    - region: ap-northeast-2
+      cache_creation_input_token_cost: 3.75e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 1.5e-5
+    - region: ap-northeast-1
+      cache_creation_input_token_cost: 3.75e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 1.5e-5

--- a/providers/aws-bedrock/apac.anthropic.claude-3-7-sonnet-20250219-v1:0.yaml
+++ b/providers/aws-bedrock/apac.anthropic.claude-3-7-sonnet-20250219-v1:0.yaml
@@ -38,5 +38,7 @@ costs:
 limits:
     max_input_tokens: 200000
     max_output_tokens: 128000
-features: [function_calling, vision]
+features:
+    - function_calling
+    - vision
 mode: chat

--- a/providers/aws-bedrock/apac.anthropic.claude-3-haiku-20240307-v1:0.yaml
+++ b/providers/aws-bedrock/apac.anthropic.claude-3-haiku-20240307-v1:0.yaml
@@ -2,32 +2,24 @@ model: apac.anthropic.claude-3-haiku-20240307-v1:0
 costs:
     - region: ap-southeast-2
       input_cost_per_token: 2.5e-7
-      input_cost_per_token_batches: 1.25e-7
       output_cost_per_token: 1.25e-6
-      output_cost_per_token_batches: 6.25e-7
-    - region: ap-northeast-1
-      input_cost_per_token: 2.5e-7
-      input_cost_per_token_batches: 1.25e-7
-      output_cost_per_token: 1.25e-6
-      output_cost_per_token_batches: 6.25e-7
     - region: ap-southeast-1
       input_cost_per_token: 2.5e-7
-      input_cost_per_token_batches: 1.25e-7
       output_cost_per_token: 1.25e-6
-      output_cost_per_token_batches: 6.25e-7
-    - region: ap-northeast-2
-      input_cost_per_token: 2.5e-7
-      input_cost_per_token_batches: 1.25e-7
-      output_cost_per_token: 1.25e-6
-      output_cost_per_token_batches: 6.25e-7
     - region: ap-south-1
       input_cost_per_token: 2.5e-7
-      input_cost_per_token_batches: 1.25e-7
       output_cost_per_token: 1.25e-6
-      output_cost_per_token_batches: 6.25e-7
+    - region: ap-northeast-2
+      input_cost_per_token: 2.5e-7
+      output_cost_per_token: 1.25e-6
+    - region: ap-northeast-1
+      input_cost_per_token: 2.5e-7
+      output_cost_per_token: 1.25e-6
 limits:
     max_tokens: 4096
     max_input_tokens: 200000
     max_output_tokens: 4096
-features: [function_calling, vision]
+features:
+    - function_calling
+    - vision
 mode: chat

--- a/providers/aws-bedrock/apac.anthropic.claude-3-sonnet-20240229-v1:0.yaml
+++ b/providers/aws-bedrock/apac.anthropic.claude-3-sonnet-20240229-v1:0.yaml
@@ -1,11 +1,25 @@
 model: apac.anthropic.claude-3-sonnet-20240229-v1:0
 costs:
-    - region: "*"
-      input_cost_per_token: 0.000003
-      output_cost_per_token: 0.000015
+    - region: ap-southeast-2
+      input_cost_per_token: 1.5e-6
+      output_cost_per_token: 7.5e-6
+    - region: ap-southeast-1
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 7.5e-6
+    - region: ap-south-1
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 1.5e-5
+    - region: ap-northeast-2
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 1.5e-5
+    - region: ap-northeast-1
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 7.5e-6
 limits:
     max_tokens: 4096
     max_input_tokens: 200000
     max_output_tokens: 4096
-features: [function_calling, vision]
+features:
+    - function_calling
+    - vision
 mode: chat

--- a/providers/aws-bedrock/apac.anthropic.claude-sonnet-4-20250514-v1:0.yaml
+++ b/providers/aws-bedrock/apac.anthropic.claude-sonnet-4-20250514-v1:0.yaml
@@ -1,56 +1,66 @@
 model: apac.anthropic.claude-sonnet-4-20250514-v1:0
 costs:
-    - region: ap-northeast-1
+    - region: me-central-1
       cache_creation_input_token_cost: 3.75e-6
       cache_read_input_token_cost: 3e-7
       input_cost_per_token: 3e-6
-      input_cost_per_token_batches: 1.5e-6
-      output_cost_per_token: 1.5e-05
-      output_cost_per_token_batches: 7.5e-6
+      output_cost_per_token: 1.5e-5
+    - region: ap-southeast-7
+      cache_creation_input_token_cost: 3.75e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 1.5e-5
+    - region: ap-southeast-5
+      cache_creation_input_token_cost: 3.75e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 1.5e-5
     - region: ap-southeast-2
       cache_creation_input_token_cost: 3.75e-6
       cache_read_input_token_cost: 3e-7
       input_cost_per_token: 3e-6
-      input_cost_per_token_batches: 1.5e-6
-      output_cost_per_token: 1.5e-05
-      output_cost_per_token_batches: 7.5e-6
+      output_cost_per_token: 1.5e-5
     - region: ap-southeast-1
       cache_creation_input_token_cost: 3.75e-6
       cache_read_input_token_cost: 3e-7
       input_cost_per_token: 3e-6
-      input_cost_per_token_batches: 1.5e-6
-      output_cost_per_token: 1.5e-05
-      output_cost_per_token_batches: 7.5e-6
-    - region: ap-northeast-2
-      cache_creation_input_token_cost: 3.75e-6
-      cache_read_input_token_cost: 3e-7
-      input_cost_per_token: 3e-6
-      input_cost_per_token_batches: 1.5e-6
-      output_cost_per_token: 1.5e-05
-      output_cost_per_token_batches: 7.5e-6
-    - region: ap-northeast-3
-      cache_creation_input_token_cost: 3.75e-6
-      cache_read_input_token_cost: 3e-7
-      input_cost_per_token: 3e-6
-      output_cost_per_token: 1.5e-05
-    - region: ap-south-1
-      cache_creation_input_token_cost: 3.75e-6
-      cache_read_input_token_cost: 3e-7
-      input_cost_per_token: 3e-6
-      input_cost_per_token_batches: 1.5e-6
-      output_cost_per_token: 1.5e-05
-      output_cost_per_token_batches: 7.5e-6
+      output_cost_per_token: 1.5e-5
     - region: ap-south-2
       cache_creation_input_token_cost: 3.75e-6
       cache_read_input_token_cost: 3e-7
       input_cost_per_token: 3e-6
-      input_cost_per_token_batches: 1.5e-6
-      output_cost_per_token: 1.5e-05
-      output_cost_per_token_batches: 7.5e-6
+      output_cost_per_token: 1.5e-5
+    - region: ap-south-1
+      cache_creation_input_token_cost: 3.75e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 1.5e-5
+    - region: ap-northeast-3
+      cache_creation_input_token_cost: 3.75e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 1.5e-5
+    - region: ap-northeast-2
+      cache_creation_input_token_cost: 3.75e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 1.5e-5
+    - region: ap-northeast-1
+      cache_creation_input_token_cost: 3.75e-6
+      cache_read_input_token_cost: 6e-7
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 2.25e-5
+    - region: ap-east-2
+      cache_creation_input_token_cost: 3.75e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 1.5e-5
 limits:
     max_tokens: 64000
     max_input_tokens: 1000000
     max_output_tokens: 64000
     tool_use_system_prompt_tokens: 159
-features: [function_calling, vision]
+features:
+    - function_calling
+    - vision
 mode: chat

--- a/providers/aws-bedrock/apac.twelvelabs.marengo-embed-2-7-v1:0.yaml
+++ b/providers/aws-bedrock/apac.twelvelabs.marengo-embed-2-7-v1:0.yaml
@@ -1,7 +1,4 @@
 model: apac.twelvelabs.marengo-embed-2-7-v1:0
 costs:
     - region: ap-northeast-2
-      input_cost_per_audio_token: 0.00014
-      input_cost_per_image: 0.0001
-      input_cost_per_request: 7e-05
-      input_cost_per_second: 0.0007
+      input_cost_per_token: 1e-10

--- a/providers/aws-bedrock/apac.twelvelabs.marengo-embed-2-7-v1:0.yaml
+++ b/providers/aws-bedrock/apac.twelvelabs.marengo-embed-2-7-v1:0.yaml
@@ -2,3 +2,8 @@ model: apac.twelvelabs.marengo-embed-2-7-v1:0
 costs:
     - region: ap-northeast-2
       input_cost_per_token: 1e-10
+limits:
+    max_tokens: 77
+    max_input_tokens: 77
+    output_vector_size: 1024
+mode: embedding

--- a/providers/aws-bedrock/apac.twelvelabs.marengo-embed-2-7-v1:0.yaml
+++ b/providers/aws-bedrock/apac.twelvelabs.marengo-embed-2-7-v1:0.yaml
@@ -1,6 +1,8 @@
 model: apac.twelvelabs.marengo-embed-2-7-v1:0
 costs:
     - region: ap-northeast-2
+      input_cost_per_image: 1e-4
+      input_cost_per_second: 1.4e-4
       input_cost_per_token: 1e-10
 limits:
     max_tokens: 77

--- a/providers/aws-bedrock/apac.twelvelabs.pegasus-1-2-v1:0.yaml
+++ b/providers/aws-bedrock/apac.twelvelabs.pegasus-1-2-v1:0.yaml
@@ -1,7 +1,7 @@
 model: apac.twelvelabs.pegasus-1-2-v1:0
 costs:
     - region: ap-northeast-2
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
 limits:
     max_tokens: 4096

--- a/providers/aws-bedrock/apac.twelvelabs.pegasus-1-2-v1:0.yaml
+++ b/providers/aws-bedrock/apac.twelvelabs.pegasus-1-2-v1:0.yaml
@@ -1,5 +1,5 @@
 model: apac.twelvelabs.pegasus-1-2-v1:0
 costs:
     - region: ap-northeast-2
-      input_cost_per_second: 0.00049
+      input_cost_per_token: 5e-10
       output_cost_per_token: 7.5e-6

--- a/providers/aws-bedrock/apac.twelvelabs.pegasus-1-2-v1:0.yaml
+++ b/providers/aws-bedrock/apac.twelvelabs.pegasus-1-2-v1:0.yaml
@@ -3,3 +3,6 @@ costs:
     - region: ap-northeast-2
       input_cost_per_token: 5e-10
       output_cost_per_token: 7.5e-6
+limits:
+    max_tokens: 4096
+mode: chat

--- a/providers/aws-bedrock/au.anthropic.claude-haiku-4-5-20251001-v1:0.yaml
+++ b/providers/aws-bedrock/au.anthropic.claude-haiku-4-5-20251001-v1:0.yaml
@@ -1,16 +1,21 @@
 model: au.anthropic.claude-haiku-4-5-20251001-v1:0
 costs:
+    - region: ap-southeast-4
+      cache_creation_input_token_cost: 1.25e-6
+      cache_read_input_token_cost: 1e-7
+      input_cost_per_token: 1e-6
+      output_cost_per_token: 5e-6
     - region: ap-southeast-2
       cache_creation_input_token_cost: 1.25e-6
       cache_read_input_token_cost: 1e-7
       input_cost_per_token: 1e-6
-      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 5e-6
-      output_cost_per_token_batches: 2.5e-6
 limits:
     max_tokens: 64000
     max_input_tokens: 200000
     max_output_tokens: 64000
     tool_use_system_prompt_tokens: 346
-features: [function_calling, vision]
+features:
+    - function_calling
+    - vision
 mode: chat

--- a/providers/aws-bedrock/au.anthropic.claude-opus-4-6-v1.yaml
+++ b/providers/aws-bedrock/au.anthropic.claude-opus-4-6-v1.yaml
@@ -10,3 +10,10 @@ costs:
       cache_read_input_token_cost: 5e-7
       input_cost_per_token: 5e-6
       output_cost_per_token: 2.5e-5
+limits:
+    max_tokens: 128000
+    max_input_tokens: 1000000
+    max_output_tokens: 128000
+    tool_use_system_prompt_tokens: 346
+features: [function_calling, vision]
+mode: chat

--- a/providers/aws-bedrock/au.anthropic.claude-opus-4-6-v1.yaml
+++ b/providers/aws-bedrock/au.anthropic.claude-opus-4-6-v1.yaml
@@ -1,9 +1,12 @@
 model: au.anthropic.claude-opus-4-6-v1
 costs:
+    - region: ap-southeast-4
+      cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 1e-6
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 2.5e-5
     - region: ap-southeast-2
-      cache_creation_input_token_cost: 6.875e-6
-      cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 5.5e-6
-      input_cost_per_token_batches: 2.75e-6
-      output_cost_per_token: 2.75e-05
-      output_cost_per_token_batches: 1.375e-05
+      cache_creation_input_token_cost: 1.25e-5
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 2.5e-5

--- a/providers/aws-bedrock/au.anthropic.claude-opus-4-6-v1.yaml
+++ b/providers/aws-bedrock/au.anthropic.claude-opus-4-6-v1.yaml
@@ -15,5 +15,7 @@ limits:
     max_input_tokens: 1000000
     max_output_tokens: 128000
     tool_use_system_prompt_tokens: 346
-features: [function_calling, vision]
+features:
+    - function_calling
+    - vision
 mode: chat

--- a/providers/aws-bedrock/au.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
+++ b/providers/aws-bedrock/au.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
@@ -1,16 +1,21 @@
 model: au.anthropic.claude-sonnet-4-5-20250929-v1:0
 costs:
+    - region: ap-southeast-4
+      cache_creation_input_token_cost: 3.75e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 6e-6
+      output_cost_per_token: 2.25e-5
     - region: ap-southeast-2
-      cache_creation_input_token_cost: 4.125e-6
-      cache_read_input_token_cost: 3.3e-7
-      input_cost_per_token: 3.3e-6
-      input_cost_per_token_batches: 1.65e-6
-      output_cost_per_token: 1.65e-05
-      output_cost_per_token_batches: 8.25e-6
+      cache_creation_input_token_cost: 7.5e-6
+      cache_read_input_token_cost: 6e-7
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 2.25e-5
 limits:
     max_tokens: 64000
     max_input_tokens: 200000
     max_output_tokens: 64000
     tool_use_system_prompt_tokens: 346
-features: [function_calling, vision]
+features:
+    - function_calling
+    - vision
 mode: chat

--- a/providers/aws-bedrock/ca.amazon.nova-lite-v1:0.yaml
+++ b/providers/aws-bedrock/ca.amazon.nova-lite-v1:0.yaml
@@ -1,5 +1,6 @@
 model: ca.amazon.nova-lite-v1:0
 costs:
     - region: ca-central-1
+      cache_read_input_token_cost: 1.6e-8
       input_cost_per_token: 6.4e-8
       output_cost_per_token: 2.56e-7

--- a/providers/aws-bedrock/ca.amazon.nova-lite-v1:0.yaml
+++ b/providers/aws-bedrock/ca.amazon.nova-lite-v1:0.yaml
@@ -4,3 +4,9 @@ costs:
       cache_read_input_token_cost: 1.6e-8
       input_cost_per_token: 6.4e-8
       output_cost_per_token: 2.56e-7
+limits:
+    max_tokens: 4096
+    max_input_tokens: 300000
+    max_output_tokens: 10000
+features: [function_calling, vision, chat]
+mode: chat

--- a/providers/aws-bedrock/ca.amazon.nova-lite-v1:0.yaml
+++ b/providers/aws-bedrock/ca.amazon.nova-lite-v1:0.yaml
@@ -8,5 +8,8 @@ limits:
     max_tokens: 4096
     max_input_tokens: 300000
     max_output_tokens: 10000
-features: [function_calling, vision, chat]
+features:
+    - function_calling
+    - vision
+    - chat
 mode: chat

--- a/providers/aws-bedrock/cohere.command-light-text-v14.yaml
+++ b/providers/aws-bedrock/cohere.command-light-text-v14.yaml
@@ -1,11 +1,16 @@
 model: cohere.command-light-text-v14
 costs:
-    - region: "*"
-      input_cost_per_token: 3.e-7
-      output_cost_per_token: 6.e-7
+    - region: us-west-2
+      input_cost_per_token: 3e-7
+      output_cost_per_token: 6e-7
+    - region: us-east-1
+      input_cost_per_token: 3e-7
+      output_cost_per_token: 6e-7
 limits:
     max_tokens: 4096
     max_input_tokens: 4096
     max_output_tokens: 4096
-features: [chat]
+features:
+    - chat
 mode: chat
+isDeprecated: true

--- a/providers/aws-bedrock/cohere.command-r-plus-v1:0.yaml
+++ b/providers/aws-bedrock/cohere.command-r-plus-v1:0.yaml
@@ -2,13 +2,14 @@ model: cohere.command-r-plus-v1:0
 costs:
     - region: us-west-2
       input_cost_per_token: 3e-6
-      output_cost_per_token: 1.5e-05
+      output_cost_per_token: 1.5e-5
     - region: us-east-1
       input_cost_per_token: 3e-6
-      output_cost_per_token: 1.5e-05
+      output_cost_per_token: 1.5e-5
 limits:
     max_tokens: 4096
     max_input_tokens: 128000
     max_output_tokens: 4096
-features: [chat]
+features:
+    - chat
 mode: chat

--- a/providers/aws-bedrock/cohere.command-r-v1:0.yaml
+++ b/providers/aws-bedrock/cohere.command-r-v1:0.yaml
@@ -10,5 +10,6 @@ limits:
     max_tokens: 4096
     max_input_tokens: 128000
     max_output_tokens: 4096
-features: [chat]
+features:
+    - chat
 mode: chat

--- a/providers/aws-bedrock/cohere.command-text-v14.yaml
+++ b/providers/aws-bedrock/cohere.command-text-v14.yaml
@@ -1,12 +1,16 @@
 model: cohere.command-text-v14
 costs:
-    - region: "*"
-      input_cost_per_token: 0.0000015
-      output_cost_per_token: 0.000002
+    - region: us-west-2
+      input_cost_per_token: 1e-6
+      output_cost_per_token: 2e-6
+    - region: us-east-1
+      input_cost_per_token: 1e-6
+      output_cost_per_token: 2e-6
 limits:
     max_tokens: 4096
     max_input_tokens: 4096
     max_output_tokens: 4096
-features: [chat]
+features:
+    - chat
 mode: chat
 isDeprecated: true

--- a/providers/aws-bedrock/cohere.embed-english-v3.yaml
+++ b/providers/aws-bedrock/cohere.embed-english-v3.yaml
@@ -1,28 +1,40 @@
 model: cohere.embed-english-v3
 costs:
     - region: us-west-2
+      input_cost_per_image: 1e-4
       input_cost_per_token: 1e-7
     - region: us-east-1
+      input_cost_per_image: 1e-4
       input_cost_per_token: 1e-7
     - region: sa-east-1
-      input_cost_per_token: 1e-10
+      input_cost_per_image: 1e-4
+      input_cost_per_token: 1e-7
     - region: eu-west-3
+      input_cost_per_image: 1e-4
       input_cost_per_token: 1e-7
     - region: eu-west-2
-      input_cost_per_token: 1e-10
+      input_cost_per_image: 1e-4
+      input_cost_per_token: 1e-7
     - region: eu-west-1
+      input_cost_per_image: 1e-4
       input_cost_per_token: 1e-7
     - region: eu-central-1
+      input_cost_per_image: 1e-4
       input_cost_per_token: 1e-7
     - region: ca-central-1
+      input_cost_per_image: 1e-4
       input_cost_per_token: 1e-7
     - region: ap-southeast-2
+      input_cost_per_image: 1e-4
       input_cost_per_token: 1e-7
     - region: ap-southeast-1
+      input_cost_per_image: 1e-4
       input_cost_per_token: 1e-7
     - region: ap-south-1
+      input_cost_per_image: 1e-4
       input_cost_per_token: 1e-7
     - region: ap-northeast-1
+      input_cost_per_image: 1e-4
       input_cost_per_token: 1e-7
 limits:
     max_tokens: 4096

--- a/providers/aws-bedrock/cohere.embed-english-v3.yaml
+++ b/providers/aws-bedrock/cohere.embed-english-v3.yaml
@@ -5,24 +5,24 @@ costs:
     - region: us-east-1
       input_cost_per_token: 1e-7
     - region: sa-east-1
-      input_cost_per_token: 1e-7
+      input_cost_per_token: 1e-10
     - region: eu-west-3
       input_cost_per_token: 1e-7
     - region: eu-west-2
-      input_cost_per_token: 1e-7
+      input_cost_per_token: 1e-10
     - region: eu-west-1
       input_cost_per_token: 1e-7
     - region: eu-central-1
       input_cost_per_token: 1e-7
     - region: ca-central-1
       input_cost_per_token: 1e-7
-    - region: ap-northeast-1
-      input_cost_per_token: 1e-7
     - region: ap-southeast-2
       input_cost_per_token: 1e-7
     - region: ap-southeast-1
       input_cost_per_token: 1e-7
     - region: ap-south-1
+      input_cost_per_token: 1e-7
+    - region: ap-northeast-1
       input_cost_per_token: 1e-7
 limits:
     max_tokens: 4096

--- a/providers/aws-bedrock/cohere.embed-multilingual-v3.yaml
+++ b/providers/aws-bedrock/cohere.embed-multilingual-v3.yaml
@@ -15,17 +15,18 @@ costs:
     - region: eu-central-1
       input_cost_per_token: 1e-7
     - region: ca-central-1
-      input_cost_per_token: 1e-7
-    - region: ap-northeast-1
-      input_cost_per_token: 1e-7
+      input_cost_per_token: 1e-10
     - region: ap-southeast-2
       input_cost_per_token: 1e-7
     - region: ap-southeast-1
       input_cost_per_token: 1e-7
     - region: ap-south-1
       input_cost_per_token: 1e-7
+    - region: ap-northeast-1
+      input_cost_per_token: 1e-7
 limits:
     max_tokens: 4096
     max_input_tokens: 512
-removeParams: [stream]
+removeParams:
+    - stream
 mode: embedding

--- a/providers/aws-bedrock/cohere.embed-multilingual-v3.yaml
+++ b/providers/aws-bedrock/cohere.embed-multilingual-v3.yaml
@@ -1,28 +1,40 @@
 model: cohere.embed-multilingual-v3
 costs:
     - region: us-west-2
+      input_cost_per_image: 1e-4
       input_cost_per_token: 1e-7
     - region: us-east-1
+      input_cost_per_image: 1e-4
       input_cost_per_token: 1e-7
     - region: sa-east-1
+      input_cost_per_image: 1e-4
       input_cost_per_token: 1e-7
     - region: eu-west-3
+      input_cost_per_image: 1e-4
       input_cost_per_token: 1e-7
     - region: eu-west-2
+      input_cost_per_image: 1e-4
       input_cost_per_token: 1e-7
     - region: eu-west-1
+      input_cost_per_image: 1e-4
       input_cost_per_token: 1e-7
     - region: eu-central-1
+      input_cost_per_image: 1e-4
       input_cost_per_token: 1e-7
     - region: ca-central-1
-      input_cost_per_token: 1e-10
+      input_cost_per_image: 1e-4
+      input_cost_per_token: 1e-7
     - region: ap-southeast-2
+      input_cost_per_image: 1e-4
       input_cost_per_token: 1e-7
     - region: ap-southeast-1
+      input_cost_per_image: 1e-4
       input_cost_per_token: 1e-7
     - region: ap-south-1
+      input_cost_per_image: 1e-4
       input_cost_per_token: 1e-7
     - region: ap-northeast-1
+      input_cost_per_image: 1e-4
       input_cost_per_token: 1e-7
 limits:
     max_tokens: 4096

--- a/providers/aws-bedrock/cohere.rerank-v3-5:0.yaml
+++ b/providers/aws-bedrock/cohere.rerank-v3-5:0.yaml
@@ -1,9 +1,15 @@
 model: cohere.rerank-v3-5:0
 costs:
-    - region: "*"
-      input_cost_per_token: 0
-      output_cost_per_token: 0
-      input_cost_per_query: 0.002
+    - region: us-west-2
+      input_cost_per_query: 2e-3
+    - region: us-east-1
+      input_cost_per_query: 2e-3
+    - region: eu-central-1
+      input_cost_per_query: 2e-3
+    - region: ca-central-1
+      input_cost_per_query: 2e-3
+    - region: ap-northeast-1
+      input_cost_per_query: 2e-3
 limits:
     max_tokens: 4096
     max_input_tokens: 32000

--- a/providers/aws-bedrock/deepseek.r1-v1:0.yaml
+++ b/providers/aws-bedrock/deepseek.r1-v1:0.yaml
@@ -9,3 +9,8 @@ costs:
     - region: us-east-1
       input_cost_per_token: 1.35e-6
       output_cost_per_token: 5.4e-6
+limits:
+    max_tokens: 4096
+    max_input_tokens: 128000
+    max_output_tokens: 4096
+mode: chat

--- a/providers/aws-bedrock/deepseek.v3-v1:0.yaml
+++ b/providers/aws-bedrock/deepseek.v3-v1:0.yaml
@@ -1,26 +1,31 @@
 model: deepseek.v3-v1:0
 costs:
     - region: us-west-2
-      input_cost_per_token: 2.9e-7
-      output_cost_per_token: 8.4e-7
+      input_cost_per_token: 5.8e-7
+      output_cost_per_token: 1.68e-6
     - region: us-east-2
-      input_cost_per_token: 2.9e-7
-      output_cost_per_token: 8.4e-7
-    - region: eu-north-1
-      input_cost_per_token: 2.9e-7
-      output_cost_per_token: 8.4e-7
+      input_cost_per_token: 5.8e-7
+      output_cost_per_token: 1.68e-6
     - region: eu-west-2
-      input_cost_per_token: 4.49993e-7
-      output_cost_per_token: 1.303427e-6
-    - region: ap-northeast-1
-      input_cost_per_token: 3.50833e-7
-      output_cost_per_token: 1.016206e-6
+      input_cost_per_token: 9e-7
+      output_cost_per_token: 2.6069e-6
+    - region: eu-north-1
+      input_cost_per_token: 5.8e-7
+      output_cost_per_token: 1.68e-6
+    - region: ap-southeast-3
+      input_cost_per_token: 6e-7
+      output_cost_per_token: 1.74e-6
     - region: ap-south-1
-      input_cost_per_token: 3.41212e-7
-      output_cost_per_token: 9.88339e-7
+      input_cost_per_token: 6.824e-7
+      output_cost_per_token: 1.9767e-6
+    - region: ap-northeast-1
+      input_cost_per_token: 7.017e-7
+      output_cost_per_token: 2.0324e-6
 limits:
     max_tokens: 4096
     max_input_tokens: 163840
     max_output_tokens: 81920
-features: [function_calling, chat]
+features:
+    - function_calling
+    - chat
 mode: chat

--- a/providers/aws-bedrock/eu.amazon.nova-2-lite-v1:0.yaml
+++ b/providers/aws-bedrock/eu.amazon.nova-2-lite-v1:0.yaml
@@ -1,27 +1,34 @@
 model: eu.amazon.nova-2-lite-v1:0
 costs:
-    - region: eu-north-1
-      input_cost_per_query: 0.03
-      input_cost_per_token: 1.815e-7
-      output_cost_per_token: 1.496e-6
-    - region: eu-south-2
-      input_cost_per_token: 1.815e-7
-      output_cost_per_token: 1.5125e-6
     - region: eu-west-3
-      input_cost_per_token: 2.42e-7
-      output_cost_per_token: 2.0295e-6
-    - region: eu-south-1
-      input_cost_per_token: 2.64e-7
-      output_cost_per_token: 2.2055e-6
+      cache_read_input_token_cost: 1.1e-7
+      input_cost_per_token: 4.4e-7
+      output_cost_per_token: 3.69e-6
     - region: eu-west-1
-      input_cost_per_token: 1.87e-7
-      output_cost_per_token: 1.5785e-6
+      cache_read_input_token_cost: 8.5e-8
+      input_cost_per_token: 3.4e-7
+      output_cost_per_token: 2.87e-6
+    - region: eu-south-2
+      cache_read_input_token_cost: 8.25e-8
+      input_cost_per_token: 3.3e-7
+      output_cost_per_token: 2.75e-6
+    - region: eu-south-1
+      cache_read_input_token_cost: 8.25e-8
+      input_cost_per_token: 4.81e-7
+      output_cost_per_token: 4.1e-6
+    - region: eu-north-1
+      cache_read_input_token_cost: 8.25e-8
+      input_cost_per_token: 3.3e-7
+      output_cost_per_token: 2.72e-6
     - region: eu-central-1
-      input_cost_per_token: 2.145e-7
-      output_cost_per_token: 1.9785e-6
+      cache_read_input_token_cost: 9.75e-8
+      input_cost_per_token: 3.9e-7
+      output_cost_per_token: 3.27e-6
 limits:
     max_tokens: 64000
     max_input_tokens: 1000000
     max_output_tokens: 64000
-features: [function_calling, vision]
+features:
+    - function_calling
+    - vision
 mode: chat

--- a/providers/aws-bedrock/eu.amazon.nova-lite-v1:0.yaml
+++ b/providers/aws-bedrock/eu.amazon.nova-lite-v1:0.yaml
@@ -1,26 +1,39 @@
 model: eu.amazon.nova-lite-v1:0
 costs:
-    - region: eu-north-1
-      input_cost_per_token: 6.5e-8
-      output_cost_per_token: 2.6e-7
-    - region: eu-south-2
-      input_cost_per_token: 6.6e-8
-      output_cost_per_token: 2.64e-7
+    - region: il-central-1
+      cache_read_input_token_cost: 1.87e-8
+      input_cost_per_token: 7.5e-8
+      output_cost_per_token: 3e-7
     - region: eu-west-3
+      cache_read_input_token_cost: 2.2e-8
       input_cost_per_token: 8.8e-8
       output_cost_per_token: 3.52e-7
-    - region: eu-south-1
-      input_cost_per_token: 9.6e-8
-      output_cost_per_token: 3.84e-7
     - region: eu-west-1
+      cache_read_input_token_cost: 1.72e-8
       input_cost_per_token: 6.9e-8
       output_cost_per_token: 2.76e-7
+    - region: eu-south-2
+      cache_read_input_token_cost: 1.65e-8
+      input_cost_per_token: 6.6e-8
+      output_cost_per_token: 2.64e-7
+    - region: eu-south-1
+      cache_read_input_token_cost: 2.4e-8
+      input_cost_per_token: 9.6e-8
+      output_cost_per_token: 3.84e-7
+    - region: eu-north-1
+      cache_read_input_token_cost: 1.62e-8
+      input_cost_per_token: 6.5e-8
+      output_cost_per_token: 2.6e-7
     - region: eu-central-1
+      cache_read_input_token_cost: 1.95e-8
       input_cost_per_token: 7.8e-8
       output_cost_per_token: 3.12e-7
 limits:
     max_tokens: 4096
     max_input_tokens: 300000
     max_output_tokens: 10000
-features: [function_calling, vision, chat]
+features:
+    - function_calling
+    - vision
+    - chat
 mode: chat

--- a/providers/aws-bedrock/eu.amazon.nova-micro-v1:0.yaml
+++ b/providers/aws-bedrock/eu.amazon.nova-micro-v1:0.yaml
@@ -1,26 +1,38 @@
 model: eu.amazon.nova-micro-v1:0
 costs:
-    - region: eu-north-1
-      input_cost_per_token: 3.8e-8
-      output_cost_per_token: 1.52e-7
-    - region: eu-south-2
-      input_cost_per_token: 3.9e-8
-      output_cost_per_token: 1.56e-7
+    - region: il-central-1
+      cache_read_input_token_cost: 1.1e-8
+      input_cost_per_token: 4.4e-8
+      output_cost_per_token: 1.76e-7
     - region: eu-west-3
+      cache_read_input_token_cost: 1.3e-8
       input_cost_per_token: 5.2e-8
       output_cost_per_token: 2.08e-7
-    - region: eu-south-1
-      input_cost_per_token: 5.6e-8
-      output_cost_per_token: 2.24e-7
     - region: eu-west-1
+      cache_read_input_token_cost: 1e-8
       input_cost_per_token: 4e-8
       output_cost_per_token: 1.6e-7
+    - region: eu-south-2
+      cache_read_input_token_cost: 9.7e-9
+      input_cost_per_token: 3.9e-8
+      output_cost_per_token: 1.56e-7
+    - region: eu-south-1
+      cache_read_input_token_cost: 1.4e-8
+      input_cost_per_token: 5.6e-8
+      output_cost_per_token: 2.24e-7
+    - region: eu-north-1
+      cache_read_input_token_cost: 9.5e-9
+      input_cost_per_token: 3.8e-8
+      output_cost_per_token: 1.52e-7
     - region: eu-central-1
+      cache_read_input_token_cost: 1.15e-8
       input_cost_per_token: 4.6e-8
       output_cost_per_token: 1.84e-7
 limits:
     max_tokens: 4096
     max_input_tokens: 128000
     max_output_tokens: 10000
-features: [function_calling, chat]
+features:
+    - function_calling
+    - chat
 mode: chat

--- a/providers/aws-bedrock/eu.amazon.nova-pro-v1:0.yaml
+++ b/providers/aws-bedrock/eu.amazon.nova-pro-v1:0.yaml
@@ -1,26 +1,39 @@
 model: eu.amazon.nova-pro-v1:0
 costs:
-    - region: eu-north-1
-      input_cost_per_token: 8.7e-7
-      output_cost_per_token: 3.48e-6
-    - region: eu-south-2
-      input_cost_per_token: 8.8e-7
-      output_cost_per_token: 3.52e-6
+    - region: il-central-1
+      input_cost_per_audio_token: 1.56e-6
+      input_cost_per_token: 1.56e-6
+      output_cost_per_token: 1.251e-5
     - region: eu-west-3
-      input_cost_per_token: 1.18e-6
-      output_cost_per_token: 4.72e-6
-    - region: eu-south-1
-      input_cost_per_token: 1.28e-6
-      output_cost_per_token: 5.21e-6
+      input_cost_per_audio_token: 1.84e-6
+      input_cost_per_token: 1.84e-6
+      output_cost_per_token: 1.474e-5
     - region: eu-west-1
-      input_cost_per_token: 9.2e-7
-      output_cost_per_token: 3.68e-6
+      input_cost_per_audio_token: 1.43e-6
+      input_cost_per_token: 1.43e-6
+      output_cost_per_token: 1.147e-5
+    - region: eu-south-2
+      input_cost_per_audio_token: 1.38e-6
+      input_cost_per_token: 1.38e-6
+      output_cost_per_token: 1.102e-5
+    - region: eu-south-1
+      input_cost_per_audio_token: 2.01e-6
+      input_cost_per_token: 2.01e-6
+      output_cost_per_token: 1.605e-5
+    - region: eu-north-1
+      input_cost_per_audio_token: 1.36e-6
+      input_cost_per_token: 1.36e-6
+      output_cost_per_token: 1.087e-5
     - region: eu-central-1
-      input_cost_per_token: 1.05e-6
-      output_cost_per_token: 4.2e-6
+      input_cost_per_audio_token: 1.63e-6
+      input_cost_per_token: 1.63e-6
+      output_cost_per_token: 1.308e-5
 limits:
     max_tokens: 4096
     max_input_tokens: 300000
     max_output_tokens: 10000
-features: [function_calling, vision, chat]
+features:
+    - function_calling
+    - vision
+    - chat
 mode: chat

--- a/providers/aws-bedrock/eu.amazon.nova-pro-v1:0.yaml
+++ b/providers/aws-bedrock/eu.amazon.nova-pro-v1:0.yaml
@@ -1,33 +1,33 @@
 model: eu.amazon.nova-pro-v1:0
 costs:
     - region: il-central-1
-      input_cost_per_audio_token: 1.56e-6
-      input_cost_per_token: 1.56e-6
-      output_cost_per_token: 1.251e-5
+      cache_read_input_token_cost: 2.5e-7
+      input_cost_per_token: 1e-6
+      output_cost_per_token: 4e-6
     - region: eu-west-3
-      input_cost_per_audio_token: 1.84e-6
-      input_cost_per_token: 1.84e-6
-      output_cost_per_token: 1.474e-5
+      cache_read_input_token_cost: 2.95e-7
+      input_cost_per_token: 1.18e-6
+      output_cost_per_token: 4.72e-6
     - region: eu-west-1
-      input_cost_per_audio_token: 1.43e-6
-      input_cost_per_token: 1.43e-6
-      output_cost_per_token: 1.147e-5
+      cache_read_input_token_cost: 2.3e-7
+      input_cost_per_token: 9.2e-7
+      output_cost_per_token: 3.68e-6
     - region: eu-south-2
-      input_cost_per_audio_token: 1.38e-6
-      input_cost_per_token: 1.38e-6
-      output_cost_per_token: 1.102e-5
+      cache_read_input_token_cost: 2.2e-7
+      input_cost_per_token: 8.8e-7
+      output_cost_per_token: 3.52e-6
     - region: eu-south-1
-      input_cost_per_audio_token: 2.01e-6
-      input_cost_per_token: 2.01e-6
-      output_cost_per_token: 1.605e-5
+      cache_read_input_token_cost: 3.2e-7
+      input_cost_per_token: 1.28e-6
+      output_cost_per_token: 5.21e-6
     - region: eu-north-1
-      input_cost_per_audio_token: 1.36e-6
-      input_cost_per_token: 1.36e-6
-      output_cost_per_token: 1.087e-5
+      cache_read_input_token_cost: 2.175e-7
+      input_cost_per_token: 8.7e-7
+      output_cost_per_token: 3.48e-6
     - region: eu-central-1
-      input_cost_per_audio_token: 1.63e-6
-      input_cost_per_token: 1.63e-6
-      output_cost_per_token: 1.308e-5
+      cache_read_input_token_cost: 2.625e-7
+      input_cost_per_token: 1.05e-6
+      output_cost_per_token: 4.2e-6
 limits:
     max_tokens: 4096
     max_input_tokens: 300000

--- a/providers/aws-bedrock/eu.anthropic.claude-3-5-sonnet-20240620-v1:0.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-3-5-sonnet-20240620-v1:0.yaml
@@ -1,0 +1,19 @@
+model: eu.anthropic.claude-3-5-sonnet-20240620-v1:0
+costs:
+    - region: eu-west-3
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 1.5e-5
+    - region: eu-west-1
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 1.5e-5
+    - region: eu-central-1
+      input_cost_per_token: 1.5e-6
+      output_cost_per_token: 1.5e-5
+limits:
+    max_tokens: 8192
+    max_input_tokens: 200000
+    max_output_tokens: 8192
+features:
+    - function_calling
+    - vision
+mode: chat

--- a/providers/aws-bedrock/eu.anthropic.claude-3-7-sonnet-20250219-v1:0.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-3-7-sonnet-20250219-v1:0.yaml
@@ -20,3 +20,8 @@ costs:
       cache_read_input_token_cost: 3e-7
       input_cost_per_token: 3e-6
       output_cost_per_token: 1.5e-5
+limits:
+    max_input_tokens: 200000
+    max_output_tokens: 128000
+features: [function_calling, vision]
+mode: chat

--- a/providers/aws-bedrock/eu.anthropic.claude-3-7-sonnet-20250219-v1:0.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-3-7-sonnet-20250219-v1:0.yaml
@@ -1,0 +1,22 @@
+model: eu.anthropic.claude-3-7-sonnet-20250219-v1:0
+costs:
+    - region: eu-west-3
+      cache_creation_input_token_cost: 3.75e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 1.5e-5
+    - region: eu-west-1
+      cache_creation_input_token_cost: 3.75e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 1.5e-5
+    - region: eu-north-1
+      cache_creation_input_token_cost: 3.75e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 1.5e-5
+    - region: eu-central-1
+      cache_creation_input_token_cost: 3.75e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 1.5e-5

--- a/providers/aws-bedrock/eu.anthropic.claude-3-7-sonnet-20250219-v1:0.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-3-7-sonnet-20250219-v1:0.yaml
@@ -23,5 +23,7 @@ costs:
 limits:
     max_input_tokens: 200000
     max_output_tokens: 128000
-features: [function_calling, vision]
+features:
+    - function_calling
+    - vision
 mode: chat

--- a/providers/aws-bedrock/eu.anthropic.claude-3-haiku-20240307-v1:0.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-3-haiku-20240307-v1:0.yaml
@@ -13,5 +13,7 @@ limits:
     max_tokens: 4096
     max_input_tokens: 200000
     max_output_tokens: 4096
-features: [function_calling, vision]
+features:
+    - function_calling
+    - vision
 mode: chat

--- a/providers/aws-bedrock/eu.anthropic.claude-3-haiku-20240307-v1:0.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-3-haiku-20240307-v1:0.yaml
@@ -2,16 +2,10 @@ model: eu.anthropic.claude-3-haiku-20240307-v1:0
 costs:
     - region: eu-west-3
       input_cost_per_token: 2.5e-7
-      input_cost_per_token_batches: 1.25e-7
       output_cost_per_token: 1.25e-6
-      output_cost_per_token_batches: 6.25e-7
     - region: eu-west-1
       input_cost_per_token: 2.5e-7
-      input_cost_per_token_batches: 1.25e-7
       output_cost_per_token: 1.25e-6
-      output_cost_per_token_batches: 6.25e-7
     - region: eu-central-1
       input_cost_per_token: 2.5e-7
-      input_cost_per_token_batches: 1.25e-7
       output_cost_per_token: 1.25e-6
-      output_cost_per_token_batches: 6.25e-7

--- a/providers/aws-bedrock/eu.anthropic.claude-3-haiku-20240307-v1:0.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-3-haiku-20240307-v1:0.yaml
@@ -9,3 +9,9 @@ costs:
     - region: eu-central-1
       input_cost_per_token: 2.5e-7
       output_cost_per_token: 1.25e-6
+limits:
+    max_tokens: 4096
+    max_input_tokens: 200000
+    max_output_tokens: 4096
+features: [function_calling, vision]
+mode: chat

--- a/providers/aws-bedrock/eu.anthropic.claude-3-sonnet-20240229-v1:0.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-3-sonnet-20240229-v1:0.yaml
@@ -1,0 +1,49 @@
+model: eu.anthropic.claude-3-sonnet-20240229-v1:0
+costs:
+    - region: eu-west-3
+      input_cost_per_token: 1.5e-6
+      output_cost_per_token: 1.5e-5
+    - region: eu-west-1
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 7.5e-6
+    - region: eu-central-1
+      input_cost_per_token: 1.5e-6
+      output_cost_per_token: 7.5e-6
+limits:
+    max_tokens: 4096
+    max_input_tokens: 200000
+    max_output_tokens: 4096
+features:
+    - function_calling
+    - vision
+    - chat
+    - image
+params:
+    -
+        key: tool_choice
+        type: non-view-manage-data
+        defaultValue: null
+        options:
+            -
+                value: none
+                name: None
+            -
+                value: auto
+                name: Auto
+            -
+                value: required
+                name: Required
+            -
+                value: custom
+                name: Custom
+                schema:
+                    type: json
+        skipValues:
+            - null
+            - []
+        rule:
+            default:
+                condition: tools
+                then: auto
+                else: null
+mode: chat

--- a/providers/aws-bedrock/eu.anthropic.claude-3-sonnet-20240229-v1:0.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-3-sonnet-20240229-v1:0.yaml
@@ -19,31 +19,26 @@ features:
     - chat
     - image
 params:
-    -
-        key: tool_choice
-        type: non-view-manage-data
-        defaultValue: null
-        options:
-            -
-                value: none
-                name: None
-            -
-                value: auto
-                name: Auto
-            -
-                value: required
-                name: Required
-            -
-                value: custom
-                name: Custom
-                schema:
-                    type: json
-        skipValues:
-            - null
-            - []
-        rule:
-            default:
-                condition: tools
-                then: auto
-                else: null
+    - key: tool_choice
+      type: non-view-manage-data
+      defaultValue: null
+      options:
+          - value: none
+            name: None
+          - value: auto
+            name: Auto
+          - value: required
+            name: Required
+          - value: custom
+            name: Custom
+            schema:
+                type: json
+      skipValues:
+          - null
+          - []
+      rule:
+          default:
+              condition: tools
+              then: auto
+              else: null
 mode: chat

--- a/providers/aws-bedrock/eu.anthropic.claude-haiku-4-5-20251001-v1:0.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-haiku-4-5-20251001-v1:0.yaml
@@ -1,77 +1,72 @@
 model: eu.anthropic.claude-haiku-4-5-20251001-v1:0
 costs:
-    - region: eu-central-2
-      cache_creation_input_token_cost: 1.25e-6
-      cache_read_input_token_cost: 1e-7
-      input_cost_per_token: 1e-6
-      input_cost_per_token_batches: 5e-7
-      output_cost_per_token: 5e-6
-      output_cost_per_token_batches: 2.5e-6
-    - region: eu-north-1
-      cache_creation_input_token_cost: 1.25e-6
-      cache_read_input_token_cost: 1e-7
-      input_cost_per_token: 1e-6
-      input_cost_per_token_batches: 5e-7
-      output_cost_per_token: 5e-6
-      output_cost_per_token_batches: 2.5e-6
-    - region: eu-south-2
-      cache_creation_input_token_cost: 1.25e-6
-      cache_read_input_token_cost: 1e-7
-      input_cost_per_token: 1e-6
-      input_cost_per_token_batches: 5e-7
-      output_cost_per_token: 5e-6
-      output_cost_per_token_batches: 2.5e-6
     - region: eu-west-3
       cache_creation_input_token_cost: 1.25e-6
       cache_read_input_token_cost: 1e-7
       input_cost_per_token: 1e-6
-      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 5e-6
-      output_cost_per_token_batches: 2.5e-6
-    - region: eu-south-1
-      cache_creation_input_token_cost: 1.25e-6
-      cache_read_input_token_cost: 1e-7
-      input_cost_per_token: 1e-6
-      input_cost_per_token_batches: 5e-7
-      output_cost_per_token: 5e-6
-      output_cost_per_token_batches: 2.5e-6
     - region: eu-west-2
       cache_creation_input_token_cost: 1.25e-6
       cache_read_input_token_cost: 1e-7
       input_cost_per_token: 1e-6
-      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 5e-6
-      output_cost_per_token_batches: 2.5e-6
     - region: eu-west-1
       cache_creation_input_token_cost: 1.25e-6
       cache_read_input_token_cost: 1e-7
       input_cost_per_token: 1e-6
-      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 5e-6
-      output_cost_per_token_batches: 2.5e-6
+    - region: eu-south-2
+      cache_creation_input_token_cost: 1.25e-6
+      cache_read_input_token_cost: 1e-7
+      input_cost_per_token: 1e-6
+      output_cost_per_token: 5e-6
+    - region: eu-south-1
+      cache_creation_input_token_cost: 1.25e-6
+      cache_read_input_token_cost: 1e-7
+      input_cost_per_token: 1e-6
+      output_cost_per_token: 5e-6
+    - region: eu-north-1
+      cache_creation_input_token_cost: 1.25e-6
+      cache_read_input_token_cost: 1e-7
+      input_cost_per_token: 1e-6
+      output_cost_per_token: 5e-6
+    - region: eu-central-2
+      cache_creation_input_token_cost: 1.25e-6
+      cache_read_input_token_cost: 1e-7
+      input_cost_per_token: 1e-6
+      output_cost_per_token: 5e-6
     - region: eu-central-1
       cache_creation_input_token_cost: 1.25e-6
       cache_read_input_token_cost: 1e-7
       input_cost_per_token: 1e-6
-      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 5e-6
-      output_cost_per_token_batches: 2.5e-6
 limits:
     max_input_tokens: 200000
     max_output_tokens: 64000
     tool_use_system_prompt_tokens: 346
-features: [function_calling, vision, chat, image]
+features:
+    - function_calling
+    - vision
+    - chat
+    - image
 params:
-    - key: max_tokens
-      maxValue: 64000
-    - key: thinking
-      type: number
-      enum: [enabled, disabled]
-      minValue: 1024
-      maxValue: 128000
-      withdrawParams: [top_k, top_p]
-      skipValues:
-          - disabled
-          - null
-removeParams: [top_p]
+    -
+        key: max_tokens
+        maxValue: 64000
+    -
+        key: thinking
+        type: number
+        enum:
+            - enabled
+            - disabled
+        minValue: 1024
+        maxValue: 128000
+        withdrawParams:
+            - top_k
+            - top_p
+        skipValues:
+            - disabled
+            - null
+removeParams:
+    - top_p
 mode: chat

--- a/providers/aws-bedrock/eu.anthropic.claude-haiku-4-5-20251001-v1:0.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-haiku-4-5-20251001-v1:0.yaml
@@ -50,23 +50,21 @@ features:
     - chat
     - image
 params:
-    -
-        key: max_tokens
-        maxValue: 64000
-    -
-        key: thinking
-        type: number
-        enum:
-            - enabled
-            - disabled
-        minValue: 1024
-        maxValue: 128000
-        withdrawParams:
-            - top_k
-            - top_p
-        skipValues:
-            - disabled
-            - null
+    - key: max_tokens
+      maxValue: 64000
+    - key: thinking
+      type: number
+      enum:
+          - enabled
+          - disabled
+      minValue: 1024
+      maxValue: 128000
+      withdrawParams:
+          - top_k
+          - top_p
+      skipValues:
+          - disabled
+          - null
 removeParams:
     - top_p
 mode: chat

--- a/providers/aws-bedrock/eu.anthropic.claude-opus-4-5-20251101-v1:0.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-opus-4-5-20251101-v1:0.yaml
@@ -1,71 +1,68 @@
 model: eu.anthropic.claude-opus-4-5-20251101-v1:0
 costs:
-    - region: eu-central-2
-      cache_creation_input_token_cost: 1.1e-05
-    - region: eu-north-1
-      cache_creation_input_token_cost: 6.875e-6
-      cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 5.5e-6
-      input_cost_per_token_batches: 2.75e-6
-      output_cost_per_token: 2.75e-05
-      output_cost_per_token_batches: 1.375e-05
-    - region: eu-south-2
-      cache_creation_input_token_cost: 6.875e-6
-      cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 5.5e-6
-      input_cost_per_token_batches: 2.75e-6
-      output_cost_per_token: 2.75e-05
-      output_cost_per_token_batches: 1.375e-05
     - region: eu-west-3
-      cache_creation_input_token_cost: 6.875e-6
-      cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 5.5e-6
-      input_cost_per_token_batches: 2.75e-6
-      output_cost_per_token: 2.75e-05
-      output_cost_per_token_batches: 1.375e-05
-    - region: eu-south-1
-      cache_creation_input_token_cost: 6.875e-6
-      cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 5.5e-6
-      input_cost_per_token_batches: 2.75e-6
-      output_cost_per_token: 2.75e-05
-      output_cost_per_token_batches: 1.375e-05
-    - region: eu-west-2
-      cache_creation_input_token_cost: 1.1e-05
+      cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 5e-6
-      input_cost_per_token_batches: 2.5e-6
-      output_cost_per_token: 2.5e-05
-      output_cost_per_token_batches: 1.25e-05
+      output_cost_per_token: 2.5e-5
+    - region: eu-west-2
+      cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 2.5e-5
     - region: eu-west-1
-      cache_creation_input_token_cost: 6.875e-6
-      cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 5.5e-6
-      input_cost_per_token_batches: 2.75e-6
-      output_cost_per_token: 2.75e-05
-      output_cost_per_token_batches: 1.375e-05
+      cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 2.5e-5
+    - region: eu-south-2
+      cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 2.5e-5
+    - region: eu-south-1
+      cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 2.5e-5
+    - region: eu-north-1
+      cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 2.5e-5
     - region: eu-central-1
-      cache_creation_input_token_cost: 6.875e-6
-      cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 5.5e-6
-      input_cost_per_token_batches: 2.75e-6
-      output_cost_per_token: 2.75e-05
-      output_cost_per_token_batches: 1.375e-05
+      cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 2.5e-5
 limits:
     max_input_tokens: 200000
     max_output_tokens: 64000
     tool_use_system_prompt_tokens: 159
-features: [function_calling, vision, chat, image]
+features:
+    - function_calling
+    - vision
+    - chat
+    - image
 params:
-    - key: max_tokens
-      maxValue: 64000
-    - key: thinking
-      type: number
-      enum: [enabled, disabled]
-      minValue: 1024
-      maxValue: 128000
-      withdrawParams: [top_k, top_p]
-      skipValues:
-          - disabled
-          - null
-removeParams: [temperature, top_p]
+    -
+        key: max_tokens
+        maxValue: 64000
+    -
+        key: thinking
+        type: number
+        enum:
+            - enabled
+            - disabled
+        minValue: 1024
+        maxValue: 128000
+        withdrawParams:
+            - top_k
+            - top_p
+        skipValues:
+            - disabled
+            - null
+removeParams:
+    - temperature
+    - top_p
 mode: chat

--- a/providers/aws-bedrock/eu.anthropic.claude-opus-4-5-20251101-v1:0.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-opus-4-5-20251101-v1:0.yaml
@@ -45,23 +45,21 @@ features:
     - chat
     - image
 params:
-    -
-        key: max_tokens
-        maxValue: 64000
-    -
-        key: thinking
-        type: number
-        enum:
-            - enabled
-            - disabled
-        minValue: 1024
-        maxValue: 128000
-        withdrawParams:
-            - top_k
-            - top_p
-        skipValues:
-            - disabled
-            - null
+    - key: max_tokens
+      maxValue: 64000
+    - key: thinking
+      type: number
+      enum:
+          - enabled
+          - disabled
+      minValue: 1024
+      maxValue: 128000
+      withdrawParams:
+          - top_k
+          - top_p
+      skipValues:
+          - disabled
+          - null
 removeParams:
     - temperature
     - top_p

--- a/providers/aws-bedrock/eu.anthropic.claude-opus-4-6-v1.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-opus-4-6-v1.yaml
@@ -1,65 +1,51 @@
 model: eu.anthropic.claude-opus-4-6-v1
 costs:
-    - region: eu-central-2
-      cache_creation_input_token_cost: 6.875e-6
-      cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 5.5e-6
-      input_cost_per_token_batches: 2.75e-6
-      output_cost_per_token: 2.75e-05
-      output_cost_per_token_batches: 1.375e-05
-    - region: eu-north-1
-      cache_creation_input_token_cost: 6.875e-6
-      cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 5.5e-6
-      input_cost_per_token_batches: 2.75e-6
-      output_cost_per_token: 2.75e-05
-      output_cost_per_token_batches: 1.375e-05
-    - region: eu-south-2
-      cache_creation_input_token_cost: 6.875e-6
-      cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 5.5e-6
-      input_cost_per_token_batches: 2.75e-6
-      output_cost_per_token: 2.75e-05
-      output_cost_per_token_batches: 1.375e-05
     - region: eu-west-3
-      cache_creation_input_token_cost: 6.875e-6
-      cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 5.5e-6
-      input_cost_per_token_batches: 2.75e-6
-      output_cost_per_token: 2.75e-05
-      output_cost_per_token_batches: 1.375e-05
-    - region: eu-south-1
-      cache_creation_input_token_cost: 6.875e-6
-      cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 5.5e-6
-      input_cost_per_token_batches: 2.75e-6
-      output_cost_per_token: 2.75e-05
-      output_cost_per_token_batches: 1.375e-05
+      cache_creation_input_token_cost: 1.25e-5
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 2.5e-5
     - region: eu-west-2
-      cache_creation_input_token_cost: 6.875e-6
-      cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 5.5e-6
-      input_cost_per_token_batches: 2.75e-6
-      output_cost_per_token: 2.75e-05
-      output_cost_per_token_batches: 1.375e-05
+      cache_creation_input_token_cost: 1.25e-5
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 1e-5
+      output_cost_per_token: 3.75e-5
     - region: eu-west-1
-      cache_creation_input_token_cost: 6.875e-6
-      cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 5.5e-6
-      input_cost_per_token_batches: 2.75e-6
-      output_cost_per_token: 2.75e-05
-      output_cost_per_token_batches: 1.375e-05
+      cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 1e-6
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 3.75e-5
+    - region: eu-south-2
+      cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 3.75e-5
+    - region: eu-south-1
+      cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 1e-6
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 3.75e-5
+    - region: eu-north-1
+      cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 1e-5
+      output_cost_per_token: 2.5e-5
+    - region: eu-central-2
+      cache_creation_input_token_cost: 1.25e-5
+      cache_read_input_token_cost: 1e-6
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 2.5e-5
     - region: eu-central-1
-      cache_creation_input_token_cost: 6.875e-6
-      cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 5.5e-6
-      input_cost_per_token_batches: 2.75e-6
-      output_cost_per_token: 2.75e-05
-      output_cost_per_token_batches: 1.375e-05
+      cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 3.75e-5
 limits:
     max_tokens: 128000
     max_input_tokens: 1000000
     max_output_tokens: 128000
     tool_use_system_prompt_tokens: 346
-features: [function_calling, vision]
+features:
+    - function_calling
+    - vision
 mode: chat

--- a/providers/aws-bedrock/eu.anthropic.claude-sonnet-4-20250514-v1:0.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-sonnet-4-20250514-v1:0.yaml
@@ -45,46 +45,39 @@ features:
     - chat
     - image
 params:
-    -
-        key: max_tokens
-        maxValue: 128000
-    -
-        key: thinking
-        type: number
-        enum:
-            - enabled
-            - disabled
-        minValue: 1024
-        maxValue: 128000
-        withdrawParams:
-            - top_k
-            - top_p
-        skipValues:
-            - disabled
-            - null
-    -
-        key: tool_choice
-        type: json
-        options:
-            -
-                value: none
-                name: None
-            -
-                value: auto
-                name: Auto
-            -
-                value: required
-                name: Required
-            -
-                value: custom
-                name: Custom
-                schema: null
-                type: json
-        skipValues:
-            - null
-        rule: null
-        default:
-            condition: tools
-            then: auto
-            else: null
+    - key: max_tokens
+      maxValue: 128000
+    - key: thinking
+      type: number
+      enum:
+          - enabled
+          - disabled
+      minValue: 1024
+      maxValue: 128000
+      withdrawParams:
+          - top_k
+          - top_p
+      skipValues:
+          - disabled
+          - null
+    - key: tool_choice
+      type: json
+      options:
+          - value: none
+            name: None
+          - value: auto
+            name: Auto
+          - value: required
+            name: Required
+          - value: custom
+            name: Custom
+            schema: null
+            type: json
+      skipValues:
+          - null
+      rule: null
+      default:
+          condition: tools
+          then: auto
+          else: null
 mode: chat

--- a/providers/aws-bedrock/eu.anthropic.claude-sonnet-4-20250514-v1:0.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-sonnet-4-20250514-v1:0.yaml
@@ -1,70 +1,90 @@
 model: eu.anthropic.claude-sonnet-4-20250514-v1:0
 costs:
-    - region: eu-north-1
+    - region: il-central-1
       cache_creation_input_token_cost: 3.75e-6
       cache_read_input_token_cost: 3e-7
       input_cost_per_token: 3e-6
-      output_cost_per_token: 1.5e-05
-    - region: eu-south-2
-      cache_creation_input_token_cost: 3.75e-6
-      cache_read_input_token_cost: 3e-7
-      input_cost_per_token: 3e-6
-      output_cost_per_token: 1.5e-05
+      output_cost_per_token: 1.5e-5
     - region: eu-west-3
       cache_creation_input_token_cost: 3.75e-6
       cache_read_input_token_cost: 3e-7
       input_cost_per_token: 3e-6
-      output_cost_per_token: 1.5e-05
+      output_cost_per_token: 1.5e-5
+    - region: eu-west-1
+      cache_creation_input_token_cost: 7.5e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 1.5e-5
+    - region: eu-south-2
+      cache_creation_input_token_cost: 3.75e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 1.5e-5
     - region: eu-south-1
       cache_creation_input_token_cost: 3.75e-6
       cache_read_input_token_cost: 3e-7
       input_cost_per_token: 3e-6
-      output_cost_per_token: 1.5e-05
-    - region: eu-west-1
+      output_cost_per_token: 1.5e-5
+    - region: eu-north-1
       cache_creation_input_token_cost: 3.75e-6
       cache_read_input_token_cost: 3e-7
       input_cost_per_token: 3e-6
-      output_cost_per_token: 1.5e-05
+      output_cost_per_token: 1.5e-5
     - region: eu-central-1
       cache_creation_input_token_cost: 3.75e-6
       cache_read_input_token_cost: 3e-7
       input_cost_per_token: 3e-6
-      output_cost_per_token: 1.5e-05
+      output_cost_per_token: 1.5e-5
 limits:
     max_input_tokens: 1000000
     max_output_tokens: 64000
     tool_use_system_prompt_tokens: 159
-features: [function_calling, vision, chat, image]
+features:
+    - function_calling
+    - vision
+    - chat
+    - image
 params:
-    - key: max_tokens
-      maxValue: 128000
-    - key: thinking
-      type: number
-      enum: [enabled, disabled]
-      minValue: 1024
-      maxValue: 128000
-      withdrawParams: [top_k, top_p]
-      skipValues:
-          - disabled
-          - null
-    - key: tool_choice
-      type: json
-      options:
-          - value: none
-            name: None
-          - value: auto
-            name: Auto
-          - value: required
-            name: Required
-          - value: custom
-            name: Custom
-            schema:
-            type: json
-      skipValues:
-          - null
-      rule:
-      default:
-          condition: tools
-          then: auto
-          else: null
+    -
+        key: max_tokens
+        maxValue: 128000
+    -
+        key: thinking
+        type: number
+        enum:
+            - enabled
+            - disabled
+        minValue: 1024
+        maxValue: 128000
+        withdrawParams:
+            - top_k
+            - top_p
+        skipValues:
+            - disabled
+            - null
+    -
+        key: tool_choice
+        type: json
+        options:
+            -
+                value: none
+                name: None
+            -
+                value: auto
+                name: Auto
+            -
+                value: required
+                name: Required
+            -
+                value: custom
+                name: Custom
+                schema: null
+                type: json
+        skipValues:
+            - null
+        rule: null
+        default:
+            condition: tools
+            then: auto
+            else: null
 mode: chat

--- a/providers/aws-bedrock/eu.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
@@ -1,97 +1,97 @@
 model: eu.anthropic.claude-sonnet-4-5-20250929-v1:0
 costs:
-    - region: eu-central-2
-      cache_creation_input_token_cost: 4.125e-6
-      cache_read_input_token_cost: 3.3e-7
-      input_cost_per_token: 3.3e-6
-      input_cost_per_token_batches: 1.65e-6
-      output_cost_per_token: 1.65e-05
-      output_cost_per_token_batches: 8.25e-6
-    - region: eu-north-1
-      cache_creation_input_token_cost: 4.125e-6
-      cache_read_input_token_cost: 3.3e-7
-      input_cost_per_token: 3.3e-6
-      input_cost_per_token_batches: 1.65e-6
-      output_cost_per_token: 1.65e-05
-      output_cost_per_token_batches: 8.25e-6
-    - region: eu-south-2
-      cache_creation_input_token_cost: 4.125e-6
-      cache_read_input_token_cost: 3.3e-7
-      input_cost_per_token: 3.3e-6
-      input_cost_per_token_batches: 1.65e-6
-      output_cost_per_token: 1.65e-05
-      output_cost_per_token_batches: 8.25e-6
     - region: eu-west-3
-      cache_creation_input_token_cost: 4.125e-6
-      cache_read_input_token_cost: 3.3e-7
-      input_cost_per_token: 3.3e-6
-      input_cost_per_token_batches: 1.65e-6
-      output_cost_per_token: 1.65e-05
-      output_cost_per_token_batches: 8.25e-6
-    - region: eu-south-1
-      cache_creation_input_token_cost: 4.125e-6
-      cache_read_input_token_cost: 3.3e-7
-      input_cost_per_token: 3.3e-6
-      input_cost_per_token_batches: 1.65e-6
-      output_cost_per_token: 1.65e-05
-      output_cost_per_token_batches: 8.25e-6
+      cache_creation_input_token_cost: 7.5e-6
+      cache_read_input_token_cost: 6e-7
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 1.5e-5
     - region: eu-west-2
-      cache_creation_input_token_cost: 4.125e-6
-      cache_read_input_token_cost: 3.3e-7
-      input_cost_per_token: 3.3e-6
-      input_cost_per_token_batches: 1.65e-6
-      output_cost_per_token: 1.65e-05
-      output_cost_per_token_batches: 8.25e-6
+      cache_creation_input_token_cost: 3.75e-6
+      cache_read_input_token_cost: 6e-7
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 1.5e-5
     - region: eu-west-1
-      cache_creation_input_token_cost: 4.125e-6
-      cache_read_input_token_cost: 3.3e-7
-      input_cost_per_token: 3.3e-6
-      input_cost_per_token_batches: 1.65e-6
-      output_cost_per_token: 1.65e-05
-      output_cost_per_token_batches: 8.25e-6
+      cache_creation_input_token_cost: 7.5e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 6e-6
+      output_cost_per_token: 2.25e-5
+    - region: eu-south-2
+      cache_creation_input_token_cost: 7.5e-6
+      cache_read_input_token_cost: 6e-7
+      input_cost_per_token: 6e-6
+      output_cost_per_token: 1.5e-5
+    - region: eu-south-1
+      cache_creation_input_token_cost: 7.5e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 6e-6
+      output_cost_per_token: 2.25e-5
+    - region: eu-north-1
+      cache_creation_input_token_cost: 3.75e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 6e-6
+      output_cost_per_token: 2.25e-5
+    - region: eu-central-2
+      cache_creation_input_token_cost: 3.75e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 6e-6
+      output_cost_per_token: 2.25e-5
     - region: eu-central-1
-      cache_creation_input_token_cost: 4.125e-6
-      cache_read_input_token_cost: 3.3e-7
-      input_cost_per_token: 3.3e-6
-      input_cost_per_token_batches: 1.65e-6
-      output_cost_per_token: 1.65e-05
-      output_cost_per_token_batches: 8.25e-6
+      cache_creation_input_token_cost: 3.75e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 6e-6
+      output_cost_per_token: 2.25e-5
 limits:
     max_input_tokens: 200000
     max_output_tokens: 64000
     tool_use_system_prompt_tokens: 346
-features: [function_calling, vision, chat, image]
+features:
+    - function_calling
+    - vision
+    - chat
+    - image
 params:
-    - key: max_tokens
-      maxValue: 8192
-    - key: thinking
-      type: number
-      enum: [enabled, disabled]
-      minValue: 1024
-      maxValue: 128000
-      withdrawParams: [top_k, top_p]
-      skipValues:
-          - disabled
-          - null
-    - key: tool_choice
-      type: json
-      options:
-          - value: none
-            name: None
-          - value: auto
-            name: Auto
-          - value: required
-            name: Required
-          - value: custom
-            name: Custom
-            schema:
-            type: json
-      skipValues:
-          - null
-      rule:
-      default:
-          condition: tools
-          then: auto
-          else: null
-removeParams: [top_p]
+    -
+        key: max_tokens
+        maxValue: 8192
+    -
+        key: thinking
+        type: number
+        enum:
+            - enabled
+            - disabled
+        minValue: 1024
+        maxValue: 128000
+        withdrawParams:
+            - top_k
+            - top_p
+        skipValues:
+            - disabled
+            - null
+    -
+        key: tool_choice
+        type: json
+        options:
+            -
+                value: none
+                name: None
+            -
+                value: auto
+                name: Auto
+            -
+                value: required
+                name: Required
+            -
+                value: custom
+                name: Custom
+                schema: null
+                type: json
+        skipValues:
+            - null
+        rule: null
+        default:
+            condition: tools
+            then: auto
+            else: null
+removeParams:
+    - top_p
 mode: chat

--- a/providers/aws-bedrock/eu.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
@@ -50,48 +50,41 @@ features:
     - chat
     - image
 params:
-    -
-        key: max_tokens
-        maxValue: 8192
-    -
-        key: thinking
-        type: number
-        enum:
-            - enabled
-            - disabled
-        minValue: 1024
-        maxValue: 128000
-        withdrawParams:
-            - top_k
-            - top_p
-        skipValues:
-            - disabled
-            - null
-    -
-        key: tool_choice
-        type: json
-        options:
-            -
-                value: none
-                name: None
-            -
-                value: auto
-                name: Auto
-            -
-                value: required
-                name: Required
-            -
-                value: custom
-                name: Custom
-                schema: null
-                type: json
-        skipValues:
-            - null
-        rule: null
-        default:
-            condition: tools
-            then: auto
-            else: null
+    - key: max_tokens
+      maxValue: 8192
+    - key: thinking
+      type: number
+      enum:
+          - enabled
+          - disabled
+      minValue: 1024
+      maxValue: 128000
+      withdrawParams:
+          - top_k
+          - top_p
+      skipValues:
+          - disabled
+          - null
+    - key: tool_choice
+      type: json
+      options:
+          - value: none
+            name: None
+          - value: auto
+            name: Auto
+          - value: required
+            name: Required
+          - value: custom
+            name: Custom
+            schema: null
+            type: json
+      skipValues:
+          - null
+      rule: null
+      default:
+          condition: tools
+          then: auto
+          else: null
 removeParams:
     - top_p
 mode: chat

--- a/providers/aws-bedrock/eu.cohere.embed-v4:0.yaml
+++ b/providers/aws-bedrock/eu.cohere.embed-v4:0.yaml
@@ -2,8 +2,6 @@ model: eu.cohere.embed-v4:0
 costs:
     - region: eu-west-3
       input_cost_per_token: 1.2e-7
-    - region: eu-west-1
-      input_cost_per_token: 1.2e-7
     - region: eu-south-2
       input_cost_per_token: 1.2e-7
     - region: eu-south-1

--- a/providers/aws-bedrock/eu.cohere.embed-v4:0.yaml
+++ b/providers/aws-bedrock/eu.cohere.embed-v4:0.yaml
@@ -1,0 +1,19 @@
+model: eu.cohere.embed-v4:0
+costs:
+    - region: eu-west-3
+      input_cost_per_token: 1.2e-7
+    - region: eu-west-1
+      input_cost_per_token: 1.2e-7
+    - region: eu-south-2
+      input_cost_per_token: 1.2e-7
+    - region: eu-south-1
+      input_cost_per_token: 1.2e-7
+    - region: eu-north-1
+      input_cost_per_token: 1.2e-7
+    - region: eu-central-1
+      input_cost_per_token: 1.2e-7
+limits:
+    max_tokens: 128000
+    max_input_tokens: 128000
+    output_vector_size: 1536
+mode: embedding

--- a/providers/aws-bedrock/eu.meta.llama3-2-1b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/eu.meta.llama3-2-1b-instruct-v1:0.yaml
@@ -9,3 +9,9 @@ costs:
     - region: eu-central-1
       input_cost_per_token: 1.3e-7
       output_cost_per_token: 1.3e-7
+limits:
+    max_tokens: 4096
+    max_input_tokens: 128000
+    max_output_tokens: 4096
+features: [function_calling, chat]
+mode: chat

--- a/providers/aws-bedrock/eu.meta.llama3-2-1b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/eu.meta.llama3-2-1b-instruct-v1:0.yaml
@@ -8,6 +8,4 @@ costs:
       output_cost_per_token: 1.1e-7
     - region: eu-central-1
       input_cost_per_token: 1.3e-7
-      input_cost_per_token_batches: 6.5e-8
       output_cost_per_token: 1.3e-7
-      output_cost_per_token_batches: 6.5e-8

--- a/providers/aws-bedrock/eu.meta.llama3-2-1b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/eu.meta.llama3-2-1b-instruct-v1:0.yaml
@@ -13,5 +13,7 @@ limits:
     max_tokens: 4096
     max_input_tokens: 128000
     max_output_tokens: 4096
-features: [function_calling, chat]
+features:
+    - function_calling
+    - chat
 mode: chat

--- a/providers/aws-bedrock/eu.meta.llama3-2-3b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/eu.meta.llama3-2-3b-instruct-v1:0.yaml
@@ -9,3 +9,9 @@ costs:
     - region: eu-central-1
       input_cost_per_token: 1.9e-7
       output_cost_per_token: 1.9e-7
+limits:
+    max_tokens: 4096
+    max_input_tokens: 128000
+    max_output_tokens: 4096
+features: [function_calling, chat]
+mode: chat

--- a/providers/aws-bedrock/eu.meta.llama3-2-3b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/eu.meta.llama3-2-3b-instruct-v1:0.yaml
@@ -8,6 +8,4 @@ costs:
       output_cost_per_token: 1.7e-7
     - region: eu-central-1
       input_cost_per_token: 1.9e-7
-      input_cost_per_token_batches: 9.5e-8
       output_cost_per_token: 1.9e-7
-      output_cost_per_token_batches: 9.5e-8

--- a/providers/aws-bedrock/eu.meta.llama3-2-3b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/eu.meta.llama3-2-3b-instruct-v1:0.yaml
@@ -13,5 +13,7 @@ limits:
     max_tokens: 4096
     max_input_tokens: 128000
     max_output_tokens: 4096
-features: [function_calling, chat]
+features:
+    - function_calling
+    - chat
 mode: chat

--- a/providers/aws-bedrock/eu.mistral.pixtral-large-2502-v1:0.yaml
+++ b/providers/aws-bedrock/eu.mistral.pixtral-large-2502-v1:0.yaml
@@ -16,5 +16,7 @@ limits:
     max_tokens: 4096
     max_input_tokens: 128000
     max_output_tokens: 4096
-features: [function_calling, image]
+features:
+    - function_calling
+    - image
 mode: chat

--- a/providers/aws-bedrock/eu.twelvelabs.marengo-embed-2-7-v1:0.yaml
+++ b/providers/aws-bedrock/eu.twelvelabs.marengo-embed-2-7-v1:0.yaml
@@ -1,6 +1,8 @@
 model: eu.twelvelabs.marengo-embed-2-7-v1:0
 costs:
     - region: eu-west-1
+      input_cost_per_image: 1e-4
+      input_cost_per_second: 1.4e-4
       input_cost_per_token: 1e-10
 limits:
     max_tokens: 77

--- a/providers/aws-bedrock/eu.twelvelabs.marengo-embed-2-7-v1:0.yaml
+++ b/providers/aws-bedrock/eu.twelvelabs.marengo-embed-2-7-v1:0.yaml
@@ -1,10 +1,7 @@
 model: eu.twelvelabs.marengo-embed-2-7-v1:0
 costs:
     - region: eu-west-1
-      input_cost_per_audio_token: 0.00014
-      input_cost_per_image: 0.0001
-      input_cost_per_request: 7e-05
-      input_cost_per_second: 0.0007
+      input_cost_per_token: 1e-10
 limits:
     max_tokens: 77
     max_input_tokens: 77

--- a/providers/aws-bedrock/eu.twelvelabs.marengo-embed-3-0-v1:0.yaml
+++ b/providers/aws-bedrock/eu.twelvelabs.marengo-embed-3-0-v1:0.yaml
@@ -1,7 +1,4 @@
 model: eu.twelvelabs.marengo-embed-3-0-v1:0
 costs:
     - region: eu-west-1
-      input_cost_per_audio_token: 0.00014
-      input_cost_per_image: 0.0001
-      input_cost_per_request: 7e-05
-      input_cost_per_second: 0.0007
+      input_cost_per_token: 1e-10

--- a/providers/aws-bedrock/eu.twelvelabs.marengo-embed-3-0-v1:0.yaml
+++ b/providers/aws-bedrock/eu.twelvelabs.marengo-embed-3-0-v1:0.yaml
@@ -1,6 +1,8 @@
 model: eu.twelvelabs.marengo-embed-3-0-v1:0
 costs:
     - region: eu-west-1
+      input_cost_per_image: 1e-4
+      input_cost_per_second: 1.4e-4
       input_cost_per_token: 1e-10
 limits:
     max_tokens: 500

--- a/providers/aws-bedrock/eu.twelvelabs.marengo-embed-3-0-v1:0.yaml
+++ b/providers/aws-bedrock/eu.twelvelabs.marengo-embed-3-0-v1:0.yaml
@@ -2,3 +2,8 @@ model: eu.twelvelabs.marengo-embed-3-0-v1:0
 costs:
     - region: eu-west-1
       input_cost_per_token: 1e-10
+limits:
+    max_tokens: 500
+    max_input_tokens: 500
+    output_vector_size: 1024
+mode: embedding

--- a/providers/aws-bedrock/eu.twelvelabs.pegasus-1-2-v1:0.yaml
+++ b/providers/aws-bedrock/eu.twelvelabs.pegasus-1-2-v1:0.yaml
@@ -1,28 +1,28 @@
 model: eu.twelvelabs.pegasus-1-2-v1:0
 costs:
-    - region: eu-central-2
-      input_cost_per_second: 0.00049
-      output_cost_per_token: 7.5e-6
-    - region: eu-north-1
-      input_cost_per_second: 0.00049
-      output_cost_per_token: 7.5e-6
-    - region: eu-south-2
-      input_cost_per_second: 0.00049
-      output_cost_per_token: 7.5e-6
     - region: eu-west-3
-      input_cost_per_second: 0.00049
-      output_cost_per_token: 7.5e-6
-    - region: eu-south-1
-      input_cost_per_second: 0.00049
+      input_cost_per_token: 5e-10
       output_cost_per_token: 7.5e-6
     - region: eu-west-2
-      input_cost_per_second: 0.00049
-      output_cost_per_token: 7.5e-6
-    - region: eu-central-1
-      input_cost_per_second: 0.00049
+      input_cost_per_token: 5e-10
       output_cost_per_token: 7.5e-6
     - region: eu-west-1
-      input_cost_per_second: 0.00049
+      input_cost_per_token: 5e-10
+      output_cost_per_token: 7.5e-6
+    - region: eu-south-2
+      input_cost_per_token: 5e-10
+      output_cost_per_token: 7.5e-6
+    - region: eu-south-1
+      input_cost_per_token: 5e-10
+      output_cost_per_token: 7.5e-6
+    - region: eu-north-1
+      input_cost_per_token: 5e-10
+      output_cost_per_token: 7.5e-6
+    - region: eu-central-2
+      input_cost_per_token: 5e-10
+      output_cost_per_token: 7.5e-6
+    - region: eu-central-1
+      input_cost_per_token: 5e-10
       output_cost_per_token: 7.5e-6
 limits:
     max_tokens: 4096

--- a/providers/aws-bedrock/eu.twelvelabs.pegasus-1-2-v1:0.yaml
+++ b/providers/aws-bedrock/eu.twelvelabs.pegasus-1-2-v1:0.yaml
@@ -1,28 +1,28 @@
 model: eu.twelvelabs.pegasus-1-2-v1:0
 costs:
     - region: eu-west-3
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
     - region: eu-west-2
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
     - region: eu-west-1
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
     - region: eu-south-2
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
     - region: eu-south-1
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
     - region: eu-north-1
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
     - region: eu-central-2
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
     - region: eu-central-1
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
 limits:
     max_tokens: 4096

--- a/providers/aws-bedrock/global.amazon.nova-2-lite-v1:0.yaml
+++ b/providers/aws-bedrock/global.amazon.nova-2-lite-v1:0.yaml
@@ -1,63 +1,110 @@
 model: global.amazon.nova-2-lite-v1:0
 costs:
     - region: us-west-2
-      input_cost_per_query: 0.03
-      input_cost_per_token: 1.595e-7
-      output_cost_per_token: 1.3255e-6
+      cache_read_input_token_cost: 7.5e-8
+      input_cost_per_token: 3e-7
+      output_cost_per_token: 2.5e-6
     - region: us-west-1
-      input_cost_per_token: 2.145e-7
-      output_cost_per_token: 1.6755e-6
+      cache_read_input_token_cost: 9.75e-8
+      input_cost_per_token: 3.9e-7
+      output_cost_per_token: 3.21e-6
     - region: us-east-2
-      input_cost_per_token: 1.595e-7
-      output_cost_per_token: 1.342e-6
+      cache_read_input_token_cost: 7.5e-8
+      input_cost_per_token: 3e-7
+      output_cost_per_token: 2.5e-6
     - region: us-east-1
-      input_cost_per_query: 0.03
-      input_cost_per_token: 1.65e-7
-      output_cost_per_token: 1.375e-6
-    - region: eu-north-1
-      input_cost_per_query: 0.03
-      input_cost_per_token: 1.815e-7
-      output_cost_per_token: 1.496e-6
-    - region: eu-south-2
-      input_cost_per_token: 1.815e-7
-      output_cost_per_token: 1.5125e-6
+      cache_read_input_token_cost: 7.5e-8
+      input_cost_per_token: 3e-7
+      output_cost_per_token: 2.5e-6
+    - region: me-central-1
+      cache_read_input_token_cost: 8e-8
+      input_cost_per_token: 3e-7
+      output_cost_per_token: 2.5e-6
+    - region: il-central-1
+      cache_read_input_token_cost: 9.5e-8
+      input_cost_per_token: 3.8e-7
+      output_cost_per_token: 3.13e-6
     - region: eu-west-3
-      input_cost_per_token: 2.42e-7
-      output_cost_per_token: 2.0295e-6
-    - region: eu-south-1
-      input_cost_per_token: 2.64e-7
-      output_cost_per_token: 2.2055e-6
+      cache_read_input_token_cost: 1.1e-7
+      input_cost_per_token: 4.4e-7
+      output_cost_per_token: 3.69e-6
     - region: eu-west-2
-      input_cost_per_token: 2.1e-7
-      output_cost_per_token: 1.76e-6
+      cache_read_input_token_cost: 1.05e-7
+      input_cost_per_token: 4.2e-7
+      output_cost_per_token: 3.52e-6
     - region: eu-west-1
-      input_cost_per_token: 1.87e-7
-      output_cost_per_token: 1.5785e-6
+      cache_read_input_token_cost: 8.5e-8
+      input_cost_per_token: 3.4e-7
+      output_cost_per_token: 2.87e-6
+    - region: eu-south-2
+      cache_read_input_token_cost: 8.25e-8
+      input_cost_per_token: 3.3e-7
+      output_cost_per_token: 2.75e-6
+    - region: eu-south-1
+      cache_read_input_token_cost: 8.25e-8
+      input_cost_per_token: 4.81e-7
+      output_cost_per_token: 4.1e-6
+    - region: eu-north-1
+      cache_read_input_token_cost: 8.25e-8
+      input_cost_per_token: 3.3e-7
+      output_cost_per_token: 2.72e-6
     - region: eu-central-1
-      input_cost_per_token: 2.145e-7
-      output_cost_per_token: 1.9785e-6
+      cache_read_input_token_cost: 9.75e-8
+      input_cost_per_token: 3.9e-7
+      output_cost_per_token: 3.27e-6
+    - region: ca-west-1
+      cache_read_input_token_cost: 8.5e-7
+      input_cost_per_token: 3.4e-7
+      output_cost_per_token: 2.81e-6
     - region: ca-central-1
-      input_cost_per_token: 1.76e-7
-      output_cost_per_token: 1.4685e-6
-    - region: ap-northeast-1
-      input_cost_per_query: 0.03
-      input_cost_per_token: 1.98e-7
-      output_cost_per_token: 1.6555e-6
+      cache_read_input_token_cost: 8e-8
+      input_cost_per_token: 3.2e-7
+      output_cost_per_token: 2.67e-6
+    - region: ap-southeast-7
+      cache_read_input_token_cost: 1.025e-7
+      input_cost_per_token: 4.1e-7
+      output_cost_per_token: 3.39e-6
+    - region: ap-southeast-5
+      cache_read_input_token_cost: 1.025e-7
+      input_cost_per_token: 4.1e-7
+      output_cost_per_token: 3.39e-6
+    - region: ap-southeast-4
+      cache_read_input_token_cost: 8.25e-8
+      input_cost_per_token: 3.3e-7
+      output_cost_per_token: 2.71e-6
+    - region: ap-southeast-3
+      cache_read_input_token_cost: 8e-8
+      input_cost_per_token: 3.2e-7
+      output_cost_per_token: 2.64e-6
     - region: ap-southeast-2
-      input_cost_per_token: 1.6e-7
-      output_cost_per_token: 1.315e-6
+      cache_read_input_token_cost: 8e-8
+      input_cost_per_token: 3.2e-7
+      output_cost_per_token: 2.63e-6
     - region: ap-southeast-1
-      input_cost_per_token: 2.05e-7
-      output_cost_per_token: 1.695e-6
-    - region: ap-northeast-2
-      input_cost_per_token: 1.8e-7
-      output_cost_per_token: 1.48e-6
+      cache_read_input_token_cost: 1.025e-7
+      input_cost_per_token: 4.1e-7
+      output_cost_per_token: 3.39e-6
     - region: ap-south-1
-      input_cost_per_token: 1.75e-7
-      output_cost_per_token: 1.475e-6
+      cache_read_input_token_cost: 8.75e-8
+      input_cost_per_token: 3.5e-7
+      output_cost_per_token: 2.95e-6
+    - region: ap-northeast-2
+      cache_read_input_token_cost: 9e-8
+      input_cost_per_token: 3.6e-7
+      output_cost_per_token: 2.96e-6
+    - region: ap-northeast-1
+      cache_read_input_token_cost: 9e-8
+      input_cost_per_token: 3.6e-7
+      output_cost_per_token: 3.01e-6
+    - region: ap-east-2
+      cache_read_input_token_cost: 9e-8
+      input_cost_per_token: 3.6e-7
+      output_cost_per_token: 3.01e-6
 limits:
     max_tokens: 64000
     max_input_tokens: 1000000
     max_output_tokens: 64000
-features: [function_calling, vision]
+features:
+    - function_calling
+    - vision
 mode: chat

--- a/providers/aws-bedrock/global.anthropic.claude-haiku-4-5-20251001-v1:0.yaml
+++ b/providers/aws-bedrock/global.anthropic.claude-haiku-4-5-20251001-v1:0.yaml
@@ -4,165 +4,164 @@ costs:
       cache_creation_input_token_cost: 1.25e-6
       cache_read_input_token_cost: 1e-7
       input_cost_per_token: 1e-6
-      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 5e-6
-      output_cost_per_token_batches: 2.5e-6
     - region: us-west-1
       cache_creation_input_token_cost: 1.25e-6
       cache_read_input_token_cost: 1e-7
       input_cost_per_token: 1e-6
-      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 5e-6
-      output_cost_per_token_batches: 2.5e-6
     - region: us-east-2
       cache_creation_input_token_cost: 1.25e-6
       cache_read_input_token_cost: 1e-7
       input_cost_per_token: 1e-6
-      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 5e-6
-      output_cost_per_token_batches: 2.5e-6
     - region: us-east-1
       cache_creation_input_token_cost: 1.25e-6
       cache_read_input_token_cost: 1e-7
       input_cost_per_token: 1e-6
-      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 5e-6
-      output_cost_per_token_batches: 2.5e-6
     - region: sa-east-1
       cache_creation_input_token_cost: 1.25e-6
       cache_read_input_token_cost: 1e-7
       input_cost_per_token: 1e-6
-      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 5e-6
-      output_cost_per_token_batches: 2.5e-6
-    - region: eu-central-2
+    - region: me-south-1
       cache_creation_input_token_cost: 1.25e-6
       cache_read_input_token_cost: 1e-7
       input_cost_per_token: 1e-6
-      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 5e-6
-      output_cost_per_token_batches: 2.5e-6
-    - region: eu-north-1
+    - region: me-central-1
       cache_creation_input_token_cost: 1.25e-6
       cache_read_input_token_cost: 1e-7
       input_cost_per_token: 1e-6
-      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 5e-6
-      output_cost_per_token_batches: 2.5e-6
-    - region: eu-south-2
+    - region: il-central-1
       cache_creation_input_token_cost: 1.25e-6
       cache_read_input_token_cost: 1e-7
       input_cost_per_token: 1e-6
-      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 5e-6
-      output_cost_per_token_batches: 2.5e-6
     - region: eu-west-3
       cache_creation_input_token_cost: 1.25e-6
       cache_read_input_token_cost: 1e-7
       input_cost_per_token: 1e-6
-      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 5e-6
-      output_cost_per_token_batches: 2.5e-6
-    - region: eu-south-1
-      cache_creation_input_token_cost: 1.25e-6
-      cache_read_input_token_cost: 1e-7
-      input_cost_per_token: 1e-6
-      input_cost_per_token_batches: 5e-7
-      output_cost_per_token: 5e-6
-      output_cost_per_token_batches: 2.5e-6
     - region: eu-west-2
       cache_creation_input_token_cost: 1.25e-6
       cache_read_input_token_cost: 1e-7
       input_cost_per_token: 1e-6
-      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 5e-6
-      output_cost_per_token_batches: 2.5e-6
     - region: eu-west-1
       cache_creation_input_token_cost: 1.25e-6
       cache_read_input_token_cost: 1e-7
       input_cost_per_token: 1e-6
-      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 5e-6
-      output_cost_per_token_batches: 2.5e-6
+    - region: eu-south-2
+      cache_creation_input_token_cost: 1.25e-6
+      cache_read_input_token_cost: 1e-7
+      input_cost_per_token: 1e-6
+      output_cost_per_token: 5e-6
+    - region: eu-south-1
+      cache_creation_input_token_cost: 1.25e-6
+      cache_read_input_token_cost: 1e-7
+      input_cost_per_token: 1e-6
+      output_cost_per_token: 5e-6
+    - region: eu-north-1
+      cache_creation_input_token_cost: 1.25e-6
+      cache_read_input_token_cost: 1e-7
+      input_cost_per_token: 1e-6
+      output_cost_per_token: 5e-6
+    - region: eu-central-2
+      cache_creation_input_token_cost: 1.25e-6
+      cache_read_input_token_cost: 1e-7
+      input_cost_per_token: 1e-6
+      output_cost_per_token: 5e-6
     - region: eu-central-1
       cache_creation_input_token_cost: 1.25e-6
       cache_read_input_token_cost: 1e-7
       input_cost_per_token: 1e-6
-      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 5e-6
-      output_cost_per_token_batches: 2.5e-6
     - region: ca-central-1
       cache_creation_input_token_cost: 1.25e-6
       cache_read_input_token_cost: 1e-7
       input_cost_per_token: 1e-6
-      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 5e-6
-      output_cost_per_token_batches: 2.5e-6
-    - region: ap-northeast-1
+    - region: ap-southeast-4
       cache_creation_input_token_cost: 1.25e-6
       cache_read_input_token_cost: 1e-7
       input_cost_per_token: 1e-6
-      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 5e-6
-      output_cost_per_token_batches: 2.5e-6
+    - region: ap-southeast-3
+      cache_creation_input_token_cost: 1.25e-6
+      cache_read_input_token_cost: 1e-7
+      input_cost_per_token: 1e-6
+      output_cost_per_token: 5e-6
     - region: ap-southeast-2
       cache_creation_input_token_cost: 1.25e-6
       cache_read_input_token_cost: 1e-7
       input_cost_per_token: 1e-6
-      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 5e-6
-      output_cost_per_token_batches: 2.5e-6
     - region: ap-southeast-1
       cache_creation_input_token_cost: 1.25e-6
       cache_read_input_token_cost: 1e-7
       input_cost_per_token: 1e-6
-      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 5e-6
-      output_cost_per_token_batches: 2.5e-6
-    - region: ap-northeast-2
-      cache_creation_input_token_cost: 1.25e-6
-      cache_read_input_token_cost: 1e-7
-      input_cost_per_token: 1e-6
-      input_cost_per_token_batches: 5e-7
-      output_cost_per_token: 5e-6
-      output_cost_per_token_batches: 2.5e-6
-    - region: ap-northeast-3
-      cache_creation_input_token_cost: 1.25e-6
-      cache_read_input_token_cost: 1e-7
-      input_cost_per_token: 1e-6
-      input_cost_per_token_batches: 5e-7
-      output_cost_per_token: 5e-6
-      output_cost_per_token_batches: 2.5e-6
-    - region: ap-south-1
-      cache_creation_input_token_cost: 1.25e-6
-      cache_read_input_token_cost: 1e-7
-      input_cost_per_token: 1e-6
-      input_cost_per_token_batches: 5e-7
-      output_cost_per_token: 5e-6
-      output_cost_per_token_batches: 2.5e-6
     - region: ap-south-2
       cache_creation_input_token_cost: 1.25e-6
       cache_read_input_token_cost: 1e-7
       input_cost_per_token: 1e-6
-      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 5e-6
-      output_cost_per_token_batches: 2.5e-6
+    - region: ap-south-1
+      cache_creation_input_token_cost: 1.25e-6
+      cache_read_input_token_cost: 1e-7
+      input_cost_per_token: 1e-6
+      output_cost_per_token: 5e-6
+    - region: ap-northeast-3
+      cache_creation_input_token_cost: 1.25e-6
+      cache_read_input_token_cost: 1e-7
+      input_cost_per_token: 1e-6
+      output_cost_per_token: 5e-6
+    - region: ap-northeast-2
+      cache_creation_input_token_cost: 1.25e-6
+      cache_read_input_token_cost: 1e-7
+      input_cost_per_token: 1e-6
+      output_cost_per_token: 5e-6
+    - region: ap-northeast-1
+      cache_creation_input_token_cost: 1.25e-6
+      cache_read_input_token_cost: 1e-7
+      input_cost_per_token: 1e-6
+      output_cost_per_token: 5e-6
+    - region: af-south-1
+      cache_creation_input_token_cost: 1.25e-6
+      cache_read_input_token_cost: 1e-7
+      input_cost_per_token: 1e-6
+      output_cost_per_token: 5e-6
 limits:
     max_input_tokens: 200000
     max_output_tokens: 64000
     tool_use_system_prompt_tokens: 346
-features: [function_calling, vision, chat, image]
+features:
+    - function_calling
+    - vision
+    - chat
+    - image
 params:
-    - key: max_tokens
-      maxValue: 64000
-    - key: thinking
-      type: number
-      enum: [enabled, disabled]
-      minValue: 1024
-      maxValue: 128000
-      withdrawParams: [top_k, top_p]
-      skipValues:
-          - disabled
-          - null
-removeParams: [top_p]
+    -
+        key: max_tokens
+        maxValue: 64000
+    -
+        key: thinking
+        type: number
+        enum:
+            - enabled
+            - disabled
+        minValue: 1024
+        maxValue: 128000
+        withdrawParams:
+            - top_k
+            - top_p
+        skipValues:
+            - disabled
+            - null
+removeParams:
+    - top_p
 mode: chat

--- a/providers/aws-bedrock/global.anthropic.claude-haiku-4-5-20251001-v1:0.yaml
+++ b/providers/aws-bedrock/global.anthropic.claude-haiku-4-5-20251001-v1:0.yaml
@@ -145,23 +145,21 @@ features:
     - chat
     - image
 params:
-    -
-        key: max_tokens
-        maxValue: 64000
-    -
-        key: thinking
-        type: number
-        enum:
-            - enabled
-            - disabled
-        minValue: 1024
-        maxValue: 128000
-        withdrawParams:
-            - top_k
-            - top_p
-        skipValues:
-            - disabled
-            - null
+    - key: max_tokens
+      maxValue: 64000
+    - key: thinking
+      type: number
+      enum:
+          - enabled
+          - disabled
+      minValue: 1024
+      maxValue: 128000
+      withdrawParams:
+          - top_k
+          - top_p
+      skipValues:
+          - disabled
+          - null
 removeParams:
     - top_p
 mode: chat

--- a/providers/aws-bedrock/global.anthropic.claude-opus-4-5-20251101-v1:0.yaml
+++ b/providers/aws-bedrock/global.anthropic.claude-opus-4-5-20251101-v1:0.yaml
@@ -1,141 +1,143 @@
 model: global.anthropic.claude-opus-4-5-20251101-v1:0
 costs:
     - region: us-west-2
-      cache_creation_input_token_cost: 6.875e-6
-      cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 5.5e-6
-      input_cost_per_token_batches: 2.75e-6
-      output_cost_per_token: 2.75e-05
-      output_cost_per_token_batches: 1.375e-05
+      cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 2.5e-5
     - region: us-west-1
-      cache_creation_input_token_cost: 6.875e-6
-      cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 5.5e-6
-      input_cost_per_token_batches: 2.75e-6
-      output_cost_per_token: 2.75e-05
-      output_cost_per_token_batches: 1.375e-05
+      cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 2.5e-5
     - region: us-east-2
-      cache_creation_input_token_cost: 6.875e-6
-      cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 5.5e-6
-      input_cost_per_token_batches: 2.75e-6
-      output_cost_per_token: 2.75e-05
-      output_cost_per_token_batches: 1.375e-05
+      cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 2.5e-5
     - region: us-east-1
-      cache_creation_input_token_cost: 6.875e-6
-      cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 5.5e-6
-      input_cost_per_token_batches: 2.75e-6
-      output_cost_per_token: 2.75e-05
-      output_cost_per_token_batches: 1.375e-05
+      cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 2.5e-5
     - region: sa-east-1
       cache_creation_input_token_cost: 6.25e-6
       cache_read_input_token_cost: 5e-7
       input_cost_per_token: 5e-6
-      input_cost_per_token_batches: 2.5e-6
-      output_cost_per_token: 2.5e-05
-      output_cost_per_token_batches: 1.25e-05
-    - region: eu-central-2
-      cache_creation_input_token_cost: 1.1e-05
-    - region: eu-north-1
-      cache_creation_input_token_cost: 6.875e-6
-      cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 5.5e-6
-      input_cost_per_token_batches: 2.75e-6
-      output_cost_per_token: 2.75e-05
-      output_cost_per_token_batches: 1.375e-05
-    - region: eu-south-2
-      cache_creation_input_token_cost: 6.875e-6
-      cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 5.5e-6
-      input_cost_per_token_batches: 2.75e-6
-      output_cost_per_token: 2.75e-05
-      output_cost_per_token_batches: 1.375e-05
-    - region: eu-west-3
-      cache_creation_input_token_cost: 6.875e-6
-      cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 5.5e-6
-      input_cost_per_token_batches: 2.75e-6
-      output_cost_per_token: 2.75e-05
-      output_cost_per_token_batches: 1.375e-05
-    - region: eu-south-1
-      cache_creation_input_token_cost: 6.875e-6
-      cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 5.5e-6
-      input_cost_per_token_batches: 2.75e-6
-      output_cost_per_token: 2.75e-05
-      output_cost_per_token_batches: 1.375e-05
-    - region: eu-west-2
-      cache_creation_input_token_cost: 1.1e-05
+      output_cost_per_token: 2.5e-5
+    - region: me-south-1
+      cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 5e-6
-      input_cost_per_token_batches: 2.5e-6
-      output_cost_per_token: 2.5e-05
-      output_cost_per_token_batches: 1.25e-05
+      output_cost_per_token: 2.5e-5
+    - region: me-central-1
+      cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 2.5e-5
+    - region: il-central-1
+      cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 2.5e-5
+    - region: eu-west-3
+      cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 2.5e-5
+    - region: eu-west-2
+      cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 2.5e-5
     - region: eu-west-1
-      cache_creation_input_token_cost: 6.875e-6
-      cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 5.5e-6
-      input_cost_per_token_batches: 2.75e-6
-      output_cost_per_token: 2.75e-05
-      output_cost_per_token_batches: 1.375e-05
+      cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 2.5e-5
+    - region: eu-south-2
+      cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 2.5e-5
+    - region: eu-south-1
+      cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 2.5e-5
+    - region: eu-north-1
+      cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 2.5e-5
     - region: eu-central-1
-      cache_creation_input_token_cost: 6.875e-6
-      cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 5.5e-6
-      input_cost_per_token_batches: 2.75e-6
-      output_cost_per_token: 2.75e-05
-      output_cost_per_token_batches: 1.375e-05
+      cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 2.5e-5
     - region: ca-central-1
-      cache_creation_input_token_cost: 6.875e-6
-      cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 5.5e-6
-      input_cost_per_token_batches: 2.75e-6
-      output_cost_per_token: 2.75e-05
-      output_cost_per_token_batches: 1.375e-05
+      cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 2.5e-5
+    - region: ap-southeast-3
+      cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 2.5e-5
     - region: ap-southeast-1
       cache_creation_input_token_cost: 6.25e-6
       cache_read_input_token_cost: 5e-7
       input_cost_per_token: 5e-6
-      input_cost_per_token_batches: 2.5e-6
-      output_cost_per_token: 2.5e-05
-      output_cost_per_token_batches: 1.25e-05
-    - region: ap-northeast-2
-      cache_creation_input_token_cost: 6.25e-6
-      cache_read_input_token_cost: 5e-7
-      input_cost_per_token: 5e-6
-      input_cost_per_token_batches: 2.5e-6
-      output_cost_per_token: 2.5e-05
-      output_cost_per_token_batches: 1.25e-05
-    - region: ap-south-1
-      cache_creation_input_token_cost: 6.25e-6
-      cache_read_input_token_cost: 5e-7
-      input_cost_per_token: 5e-6
-      input_cost_per_token_batches: 2.5e-6
-      output_cost_per_token: 2.5e-05
-      output_cost_per_token_batches: 1.25e-05
+      output_cost_per_token: 2.5e-5
     - region: ap-south-2
       cache_creation_input_token_cost: 6.25e-6
       cache_read_input_token_cost: 5e-7
       input_cost_per_token: 5e-6
-      input_cost_per_token_batches: 2.5e-6
-      output_cost_per_token: 2.5e-05
-      output_cost_per_token_batches: 1.25e-05
+      output_cost_per_token: 2.5e-5
+    - region: ap-south-1
+      cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 2.5e-5
+    - region: ap-northeast-2
+      cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 2.5e-5
+    - region: af-south-1
+      cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 2.5e-5
 limits:
     max_input_tokens: 200000
     max_output_tokens: 64000
     tool_use_system_prompt_tokens: 159
-features: [function_calling, vision, chat, image]
+features:
+    - function_calling
+    - vision
+    - chat
+    - image
 params:
-    - key: max_tokens
-      maxValue: 64000
-    - key: thinking
-      type: number
-      enum: [enabled, disabled]
-      minValue: 1024
-      maxValue: 128000
-      withdrawParams: [top_k, top_p]
-      skipValues:
-          - disabled
-          - null
-removeParams: [temperature, top_p]
+    -
+        key: max_tokens
+        maxValue: 64000
+    -
+        key: thinking
+        type: number
+        enum:
+            - enabled
+            - disabled
+        minValue: 1024
+        maxValue: 128000
+        withdrawParams:
+            - top_k
+            - top_p
+        skipValues:
+            - disabled
+            - null
+removeParams:
+    - temperature
+    - top_p
 mode: chat

--- a/providers/aws-bedrock/global.anthropic.claude-opus-4-5-20251101-v1:0.yaml
+++ b/providers/aws-bedrock/global.anthropic.claude-opus-4-5-20251101-v1:0.yaml
@@ -120,23 +120,21 @@ features:
     - chat
     - image
 params:
-    -
-        key: max_tokens
-        maxValue: 64000
-    -
-        key: thinking
-        type: number
-        enum:
-            - enabled
-            - disabled
-        minValue: 1024
-        maxValue: 128000
-        withdrawParams:
-            - top_k
-            - top_p
-        skipValues:
-            - disabled
-            - null
+    - key: max_tokens
+      maxValue: 64000
+    - key: thinking
+      type: number
+      enum:
+          - enabled
+          - disabled
+      minValue: 1024
+      maxValue: 128000
+      withdrawParams:
+          - top_k
+          - top_p
+      skipValues:
+          - disabled
+          - null
 removeParams:
     - temperature
     - top_p

--- a/providers/aws-bedrock/global.anthropic.claude-opus-4-6-v1.yaml
+++ b/providers/aws-bedrock/global.anthropic.claude-opus-4-6-v1.yaml
@@ -1,156 +1,171 @@
 model: global.anthropic.claude-opus-4-6-v1
 costs:
     - region: us-west-2
-      cache_creation_input_token_cost: 6.875e-6
-      cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 5.5e-6
-      input_cost_per_token_batches: 2.75e-6
-      output_cost_per_token: 2.75e-05
-      output_cost_per_token_batches: 1.375e-05
+      cache_creation_input_token_cost: 1.25e-5
+      cache_read_input_token_cost: 1e-6
+      input_cost_per_token: 1e-5
+      output_cost_per_token: 2.5e-5
     - region: us-west-1
-      cache_creation_input_token_cost: 6.875e-6
-      cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 5.5e-6
-      input_cost_per_token_batches: 2.75e-6
-      output_cost_per_token: 2.75e-05
-      output_cost_per_token_batches: 1.375e-05
+      cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 1e-5
+      output_cost_per_token: 3.75e-5
     - region: us-east-2
-      cache_creation_input_token_cost: 6.875e-6
-      cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 5.5e-6
-      input_cost_per_token_batches: 2.75e-6
-      output_cost_per_token: 2.75e-05
-      output_cost_per_token_batches: 1.375e-05
+      cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 1e-5
+      output_cost_per_token: 3.75e-5
     - region: us-east-1
-      cache_creation_input_token_cost: 6.875e-6
-      cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 5.5e-6
-      input_cost_per_token_batches: 2.75e-6
-      output_cost_per_token: 2.75e-05
-      output_cost_per_token_batches: 1.375e-05
+      cache_creation_input_token_cost: 1.25e-5
+      cache_read_input_token_cost: 1e-6
+      input_cost_per_token: 1e-5
+      output_cost_per_token: 2.5e-5
     - region: sa-east-1
+      cache_creation_input_token_cost: 1.25e-5
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 1e-5
+      output_cost_per_token: 2.5e-5
+    - region: mx-central-1
+      cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 1e-6
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 2.5e-5
+    - region: me-south-1
+      cache_creation_input_token_cost: 1.25e-5
+      cache_read_input_token_cost: 1e-6
+      input_cost_per_token: 1e-5
+      output_cost_per_token: 2.5e-5
+    - region: me-central-1
+      cache_creation_input_token_cost: 1.25e-5
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 3.75e-5
+    - region: il-central-1
       cache_creation_input_token_cost: 6.25e-6
       cache_read_input_token_cost: 5e-7
       input_cost_per_token: 5e-6
-      input_cost_per_token_batches: 2.5e-6
-      output_cost_per_token: 2.5e-05
-      output_cost_per_token_batches: 1.25e-05
-    - region: eu-central-2
-      cache_creation_input_token_cost: 6.875e-6
-      cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 5.5e-6
-      input_cost_per_token_batches: 2.75e-6
-      output_cost_per_token: 2.75e-05
-      output_cost_per_token_batches: 1.375e-05
-    - region: eu-north-1
-      cache_creation_input_token_cost: 6.875e-6
-      cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 5.5e-6
-      input_cost_per_token_batches: 2.75e-6
-      output_cost_per_token: 2.75e-05
-      output_cost_per_token_batches: 1.375e-05
-    - region: eu-south-2
-      cache_creation_input_token_cost: 6.875e-6
-      cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 5.5e-6
-      input_cost_per_token_batches: 2.75e-6
-      output_cost_per_token: 2.75e-05
-      output_cost_per_token_batches: 1.375e-05
+      output_cost_per_token: 3.75e-5
     - region: eu-west-3
-      cache_creation_input_token_cost: 6.875e-6
-      cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 5.5e-6
-      input_cost_per_token_batches: 2.75e-6
-      output_cost_per_token: 2.75e-05
-      output_cost_per_token_batches: 1.375e-05
-    - region: eu-south-1
-      cache_creation_input_token_cost: 6.875e-6
-      cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 5.5e-6
-      input_cost_per_token_batches: 2.75e-6
-      output_cost_per_token: 2.75e-05
-      output_cost_per_token_batches: 1.375e-05
+      cache_creation_input_token_cost: 1.25e-5
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 2.5e-5
     - region: eu-west-2
-      cache_creation_input_token_cost: 6.875e-6
-      cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 5.5e-6
-      input_cost_per_token_batches: 2.75e-6
-      output_cost_per_token: 2.75e-05
-      output_cost_per_token_batches: 1.375e-05
+      cache_creation_input_token_cost: 1.25e-5
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 1e-5
+      output_cost_per_token: 3.75e-5
     - region: eu-west-1
-      cache_creation_input_token_cost: 6.875e-6
-      cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 5.5e-6
-      input_cost_per_token_batches: 2.75e-6
-      output_cost_per_token: 2.75e-05
-      output_cost_per_token_batches: 1.375e-05
-    - region: eu-central-1
-      cache_creation_input_token_cost: 6.875e-6
-      cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 5.5e-6
-      input_cost_per_token_batches: 2.75e-6
-      output_cost_per_token: 2.75e-05
-      output_cost_per_token_batches: 1.375e-05
-    - region: ca-central-1
-      cache_creation_input_token_cost: 6.875e-6
-      cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 5.5e-6
-      input_cost_per_token_batches: 2.75e-6
-      output_cost_per_token: 2.75e-05
-      output_cost_per_token_batches: 1.375e-05
-    - region: ap-northeast-1
+      cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 1e-6
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 3.75e-5
+    - region: eu-south-2
       cache_creation_input_token_cost: 6.25e-6
       cache_read_input_token_cost: 5e-7
       input_cost_per_token: 5e-6
-      input_cost_per_token_batches: 2.5e-6
-      output_cost_per_token: 2.5e-05
-      output_cost_per_token_batches: 1.25e-05
+      output_cost_per_token: 3.75e-5
+    - region: eu-south-1
+      cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 1e-6
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 3.75e-5
+    - region: eu-north-1
+      cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 1e-5
+      output_cost_per_token: 2.5e-5
+    - region: eu-central-2
+      cache_creation_input_token_cost: 1.25e-5
+      cache_read_input_token_cost: 1e-6
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 2.5e-5
+    - region: eu-central-1
+      cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 3.75e-5
+    - region: ca-west-1
+      cache_creation_input_token_cost: 1.25e-5
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 1e-5
+      output_cost_per_token: 3.75e-5
+    - region: ca-central-1
+      cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 1e-6
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 2.5e-5
+    - region: ap-southeast-7
+      cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 1e-6
+      input_cost_per_token: 1e-5
+      output_cost_per_token: 3.75e-5
+    - region: ap-southeast-5
+      cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 1e-6
+      input_cost_per_token: 1e-5
+      output_cost_per_token: 3.75e-5
+    - region: ap-southeast-4
+      cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 1e-6
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 2.5e-5
+    - region: ap-southeast-3
+      cache_creation_input_token_cost: 1.25e-5
+      cache_read_input_token_cost: 1e-6
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 2.5e-5
     - region: ap-southeast-2
-      cache_creation_input_token_cost: 6.875e-6
-      cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 5.5e-6
-      input_cost_per_token_batches: 2.75e-6
-      output_cost_per_token: 2.75e-05
-      output_cost_per_token_batches: 1.375e-05
+      cache_creation_input_token_cost: 1.25e-5
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 2.5e-5
     - region: ap-southeast-1
       cache_creation_input_token_cost: 6.25e-6
       cache_read_input_token_cost: 5e-7
-      input_cost_per_token: 5e-6
-      input_cost_per_token_batches: 2.5e-6
-      output_cost_per_token: 2.5e-05
-      output_cost_per_token_batches: 1.25e-05
-    - region: ap-northeast-2
+      input_cost_per_token: 1e-5
+      output_cost_per_token: 3.75e-5
+    - region: ap-south-2
       cache_creation_input_token_cost: 6.25e-6
-      cache_read_input_token_cost: 5e-7
-      input_cost_per_token: 5e-6
-      input_cost_per_token_batches: 2.5e-6
-      output_cost_per_token: 2.5e-05
-      output_cost_per_token_batches: 1.25e-05
+      cache_read_input_token_cost: 1e-6
+      input_cost_per_token: 1e-5
+      output_cost_per_token: 3.75e-5
+    - region: ap-south-1
+      cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 1e-6
+      input_cost_per_token: 1e-5
+      output_cost_per_token: 3.75e-5
     - region: ap-northeast-3
       cache_creation_input_token_cost: 6.25e-6
       cache_read_input_token_cost: 5e-7
-      input_cost_per_token: 5e-6
-      input_cost_per_token_batches: 2.5e-6
-      output_cost_per_token: 2.5e-05
-      output_cost_per_token_batches: 1.25e-05
-    - region: ap-south-1
-      cache_creation_input_token_cost: 6.25e-6
+      input_cost_per_token: 1e-5
+      output_cost_per_token: 2.5e-5
+    - region: ap-northeast-2
+      cache_creation_input_token_cost: 1.25e-5
       cache_read_input_token_cost: 5e-7
       input_cost_per_token: 5e-6
-      input_cost_per_token_batches: 2.5e-6
-      output_cost_per_token: 2.5e-05
-      output_cost_per_token_batches: 1.25e-05
-    - region: ap-south-2
-      cache_creation_input_token_cost: 6.25e-6
+      output_cost_per_token: 2.5e-5
+    - region: ap-northeast-1
+      cache_creation_input_token_cost: 1.25e-5
       cache_read_input_token_cost: 5e-7
       input_cost_per_token: 5e-6
-      input_cost_per_token_batches: 2.5e-6
-      output_cost_per_token: 2.5e-05
-      output_cost_per_token_batches: 1.25e-05
+      output_cost_per_token: 3.75e-5
+    - region: ap-east-2
+      cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 1e-6
+      input_cost_per_token: 1e-5
+      output_cost_per_token: 3.75e-5
+    - region: af-south-1
+      cache_creation_input_token_cost: 1.25e-5
+      cache_read_input_token_cost: 1e-6
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 3.75e-5
 limits:
     max_tokens: 128000
     max_input_tokens: 1000000
     max_output_tokens: 128000
     tool_use_system_prompt_tokens: 346
-features: [function_calling, vision]
+features:
+    - function_calling
+    - vision
 mode: chat

--- a/providers/aws-bedrock/global.anthropic.claude-sonnet-4-20250514-v1:0.yaml
+++ b/providers/aws-bedrock/global.anthropic.claude-sonnet-4-20250514-v1:0.yaml
@@ -1,42 +1,36 @@
 model: global.anthropic.claude-sonnet-4-20250514-v1:0
 costs:
     - region: us-west-2
-      cache_creation_input_token_cost: 3.75e-6
+      cache_creation_input_token_cost: 7.5e-6
       cache_read_input_token_cost: 3e-7
       input_cost_per_token: 3e-6
-      input_cost_per_token_batches: 1.5e-6
-      output_cost_per_token: 1.5e-05
-      output_cost_per_token_batches: 7.5e-6
+      output_cost_per_token: 2.25e-5
     - region: us-east-2
       cache_creation_input_token_cost: 3.75e-6
       cache_read_input_token_cost: 3e-7
-      input_cost_per_token: 3e-6
-      input_cost_per_token_batches: 1.5e-6
-      output_cost_per_token: 1.5e-05
-      output_cost_per_token_batches: 7.5e-6
+      input_cost_per_token: 6e-6
+      output_cost_per_token: 2.25e-5
     - region: us-east-1
-      cache_creation_input_token_cost: 3.75e-6
-      cache_read_input_token_cost: 3e-7
-      input_cost_per_token: 3e-6
-      input_cost_per_token_batches: 1.5e-6
-      output_cost_per_token: 1.5e-05
-      output_cost_per_token_batches: 7.5e-6
+      cache_creation_input_token_cost: 7.5e-6
+      cache_read_input_token_cost: 6e-7
+      input_cost_per_token: 6e-6
+      output_cost_per_token: 2.25e-5
     - region: eu-west-1
-      cache_creation_input_token_cost: 3.75e-6
+      cache_creation_input_token_cost: 7.5e-6
       cache_read_input_token_cost: 3e-7
       input_cost_per_token: 3e-6
-      output_cost_per_token: 1.5e-05
+      output_cost_per_token: 1.5e-5
     - region: ap-northeast-1
       cache_creation_input_token_cost: 3.75e-6
-      cache_read_input_token_cost: 3e-7
+      cache_read_input_token_cost: 6e-7
       input_cost_per_token: 3e-6
-      input_cost_per_token_batches: 1.5e-6
-      output_cost_per_token: 1.5e-05
-      output_cost_per_token_batches: 7.5e-6
+      output_cost_per_token: 2.25e-5
 limits:
     max_tokens: 64000
     max_input_tokens: 1000000
     max_output_tokens: 64000
     tool_use_system_prompt_tokens: 159
-features: [function_calling, vision]
+features:
+    - function_calling
+    - vision
 mode: chat

--- a/providers/aws-bedrock/global.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
+++ b/providers/aws-bedrock/global.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
@@ -1,156 +1,141 @@
 model: global.anthropic.claude-sonnet-4-5-20250929-v1:0
 costs:
     - region: us-west-2
-      cache_creation_input_token_cost: 4.125e-6
-      cache_read_input_token_cost: 3.3e-7
-      input_cost_per_token: 3.3e-6
-      input_cost_per_token_batches: 1.65e-6
-      output_cost_per_token: 1.65e-05
-      output_cost_per_token_batches: 8.25e-6
+      cache_creation_input_token_cost: 7.5e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 2.25e-5
     - region: us-west-1
-      cache_creation_input_token_cost: 4.125e-6
-      cache_read_input_token_cost: 3.3e-7
-      input_cost_per_token: 3.3e-6
-      input_cost_per_token_batches: 1.65e-6
-      output_cost_per_token: 1.65e-05
-      output_cost_per_token_batches: 8.25e-6
+      cache_creation_input_token_cost: 7.5e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 2.25e-5
     - region: us-east-2
-      cache_creation_input_token_cost: 4.125e-6
-      cache_read_input_token_cost: 3.3e-7
-      input_cost_per_token: 3.3e-6
-      input_cost_per_token_batches: 1.65e-6
-      output_cost_per_token: 1.65e-05
-      output_cost_per_token_batches: 8.25e-6
+      cache_creation_input_token_cost: 7.5e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 1.5e-5
     - region: us-east-1
-      cache_creation_input_token_cost: 4.125e-6
-      cache_read_input_token_cost: 3.3e-7
-      input_cost_per_token: 3.3e-6
-      input_cost_per_token_batches: 1.65e-6
-      output_cost_per_token: 1.65e-05
-      output_cost_per_token_batches: 8.25e-6
+      cache_creation_input_token_cost: 3.75e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 6e-6
+      output_cost_per_token: 2.25e-5
     - region: sa-east-1
       cache_creation_input_token_cost: 3.75e-6
-      cache_read_input_token_cost: 3e-7
+      cache_read_input_token_cost: 6e-7
       input_cost_per_token: 3e-6
-      input_cost_per_token_batches: 1.5e-6
-      output_cost_per_token: 1.5e-05
-      output_cost_per_token_batches: 7.5e-6
-    - region: eu-central-2
-      cache_creation_input_token_cost: 4.125e-6
-      cache_read_input_token_cost: 3.3e-7
-      input_cost_per_token: 3.3e-6
-      input_cost_per_token_batches: 1.65e-6
-      output_cost_per_token: 1.65e-05
-      output_cost_per_token_batches: 8.25e-6
-    - region: eu-north-1
-      cache_creation_input_token_cost: 4.125e-6
-      cache_read_input_token_cost: 3.3e-7
-      input_cost_per_token: 3.3e-6
-      input_cost_per_token_batches: 1.65e-6
-      output_cost_per_token: 1.65e-05
-      output_cost_per_token_batches: 8.25e-6
-    - region: eu-south-2
-      cache_creation_input_token_cost: 4.125e-6
-      cache_read_input_token_cost: 3.3e-7
-      input_cost_per_token: 3.3e-6
-      input_cost_per_token_batches: 1.65e-6
-      output_cost_per_token: 1.65e-05
-      output_cost_per_token_batches: 8.25e-6
+      output_cost_per_token: 2.25e-5
+    - region: me-central-1
+      cache_creation_input_token_cost: 3.75e-6
+      cache_read_input_token_cost: 6e-7
+      input_cost_per_token: 6e-6
+      output_cost_per_token: 1.5e-5
+    - region: il-central-1
+      cache_creation_input_token_cost: 7.5e-6
+      cache_read_input_token_cost: 6e-7
+      input_cost_per_token: 6e-6
+      output_cost_per_token: 2.25e-5
     - region: eu-west-3
-      cache_creation_input_token_cost: 4.125e-6
-      cache_read_input_token_cost: 3.3e-7
-      input_cost_per_token: 3.3e-6
-      input_cost_per_token_batches: 1.65e-6
-      output_cost_per_token: 1.65e-05
-      output_cost_per_token_batches: 8.25e-6
-    - region: eu-south-1
-      cache_creation_input_token_cost: 4.125e-6
-      cache_read_input_token_cost: 3.3e-7
-      input_cost_per_token: 3.3e-6
-      input_cost_per_token_batches: 1.65e-6
-      output_cost_per_token: 1.65e-05
-      output_cost_per_token_batches: 8.25e-6
+      cache_creation_input_token_cost: 7.5e-6
+      cache_read_input_token_cost: 6e-7
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 1.5e-5
     - region: eu-west-2
-      cache_creation_input_token_cost: 4.125e-6
-      cache_read_input_token_cost: 3.3e-7
-      input_cost_per_token: 3.3e-6
-      input_cost_per_token_batches: 1.65e-6
-      output_cost_per_token: 1.65e-05
-      output_cost_per_token_batches: 8.25e-6
+      cache_creation_input_token_cost: 3.75e-6
+      cache_read_input_token_cost: 6e-7
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 1.5e-5
     - region: eu-west-1
-      cache_creation_input_token_cost: 4.125e-6
-      cache_read_input_token_cost: 3.3e-7
-      input_cost_per_token: 3.3e-6
-      input_cost_per_token_batches: 1.65e-6
-      output_cost_per_token: 1.65e-05
-      output_cost_per_token_batches: 8.25e-6
+      cache_creation_input_token_cost: 7.5e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 6e-6
+      output_cost_per_token: 2.25e-5
+    - region: eu-south-2
+      cache_creation_input_token_cost: 7.5e-6
+      cache_read_input_token_cost: 6e-7
+      input_cost_per_token: 6e-6
+      output_cost_per_token: 1.5e-5
+    - region: eu-south-1
+      cache_creation_input_token_cost: 7.5e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 6e-6
+      output_cost_per_token: 2.25e-5
+    - region: eu-north-1
+      cache_creation_input_token_cost: 3.75e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 6e-6
+      output_cost_per_token: 2.25e-5
+    - region: eu-central-2
+      cache_creation_input_token_cost: 3.75e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 6e-6
+      output_cost_per_token: 2.25e-5
     - region: eu-central-1
-      cache_creation_input_token_cost: 4.125e-6
-      cache_read_input_token_cost: 3.3e-7
-      input_cost_per_token: 3.3e-6
-      input_cost_per_token_batches: 1.65e-6
-      output_cost_per_token: 1.65e-05
-      output_cost_per_token_batches: 8.25e-6
+      cache_creation_input_token_cost: 3.75e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 6e-6
+      output_cost_per_token: 2.25e-5
     - region: ca-central-1
-      cache_creation_input_token_cost: 4.125e-6
-      cache_read_input_token_cost: 3.3e-7
-      input_cost_per_token: 3.3e-6
-      input_cost_per_token_batches: 1.65e-6
-      output_cost_per_token: 1.65e-05
-      output_cost_per_token_batches: 8.25e-6
-    - region: ap-northeast-1
-      cache_creation_input_token_cost: 4.125e-6
-      cache_read_input_token_cost: 3.3e-7
-      input_cost_per_token: 3.3e-6
-      input_cost_per_token_batches: 1.65e-6
-      output_cost_per_token: 1.65e-05
-      output_cost_per_token_batches: 8.25e-6
+      cache_creation_input_token_cost: 7.5e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 6e-6
+      output_cost_per_token: 1.5e-5
+    - region: ap-southeast-4
+      cache_creation_input_token_cost: 3.75e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 6e-6
+      output_cost_per_token: 2.25e-5
+    - region: ap-southeast-3
+      cache_creation_input_token_cost: 7.5e-6
+      cache_read_input_token_cost: 6e-7
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 1.5e-5
     - region: ap-southeast-2
-      cache_creation_input_token_cost: 4.125e-6
-      cache_read_input_token_cost: 3.3e-7
-      input_cost_per_token: 3.3e-6
-      input_cost_per_token_batches: 1.65e-6
-      output_cost_per_token: 1.65e-05
-      output_cost_per_token_batches: 8.25e-6
+      cache_creation_input_token_cost: 7.5e-6
+      cache_read_input_token_cost: 6e-7
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 2.25e-5
     - region: ap-southeast-1
       cache_creation_input_token_cost: 3.75e-6
-      cache_read_input_token_cost: 3e-7
+      cache_read_input_token_cost: 6e-7
       input_cost_per_token: 3e-6
-      input_cost_per_token_batches: 1.5e-6
-      output_cost_per_token: 1.5e-05
-      output_cost_per_token_batches: 7.5e-6
-    - region: ap-northeast-2
-      cache_creation_input_token_cost: 3.75e-6
-      cache_read_input_token_cost: 3e-7
-      input_cost_per_token: 3e-6
-      input_cost_per_token_batches: 1.5e-6
-      output_cost_per_token: 1.5e-05
-      output_cost_per_token_batches: 7.5e-6
-    - region: ap-northeast-3
-      cache_creation_input_token_cost: 4.125e-6
-      cache_read_input_token_cost: 3.3e-7
-      input_cost_per_token: 3.3e-6
-      input_cost_per_token_batches: 1.65e-6
-      output_cost_per_token: 1.65e-05
-      output_cost_per_token_batches: 8.25e-6
-    - region: ap-south-1
-      cache_creation_input_token_cost: 3.75e-6
-      cache_read_input_token_cost: 3e-7
-      input_cost_per_token: 3e-6
-      input_cost_per_token_batches: 1.5e-6
-      output_cost_per_token: 1.5e-05
-      output_cost_per_token_batches: 7.5e-6
+      output_cost_per_token: 2.25e-5
     - region: ap-south-2
+      cache_creation_input_token_cost: 7.5e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 1.5e-5
+    - region: ap-south-1
+      cache_creation_input_token_cost: 7.5e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 6e-6
+      output_cost_per_token: 2.25e-5
+    - region: ap-northeast-3
+      cache_creation_input_token_cost: 7.5e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 2.25e-5
+    - region: ap-northeast-2
+      cache_creation_input_token_cost: 7.5e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 2.25e-5
+    - region: ap-northeast-1
+      cache_creation_input_token_cost: 3.75e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 6e-6
+      output_cost_per_token: 1.5e-5
+    - region: af-south-1
       cache_creation_input_token_cost: 3.75e-6
       cache_read_input_token_cost: 3e-7
       input_cost_per_token: 3e-6
-      input_cost_per_token_batches: 1.5e-6
-      output_cost_per_token: 1.5e-05
-      output_cost_per_token_batches: 7.5e-6
+      output_cost_per_token: 2.25e-5
 limits:
     max_tokens: 64000
     max_input_tokens: 200000
     max_output_tokens: 64000
     tool_use_system_prompt_tokens: 346
-features: [function_calling, vision]
+features:
+    - function_calling
+    - vision
 mode: chat

--- a/providers/aws-bedrock/global.cohere.embed-v4:0.yaml
+++ b/providers/aws-bedrock/global.cohere.embed-v4:0.yaml
@@ -14,8 +14,6 @@ costs:
       input_cost_per_token: 1.2e-7
     - region: eu-west-2
       input_cost_per_token: 1.2e-7
-    - region: eu-west-1
-      input_cost_per_token: 1.2e-7
     - region: eu-south-2
       input_cost_per_token: 1.2e-7
     - region: eu-south-1

--- a/providers/aws-bedrock/global.cohere.embed-v4:0.yaml
+++ b/providers/aws-bedrock/global.cohere.embed-v4:0.yaml
@@ -1,0 +1,53 @@
+model: global.cohere.embed-v4:0
+costs:
+    - region: us-west-2
+      input_cost_per_token: 1.2e-7
+    - region: us-west-1
+      input_cost_per_token: 1.2e-7
+    - region: us-east-2
+      input_cost_per_token: 1.2e-7
+    - region: us-east-1
+      input_cost_per_token: 1.2e-7
+    - region: sa-east-1
+      input_cost_per_token: 1.2e-7
+    - region: eu-west-3
+      input_cost_per_token: 1.2e-7
+    - region: eu-west-2
+      input_cost_per_token: 1.2e-7
+    - region: eu-west-1
+      input_cost_per_token: 1.2e-7
+    - region: eu-south-2
+      input_cost_per_token: 1.2e-7
+    - region: eu-south-1
+      input_cost_per_token: 1.2e-7
+    - region: eu-north-1
+      input_cost_per_token: 1.2e-7
+    - region: eu-central-2
+      input_cost_per_token: 1.2e-7
+    - region: eu-central-1
+      input_cost_per_token: 1.2e-7
+    - region: ca-central-1
+      input_cost_per_token: 1.2e-7
+    - region: ap-southeast-4
+      input_cost_per_token: 1.2e-7
+    - region: ap-southeast-3
+      input_cost_per_token: 1.2e-7
+    - region: ap-southeast-2
+      input_cost_per_token: 1.2e-7
+    - region: ap-southeast-1
+      input_cost_per_token: 1.2e-7
+    - region: ap-south-2
+      input_cost_per_token: 1.2e-7
+    - region: ap-south-1
+      input_cost_per_token: 1.2e-7
+    - region: ap-northeast-3
+      input_cost_per_token: 1.2e-7
+    - region: ap-northeast-2
+      input_cost_per_token: 1.2e-7
+    - region: ap-northeast-1
+      input_cost_per_token: 1.2e-7
+limits:
+    max_tokens: 128000
+    max_input_tokens: 128000
+    output_vector_size: 1536
+mode: embedding

--- a/providers/aws-bedrock/global.twelvelabs.pegasus-1-2-v1:0.yaml
+++ b/providers/aws-bedrock/global.twelvelabs.pegasus-1-2-v1:0.yaml
@@ -1,59 +1,92 @@
 model: global.twelvelabs.pegasus-1-2-v1:0
 costs:
+    - region: us-west-2
+      input_cost_per_token: 5e-10
+      output_cost_per_token: 7.5e-6
     - region: us-west-1
-      input_cost_per_second: 0.00049
+      input_cost_per_token: 5e-10
       output_cost_per_token: 7.5e-6
     - region: us-east-2
-      input_cost_per_second: 0.00049
+      input_cost_per_token: 5e-10
       output_cost_per_token: 7.5e-6
     - region: us-east-1
-      input_cost_per_second: 0.00049
+      input_cost_per_token: 5e-10
       output_cost_per_token: 7.5e-6
     - region: sa-east-1
-      input_cost_per_second: 0.00049
+      input_cost_per_token: 5e-10
       output_cost_per_token: 7.5e-6
-    - region: eu-central-2
-      input_cost_per_second: 0.00049
+    - region: mx-central-1
+      input_cost_per_token: 5e-10
       output_cost_per_token: 7.5e-6
-    - region: eu-north-1
-      input_cost_per_second: 0.00049
+    - region: me-south-1
+      input_cost_per_token: 5e-10
       output_cost_per_token: 7.5e-6
-    - region: eu-south-2
-      input_cost_per_second: 0.00049
+    - region: me-central-1
+      input_cost_per_token: 5e-10
+      output_cost_per_token: 7.5e-6
+    - region: il-central-1
+      input_cost_per_token: 5e-10
       output_cost_per_token: 7.5e-6
     - region: eu-west-3
-      input_cost_per_second: 0.00049
-      output_cost_per_token: 7.5e-6
-    - region: eu-south-1
-      input_cost_per_second: 0.00049
+      input_cost_per_token: 5e-10
       output_cost_per_token: 7.5e-6
     - region: eu-west-2
-      input_cost_per_second: 0.00049
-      output_cost_per_token: 7.5e-6
-    - region: eu-central-1
-      input_cost_per_second: 0.00049
-      output_cost_per_token: 7.5e-6
-    - region: ca-central-1
-      input_cost_per_second: 0.00049
-      output_cost_per_token: 7.5e-6
-    - region: ap-northeast-1
-      input_cost_per_second: 0.00049
-      output_cost_per_token: 7.5e-6
-    - region: ap-northeast-2
-      input_cost_per_second: 0.00049
-      output_cost_per_token: 7.5e-6
-    - region: ap-northeast-3
-      input_cost_per_second: 0.00049
-      output_cost_per_token: 7.5e-6
-    - region: ap-south-1
-      input_cost_per_second: 0.00049
-      output_cost_per_token: 7.5e-6
-    - region: ap-south-2
-      input_cost_per_second: 0.00049
+      input_cost_per_token: 5e-10
       output_cost_per_token: 7.5e-6
     - region: eu-west-1
-      input_cost_per_second: 0.00049
+      input_cost_per_token: 5e-10
       output_cost_per_token: 7.5e-6
-    - region: us-west-2
-      input_cost_per_second: 0.00049
+    - region: eu-south-2
+      input_cost_per_token: 5e-10
+      output_cost_per_token: 7.5e-6
+    - region: eu-south-1
+      input_cost_per_token: 5e-10
+      output_cost_per_token: 7.5e-6
+    - region: eu-north-1
+      input_cost_per_token: 5e-10
+      output_cost_per_token: 7.5e-6
+    - region: eu-central-2
+      input_cost_per_token: 5e-10
+      output_cost_per_token: 7.5e-6
+    - region: eu-central-1
+      input_cost_per_token: 5e-10
+      output_cost_per_token: 7.5e-6
+    - region: ca-west-1
+      input_cost_per_token: 5e-10
+      output_cost_per_token: 7.5e-6
+    - region: ca-central-1
+      input_cost_per_token: 5e-10
+      output_cost_per_token: 7.5e-6
+    - region: ap-southeast-7
+      input_cost_per_token: 5e-10
+      output_cost_per_token: 7.5e-6
+    - region: ap-southeast-5
+      input_cost_per_token: 5e-10
+      output_cost_per_token: 7.5e-6
+    - region: ap-southeast-4
+      input_cost_per_token: 5e-10
+      output_cost_per_token: 7.5e-6
+    - region: ap-southeast-3
+      input_cost_per_token: 5e-10
+      output_cost_per_token: 7.5e-6
+    - region: ap-south-2
+      input_cost_per_token: 5e-10
+      output_cost_per_token: 7.5e-6
+    - region: ap-south-1
+      input_cost_per_token: 5e-10
+      output_cost_per_token: 7.5e-6
+    - region: ap-northeast-3
+      input_cost_per_token: 5e-10
+      output_cost_per_token: 7.5e-6
+    - region: ap-northeast-2
+      input_cost_per_token: 5e-10
+      output_cost_per_token: 7.5e-6
+    - region: ap-northeast-1
+      input_cost_per_token: 5e-10
+      output_cost_per_token: 7.5e-6
+    - region: ap-east-2
+      input_cost_per_token: 5e-10
+      output_cost_per_token: 7.5e-6
+    - region: af-south-1
+      input_cost_per_token: 5e-10
       output_cost_per_token: 7.5e-6

--- a/providers/aws-bedrock/global.twelvelabs.pegasus-1-2-v1:0.yaml
+++ b/providers/aws-bedrock/global.twelvelabs.pegasus-1-2-v1:0.yaml
@@ -90,3 +90,6 @@ costs:
     - region: af-south-1
       input_cost_per_token: 5e-10
       output_cost_per_token: 7.5e-6
+limits:
+    max_tokens: 4096
+mode: chat

--- a/providers/aws-bedrock/global.twelvelabs.pegasus-1-2-v1:0.yaml
+++ b/providers/aws-bedrock/global.twelvelabs.pegasus-1-2-v1:0.yaml
@@ -1,94 +1,94 @@
 model: global.twelvelabs.pegasus-1-2-v1:0
 costs:
     - region: us-west-2
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
     - region: us-west-1
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
     - region: us-east-2
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
     - region: us-east-1
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
     - region: sa-east-1
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
     - region: mx-central-1
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
     - region: me-south-1
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
     - region: me-central-1
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
     - region: il-central-1
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
     - region: eu-west-3
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
     - region: eu-west-2
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
     - region: eu-west-1
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
     - region: eu-south-2
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
     - region: eu-south-1
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
     - region: eu-north-1
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
     - region: eu-central-2
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
     - region: eu-central-1
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
     - region: ca-west-1
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
     - region: ca-central-1
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
     - region: ap-southeast-7
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
     - region: ap-southeast-5
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
     - region: ap-southeast-4
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
     - region: ap-southeast-3
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
     - region: ap-south-2
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
     - region: ap-south-1
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
     - region: ap-northeast-3
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
     - region: ap-northeast-2
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
     - region: ap-northeast-1
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
     - region: ap-east-2
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
     - region: af-south-1
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
 limits:
     max_tokens: 4096

--- a/providers/aws-bedrock/google.gemma-3-12b-it.yaml
+++ b/providers/aws-bedrock/google.gemma-3-12b-it.yaml
@@ -1,11 +1,36 @@
 model: google.gemma-3-12b-it
 costs:
-    - region: "*"
-      input_cost_per_token: 9.e-8
+    - region: us-west-2
+      input_cost_per_token: 9e-8
       output_cost_per_token: 2.9e-7
+    - region: us-east-2
+      input_cost_per_token: 9e-8
+      output_cost_per_token: 2.9e-7
+    - region: us-east-1
+      input_cost_per_token: 9e-8
+      output_cost_per_token: 2.9e-7
+    - region: sa-east-1
+      input_cost_per_token: 1.1e-7
+      output_cost_per_token: 3.5e-7
+    - region: eu-west-2
+      input_cost_per_token: 1.4e-7
+      output_cost_per_token: 4.5e-7
+    - region: eu-west-1
+      input_cost_per_token: 1.1e-7
+      output_cost_per_token: 3.4e-7
+    - region: eu-south-1
+      input_cost_per_token: 1.1e-7
+      output_cost_per_token: 3.4e-7
+    - region: ap-south-1
+      input_cost_per_token: 1.1e-7
+      output_cost_per_token: 3.4e-7
+    - region: ap-northeast-1
+      input_cost_per_token: 1.1e-7
+      output_cost_per_token: 3.5e-7
 limits:
     max_tokens: 8192
     max_input_tokens: 128000
     max_output_tokens: 8192
-features: [vision]
+features:
+    - vision
 mode: chat

--- a/providers/aws-bedrock/google.gemma-3-27b-it.yaml
+++ b/providers/aws-bedrock/google.gemma-3-27b-it.yaml
@@ -7,14 +7,11 @@ costs:
       input_cost_per_token: 2.3e-7
       output_cost_per_token: 3.8e-7
     - region: us-east-1
-      input_cost_per_token: 1.5e-7
-      output_cost_per_token: 2e-7
+      input_cost_per_token: 2.3e-7
+      output_cost_per_token: 3.8e-7
     - region: sa-east-1
       input_cost_per_token: 2.8e-7
       output_cost_per_token: 4.6e-7
-    - region: eu-west-3
-      input_cost_per_token: 2e-7
-      output_cost_per_token: 2.6e-7
     - region: eu-west-2
       input_cost_per_token: 3.6e-7
       output_cost_per_token: 5.9e-7
@@ -24,15 +21,9 @@ costs:
     - region: eu-south-1
       input_cost_per_token: 2.7e-7
       output_cost_per_token: 4.5e-7
-    - region: ca-central-1
-      input_cost_per_token: 1.7e-7
-      output_cost_per_token: 2.3e-7
-    - region: ap-southeast-2
-      input_cost_per_token: 2e-7
-      output_cost_per_token: 2.6e-7
     - region: ap-south-1
-      input_cost_per_token: 1.8e-7
-      output_cost_per_token: 2.4e-7
+      input_cost_per_token: 2.7e-7
+      output_cost_per_token: 4.5e-7
     - region: ap-northeast-1
       input_cost_per_token: 2.8e-7
       output_cost_per_token: 4.6e-7

--- a/providers/aws-bedrock/google.gemma-3-27b-it.yaml
+++ b/providers/aws-bedrock/google.gemma-3-27b-it.yaml
@@ -1,11 +1,45 @@
 model: google.gemma-3-27b-it
 costs:
-    - region: "*"
+    - region: us-west-2
       input_cost_per_token: 2.3e-7
       output_cost_per_token: 3.8e-7
+    - region: us-east-2
+      input_cost_per_token: 2.3e-7
+      output_cost_per_token: 3.8e-7
+    - region: us-east-1
+      input_cost_per_token: 1.5e-7
+      output_cost_per_token: 2e-7
+    - region: sa-east-1
+      input_cost_per_token: 2.8e-7
+      output_cost_per_token: 4.6e-7
+    - region: eu-west-3
+      input_cost_per_token: 2e-7
+      output_cost_per_token: 2.6e-7
+    - region: eu-west-2
+      input_cost_per_token: 3.6e-7
+      output_cost_per_token: 5.9e-7
+    - region: eu-west-1
+      input_cost_per_token: 2.7e-7
+      output_cost_per_token: 4.5e-7
+    - region: eu-south-1
+      input_cost_per_token: 2.7e-7
+      output_cost_per_token: 4.5e-7
+    - region: ca-central-1
+      input_cost_per_token: 1.7e-7
+      output_cost_per_token: 2.3e-7
+    - region: ap-southeast-2
+      input_cost_per_token: 2e-7
+      output_cost_per_token: 2.6e-7
+    - region: ap-south-1
+      input_cost_per_token: 1.8e-7
+      output_cost_per_token: 2.4e-7
+    - region: ap-northeast-1
+      input_cost_per_token: 2.8e-7
+      output_cost_per_token: 4.6e-7
 limits:
     max_tokens: 8192
     max_input_tokens: 128000
     max_output_tokens: 8192
-features: [vision]
+features:
+    - vision
 mode: chat

--- a/providers/aws-bedrock/google.gemma-3-4b-it.yaml
+++ b/providers/aws-bedrock/google.gemma-3-4b-it.yaml
@@ -1,11 +1,36 @@
 model: google.gemma-3-4b-it
 costs:
-    - region: "*"
-      input_cost_per_token: 4.e-8
-      output_cost_per_token: 8.e-8
+    - region: us-west-2
+      input_cost_per_token: 4e-8
+      output_cost_per_token: 8e-8
+    - region: us-east-2
+      input_cost_per_token: 4e-8
+      output_cost_per_token: 8e-8
+    - region: us-east-1
+      input_cost_per_token: 4e-8
+      output_cost_per_token: 8e-8
+    - region: sa-east-1
+      input_cost_per_token: 5e-8
+      output_cost_per_token: 1e-7
+    - region: eu-west-2
+      input_cost_per_token: 6e-8
+      output_cost_per_token: 1.2e-7
+    - region: eu-west-1
+      input_cost_per_token: 5e-8
+      output_cost_per_token: 9e-8
+    - region: eu-south-1
+      input_cost_per_token: 5e-8
+      output_cost_per_token: 9e-8
+    - region: ap-south-1
+      input_cost_per_token: 5e-8
+      output_cost_per_token: 9e-8
+    - region: ap-northeast-1
+      input_cost_per_token: 5e-8
+      output_cost_per_token: 1e-7
 limits:
     max_tokens: 8192
     max_input_tokens: 128000
     max_output_tokens: 8192
-features: [vision]
+features:
+    - vision
 mode: chat

--- a/providers/aws-bedrock/jp.amazon.nova-2-lite-v1:0.yaml
+++ b/providers/aws-bedrock/jp.amazon.nova-2-lite-v1:0.yaml
@@ -1,6 +1,6 @@
 model: jp.amazon.nova-2-lite-v1:0
 costs:
     - region: ap-northeast-1
-      input_cost_per_query: 0.03
-      input_cost_per_token: 1.98e-7
-      output_cost_per_token: 1.6555e-6
+      cache_read_input_token_cost: 9e-8
+      input_cost_per_token: 3.6e-7
+      output_cost_per_token: 3.01e-6

--- a/providers/aws-bedrock/jp.amazon.nova-2-lite-v1:0.yaml
+++ b/providers/aws-bedrock/jp.amazon.nova-2-lite-v1:0.yaml
@@ -8,5 +8,7 @@ limits:
     max_tokens: 64000
     max_input_tokens: 1000000
     max_output_tokens: 64000
-features: [function_calling, vision]
+features:
+    - function_calling
+    - vision
 mode: chat

--- a/providers/aws-bedrock/jp.amazon.nova-2-lite-v1:0.yaml
+++ b/providers/aws-bedrock/jp.amazon.nova-2-lite-v1:0.yaml
@@ -4,3 +4,9 @@ costs:
       cache_read_input_token_cost: 9e-8
       input_cost_per_token: 3.6e-7
       output_cost_per_token: 3.01e-6
+limits:
+    max_tokens: 64000
+    max_input_tokens: 1000000
+    max_output_tokens: 64000
+features: [function_calling, vision]
+mode: chat

--- a/providers/aws-bedrock/jp.anthropic.claude-haiku-4-5-20251001-v1:0.yaml
+++ b/providers/aws-bedrock/jp.anthropic.claude-haiku-4-5-20251001-v1:0.yaml
@@ -1,23 +1,21 @@
 model: jp.anthropic.claude-haiku-4-5-20251001-v1:0
 costs:
-    - region: ap-northeast-1
-      cache_creation_input_token_cost: 1.25e-6
-      cache_read_input_token_cost: 1e-7
-      input_cost_per_token: 1e-6
-      input_cost_per_token_batches: 5e-7
-      output_cost_per_token: 5e-6
-      output_cost_per_token_batches: 2.5e-6
     - region: ap-northeast-3
       cache_creation_input_token_cost: 1.25e-6
       cache_read_input_token_cost: 1e-7
       input_cost_per_token: 1e-6
-      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 5e-6
-      output_cost_per_token_batches: 2.5e-6
+    - region: ap-northeast-1
+      cache_creation_input_token_cost: 1.25e-6
+      cache_read_input_token_cost: 1e-7
+      input_cost_per_token: 1e-6
+      output_cost_per_token: 5e-6
 limits:
     max_tokens: 64000
     max_input_tokens: 200000
     max_output_tokens: 64000
     tool_use_system_prompt_tokens: 346
-features: [function_calling, vision]
+features:
+    - function_calling
+    - vision
 mode: chat

--- a/providers/aws-bedrock/jp.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
+++ b/providers/aws-bedrock/jp.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
@@ -1,23 +1,21 @@
 model: jp.anthropic.claude-sonnet-4-5-20250929-v1:0
 costs:
-    - region: ap-northeast-1
-      cache_creation_input_token_cost: 4.125e-6
-      cache_read_input_token_cost: 3.3e-7
-      input_cost_per_token: 3.3e-6
-      input_cost_per_token_batches: 1.65e-6
-      output_cost_per_token: 1.65e-05
-      output_cost_per_token_batches: 8.25e-6
     - region: ap-northeast-3
-      cache_creation_input_token_cost: 4.125e-6
-      cache_read_input_token_cost: 3.3e-7
-      input_cost_per_token: 3.3e-6
-      input_cost_per_token_batches: 1.65e-6
-      output_cost_per_token: 1.65e-05
-      output_cost_per_token_batches: 8.25e-6
+      cache_creation_input_token_cost: 7.5e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 2.25e-5
+    - region: ap-northeast-1
+      cache_creation_input_token_cost: 3.75e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 6e-6
+      output_cost_per_token: 1.5e-5
 limits:
     max_tokens: 64000
     max_input_tokens: 200000
     max_output_tokens: 64000
     tool_use_system_prompt_tokens: 346
-features: [function_calling, vision]
+features:
+    - function_calling
+    - vision
 mode: chat

--- a/providers/aws-bedrock/luma.ray-v2:0.yaml
+++ b/providers/aws-bedrock/luma.ray-v2:0.yaml
@@ -3,3 +3,4 @@ costs:
     - region: us-west-2
       input_cost_per_second: 1.5
       input_cost_per_token: 1.5e-6
+mode: video

--- a/providers/aws-bedrock/luma.ray-v2:0.yaml
+++ b/providers/aws-bedrock/luma.ray-v2:0.yaml
@@ -1,6 +1,6 @@
 model: luma.ray-v2:0
 costs:
     - region: us-west-2
-      input_cost_per_second: 1.5
       input_cost_per_token: 1.5e-6
+      output_cost_per_second: 1.5
 mode: video

--- a/providers/aws-bedrock/luma.ray-v2:0.yaml
+++ b/providers/aws-bedrock/luma.ray-v2:0.yaml
@@ -1,4 +1,5 @@
 model: luma.ray-v2:0
 costs:
     - region: us-west-2
-      output_cost_per_second: 0.75
+      input_cost_per_second: 1.5
+      input_cost_per_token: 1.5e-6

--- a/providers/aws-bedrock/meta.llama2-13b-chat-v1.yaml
+++ b/providers/aws-bedrock/meta.llama2-13b-chat-v1.yaml
@@ -1,12 +1,16 @@
 model: meta.llama2-13b-chat-v1
 costs:
-    - region: "*"
+    - region: us-west-2
       input_cost_per_token: 7.5e-7
-      output_cost_per_token: 0.000001
+      output_cost_per_token: 1e-6
+    - region: us-east-1
+      input_cost_per_token: 7.5e-7
+      output_cost_per_token: 1e-6
 limits:
     max_tokens: 4096
     max_input_tokens: 4096
     max_output_tokens: 4096
-features: [chat]
+features:
+    - chat
 mode: chat
 isDeprecated: true

--- a/providers/aws-bedrock/meta.llama2-70b-chat-v1.yaml
+++ b/providers/aws-bedrock/meta.llama2-70b-chat-v1.yaml
@@ -1,12 +1,16 @@
 model: meta.llama2-70b-chat-v1
 costs:
-    - region: "*"
-      input_cost_per_token: 0.00000195
-      output_cost_per_token: 0.00000256
+    - region: us-west-2
+      input_cost_per_token: 1.95e-6
+      output_cost_per_token: 2.56e-6
+    - region: us-east-1
+      input_cost_per_token: 1.95e-6
+      output_cost_per_token: 2.56e-6
 limits:
     max_tokens: 4096
     max_input_tokens: 4096
     max_output_tokens: 4096
-features: [chat]
+features:
+    - chat
 mode: chat
 isDeprecated: true

--- a/providers/aws-bedrock/meta.llama3-1-405b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/meta.llama3-1-405b-instruct-v1:0.yaml
@@ -13,3 +13,9 @@ costs:
     - region: us-east-1
       input_cost_per_token_batches: 1.2e-6
       output_cost_per_token_batches: 1.2e-6
+limits:
+    max_tokens: 4096
+    max_input_tokens: 128000
+    max_output_tokens: 4096
+features: [function_calling, chat]
+mode: chat

--- a/providers/aws-bedrock/meta.llama3-1-70b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/meta.llama3-1-70b-instruct-v1:0.yaml
@@ -15,3 +15,9 @@ costs:
       input_cost_per_token_batches: 3.6e-7
       output_cost_per_token: 7.2e-7
       output_cost_per_token_batches: 3.6e-7
+limits:
+    max_tokens: 4096
+    max_input_tokens: 128000
+    max_output_tokens: 4096
+features: [function_calling, chat]
+mode: chat

--- a/providers/aws-bedrock/meta.llama3-1-8b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/meta.llama3-1-8b-instruct-v1:0.yaml
@@ -15,3 +15,9 @@ costs:
       input_cost_per_token_batches: 1.1e-7
       output_cost_per_token: 2.2e-7
       output_cost_per_token_batches: 1.1e-7
+limits:
+    max_tokens: 4096
+    max_input_tokens: 128000
+    max_output_tokens: 4096
+features: [function_calling, chat]
+mode: chat

--- a/providers/aws-bedrock/meta.llama3-2-11b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/meta.llama3-2-11b-instruct-v1:0.yaml
@@ -11,3 +11,9 @@ costs:
     - region: us-east-1
       input_cost_per_token: 1.6e-7
       output_cost_per_token: 1.6e-7
+limits:
+    max_tokens: 4096
+    max_input_tokens: 128000
+    max_output_tokens: 4096
+features: [function_calling, vision]
+mode: chat

--- a/providers/aws-bedrock/meta.llama3-2-1b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/meta.llama3-2-1b-instruct-v1:0.yaml
@@ -22,3 +22,9 @@ costs:
       input_cost_per_token_batches: 6.5e-8
       output_cost_per_token: 1.3e-7
       output_cost_per_token_batches: 6.5e-8
+limits:
+    max_tokens: 4096
+    max_input_tokens: 128000
+    max_output_tokens: 4096
+features: [function_calling, chat]
+mode: chat

--- a/providers/aws-bedrock/meta.llama3-2-3b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/meta.llama3-2-3b-instruct-v1:0.yaml
@@ -22,3 +22,9 @@ costs:
       input_cost_per_token_batches: 9.5e-8
       output_cost_per_token: 1.9e-7
       output_cost_per_token_batches: 9.5e-8
+limits:
+    max_tokens: 4096
+    max_input_tokens: 128000
+    max_output_tokens: 4096
+features: [function_calling, chat]
+mode: chat

--- a/providers/aws-bedrock/meta.llama3-2-90b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/meta.llama3-2-90b-instruct-v1:0.yaml
@@ -11,3 +11,9 @@ costs:
     - region: us-east-1
       input_cost_per_token: 7.2e-7
       output_cost_per_token: 7.2e-7
+limits:
+    max_tokens: 4096
+    max_input_tokens: 128000
+    max_output_tokens: 4096
+features: [function_calling, vision]
+mode: chat

--- a/providers/aws-bedrock/meta.llama3-3-70b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/meta.llama3-3-70b-instruct-v1:0.yaml
@@ -15,3 +15,9 @@ costs:
       input_cost_per_token_batches: 3.6e-7
       output_cost_per_token: 7.2e-7
       output_cost_per_token_batches: 3.6e-7
+limits:
+    max_tokens: 4096
+    max_input_tokens: 128000
+    max_output_tokens: 4096
+features: [function_calling, chat]
+mode: chat

--- a/providers/aws-bedrock/meta.llama3-70b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/meta.llama3-70b-instruct-v1:0.yaml
@@ -21,3 +21,8 @@ costs:
     - region: ap-south-1
       input_cost_per_token: 3.18e-6
       output_cost_per_token: 4.2e-6
+limits:
+    max_tokens: 2048
+    max_input_tokens: 8192
+    max_output_tokens: 2048
+mode: chat

--- a/providers/aws-bedrock/meta.llama3-70b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/meta.llama3-70b-instruct-v1:0.yaml
@@ -3,6 +3,9 @@ costs:
     - region: us-west-2
       input_cost_per_token: 2.65e-6
       output_cost_per_token: 3.5e-6
+    - region: us-gov-west-1
+      input_cost_per_token: 2.65e-6
+      output_cost_per_token: 3.5e-6
     - region: us-east-1
       input_cost_per_token: 2.65e-6
       output_cost_per_token: 3.5e-6
@@ -18,6 +21,3 @@ costs:
     - region: ap-south-1
       input_cost_per_token: 3.18e-6
       output_cost_per_token: 4.2e-6
-    - region: us-gov-west-1
-      input_cost_per_token: 2.65e-6
-      output_cost_per_token: 3.5e-6

--- a/providers/aws-bedrock/meta.llama3-8b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/meta.llama3-8b-instruct-v1:0.yaml
@@ -21,3 +21,8 @@ costs:
     - region: ap-south-1
       input_cost_per_token: 3.6e-7
       output_cost_per_token: 7.2e-7
+limits:
+    max_tokens: 2048
+    max_input_tokens: 8192
+    max_output_tokens: 2048
+mode: chat

--- a/providers/aws-bedrock/meta.llama3-8b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/meta.llama3-8b-instruct-v1:0.yaml
@@ -3,6 +3,9 @@ costs:
     - region: us-west-2
       input_cost_per_token: 3e-7
       output_cost_per_token: 6e-7
+    - region: us-gov-west-1
+      input_cost_per_token: 3e-7
+      output_cost_per_token: 6e-7
     - region: us-east-1
       input_cost_per_token: 3e-7
       output_cost_per_token: 6e-7
@@ -18,6 +21,3 @@ costs:
     - region: ap-south-1
       input_cost_per_token: 3.6e-7
       output_cost_per_token: 7.2e-7
-    - region: us-gov-west-1
-      input_cost_per_token: 3e-7
-      output_cost_per_token: 6e-7

--- a/providers/aws-bedrock/meta.llama4-maverick-17b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/meta.llama4-maverick-17b-instruct-v1:0.yaml
@@ -20,3 +20,9 @@ costs:
       input_cost_per_token_batches: 1.2e-7
       output_cost_per_token: 9.7e-7
       output_cost_per_token_batches: 4.85e-7
+limits:
+    max_tokens: 16384
+    max_input_tokens: 1048576
+    max_output_tokens: 16384
+features: [function_calling, vision]
+mode: chat

--- a/providers/aws-bedrock/meta.llama4-scout-17b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/meta.llama4-scout-17b-instruct-v1:0.yaml
@@ -20,3 +20,9 @@ costs:
       input_cost_per_token_batches: 8.5e-8
       output_cost_per_token: 6.6e-7
       output_cost_per_token_batches: 3.3e-7
+limits:
+    max_tokens: 16384
+    max_input_tokens: 1048576
+    max_output_tokens: 16384
+features: [function_calling, vision]
+mode: chat

--- a/providers/aws-bedrock/minimax.minimax-m2.yaml
+++ b/providers/aws-bedrock/minimax.minimax-m2.yaml
@@ -1,8 +1,32 @@
 model: minimax.minimax-m2
 costs:
-    - region: "*"
-      input_cost_per_token: 3.e-7
-      output_cost_per_token: 0.0000012
+    - region: us-west-2
+      input_cost_per_token: 3e-7
+      output_cost_per_token: 1.2e-6
+    - region: us-east-2
+      input_cost_per_token: 3e-7
+      output_cost_per_token: 1.2e-6
+    - region: us-east-1
+      input_cost_per_token: 3e-7
+      output_cost_per_token: 1.2e-6
+    - region: sa-east-1
+      input_cost_per_token: 3.6e-7
+      output_cost_per_token: 1.45e-6
+    - region: eu-west-2
+      input_cost_per_token: 4.7e-7
+      output_cost_per_token: 1.86e-6
+    - region: eu-west-1
+      input_cost_per_token: 3.5e-7
+      output_cost_per_token: 1.41e-6
+    - region: eu-south-1
+      input_cost_per_token: 3.5e-7
+      output_cost_per_token: 1.41e-6
+    - region: ap-south-1
+      input_cost_per_token: 3.5e-7
+      output_cost_per_token: 1.41e-6
+    - region: ap-northeast-1
+      input_cost_per_token: 3.6e-7
+      output_cost_per_token: 1.45e-6
 limits:
     max_tokens: 8192
     max_input_tokens: 128000

--- a/providers/aws-bedrock/mistral.magistral-small-2509.yaml
+++ b/providers/aws-bedrock/mistral.magistral-small-2509.yaml
@@ -1,11 +1,36 @@
 model: mistral.magistral-small-2509
 costs:
-    - region: "*"
-      input_cost_per_token: 5.e-7
-      output_cost_per_token: 0.0000015
+    - region: us-west-2
+      input_cost_per_token: 5e-7
+      output_cost_per_token: 1.5e-6
+    - region: us-east-2
+      input_cost_per_token: 5e-7
+      output_cost_per_token: 1.5e-6
+    - region: us-east-1
+      input_cost_per_token: 5e-7
+      output_cost_per_token: 1.5e-6
+    - region: sa-east-1
+      input_cost_per_token: 6.1e-7
+      output_cost_per_token: 1.82e-6
+    - region: eu-west-2
+      input_cost_per_token: 7.8e-7
+      output_cost_per_token: 2.33e-6
+    - region: eu-west-1
+      input_cost_per_token: 5.9e-7
+      output_cost_per_token: 1.76e-6
+    - region: eu-south-1
+      input_cost_per_token: 5.9e-7
+      output_cost_per_token: 1.76e-6
+    - region: ap-south-1
+      input_cost_per_token: 5.9e-7
+      output_cost_per_token: 1.76e-6
+    - region: ap-northeast-1
+      input_cost_per_token: 6.1e-7
+      output_cost_per_token: 1.82e-6
 limits:
     max_tokens: 8192
     max_input_tokens: 128000
     max_output_tokens: 8192
-features: [function_calling]
+features:
+    - function_calling
 mode: chat

--- a/providers/aws-bedrock/mistral.ministral-3-14b-instruct.yaml
+++ b/providers/aws-bedrock/mistral.ministral-3-14b-instruct.yaml
@@ -1,11 +1,36 @@
 model: mistral.ministral-3-14b-instruct
 costs:
-    - region: "*"
-      input_cost_per_token: 2.e-7
-      output_cost_per_token: 2.e-7
+    - region: us-west-2
+      input_cost_per_token: 1.5e-7
+      output_cost_per_token: 1.5e-7
+    - region: us-east-2
+      input_cost_per_token: 1.5e-7
+      output_cost_per_token: 1.5e-7
+    - region: us-east-1
+      input_cost_per_token: 1.5e-7
+      output_cost_per_token: 1.5e-7
+    - region: sa-east-1
+      input_cost_per_token: 2.4e-7
+      output_cost_per_token: 2.4e-7
+    - region: eu-west-2
+      input_cost_per_token: 2.3e-7
+      output_cost_per_token: 2.3e-7
+    - region: eu-west-1
+      input_cost_per_token: 2.3e-7
+      output_cost_per_token: 2.3e-7
+    - region: eu-south-1
+      input_cost_per_token: 1.8e-7
+      output_cost_per_token: 1.8e-7
+    - region: ap-south-1
+      input_cost_per_token: 2.4e-7
+      output_cost_per_token: 2.4e-7
+    - region: ap-northeast-1
+      input_cost_per_token: 2.4e-7
+      output_cost_per_token: 2.4e-7
 limits:
     max_tokens: 8192
     max_input_tokens: 128000
     max_output_tokens: 8192
-features: [function_calling]
+features:
+    - function_calling
 mode: chat

--- a/providers/aws-bedrock/mistral.ministral-3-14b-instruct.yaml
+++ b/providers/aws-bedrock/mistral.ministral-3-14b-instruct.yaml
@@ -1,26 +1,26 @@
 model: mistral.ministral-3-14b-instruct
 costs:
     - region: us-west-2
-      input_cost_per_token: 1.5e-7
-      output_cost_per_token: 1.5e-7
+      input_cost_per_token: 2e-7
+      output_cost_per_token: 2e-7
     - region: us-east-2
-      input_cost_per_token: 1.5e-7
-      output_cost_per_token: 1.5e-7
+      input_cost_per_token: 2e-7
+      output_cost_per_token: 2e-7
     - region: us-east-1
-      input_cost_per_token: 1.5e-7
-      output_cost_per_token: 1.5e-7
+      input_cost_per_token: 2e-7
+      output_cost_per_token: 2e-7
     - region: sa-east-1
       input_cost_per_token: 2.4e-7
       output_cost_per_token: 2.4e-7
     - region: eu-west-2
-      input_cost_per_token: 2.3e-7
-      output_cost_per_token: 2.3e-7
+      input_cost_per_token: 3.1e-7
+      output_cost_per_token: 3.1e-7
     - region: eu-west-1
       input_cost_per_token: 2.3e-7
       output_cost_per_token: 2.3e-7
     - region: eu-south-1
-      input_cost_per_token: 1.8e-7
-      output_cost_per_token: 1.8e-7
+      input_cost_per_token: 2.3e-7
+      output_cost_per_token: 2.3e-7
     - region: ap-south-1
       input_cost_per_token: 2.4e-7
       output_cost_per_token: 2.4e-7

--- a/providers/aws-bedrock/mistral.ministral-3-3b-instruct.yaml
+++ b/providers/aws-bedrock/mistral.ministral-3-3b-instruct.yaml
@@ -1,11 +1,36 @@
 model: mistral.ministral-3-3b-instruct
 costs:
-    - region: "*"
-      input_cost_per_token: 1.e-7
-      output_cost_per_token: 1.e-7
+    - region: us-west-2
+      input_cost_per_token: 1e-7
+      output_cost_per_token: 1e-7
+    - region: us-east-2
+      input_cost_per_token: 1e-7
+      output_cost_per_token: 1e-7
+    - region: us-east-1
+      input_cost_per_token: 1e-7
+      output_cost_per_token: 1e-7
+    - region: sa-east-1
+      input_cost_per_token: 1.2e-7
+      output_cost_per_token: 1.2e-7
+    - region: eu-west-2
+      input_cost_per_token: 1.6e-7
+      output_cost_per_token: 1.6e-7
+    - region: eu-west-1
+      input_cost_per_token: 1.2e-7
+      output_cost_per_token: 1.2e-7
+    - region: eu-south-1
+      input_cost_per_token: 1.2e-7
+      output_cost_per_token: 1.2e-7
+    - region: ap-south-1
+      input_cost_per_token: 1.2e-7
+      output_cost_per_token: 1.2e-7
+    - region: ap-northeast-1
+      input_cost_per_token: 1.2e-7
+      output_cost_per_token: 1.2e-7
 limits:
     max_tokens: 8192
     max_input_tokens: 128000
     max_output_tokens: 8192
-features: [function_calling]
+features:
+    - function_calling
 mode: chat

--- a/providers/aws-bedrock/mistral.ministral-3-8b-instruct.yaml
+++ b/providers/aws-bedrock/mistral.ministral-3-8b-instruct.yaml
@@ -1,11 +1,36 @@
 model: mistral.ministral-3-8b-instruct
 costs:
-    - region: "*"
+    - region: us-west-2
       input_cost_per_token: 1.5e-7
       output_cost_per_token: 1.5e-7
+    - region: us-east-2
+      input_cost_per_token: 1.5e-7
+      output_cost_per_token: 1.5e-7
+    - region: us-east-1
+      input_cost_per_token: 1.5e-7
+      output_cost_per_token: 1.5e-7
+    - region: sa-east-1
+      input_cost_per_token: 1.8e-7
+      output_cost_per_token: 1.8e-7
+    - region: eu-west-2
+      input_cost_per_token: 2.3e-7
+      output_cost_per_token: 2.3e-7
+    - region: eu-west-1
+      input_cost_per_token: 1.8e-7
+      output_cost_per_token: 1.8e-7
+    - region: eu-south-1
+      input_cost_per_token: 1.8e-7
+      output_cost_per_token: 1.8e-7
+    - region: ap-south-1
+      input_cost_per_token: 1.8e-7
+      output_cost_per_token: 1.8e-7
+    - region: ap-northeast-1
+      input_cost_per_token: 1.8e-7
+      output_cost_per_token: 1.8e-7
 limits:
     max_tokens: 8192
     max_input_tokens: 128000
     max_output_tokens: 8192
-features: [function_calling]
+features:
+    - function_calling
 mode: chat

--- a/providers/aws-bedrock/mistral.mistral-7b-instruct-v0:2.yaml
+++ b/providers/aws-bedrock/mistral.mistral-7b-instruct-v0:2.yaml
@@ -27,3 +27,8 @@ costs:
     - region: ap-south-1
       input_cost_per_token: 1.8e-7
       output_cost_per_token: 2.4e-7
+limits:
+    max_tokens: 8192
+    max_input_tokens: 32000
+    max_output_tokens: 8192
+mode: chat

--- a/providers/aws-bedrock/mistral.mistral-large-2402-v1:0.yaml
+++ b/providers/aws-bedrock/mistral.mistral-large-2402-v1:0.yaml
@@ -27,3 +27,9 @@ costs:
     - region: ap-south-1
       input_cost_per_token: 4.8e-6
       output_cost_per_token: 1.44e-5
+limits:
+    max_tokens: 8192
+    max_input_tokens: 32000
+    max_output_tokens: 8192
+features: [function_calling]
+mode: chat

--- a/providers/aws-bedrock/mistral.mistral-large-2402-v1:0.yaml
+++ b/providers/aws-bedrock/mistral.mistral-large-2402-v1:0.yaml
@@ -2,28 +2,28 @@ model: mistral.mistral-large-2402-v1:0
 costs:
     - region: us-west-2
       input_cost_per_token: 4e-6
-      output_cost_per_token: 1.2e-05
+      output_cost_per_token: 1.2e-5
     - region: us-east-1
       input_cost_per_token: 4e-6
-      output_cost_per_token: 1.2e-05
+      output_cost_per_token: 1.2e-5
     - region: sa-east-1
       input_cost_per_token: 6.7e-6
-      output_cost_per_token: 2.02e-05
+      output_cost_per_token: 2.02e-5
     - region: eu-west-3
       input_cost_per_token: 5.2e-6
-      output_cost_per_token: 1.56e-05
+      output_cost_per_token: 1.56e-5
     - region: eu-west-2
       input_cost_per_token: 5.2e-6
-      output_cost_per_token: 1.56e-05
+      output_cost_per_token: 1.56e-5
     - region: eu-west-1
       input_cost_per_token: 4.3e-6
-      output_cost_per_token: 1.3e-05
+      output_cost_per_token: 1.3e-5
     - region: ca-central-1
       input_cost_per_token: 4.6e-6
-      output_cost_per_token: 1.38e-05
+      output_cost_per_token: 1.38e-5
     - region: ap-southeast-2
       input_cost_per_token: 5.2e-6
-      output_cost_per_token: 1.56e-05
+      output_cost_per_token: 1.56e-5
     - region: ap-south-1
       input_cost_per_token: 4.8e-6
-      output_cost_per_token: 1.44e-05
+      output_cost_per_token: 1.44e-5

--- a/providers/aws-bedrock/mistral.mistral-large-2402-v1:0.yaml
+++ b/providers/aws-bedrock/mistral.mistral-large-2402-v1:0.yaml
@@ -31,5 +31,6 @@ limits:
     max_tokens: 8192
     max_input_tokens: 32000
     max_output_tokens: 8192
-features: [function_calling]
+features:
+    - function_calling
 mode: chat

--- a/providers/aws-bedrock/mistral.mistral-large-2407-v1:0.yaml
+++ b/providers/aws-bedrock/mistral.mistral-large-2407-v1:0.yaml
@@ -3,3 +3,9 @@ costs:
     - region: us-west-2
       input_cost_per_token: 2e-6
       output_cost_per_token: 6e-6
+limits:
+    max_tokens: 8192
+    max_input_tokens: 128000
+    max_output_tokens: 8192
+features: [function_calling]
+mode: chat

--- a/providers/aws-bedrock/mistral.mistral-large-2407-v1:0.yaml
+++ b/providers/aws-bedrock/mistral.mistral-large-2407-v1:0.yaml
@@ -2,6 +2,4 @@ model: mistral.mistral-large-2407-v1:0
 costs:
     - region: us-west-2
       input_cost_per_token: 2e-6
-      input_cost_per_token_batches: 1.5e-6
       output_cost_per_token: 6e-6
-      output_cost_per_token_batches: 4.5e-6

--- a/providers/aws-bedrock/mistral.mistral-large-2407-v1:0.yaml
+++ b/providers/aws-bedrock/mistral.mistral-large-2407-v1:0.yaml
@@ -7,5 +7,6 @@ limits:
     max_tokens: 8192
     max_input_tokens: 128000
     max_output_tokens: 8192
-features: [function_calling]
+features:
+    - function_calling
 mode: chat

--- a/providers/aws-bedrock/mistral.mistral-large-3-675b-instruct.yaml
+++ b/providers/aws-bedrock/mistral.mistral-large-3-675b-instruct.yaml
@@ -1,11 +1,27 @@
 model: mistral.mistral-large-3-675b-instruct
 costs:
-    - region: "*"
-      input_cost_per_token: 5.e-7
-      output_cost_per_token: 0.0000015
+    - region: us-west-2
+      input_cost_per_token: 5e-7
+      output_cost_per_token: 1.5e-6
+    - region: us-east-2
+      input_cost_per_token: 5e-7
+      output_cost_per_token: 1.5e-6
+    - region: us-east-1
+      input_cost_per_token: 5e-7
+      output_cost_per_token: 1.5e-6
+    - region: sa-east-1
+      input_cost_per_token: 6.1e-7
+      output_cost_per_token: 1.82e-6
+    - region: ap-south-1
+      input_cost_per_token: 5.9e-7
+      output_cost_per_token: 1.76e-6
+    - region: ap-northeast-1
+      input_cost_per_token: 6.1e-7
+      output_cost_per_token: 1.82e-6
 limits:
     max_tokens: 8192
     max_input_tokens: 128000
     max_output_tokens: 8192
-features: [function_calling]
+features:
+    - function_calling
 mode: chat

--- a/providers/aws-bedrock/mistral.mistral-small-2402-v1:0.yaml
+++ b/providers/aws-bedrock/mistral.mistral-small-2402-v1:0.yaml
@@ -2,6 +2,4 @@ model: mistral.mistral-small-2402-v1:0
 costs:
     - region: us-east-1
       input_cost_per_token: 1e-6
-      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 3e-6
-      output_cost_per_token_batches: 1.5e-6

--- a/providers/aws-bedrock/mistral.mistral-small-2402-v1:0.yaml
+++ b/providers/aws-bedrock/mistral.mistral-small-2402-v1:0.yaml
@@ -7,5 +7,6 @@ limits:
     max_tokens: 8192
     max_input_tokens: 32000
     max_output_tokens: 8192
-features: [function_calling]
+features:
+    - function_calling
 mode: chat

--- a/providers/aws-bedrock/mistral.mistral-small-2402-v1:0.yaml
+++ b/providers/aws-bedrock/mistral.mistral-small-2402-v1:0.yaml
@@ -3,3 +3,9 @@ costs:
     - region: us-east-1
       input_cost_per_token: 1e-6
       output_cost_per_token: 3e-6
+limits:
+    max_tokens: 8192
+    max_input_tokens: 32000
+    max_output_tokens: 8192
+features: [function_calling]
+mode: chat

--- a/providers/aws-bedrock/mistral.mixtral-8x7b-instruct-v0:1.yaml
+++ b/providers/aws-bedrock/mistral.mixtral-8x7b-instruct-v0:1.yaml
@@ -27,3 +27,8 @@ costs:
     - region: ap-south-1
       input_cost_per_token: 5.4e-7
       output_cost_per_token: 8.4e-7
+limits:
+    max_tokens: 8192
+    max_input_tokens: 32000
+    max_output_tokens: 8192
+mode: chat

--- a/providers/aws-bedrock/mistral.pixtral-large-2502-v1:0.yaml
+++ b/providers/aws-bedrock/mistral.pixtral-large-2502-v1:0.yaml
@@ -21,3 +21,9 @@ costs:
     - region: eu-central-1
       input_cost_per_token: 2e-6
       output_cost_per_token: 6e-6
+limits:
+    max_tokens: 8192
+    max_input_tokens: 128000
+    max_output_tokens: 8192
+features: [function_calling, vision]
+mode: chat

--- a/providers/aws-bedrock/mistral.voxtral-mini-3b-2507.yaml
+++ b/providers/aws-bedrock/mistral.voxtral-mini-3b-2507.yaml
@@ -1,11 +1,36 @@
 model: mistral.voxtral-mini-3b-2507
 costs:
-    - region: "*"
-      input_cost_per_token: 4.e-8
-      output_cost_per_token: 4.e-8
+    - region: us-west-2
+      input_cost_per_token: 4e-8
+      output_cost_per_token: 4e-8
+    - region: us-east-2
+      input_cost_per_token: 4e-8
+      output_cost_per_token: 4e-8
+    - region: us-east-1
+      input_cost_per_token: 4e-8
+      output_cost_per_token: 4e-8
+    - region: sa-east-1
+      input_cost_per_token: 5e-8
+      output_cost_per_token: 5e-8
+    - region: eu-west-2
+      input_cost_per_token: 6e-8
+      output_cost_per_token: 6e-8
+    - region: eu-west-1
+      input_cost_per_token: 5e-8
+      output_cost_per_token: 5e-8
+    - region: eu-south-1
+      input_cost_per_token: 5e-8
+      output_cost_per_token: 5e-8
+    - region: ap-south-1
+      input_cost_per_token: 5e-8
+      output_cost_per_token: 5e-8
+    - region: ap-northeast-1
+      input_cost_per_token: 5e-8
+      output_cost_per_token: 5e-8
 limits:
     max_tokens: 8192
     max_input_tokens: 128000
     max_output_tokens: 8192
-features: [audio_input]
+features:
+    - audio_input
 mode: chat

--- a/providers/aws-bedrock/mistral.voxtral-small-24b-2507.yaml
+++ b/providers/aws-bedrock/mistral.voxtral-small-24b-2507.yaml
@@ -1,11 +1,36 @@
 model: mistral.voxtral-small-24b-2507
 costs:
-    - region: "*"
-      input_cost_per_token: 1.e-7
-      output_cost_per_token: 3.e-7
+    - region: us-west-2
+      input_cost_per_token: 1e-7
+      output_cost_per_token: 3e-7
+    - region: us-east-2
+      input_cost_per_token: 1e-7
+      output_cost_per_token: 3e-7
+    - region: us-east-1
+      input_cost_per_token: 1e-7
+      output_cost_per_token: 3e-7
+    - region: sa-east-1
+      input_cost_per_token: 1.2e-7
+      output_cost_per_token: 3.6e-7
+    - region: eu-west-2
+      input_cost_per_token: 1.6e-7
+      output_cost_per_token: 4.7e-7
+    - region: eu-west-1
+      input_cost_per_token: 1.2e-7
+      output_cost_per_token: 3.5e-7
+    - region: eu-south-1
+      input_cost_per_token: 1.2e-7
+      output_cost_per_token: 3.5e-7
+    - region: ap-south-1
+      input_cost_per_token: 1.2e-7
+      output_cost_per_token: 3.5e-7
+    - region: ap-northeast-1
+      input_cost_per_token: 1.2e-7
+      output_cost_per_token: 3.6e-7
 limits:
     max_tokens: 8192
     max_input_tokens: 128000
     max_output_tokens: 8192
-features: [audio_input]
+features:
+    - audio_input
 mode: chat

--- a/providers/aws-bedrock/moonshot.kimi-k2-thinking.yaml
+++ b/providers/aws-bedrock/moonshot.kimi-k2-thinking.yaml
@@ -1,8 +1,23 @@
 model: moonshot.kimi-k2-thinking
 costs:
-    - region: "*"
-      input_cost_per_token: 6.e-7
-      output_cost_per_token: 0.0000025
+    - region: us-west-2
+      input_cost_per_token: 6e-7
+      output_cost_per_token: 2.5e-6
+    - region: us-east-2
+      input_cost_per_token: 6e-7
+      output_cost_per_token: 2.5e-6
+    - region: us-east-1
+      input_cost_per_token: 6e-7
+      output_cost_per_token: 2.5e-6
+    - region: sa-east-1
+      input_cost_per_token: 7.3e-7
+      output_cost_per_token: 3.03e-6
+    - region: ap-south-1
+      input_cost_per_token: 7.1e-7
+      output_cost_per_token: 2.94e-6
+    - region: ap-northeast-1
+      input_cost_per_token: 7.3e-7
+      output_cost_per_token: 3.03e-6
 limits:
     max_tokens: 8192
     max_input_tokens: 128000

--- a/providers/aws-bedrock/nvidia.nemotron-nano-12b-v2.yaml
+++ b/providers/aws-bedrock/nvidia.nemotron-nano-12b-v2.yaml
@@ -1,11 +1,36 @@
 model: nvidia.nemotron-nano-12b-v2
 costs:
-    - region: "*"
-      input_cost_per_token: 2.e-7
-      output_cost_per_token: 6.e-7
+    - region: us-west-2
+      input_cost_per_token: 2e-7
+      output_cost_per_token: 6e-7
+    - region: us-east-2
+      input_cost_per_token: 2e-7
+      output_cost_per_token: 6e-7
+    - region: us-east-1
+      input_cost_per_token: 2e-7
+      output_cost_per_token: 6e-7
+    - region: sa-east-1
+      input_cost_per_token: 2.4e-7
+      output_cost_per_token: 7.3e-7
+    - region: eu-west-2
+      input_cost_per_token: 3.1e-7
+      output_cost_per_token: 9.3e-7
+    - region: eu-west-1
+      input_cost_per_token: 2.3e-7
+      output_cost_per_token: 7e-7
+    - region: eu-south-1
+      input_cost_per_token: 2.3e-7
+      output_cost_per_token: 7e-7
+    - region: ap-south-1
+      input_cost_per_token: 2.4e-7
+      output_cost_per_token: 7.1e-7
+    - region: ap-northeast-1
+      input_cost_per_token: 2.4e-7
+      output_cost_per_token: 7.3e-7
 limits:
     max_tokens: 8192
     max_input_tokens: 128000
     max_output_tokens: 8192
-features: [vision]
+features:
+    - vision
 mode: chat

--- a/providers/aws-bedrock/nvidia.nemotron-nano-3-30b.yaml
+++ b/providers/aws-bedrock/nvidia.nemotron-nano-3-30b.yaml
@@ -1,11 +1,36 @@
 model: nvidia.nemotron-nano-3-30b
 costs:
-    - region: "*"
-      input_cost_per_token: 6.e-8
+    - region: us-west-2
+      input_cost_per_token: 6e-8
       output_cost_per_token: 2.4e-7
+    - region: us-east-2
+      input_cost_per_token: 6e-8
+      output_cost_per_token: 2.4e-7
+    - region: us-east-1
+      input_cost_per_token: 6e-8
+      output_cost_per_token: 2.4e-7
+    - region: sa-east-1
+      input_cost_per_token: 7e-8
+      output_cost_per_token: 2.9e-7
+    - region: eu-west-2
+      input_cost_per_token: 9e-8
+      output_cost_per_token: 3.7e-7
+    - region: eu-west-1
+      input_cost_per_token: 7e-8
+      output_cost_per_token: 2.8e-7
+    - region: eu-south-1
+      input_cost_per_token: 7e-8
+      output_cost_per_token: 2.8e-7
+    - region: ap-south-1
+      input_cost_per_token: 7e-8
+      output_cost_per_token: 2.8e-7
+    - region: ap-northeast-1
+      input_cost_per_token: 7e-8
+      output_cost_per_token: 2.9e-7
 limits:
     max_tokens: 8192
     max_input_tokens: 262144
     max_output_tokens: 8192
-features: [function_calling]
+features:
+    - function_calling
 mode: chat

--- a/providers/aws-bedrock/nvidia.nemotron-nano-9b-v2.yaml
+++ b/providers/aws-bedrock/nvidia.nemotron-nano-9b-v2.yaml
@@ -7,26 +7,26 @@ costs:
       input_cost_per_token: 6e-8
       output_cost_per_token: 2.3e-7
     - region: us-east-1
-      input_cost_per_token: 2e-7
-      output_cost_per_token: 6e-7
+      input_cost_per_token: 6e-8
+      output_cost_per_token: 2.3e-7
     - region: sa-east-1
-      input_cost_per_token: 2.4e-7
-      output_cost_per_token: 7.3e-7
+      input_cost_per_token: 7e-8
+      output_cost_per_token: 2.8e-7
     - region: eu-west-2
-      input_cost_per_token: 3.1e-7
-      output_cost_per_token: 9.3e-7
+      input_cost_per_token: 9e-8
+      output_cost_per_token: 3.6e-7
     - region: eu-west-1
-      input_cost_per_token: 2.3e-7
-      output_cost_per_token: 7e-7
+      input_cost_per_token: 7e-8
+      output_cost_per_token: 2.7e-7
     - region: eu-south-1
-      input_cost_per_token: 2.3e-7
-      output_cost_per_token: 7e-7
+      input_cost_per_token: 7e-8
+      output_cost_per_token: 2.7e-7
     - region: ap-south-1
-      input_cost_per_token: 2.4e-7
-      output_cost_per_token: 7.1e-7
+      input_cost_per_token: 7e-8
+      output_cost_per_token: 2.7e-7
     - region: ap-northeast-1
-      input_cost_per_token: 2.4e-7
-      output_cost_per_token: 7.3e-7
+      input_cost_per_token: 7e-8
+      output_cost_per_token: 2.8e-7
 limits:
     max_tokens: 8192
     max_input_tokens: 128000

--- a/providers/aws-bedrock/nvidia.nemotron-nano-9b-v2.yaml
+++ b/providers/aws-bedrock/nvidia.nemotron-nano-9b-v2.yaml
@@ -1,8 +1,32 @@
 model: nvidia.nemotron-nano-9b-v2
 costs:
-    - region: "*"
-      input_cost_per_token: 6.e-8
+    - region: us-west-2
+      input_cost_per_token: 6e-8
       output_cost_per_token: 2.3e-7
+    - region: us-east-2
+      input_cost_per_token: 6e-8
+      output_cost_per_token: 2.3e-7
+    - region: us-east-1
+      input_cost_per_token: 2e-7
+      output_cost_per_token: 6e-7
+    - region: sa-east-1
+      input_cost_per_token: 2.4e-7
+      output_cost_per_token: 7.3e-7
+    - region: eu-west-2
+      input_cost_per_token: 3.1e-7
+      output_cost_per_token: 9.3e-7
+    - region: eu-west-1
+      input_cost_per_token: 2.3e-7
+      output_cost_per_token: 7e-7
+    - region: eu-south-1
+      input_cost_per_token: 2.3e-7
+      output_cost_per_token: 7e-7
+    - region: ap-south-1
+      input_cost_per_token: 2.4e-7
+      output_cost_per_token: 7.1e-7
+    - region: ap-northeast-1
+      input_cost_per_token: 2.4e-7
+      output_cost_per_token: 7.3e-7
 limits:
     max_tokens: 8192
     max_input_tokens: 128000

--- a/providers/aws-bedrock/openai.gpt-oss-120b-1:0.yaml
+++ b/providers/aws-bedrock/openai.gpt-oss-120b-1:0.yaml
@@ -43,9 +43,8 @@ features:
     - function_calling
     - chat
 params:
-    -
-        key: max_tokens
-        maxValue: 32768
+    - key: max_tokens
+      maxValue: 32768
 removeParams:
     - stream
     - stop

--- a/providers/aws-bedrock/openai.gpt-oss-120b-1:0.yaml
+++ b/providers/aws-bedrock/openai.gpt-oss-120b-1:0.yaml
@@ -1,66 +1,52 @@
 model: openai.gpt-oss-120b-1:0
 costs:
     - region: us-west-2
-      input_cost_per_token: 7.5e-8
-      input_cost_per_token_batches: 7.5e-8
-      output_cost_per_token: 3e-7
-      output_cost_per_token_batches: 3e-7
+      input_cost_per_token: 1.5e-7
+      output_cost_per_token: 6e-7
     - region: us-east-2
-      input_cost_per_token: 7.5e-8
-      input_cost_per_token_batches: 7.5e-8
-      output_cost_per_token: 3e-7
-      output_cost_per_token_batches: 3e-7
+      input_cost_per_token: 1.5e-7
+      output_cost_per_token: 6e-7
     - region: us-east-1
-      input_cost_per_token: 7.5e-8
-      input_cost_per_token_batches: 7.5e-8
-      output_cost_per_token: 3e-7
-      output_cost_per_token_batches: 3e-7
+      input_cost_per_token: 1.5e-7
+      output_cost_per_token: 6e-7
     - region: sa-east-1
-      input_cost_per_token: 9e-8
-      input_cost_per_token_batches: 9e-8
-      output_cost_per_token: 3.65e-7
-      output_cost_per_token_batches: 3.6e-7
-    - region: eu-north-1
-      input_cost_per_token: 7.5e-8
-      input_cost_per_token_batches: 7.5e-8
-      output_cost_per_token: 3e-7
-      output_cost_per_token_batches: 3e-7
-    - region: eu-south-1
-      input_cost_per_token: 1e-7
-      input_cost_per_token_batches: 1e-7
-      output_cost_per_token: 3.95e-7
-      output_cost_per_token_batches: 4e-7
+      input_cost_per_token: 1.8e-7
+      output_cost_per_token: 7.3e-7
     - region: eu-west-2
-      input_cost_per_token: 1.15e-7
-      input_cost_per_token_batches: 1.2e-7
-      output_cost_per_token: 4.65e-7
-      output_cost_per_token_batches: 4.7e-7
+      input_cost_per_token: 2.3e-7
+      output_cost_per_token: 9.3e-7
     - region: eu-west-1
-      input_cost_per_token: 9e-8
-      input_cost_per_token_batches: 9e-8
-      output_cost_per_token: 3.5e-7
-      output_cost_per_token_batches: 3.5e-7
+      input_cost_per_token: 1.8e-7
+      output_cost_per_token: 7e-7
+    - region: eu-south-1
+      input_cost_per_token: 2e-7
+      output_cost_per_token: 7.9e-7
+    - region: eu-north-1
+      input_cost_per_token: 1.5e-7
+      output_cost_per_token: 6e-7
     - region: eu-central-1
-      input_cost_per_token: 1e-7
-      input_cost_per_token_batches: 1e-7
-      output_cost_per_token: 3.95e-7
-      output_cost_per_token_batches: 4e-7
-    - region: ap-northeast-1
-      input_cost_per_token: 9e-8
-      input_cost_per_token_batches: 9e-8
-      output_cost_per_token: 3.65e-7
-      output_cost_per_token_batches: 3.6e-7
+      input_cost_per_token: 2e-7
+      output_cost_per_token: 7.9e-7
+    - region: ap-southeast-3
+      input_cost_per_token: 1.6e-7
+      output_cost_per_token: 6.2e-7
     - region: ap-south-1
-      input_cost_per_token: 9e-8
-      input_cost_per_token_batches: 9e-8
-      output_cost_per_token: 3.55e-7
-      output_cost_per_token_batches: 3.5e-7
+      input_cost_per_token: 1.8e-7
+      output_cost_per_token: 7.1e-7
+    - region: ap-northeast-1
+      input_cost_per_token: 1.8e-7
+      output_cost_per_token: 7.3e-7
 limits:
     max_input_tokens: 128000
     max_output_tokens: 128000
-features: [function_calling, chat]
+features:
+    - function_calling
+    - chat
 params:
-    - key: max_tokens
-      maxValue: 32768
-removeParams: [stream, stop]
+    -
+        key: max_tokens
+        maxValue: 32768
+removeParams:
+    - stream
+    - stop
 mode: chat

--- a/providers/aws-bedrock/openai.gpt-oss-20b-1:0.yaml
+++ b/providers/aws-bedrock/openai.gpt-oss-20b-1:0.yaml
@@ -1,66 +1,52 @@
 model: openai.gpt-oss-20b-1:0
 costs:
     - region: us-west-2
-      input_cost_per_token: 3.5e-8
-      input_cost_per_token_batches: 3.5e-8
-      output_cost_per_token: 1.5e-7
-      output_cost_per_token_batches: 1.5e-7
+      input_cost_per_token: 7e-8
+      output_cost_per_token: 3e-7
     - region: us-east-2
-      input_cost_per_token: 3.5e-8
-      input_cost_per_token_batches: 3.5e-8
-      output_cost_per_token: 1.5e-7
-      output_cost_per_token_batches: 1.5e-7
+      input_cost_per_token: 7e-8
+      output_cost_per_token: 3e-7
     - region: us-east-1
-      input_cost_per_token: 3.5e-8
-      input_cost_per_token_batches: 3.5e-8
-      output_cost_per_token: 1.5e-7
-      output_cost_per_token_batches: 1.5e-7
+      input_cost_per_token: 7e-8
+      output_cost_per_token: 3e-7
     - region: sa-east-1
-      input_cost_per_token: 4e-8
-      input_cost_per_token_batches: 4e-8
-      output_cost_per_token: 1.8e-7
-      output_cost_per_token_batches: 1.8e-7
-    - region: eu-north-1
-      input_cost_per_token: 3.5e-8
-      input_cost_per_token_batches: 3.5e-8
-      output_cost_per_token: 1.5e-7
-      output_cost_per_token_batches: 1.5e-7
-    - region: eu-south-1
-      input_cost_per_token: 4.5e-8
-      input_cost_per_token_batches: 5e-8
-      output_cost_per_token: 2e-7
-      output_cost_per_token_batches: 2e-7
+      input_cost_per_token: 8e-8
+      output_cost_per_token: 3.6e-7
     - region: eu-west-2
-      input_cost_per_token: 5.5e-8
-      input_cost_per_token_batches: 5e-8
-      output_cost_per_token: 2.35e-7
-      output_cost_per_token_batches: 2.3e-7
+      input_cost_per_token: 1.1e-7
+      output_cost_per_token: 4.7e-7
     - region: eu-west-1
-      input_cost_per_token: 4e-8
-      input_cost_per_token_batches: 4e-8
-      output_cost_per_token: 1.75e-7
-      output_cost_per_token_batches: 1.8e-7
+      input_cost_per_token: 8e-8
+      output_cost_per_token: 3.5e-7
+    - region: eu-south-1
+      input_cost_per_token: 9e-8
+      output_cost_per_token: 4e-7
+    - region: eu-north-1
+      input_cost_per_token: 7e-8
+      output_cost_per_token: 3e-7
     - region: eu-central-1
-      input_cost_per_token: 4.5e-8
-      input_cost_per_token_batches: 5e-8
-      output_cost_per_token: 2e-7
-      output_cost_per_token_batches: 2e-7
-    - region: ap-northeast-1
-      input_cost_per_token: 4e-8
-      input_cost_per_token_batches: 4e-8
-      output_cost_per_token: 1.8e-7
-      output_cost_per_token_batches: 1.8e-7
+      input_cost_per_token: 9e-8
+      output_cost_per_token: 4e-7
+    - region: ap-southeast-3
+      input_cost_per_token: 7e-8
+      output_cost_per_token: 3.1e-7
     - region: ap-south-1
-      input_cost_per_token: 4e-8
-      input_cost_per_token_batches: 4e-8
-      output_cost_per_token: 1.75e-7
-      output_cost_per_token_batches: 1.8e-7
+      input_cost_per_token: 8e-8
+      output_cost_per_token: 3.5e-7
+    - region: ap-northeast-1
+      input_cost_per_token: 8e-8
+      output_cost_per_token: 3.6e-7
 limits:
     max_input_tokens: 128000
     max_output_tokens: 128000
-features: [function_calling, chat]
+features:
+    - function_calling
+    - chat
 params:
-    - key: max_tokens
-      maxValue: 32768
-removeParams: [stream, stop]
+    -
+        key: max_tokens
+        maxValue: 32768
+removeParams:
+    - stream
+    - stop
 mode: chat

--- a/providers/aws-bedrock/openai.gpt-oss-20b-1:0.yaml
+++ b/providers/aws-bedrock/openai.gpt-oss-20b-1:0.yaml
@@ -43,9 +43,8 @@ features:
     - function_calling
     - chat
 params:
-    -
-        key: max_tokens
-        maxValue: 32768
+    - key: max_tokens
+      maxValue: 32768
 removeParams:
     - stream
     - stop

--- a/providers/aws-bedrock/openai.gpt-oss-safeguard-120b.yaml
+++ b/providers/aws-bedrock/openai.gpt-oss-safeguard-120b.yaml
@@ -1,8 +1,32 @@
 model: openai.gpt-oss-safeguard-120b
 costs:
-    - region: "*"
+    - region: us-west-2
       input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
+    - region: us-east-2
+      input_cost_per_token: 1.5e-7
+      output_cost_per_token: 6e-7
+    - region: us-east-1
+      input_cost_per_token: 1.5e-7
+      output_cost_per_token: 6e-7
+    - region: sa-east-1
+      input_cost_per_token: 1.8e-7
+      output_cost_per_token: 7.3e-7
+    - region: eu-west-2
+      input_cost_per_token: 2.3e-7
+      output_cost_per_token: 9.3e-7
+    - region: eu-west-1
+      input_cost_per_token: 1.8e-7
+      output_cost_per_token: 7e-7
+    - region: eu-south-1
+      input_cost_per_token: 1.8e-7
+      output_cost_per_token: 7e-7
+    - region: ap-south-1
+      input_cost_per_token: 1.8e-7
+      output_cost_per_token: 7.1e-7
+    - region: ap-northeast-1
+      input_cost_per_token: 1.8e-7
+      output_cost_per_token: 7.3e-7
 limits:
     max_tokens: 8192
     max_input_tokens: 128000

--- a/providers/aws-bedrock/openai.gpt-oss-safeguard-20b.yaml
+++ b/providers/aws-bedrock/openai.gpt-oss-safeguard-20b.yaml
@@ -1,8 +1,32 @@
 model: openai.gpt-oss-safeguard-20b
 costs:
-    - region: "*"
-      input_cost_per_token: 7.e-8
-      output_cost_per_token: 2.e-7
+    - region: us-west-2
+      input_cost_per_token: 7e-8
+      output_cost_per_token: 2e-7
+    - region: us-east-2
+      input_cost_per_token: 7e-8
+      output_cost_per_token: 2e-7
+    - region: us-east-1
+      input_cost_per_token: 7e-8
+      output_cost_per_token: 2e-7
+    - region: sa-east-1
+      input_cost_per_token: 8e-8
+      output_cost_per_token: 2.4e-7
+    - region: eu-west-2
+      input_cost_per_token: 1.1e-7
+      output_cost_per_token: 3.1e-7
+    - region: eu-west-1
+      input_cost_per_token: 8e-8
+      output_cost_per_token: 2.3e-7
+    - region: eu-south-1
+      input_cost_per_token: 8e-8
+      output_cost_per_token: 2.3e-7
+    - region: ap-south-1
+      input_cost_per_token: 8e-8
+      output_cost_per_token: 2.4e-7
+    - region: ap-northeast-1
+      input_cost_per_token: 8e-8
+      output_cost_per_token: 2.4e-7
 limits:
     max_tokens: 8192
     max_input_tokens: 128000

--- a/providers/aws-bedrock/qwen.qwen3-235b-a22b-2507-v1:0.yaml
+++ b/providers/aws-bedrock/qwen.qwen3-235b-a22b-2507-v1:0.yaml
@@ -1,48 +1,36 @@
 model: qwen.qwen3-235b-a22b-2507-v1:0
 costs:
     - region: us-west-2
-      input_cost_per_token: 1.1e-7
-      input_cost_per_token_batches: 1.1e-7
-      output_cost_per_token: 4.4e-7
-      output_cost_per_token_batches: 4.4e-7
+      input_cost_per_token: 2.2e-7
+      output_cost_per_token: 8.8e-7
     - region: us-east-2
-      input_cost_per_token: 1.1e-7
-      input_cost_per_token_batches: 1.1e-7
-      output_cost_per_token: 4.4e-7
-      output_cost_per_token_batches: 4.4e-7
-    - region: eu-north-1
-      input_cost_per_token: 1.1e-7
-      input_cost_per_token_batches: 1.1e-7
-      output_cost_per_token: 4.4e-7
-      output_cost_per_token_batches: 4.4e-7
-    - region: eu-south-1
-      input_cost_per_token: 1.45e-7
-      input_cost_per_token_batches: 1.45e-7
-      output_cost_per_token: 5.8e-7
-      output_cost_per_token_batches: 5.8e-7
+      input_cost_per_token: 2.2e-7
+      output_cost_per_token: 8.8e-7
     - region: eu-west-2
-      input_cost_per_token: 1.7e-7
-      input_cost_per_token_batches: 1.7e-7
-      output_cost_per_token: 6.85e-7
-      output_cost_per_token_batches: 6.85e-7
+      input_cost_per_token: 3.4e-7
+      output_cost_per_token: 1.37e-6
+    - region: eu-south-1
+      input_cost_per_token: 2.9e-7
+      output_cost_per_token: 1.16e-6
+    - region: eu-north-1
+      input_cost_per_token: 2.2e-7
+      output_cost_per_token: 8.8e-7
     - region: eu-central-1
-      input_cost_per_token: 1.45e-7
-      input_cost_per_token_batches: 1.5e-7
-      output_cost_per_token: 5.8e-7
-      output_cost_per_token_batches: 5.8e-7
-    - region: ap-northeast-1
-      input_cost_per_token: 1.35e-7
-      input_cost_per_token_batches: 1.35e-7
-      output_cost_per_token: 5.3e-7
-      output_cost_per_token_batches: 5.3e-7
+      input_cost_per_token: 2.9e-7
+      output_cost_per_token: 1.16e-6
+    - region: ap-southeast-3
+      input_cost_per_token: 2.3e-7
+      output_cost_per_token: 9.1e-7
     - region: ap-south-1
-      input_cost_per_token: 1.3e-7
-      input_cost_per_token_batches: 1.3e-7
-      output_cost_per_token: 5.2e-7
-      output_cost_per_token_batches: 5.2e-7
+      input_cost_per_token: 2.6e-7
+      output_cost_per_token: 1.04e-6
+    - region: ap-northeast-1
+      input_cost_per_token: 2.7e-7
+      output_cost_per_token: 1.06e-6
 limits:
     max_tokens: 131072
     max_input_tokens: 262144
     max_output_tokens: 131072
-features: [function_calling]
+features:
+    - function_calling
 mode: chat

--- a/providers/aws-bedrock/qwen.qwen3-32b-v1:0.yaml
+++ b/providers/aws-bedrock/qwen.qwen3-32b-v1:0.yaml
@@ -1,57 +1,38 @@
 model: qwen.qwen3-32b-v1:0
 costs:
     - region: us-west-2
-      input_cost_per_token: 7.5e-8
-      input_cost_per_token_batches: 7.5e-8
-      output_cost_per_token: 3e-7
-      output_cost_per_token_batches: 3e-7
+      input_cost_per_token: 1.5e-7
+      output_cost_per_token: 6e-7
     - region: us-east-2
-      input_cost_per_token: 7.5e-8
-      input_cost_per_token_batches: 7.5e-8
-      output_cost_per_token: 3e-7
-      output_cost_per_token_batches: 3e-7
+      input_cost_per_token: 1.5e-7
+      output_cost_per_token: 6e-7
     - region: us-east-1
-      input_cost_per_token: 7.5e-8
-      input_cost_per_token_batches: 7.5e-8
-      output_cost_per_token: 3e-7
-      output_cost_per_token_batches: 3e-7
+      input_cost_per_token: 1.5e-7
+      output_cost_per_token: 6e-7
     - region: sa-east-1
-      input_cost_per_token: 9e-8
-      input_cost_per_token_batches: 9e-8
-      output_cost_per_token: 3.65e-7
-      output_cost_per_token_batches: 3.65e-7
-    - region: eu-north-1
-      input_cost_per_token: 7.5e-8
-      input_cost_per_token_batches: 7.5e-8
-      output_cost_per_token: 3e-7
-      output_cost_per_token_batches: 3e-7
-    - region: eu-south-1
-      input_cost_per_token: 1e-7
-      input_cost_per_token_batches: 1e-7
-      output_cost_per_token: 3.95e-7
-      output_cost_per_token_batches: 3.95e-7
+      input_cost_per_token: 1.8e-7
+      output_cost_per_token: 7.3e-7
     - region: eu-west-2
-      input_cost_per_token: 1.15e-7
-      input_cost_per_token_batches: 1.15e-7
-      output_cost_per_token: 4.65e-7
-      output_cost_per_token_batches: 4.65e-7
+      input_cost_per_token: 2.3e-7
+      output_cost_per_token: 9.3e-7
     - region: eu-west-1
-      input_cost_per_token: 9e-8
-      input_cost_per_token_batches: 9e-8
-      output_cost_per_token: 3.5e-7
-      output_cost_per_token_batches: 3.5e-7
+      input_cost_per_token: 1.8e-7
+      output_cost_per_token: 7e-7
+    - region: eu-south-1
+      input_cost_per_token: 2e-7
+      output_cost_per_token: 7.9e-7
+    - region: eu-north-1
+      input_cost_per_token: 1.5e-7
+      output_cost_per_token: 6e-7
     - region: eu-central-1
-      input_cost_per_token: 1e-7
-      input_cost_per_token_batches: 1e-7
-      output_cost_per_token: 3.95e-7
-      output_cost_per_token_batches: 4e-7
-    - region: ap-northeast-1
-      input_cost_per_token: 9e-8
-      input_cost_per_token_batches: 9e-8
-      output_cost_per_token: 3.65e-7
-      output_cost_per_token_batches: 3.65e-7
+      input_cost_per_token: 2e-7
+      output_cost_per_token: 7.9e-7
+    - region: ap-southeast-3
+      input_cost_per_token: 1.6e-7
+      output_cost_per_token: 6.2e-7
     - region: ap-south-1
-      input_cost_per_token: 9e-8
-      input_cost_per_token_batches: 9e-8
-      output_cost_per_token: 3.55e-7
-      output_cost_per_token_batches: 3.55e-7
+      input_cost_per_token: 1.8e-7
+      output_cost_per_token: 7.1e-7
+    - region: ap-northeast-1
+      input_cost_per_token: 1.8e-7
+      output_cost_per_token: 7.3e-7

--- a/providers/aws-bedrock/qwen.qwen3-32b-v1:0.yaml
+++ b/providers/aws-bedrock/qwen.qwen3-32b-v1:0.yaml
@@ -40,5 +40,6 @@ limits:
     max_tokens: 8192
     max_input_tokens: 131072
     max_output_tokens: 8192
-features: [function_calling]
+features:
+    - function_calling
 mode: chat

--- a/providers/aws-bedrock/qwen.qwen3-32b-v1:0.yaml
+++ b/providers/aws-bedrock/qwen.qwen3-32b-v1:0.yaml
@@ -36,3 +36,9 @@ costs:
     - region: ap-northeast-1
       input_cost_per_token: 1.8e-7
       output_cost_per_token: 7.3e-7
+limits:
+    max_tokens: 8192
+    max_input_tokens: 131072
+    max_output_tokens: 8192
+features: [function_calling]
+mode: chat

--- a/providers/aws-bedrock/qwen.qwen3-coder-30b-a3b-v1:0.yaml
+++ b/providers/aws-bedrock/qwen.qwen3-coder-30b-a3b-v1:0.yaml
@@ -1,63 +1,45 @@
 model: qwen.qwen3-coder-30b-a3b-v1:0
 costs:
     - region: us-west-2
-      input_cost_per_token: 7.5e-8
-      input_cost_per_token_batches: 7.5e-8
-      output_cost_per_token: 3e-7
-      output_cost_per_token_batches: 3e-7
+      input_cost_per_token: 1.5e-7
+      output_cost_per_token: 6e-7
     - region: us-east-2
-      input_cost_per_token: 7.5e-8
-      input_cost_per_token_batches: 7.5e-8
-      output_cost_per_token: 3e-7
-      output_cost_per_token_batches: 3e-7
+      input_cost_per_token: 1.5e-7
+      output_cost_per_token: 6e-7
     - region: us-east-1
-      input_cost_per_token: 7.5e-8
-      input_cost_per_token_batches: 7.5e-8
-      output_cost_per_token: 3e-7
-      output_cost_per_token_batches: 3e-7
+      input_cost_per_token: 1.5e-7
+      output_cost_per_token: 6e-7
     - region: sa-east-1
-      input_cost_per_token: 9e-8
-      input_cost_per_token_batches: 9e-8
-      output_cost_per_token: 3.65e-7
-      output_cost_per_token_batches: 3.65e-7
-    - region: eu-north-1
-      input_cost_per_token: 7.5e-8
-      input_cost_per_token_batches: 7.5e-8
-      output_cost_per_token: 3e-7
-      output_cost_per_token_batches: 3e-7
-    - region: eu-south-1
-      input_cost_per_token: 1e-7
-      input_cost_per_token_batches: 1e-7
-      output_cost_per_token: 3.95e-7
-      output_cost_per_token_batches: 3.95e-7
+      input_cost_per_token: 1.8e-7
+      output_cost_per_token: 7.3e-7
     - region: eu-west-2
-      input_cost_per_token: 1.15e-7
-      input_cost_per_token_batches: 1.15e-7
-      output_cost_per_token: 4.65e-7
-      output_cost_per_token_batches: 4.65e-7
+      input_cost_per_token: 2.3e-7
+      output_cost_per_token: 9.3e-7
     - region: eu-west-1
-      input_cost_per_token: 9e-8
-      input_cost_per_token_batches: 9e-8
-      output_cost_per_token: 3.5e-7
-      output_cost_per_token_batches: 3.5e-7
+      input_cost_per_token: 1.8e-7
+      output_cost_per_token: 7e-7
+    - region: eu-south-1
+      input_cost_per_token: 2e-7
+      output_cost_per_token: 7.9e-7
+    - region: eu-north-1
+      input_cost_per_token: 1.5e-7
+      output_cost_per_token: 6e-7
     - region: eu-central-1
-      input_cost_per_token: 1e-7
-      input_cost_per_token_batches: 1e-7
-      output_cost_per_token: 3.95e-7
-      output_cost_per_token_batches: 4e-7
-    - region: ap-northeast-1
-      input_cost_per_token: 9e-8
-      input_cost_per_token_batches: 9e-8
-      output_cost_per_token: 3.65e-7
-      output_cost_per_token_batches: 3.65e-7
+      input_cost_per_token: 2e-7
+      output_cost_per_token: 7.9e-7
+    - region: ap-southeast-3
+      input_cost_per_token: 1.6e-7
+      output_cost_per_token: 6.2e-7
     - region: ap-south-1
-      input_cost_per_token: 9e-8
-      input_cost_per_token_batches: 9e-8
-      output_cost_per_token: 3.55e-7
-      output_cost_per_token_batches: 3.55e-7
+      input_cost_per_token: 1.8e-7
+      output_cost_per_token: 7.1e-7
+    - region: ap-northeast-1
+      input_cost_per_token: 1.8e-7
+      output_cost_per_token: 7.3e-7
 limits:
     max_tokens: 131072
     max_input_tokens: 262144
     max_output_tokens: 131072
-features: [function_calling]
+features:
+    - function_calling
 mode: chat

--- a/providers/aws-bedrock/qwen.qwen3-coder-480b-a35b-v1:0.yaml
+++ b/providers/aws-bedrock/qwen.qwen3-coder-480b-a35b-v1:0.yaml
@@ -1,38 +1,30 @@
 model: qwen.qwen3-coder-480b-a35b-v1:0
 costs:
     - region: us-west-2
-      input_cost_per_token: 2.25e-7
-      input_cost_per_token_batches: 2.25e-7
-      output_cost_per_token: 9e-7
-      output_cost_per_token_batches: 9e-7
+      input_cost_per_token: 4.5e-7
+      output_cost_per_token: 1.8e-6
     - region: us-east-2
-      input_cost_per_token: 2.25e-7
-      input_cost_per_token_batches: 2.25e-7
-      output_cost_per_token: 9e-7
-      output_cost_per_token_batches: 9e-7
-    - region: eu-north-1
-      input_cost_per_token: 2.25e-7
-      input_cost_per_token_batches: 2.25e-7
-      output_cost_per_token: 9e-7
-      output_cost_per_token_batches: 9e-7
+      input_cost_per_token: 4.5e-7
+      output_cost_per_token: 1.8e-6
     - region: eu-west-2
-      input_cost_per_token: 3.5e-7
-      input_cost_per_token_batches: 3.5e-7
-      output_cost_per_token: 1.395e-6
-      output_cost_per_token_batches: 1.395e-6
-    - region: ap-northeast-1
-      input_cost_per_token: 2.7e-7
-      input_cost_per_token_batches: 2.7e-7
-      output_cost_per_token: 1.09e-6
-      output_cost_per_token_batches: 1.09e-6
+      input_cost_per_token: 7e-7
+      output_cost_per_token: 2.79e-6
+    - region: eu-north-1
+      input_cost_per_token: 4.5e-7
+      output_cost_per_token: 1.8e-6
+    - region: ap-southeast-3
+      input_cost_per_token: 4.7e-7
+      output_cost_per_token: 1.87e-6
     - region: ap-south-1
-      input_cost_per_token: 2.65e-7
-      input_cost_per_token_batches: 2.65e-7
-      output_cost_per_token: 1.06e-6
-      output_cost_per_token_batches: 1.06e-6
+      input_cost_per_token: 5.3e-7
+      output_cost_per_token: 2.12e-6
+    - region: ap-northeast-1
+      input_cost_per_token: 5.4e-7
+      output_cost_per_token: 2.18e-6
 limits:
     max_tokens: 65536
     max_input_tokens: 262000
     max_output_tokens: 65536
-features: [function_calling]
+features:
+    - function_calling
 mode: chat

--- a/providers/aws-bedrock/qwen.qwen3-next-80b-a3b.yaml
+++ b/providers/aws-bedrock/qwen.qwen3-next-80b-a3b.yaml
@@ -1,11 +1,45 @@
 model: qwen.qwen3-next-80b-a3b
 costs:
-    - region: "*"
+    - region: us-west-2
       input_cost_per_token: 1.5e-7
-      output_cost_per_token: 0.0000012
+      output_cost_per_token: 6e-7
+    - region: us-east-2
+      input_cost_per_token: 1.5e-7
+      output_cost_per_token: 6e-7
+    - region: us-east-1
+      input_cost_per_token: 1.5e-7
+      output_cost_per_token: 6e-7
+    - region: sa-east-1
+      input_cost_per_token: 1.8e-7
+      output_cost_per_token: 7.3e-7
+    - region: eu-west-2
+      input_cost_per_token: 2.3e-7
+      output_cost_per_token: 9.3e-7
+    - region: eu-west-1
+      input_cost_per_token: 1.8e-7
+      output_cost_per_token: 7e-7
+    - region: eu-south-1
+      input_cost_per_token: 2e-7
+      output_cost_per_token: 7.9e-7
+    - region: eu-north-1
+      input_cost_per_token: 1.5e-7
+      output_cost_per_token: 6e-7
+    - region: eu-central-1
+      input_cost_per_token: 2e-7
+      output_cost_per_token: 7.9e-7
+    - region: ap-southeast-3
+      input_cost_per_token: 1.6e-7
+      output_cost_per_token: 6.2e-7
+    - region: ap-south-1
+      input_cost_per_token: 1.8e-7
+      output_cost_per_token: 7.1e-7
+    - region: ap-northeast-1
+      input_cost_per_token: 1.8e-7
+      output_cost_per_token: 7.3e-7
 limits:
     max_tokens: 8192
     max_input_tokens: 128000
     max_output_tokens: 8192
-features: [function_calling]
+features:
+    - function_calling
 mode: chat

--- a/providers/aws-bedrock/qwen.qwen3-vl-235b-a22b.yaml
+++ b/providers/aws-bedrock/qwen.qwen3-vl-235b-a22b.yaml
@@ -1,11 +1,37 @@
 model: qwen.qwen3-vl-235b-a22b
 costs:
-    - region: "*"
+    - region: us-west-2
       input_cost_per_token: 5.3e-7
-      output_cost_per_token: 0.00000266
+      output_cost_per_token: 2.66e-6
+    - region: us-east-2
+      input_cost_per_token: 5.3e-7
+      output_cost_per_token: 2.66e-6
+    - region: us-east-1
+      input_cost_per_token: 5.3e-7
+      output_cost_per_token: 2.66e-6
+    - region: sa-east-1
+      input_cost_per_token: 6.4e-7
+      output_cost_per_token: 3.22e-6
+    - region: eu-west-2
+      input_cost_per_token: 8.2e-7
+      output_cost_per_token: 4.12e-6
+    - region: eu-west-1
+      input_cost_per_token: 6.2e-7
+      output_cost_per_token: 3.12e-6
+    - region: eu-south-1
+      input_cost_per_token: 6.2e-7
+      output_cost_per_token: 3.12e-6
+    - region: ap-south-1
+      input_cost_per_token: 6.2e-7
+      output_cost_per_token: 3.13e-6
+    - region: ap-northeast-1
+      input_cost_per_token: 6.4e-7
+      output_cost_per_token: 3.22e-6
 limits:
     max_tokens: 8192
     max_input_tokens: 128000
     max_output_tokens: 8192
-features: [function_calling, vision]
+features:
+    - function_calling
+    - vision
 mode: chat

--- a/providers/aws-bedrock/stability.sd3-5-large-v1:0.yaml
+++ b/providers/aws-bedrock/stability.sd3-5-large-v1:0.yaml
@@ -1,4 +1,9 @@
 model: stability.sd3-5-large-v1:0
+costs:
+    - region: us-west-2
+      input_cost_per_token: 8e-8
+    - region: us-east-1
+      input_cost_per_token: 8e-8
 limits:
     max_tokens: 77
     max_input_tokens: 77

--- a/providers/aws-bedrock/stability.sd3-large-v1:0.yaml
+++ b/providers/aws-bedrock/stability.sd3-large-v1:0.yaml
@@ -1,5 +1,34 @@
 model: stability.sd3-large-v1:0
+costs:
+    - region: us-west-2
+      input_cost_per_token: 4e-6
+      output_cost_per_token: 1.2e-5
+    - region: us-east-1
+      input_cost_per_token: 4e-6
+      output_cost_per_token: 1.2e-5
+    - region: sa-east-1
+      input_cost_per_token: 6.7e-6
+      output_cost_per_token: 2.02e-5
+    - region: eu-west-3
+      input_cost_per_token: 5.2e-6
+      output_cost_per_token: 1.56e-5
+    - region: eu-west-2
+      input_cost_per_token: 5.2e-6
+      output_cost_per_token: 1.56e-5
+    - region: eu-west-1
+      input_cost_per_token: 4.3e-6
+      output_cost_per_token: 1.3e-5
+    - region: ca-central-1
+      input_cost_per_token: 4.6e-6
+      output_cost_per_token: 1.38e-5
+    - region: ap-southeast-2
+      input_cost_per_token: 5.2e-6
+      output_cost_per_token: 1.56e-5
+    - region: ap-south-1
+      input_cost_per_token: 4.8e-6
+      output_cost_per_token: 1.44e-5
 limits:
     max_tokens: 77
     max_input_tokens: 77
 mode: image
+isDeprecated: true

--- a/providers/aws-bedrock/stability.sd3-large-v1:0.yaml
+++ b/providers/aws-bedrock/stability.sd3-large-v1:0.yaml
@@ -1,32 +1,9 @@
 model: stability.sd3-large-v1:0
 costs:
     - region: us-west-2
-      input_cost_per_token: 4e-6
-      output_cost_per_token: 1.2e-5
+      input_cost_per_token: 8e-8
     - region: us-east-1
-      input_cost_per_token: 4e-6
-      output_cost_per_token: 1.2e-5
-    - region: sa-east-1
-      input_cost_per_token: 6.7e-6
-      output_cost_per_token: 2.02e-5
-    - region: eu-west-3
-      input_cost_per_token: 5.2e-6
-      output_cost_per_token: 1.56e-5
-    - region: eu-west-2
-      input_cost_per_token: 5.2e-6
-      output_cost_per_token: 1.56e-5
-    - region: eu-west-1
-      input_cost_per_token: 4.3e-6
-      output_cost_per_token: 1.3e-5
-    - region: ca-central-1
-      input_cost_per_token: 4.6e-6
-      output_cost_per_token: 1.38e-5
-    - region: ap-southeast-2
-      input_cost_per_token: 5.2e-6
-      output_cost_per_token: 1.56e-5
-    - region: ap-south-1
-      input_cost_per_token: 4.8e-6
-      output_cost_per_token: 1.44e-5
+      input_cost_per_token: 8e-8
 limits:
     max_tokens: 77
     max_input_tokens: 77

--- a/providers/aws-bedrock/stability.stable-image-core-v1:0.yaml
+++ b/providers/aws-bedrock/stability.stable-image-core-v1:0.yaml
@@ -1,4 +1,9 @@
 model: stability.stable-image-core-v1:0
+costs:
+    - region: us-west-2
+      input_cost_per_token: 4e-8
+    - region: us-east-1
+      input_cost_per_token: 4e-8
 limits:
     max_tokens: 77
     max_input_tokens: 77

--- a/providers/aws-bedrock/stability.stable-image-ultra-v1:0.yaml
+++ b/providers/aws-bedrock/stability.stable-image-ultra-v1:0.yaml
@@ -1,6 +1,12 @@
 model: stability.stable-image-ultra-v1:0
+costs:
+    - region: us-west-2
+      input_cost_per_token: 1.4e-7
+    - region: us-east-1
+      input_cost_per_token: 1.4e-7
 limits:
     max_tokens: 4096
     max_input_tokens: 77
-features: [image]
+features:
+    - image
 mode: image

--- a/providers/aws-bedrock/twelvelabs.marengo-embed-3-0-v1:0.yaml
+++ b/providers/aws-bedrock/twelvelabs.marengo-embed-3-0-v1:0.yaml
@@ -15,3 +15,8 @@ costs:
       input_cost_per_image: 0.0001
       input_cost_per_request: 7e-05
       input_cost_per_second: 0.0007
+limits:
+    max_tokens: 500
+    max_input_tokens: 500
+    output_vector_size: 1024
+mode: embedding

--- a/providers/aws-bedrock/twelvelabs.pegasus-1-2-v1:0.yaml
+++ b/providers/aws-bedrock/twelvelabs.pegasus-1-2-v1:0.yaml
@@ -1,43 +1,43 @@
 model: twelvelabs.pegasus-1-2-v1:0
 costs:
     - region: us-west-2
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
     - region: us-west-1
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
     - region: us-east-2
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
     - region: us-east-1
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
     - region: eu-west-3
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
     - region: eu-west-2
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
     - region: eu-west-1
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
     - region: eu-south-2
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
     - region: eu-south-1
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
     - region: eu-north-1
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
     - region: eu-central-2
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
     - region: eu-central-1
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
     - region: ap-northeast-2
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
 limits:
     max_tokens: 4096

--- a/providers/aws-bedrock/twelvelabs.pegasus-1-2-v1:0.yaml
+++ b/providers/aws-bedrock/twelvelabs.pegasus-1-2-v1:0.yaml
@@ -1,61 +1,43 @@
 model: twelvelabs.pegasus-1-2-v1:0
 costs:
+    - region: us-west-2
+      input_cost_per_token: 5e-10
+      output_cost_per_token: 7.5e-6
     - region: us-west-1
-      input_cost_per_second: 0.00049
+      input_cost_per_token: 5e-10
       output_cost_per_token: 7.5e-6
     - region: us-east-2
-      input_cost_per_second: 0.00049
+      input_cost_per_token: 5e-10
       output_cost_per_token: 7.5e-6
     - region: us-east-1
-      input_cost_per_second: 0.00049
-      output_cost_per_token: 7.5e-6
-    - region: sa-east-1
-      input_cost_per_second: 0.00049
-      output_cost_per_token: 7.5e-6
-    - region: eu-central-2
-      input_cost_per_second: 0.00049
-      output_cost_per_token: 7.5e-6
-    - region: eu-north-1
-      input_cost_per_second: 0.00049
-      output_cost_per_token: 7.5e-6
-    - region: eu-south-2
-      input_cost_per_second: 0.00049
+      input_cost_per_token: 5e-10
       output_cost_per_token: 7.5e-6
     - region: eu-west-3
-      input_cost_per_second: 0.00049
-      output_cost_per_token: 7.5e-6
-    - region: eu-south-1
-      input_cost_per_second: 0.00049
+      input_cost_per_token: 5e-10
       output_cost_per_token: 7.5e-6
     - region: eu-west-2
-      input_cost_per_second: 0.00049
-      output_cost_per_token: 7.5e-6
-    - region: eu-central-1
-      input_cost_per_second: 0.00049
-      output_cost_per_token: 7.5e-6
-    - region: ca-central-1
-      input_cost_per_second: 0.00049
-      output_cost_per_token: 7.5e-6
-    - region: ap-northeast-1
-      input_cost_per_second: 0.00049
-      output_cost_per_token: 7.5e-6
-    - region: ap-northeast-2
-      input_cost_per_second: 0.00049
-      output_cost_per_token: 7.5e-6
-    - region: ap-northeast-3
-      input_cost_per_second: 0.00049
-      output_cost_per_token: 7.5e-6
-    - region: ap-south-1
-      input_cost_per_second: 0.00049
-      output_cost_per_token: 7.5e-6
-    - region: ap-south-2
-      input_cost_per_second: 0.00049
+      input_cost_per_token: 5e-10
       output_cost_per_token: 7.5e-6
     - region: eu-west-1
-      input_cost_per_second: 0.00049
+      input_cost_per_token: 5e-10
       output_cost_per_token: 7.5e-6
-    - region: us-west-2
-      input_cost_per_second: 0.00049
+    - region: eu-south-2
+      input_cost_per_token: 5e-10
+      output_cost_per_token: 7.5e-6
+    - region: eu-south-1
+      input_cost_per_token: 5e-10
+      output_cost_per_token: 7.5e-6
+    - region: eu-north-1
+      input_cost_per_token: 5e-10
+      output_cost_per_token: 7.5e-6
+    - region: eu-central-2
+      input_cost_per_token: 5e-10
+      output_cost_per_token: 7.5e-6
+    - region: eu-central-1
+      input_cost_per_token: 5e-10
+      output_cost_per_token: 7.5e-6
+    - region: ap-northeast-2
+      input_cost_per_token: 5e-10
       output_cost_per_token: 7.5e-6
 limits:
     max_tokens: 4096

--- a/providers/aws-bedrock/us-gov.anthropic.claude-3-5-sonnet-20240620-v1:0.yaml
+++ b/providers/aws-bedrock/us-gov.anthropic.claude-3-5-sonnet-20240620-v1:0.yaml
@@ -1,0 +1,13 @@
+model: us-gov.anthropic.claude-3-5-sonnet-20240620-v1:0
+costs:
+    - region: us-gov-east-1
+      input_cost_per_token: 3.6e-6
+      output_cost_per_token: 1.8e-5
+limits:
+    max_tokens: 8192
+    max_input_tokens: 200000
+    max_output_tokens: 8192
+features:
+    - function_calling
+    - vision
+mode: chat

--- a/providers/aws-bedrock/us-gov.anthropic.claude-3-7-sonnet-20250219-v1:0.yaml
+++ b/providers/aws-bedrock/us-gov.anthropic.claude-3-7-sonnet-20250219-v1:0.yaml
@@ -1,0 +1,7 @@
+model: us-gov.anthropic.claude-3-7-sonnet-20250219-v1:0
+costs:
+    - region: us-gov-east-1
+      cache_creation_input_token_cost: 4.5e-6
+      cache_read_input_token_cost: 3.6e-7
+      input_cost_per_token: 3.6e-6
+      output_cost_per_token: 1.8e-5

--- a/providers/aws-bedrock/us-gov.anthropic.claude-3-7-sonnet-20250219-v1:0.yaml
+++ b/providers/aws-bedrock/us-gov.anthropic.claude-3-7-sonnet-20250219-v1:0.yaml
@@ -5,3 +5,8 @@ costs:
       cache_read_input_token_cost: 3.6e-7
       input_cost_per_token: 3.6e-6
       output_cost_per_token: 1.8e-5
+limits:
+    max_input_tokens: 200000
+    max_output_tokens: 128000
+features: [function_calling, vision]
+mode: chat

--- a/providers/aws-bedrock/us-gov.anthropic.claude-3-7-sonnet-20250219-v1:0.yaml
+++ b/providers/aws-bedrock/us-gov.anthropic.claude-3-7-sonnet-20250219-v1:0.yaml
@@ -8,5 +8,7 @@ costs:
 limits:
     max_input_tokens: 200000
     max_output_tokens: 128000
-features: [function_calling, vision]
+features:
+    - function_calling
+    - vision
 mode: chat

--- a/providers/aws-bedrock/us-gov.anthropic.claude-3-haiku-20240307-v1:0.yaml
+++ b/providers/aws-bedrock/us-gov.anthropic.claude-3-haiku-20240307-v1:0.yaml
@@ -3,3 +3,9 @@ costs:
     - region: us-gov-east-1
       input_cost_per_token: 3e-7
       output_cost_per_token: 1.5e-6
+limits:
+    max_tokens: 4096
+    max_input_tokens: 200000
+    max_output_tokens: 4096
+features: [function_calling, vision]
+mode: chat

--- a/providers/aws-bedrock/us-gov.anthropic.claude-3-haiku-20240307-v1:0.yaml
+++ b/providers/aws-bedrock/us-gov.anthropic.claude-3-haiku-20240307-v1:0.yaml
@@ -7,5 +7,7 @@ limits:
     max_tokens: 4096
     max_input_tokens: 200000
     max_output_tokens: 4096
-features: [function_calling, vision]
+features:
+    - function_calling
+    - vision
 mode: chat

--- a/providers/aws-bedrock/us-gov.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
+++ b/providers/aws-bedrock/us-gov.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
@@ -14,16 +14,24 @@ limits:
     max_input_tokens: 200000
     max_output_tokens: 64000
     tool_use_system_prompt_tokens: 159
-features: [function_calling, vision, chat, image]
+features:
+    - function_calling
+    - vision
+    - chat
+    - image
 params:
     - key: max_tokens
       maxValue: 8192
     - key: thinking
       type: number
-      enum: [enabled, disabled]
+      enum:
+          - enabled
+          - disabled
       minValue: 1024
       maxValue: 128000
-      withdrawParams: [top_k, top_p]
+      withdrawParams:
+          - top_k
+          - top_p
       skipValues:
           - disabled
           - null
@@ -38,14 +46,15 @@ params:
             name: Required
           - value: custom
             name: Custom
-            schema:
+            schema: null
             type: json
       skipValues:
           - null
-      rule:
+      rule: null
       default:
           condition: tools
           then: auto
           else: null
-removeParams: [top_p]
+removeParams:
+    - top_p
 mode: chat

--- a/providers/aws-bedrock/us-gov.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
+++ b/providers/aws-bedrock/us-gov.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
@@ -10,3 +10,42 @@ costs:
       cache_read_input_token_cost: 3.6e-7
       input_cost_per_token: 7.2e-6
       output_cost_per_token: 2.7e-5
+limits:
+    max_input_tokens: 200000
+    max_output_tokens: 64000
+    tool_use_system_prompt_tokens: 159
+features: [function_calling, vision, chat, image]
+params:
+    - key: max_tokens
+      maxValue: 8192
+    - key: thinking
+      type: number
+      enum: [enabled, disabled]
+      minValue: 1024
+      maxValue: 128000
+      withdrawParams: [top_k, top_p]
+      skipValues:
+          - disabled
+          - null
+    - key: tool_choice
+      type: json
+      options:
+          - value: none
+            name: None
+          - value: auto
+            name: Auto
+          - value: required
+            name: Required
+          - value: custom
+            name: Custom
+            schema:
+            type: json
+      skipValues:
+          - null
+      rule:
+      default:
+          condition: tools
+          then: auto
+          else: null
+removeParams: [top_p]
+mode: chat

--- a/providers/aws-bedrock/us-gov.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
+++ b/providers/aws-bedrock/us-gov.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
@@ -1,16 +1,12 @@
 model: us-gov.anthropic.claude-sonnet-4-5-20250929-v1:0
 costs:
-    - region: us-gov-east-1
-      cache_creation_input_token_cost: 4.5e-6
-      cache_read_input_token_cost: 3.6e-7
-      input_cost_per_token: 3.6e-6
-      input_cost_per_token_batches: 1.8e-6
-      output_cost_per_token: 1.8e-05
-      output_cost_per_token_batches: 9e-6
     - region: us-gov-west-1
       cache_creation_input_token_cost: 4.5e-6
       cache_read_input_token_cost: 3.6e-7
       input_cost_per_token: 3.6e-6
-      input_cost_per_token_batches: 1.8e-6
-      output_cost_per_token: 1.8e-05
-      output_cost_per_token_batches: 9e-6
+      output_cost_per_token: 1.8e-5
+    - region: us-gov-east-1
+      cache_creation_input_token_cost: 4.5e-6
+      cache_read_input_token_cost: 3.6e-7
+      input_cost_per_token: 7.2e-6
+      output_cost_per_token: 2.7e-5

--- a/providers/aws-bedrock/us.amazon.nova-2-lite-v1:0.yaml
+++ b/providers/aws-bedrock/us.amazon.nova-2-lite-v1:0.yaml
@@ -1,25 +1,34 @@
 model: us.amazon.nova-2-lite-v1:0
 costs:
     - region: us-west-2
-      input_cost_per_query: 0.03
-      input_cost_per_token: 1.595e-7
-      output_cost_per_token: 1.3255e-6
+      cache_read_input_token_cost: 7.5e-8
+      input_cost_per_token: 3e-7
+      output_cost_per_token: 2.5e-6
     - region: us-west-1
-      input_cost_per_token: 2.145e-7
-      output_cost_per_token: 1.6755e-6
+      cache_read_input_token_cost: 9.75e-8
+      input_cost_per_token: 3.9e-7
+      output_cost_per_token: 3.21e-6
     - region: us-east-2
-      input_cost_per_token: 1.595e-7
-      output_cost_per_token: 1.342e-6
+      cache_read_input_token_cost: 7.5e-8
+      input_cost_per_token: 3e-7
+      output_cost_per_token: 2.5e-6
     - region: us-east-1
-      input_cost_per_query: 0.03
-      input_cost_per_token: 1.65e-7
-      output_cost_per_token: 1.375e-6
+      cache_read_input_token_cost: 7.5e-8
+      input_cost_per_token: 3e-7
+      output_cost_per_token: 2.5e-6
+    - region: ca-west-1
+      cache_read_input_token_cost: 8.5e-7
+      input_cost_per_token: 3.4e-7
+      output_cost_per_token: 2.81e-6
     - region: ca-central-1
-      input_cost_per_token: 1.76e-7
-      output_cost_per_token: 1.4685e-6
+      cache_read_input_token_cost: 8e-8
+      input_cost_per_token: 3.2e-7
+      output_cost_per_token: 2.67e-6
 limits:
     max_tokens: 64000
     max_input_tokens: 1000000
     max_output_tokens: 64000
-features: [function_calling, vision]
+features:
+    - function_calling
+    - vision
 mode: chat

--- a/providers/aws-bedrock/us.amazon.nova-lite-v1:0.yaml
+++ b/providers/aws-bedrock/us.amazon.nova-lite-v1:0.yaml
@@ -1,12 +1,14 @@
 model: us.amazon.nova-lite-v1:0
 costs:
     - region: us-west-2
+      cache_read_input_token_cost: 1.5e-8
       input_cost_per_token: 6e-8
       output_cost_per_token: 2.4e-7
     - region: us-west-1
       input_cost_per_token: 7.7e-8
       output_cost_per_token: 3.08e-7
     - region: us-east-2
+      cache_read_input_token_cost: 1.5e-8
       input_cost_per_token: 6e-8
       output_cost_per_token: 2.4e-7
     - region: us-east-1
@@ -17,5 +19,8 @@ limits:
     max_tokens: 4096
     max_input_tokens: 300000
     max_output_tokens: 10000
-features: [function_calling, vision, chat]
+features:
+    - function_calling
+    - vision
+    - chat
 mode: chat

--- a/providers/aws-bedrock/us.amazon.nova-micro-v1:0.yaml
+++ b/providers/aws-bedrock/us.amazon.nova-micro-v1:0.yaml
@@ -1,18 +1,22 @@
 model: us.amazon.nova-micro-v1:0
 costs:
     - region: us-west-2
+      cache_read_input_token_cost: 8.7e-9
       input_cost_per_token: 3.5e-8
       output_cost_per_token: 1.4e-7
     - region: us-east-2
+      cache_read_input_token_cost: 8.7e-9
       input_cost_per_token: 3.5e-8
       output_cost_per_token: 1.4e-7
     - region: us-east-1
-      cache_read_input_token_cost: 8.75e-9
+      cache_read_input_token_cost: 8.7e-9
       input_cost_per_token: 3.5e-8
       output_cost_per_token: 1.4e-7
 limits:
     max_tokens: 4096
     max_input_tokens: 128000
     max_output_tokens: 10000
-features: [function_calling, chat]
+features:
+    - function_calling
+    - chat
 mode: chat

--- a/providers/aws-bedrock/us.amazon.nova-premier-v1:0.yaml
+++ b/providers/aws-bedrock/us.amazon.nova-premier-v1:0.yaml
@@ -1,20 +1,22 @@
 model: us.amazon.nova-premier-v1:0
 costs:
     - region: us-west-2
-      input_cost_per_query: 0.03
-      input_cost_per_token: 1.25e-6
-      output_cost_per_token: 6.25e-6
+      cache_read_input_token_cost: 6.25e-7
+      input_cost_per_token: 2.5e-6
+      output_cost_per_token: 1.25e-5
     - region: us-east-2
-      input_cost_per_query: 0.03
-      input_cost_per_token: 1.25e-6
-      output_cost_per_token: 6.25e-6
+      cache_read_input_token_cost: 6.25e-7
+      input_cost_per_token: 2.5e-6
+      output_cost_per_token: 1.25e-5
     - region: us-east-1
-      input_cost_per_query: 0.03
-      input_cost_per_token: 1.25e-6
-      output_cost_per_token: 6.25e-6
+      cache_read_input_token_cost: 6.25e-7
+      input_cost_per_token: 2.5e-6
+      output_cost_per_token: 1.25e-5
 limits:
     max_tokens: 4096
     max_input_tokens: 1000000
     max_output_tokens: 10000
-features: [function_calling, vision]
+features:
+    - function_calling
+    - vision
 mode: chat

--- a/providers/aws-bedrock/us.amazon.nova-pro-v1:0.yaml
+++ b/providers/aws-bedrock/us.amazon.nova-pro-v1:0.yaml
@@ -1,21 +1,27 @@
 model: us.amazon.nova-pro-v1:0
 costs:
     - region: us-west-2
-      input_cost_per_token: 8e-7
-      output_cost_per_token: 3.2e-6
+      input_cost_per_audio_token: 1.25e-6
+      input_cost_per_token: 1.25e-6
+      output_cost_per_token: 1e-5
     - region: us-west-1
-      input_cost_per_token: 1.03e-6
-      output_cost_per_token: 4.12e-6
+      input_cost_per_audio_token: 1.61e-6
+      input_cost_per_token: 1.61e-6
+      output_cost_per_token: 1.284e-5
     - region: us-east-2
-      input_cost_per_token: 8e-7
-      output_cost_per_token: 3.2e-6
+      input_cost_per_audio_token: 1.25e-6
+      input_cost_per_token: 1.25e-6
+      output_cost_per_token: 1e-5
     - region: us-east-1
-      cache_read_input_token_cost: 2e-7
-      input_cost_per_token: 8e-7
-      output_cost_per_token: 3.2e-6
+      input_cost_per_audio_token: 1.25e-6
+      input_cost_per_token: 1.25e-6
+      output_cost_per_token: 1e-5
 limits:
     max_tokens: 4096
     max_input_tokens: 300000
     max_output_tokens: 10000
-features: [function_calling, vision, chat]
+features:
+    - function_calling
+    - vision
+    - chat
 mode: chat

--- a/providers/aws-bedrock/us.amazon.nova-pro-v1:0.yaml
+++ b/providers/aws-bedrock/us.amazon.nova-pro-v1:0.yaml
@@ -1,21 +1,20 @@
 model: us.amazon.nova-pro-v1:0
 costs:
     - region: us-west-2
-      input_cost_per_audio_token: 1.25e-6
-      input_cost_per_token: 1.25e-6
-      output_cost_per_token: 1e-5
+      cache_read_input_token_cost: 2e-7
+      input_cost_per_token: 8e-7
+      output_cost_per_token: 3.2e-6
     - region: us-west-1
-      input_cost_per_audio_token: 1.61e-6
-      input_cost_per_token: 1.61e-6
-      output_cost_per_token: 1.284e-5
+      input_cost_per_token: 1.03e-6
+      output_cost_per_token: 4.12e-6
     - region: us-east-2
-      input_cost_per_audio_token: 1.25e-6
-      input_cost_per_token: 1.25e-6
-      output_cost_per_token: 1e-5
+      cache_read_input_token_cost: 2e-7
+      input_cost_per_token: 8e-7
+      output_cost_per_token: 3.2e-6
     - region: us-east-1
-      input_cost_per_audio_token: 1.25e-6
-      input_cost_per_token: 1.25e-6
-      output_cost_per_token: 1e-5
+      cache_read_input_token_cost: 2e-7
+      input_cost_per_token: 8e-7
+      output_cost_per_token: 3.2e-6
 limits:
     max_tokens: 4096
     max_input_tokens: 300000

--- a/providers/aws-bedrock/us.anthropic.claude-3-5-haiku-20241022-v1:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-3-5-haiku-20241022-v1:0.yaml
@@ -3,44 +3,48 @@ costs:
     - region: us-west-2
       cache_creation_input_token_cost: 1e-6
       cache_read_input_token_cost: 8e-8
-      input_cost_per_token: 1e-6
-      input_cost_per_token_batches: 4e-7
-      output_cost_per_token: 5e-6
-      output_cost_per_token_batches: 2e-6
+      input_cost_per_token: 8e-7
+      output_cost_per_token: 4e-6
     - region: us-east-2
       cache_creation_input_token_cost: 1e-6
       cache_read_input_token_cost: 8e-8
-      input_cost_per_token: 1e-6
-      output_cost_per_token: 5e-6
+      input_cost_per_token: 8e-7
+      output_cost_per_token: 4e-6
     - region: us-east-1
       cache_creation_input_token_cost: 1e-6
       cache_read_input_token_cost: 8e-8
-      input_cost_per_token: 1e-6
-      input_cost_per_token_batches: 4e-7
-      output_cost_per_token: 5e-6
-      output_cost_per_token_batches: 2e-6
+      input_cost_per_token: 8e-7
+      output_cost_per_token: 4e-6
 limits:
     max_tokens: 4096
     max_input_tokens: 200000
     max_output_tokens: 8192
-features: [function_calling, chat, image]
+features:
+    - function_calling
+    - chat
+    - image
 params:
-    - key: tool_choice
-      type: non-view-manage-data
-      options:
-          - value: none
-            name: None
-          - value: auto
-            name: Auto
-          - value: required
-            name: Required
-          - value: custom
-            name: Custom
-            type: json
-      skipValues:
-          - null
-      default:
-      condition: tools
-      then: auto
-      else: null
+    -
+        key: tool_choice
+        type: non-view-manage-data
+        options:
+            -
+                value: none
+                name: None
+            -
+                value: auto
+                name: Auto
+            -
+                value: required
+                name: Required
+            -
+                value: custom
+                name: Custom
+                type: json
+        skipValues:
+            - null
+        default: null
+        condition: tools
+        then: auto
+        else: null
 mode: chat

--- a/providers/aws-bedrock/us.anthropic.claude-3-5-haiku-20241022-v1:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-3-5-haiku-20241022-v1:0.yaml
@@ -24,27 +24,22 @@ features:
     - chat
     - image
 params:
-    -
-        key: tool_choice
-        type: non-view-manage-data
-        options:
-            -
-                value: none
-                name: None
-            -
-                value: auto
-                name: Auto
-            -
-                value: required
-                name: Required
-            -
-                value: custom
-                name: Custom
-                type: json
-        skipValues:
-            - null
-        default: null
-        condition: tools
-        then: auto
-        else: null
+    - key: tool_choice
+      type: non-view-manage-data
+      options:
+          - value: none
+            name: None
+          - value: auto
+            name: Auto
+          - value: required
+            name: Required
+          - value: custom
+            name: Custom
+            type: json
+      skipValues:
+          - null
+      default: null
+      condition: tools
+      then: auto
+      else: null
 mode: chat

--- a/providers/aws-bedrock/us.anthropic.claude-3-5-sonnet-20240620-v1:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-3-5-sonnet-20240620-v1:0.yaml
@@ -1,35 +1,51 @@
 model: us.anthropic.claude-3-5-sonnet-20240620-v1:0
 costs:
-    - region: "*"
-      input_cost_per_token: 0.000003
-      output_cost_per_token: 0.000015
+    - region: us-west-2
+      input_cost_per_token: 1.5e-6
+      output_cost_per_token: 1.5e-5
+    - region: us-east-2
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 1.5e-5
+    - region: us-east-1
+      input_cost_per_token: 1.5e-6
+      output_cost_per_token: 7.5e-6
 limits:
     max_input_tokens: 200000
     max_output_tokens: 4096
-features: [function_calling, vision, chat, image]
+features:
+    - function_calling
+    - vision
+    - chat
+    - image
 params:
-    - key: max_tokens
-      maxValue: 8192
-    - key: tool_choice
-      type: non-view-manage-data
-      defaultValue: null
-      options:
-          - value: none
-            name: None
-          - value: auto
-            name: Auto
-          - value: required
-            name: Required
-          - value: custom
-            name: Custom
-            schema:
-                type: json
-      skipValues:
-          - null
-          - []
-      rule:
-          default:
-              condition: tools
-              then: auto
-              else: null
+    -
+        key: max_tokens
+        maxValue: 8192
+    -
+        key: tool_choice
+        type: non-view-manage-data
+        defaultValue: null
+        options:
+            -
+                value: none
+                name: None
+            -
+                value: auto
+                name: Auto
+            -
+                value: required
+                name: Required
+            -
+                value: custom
+                name: Custom
+                schema:
+                    type: json
+        skipValues:
+            - null
+            - []
+        rule:
+            default:
+                condition: tools
+                then: auto
+                else: null
 mode: chat

--- a/providers/aws-bedrock/us.anthropic.claude-3-5-sonnet-20240620-v1:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-3-5-sonnet-20240620-v1:0.yaml
@@ -18,34 +18,28 @@ features:
     - chat
     - image
 params:
-    -
-        key: max_tokens
-        maxValue: 8192
-    -
-        key: tool_choice
-        type: non-view-manage-data
-        defaultValue: null
-        options:
-            -
-                value: none
-                name: None
-            -
-                value: auto
-                name: Auto
-            -
-                value: required
-                name: Required
-            -
-                value: custom
-                name: Custom
-                schema:
-                    type: json
-        skipValues:
-            - null
-            - []
-        rule:
-            default:
-                condition: tools
-                then: auto
-                else: null
+    - key: max_tokens
+      maxValue: 8192
+    - key: tool_choice
+      type: non-view-manage-data
+      defaultValue: null
+      options:
+          - value: none
+            name: None
+          - value: auto
+            name: Auto
+          - value: required
+            name: Required
+          - value: custom
+            name: Custom
+            schema:
+                type: json
+      skipValues:
+          - null
+          - []
+      rule:
+          default:
+              condition: tools
+              then: auto
+              else: null
 mode: chat

--- a/providers/aws-bedrock/us.anthropic.claude-3-5-sonnet-20241022-v2:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-3-5-sonnet-20241022-v2:0.yaml
@@ -1,37 +1,57 @@
 model: us.anthropic.claude-3-5-sonnet-20241022-v2:0
 costs:
-    - region: "*"
-      input_cost_per_token: 0.000003
-      output_cost_per_token: 0.000015
-      cache_read_input_token_cost: 3.e-7
-      cache_creation_input_token_cost: 0.00000375
+    - region: us-west-2
+      cache_creation_input_token_cost: 3.75e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 1.5e-5
+    - region: us-east-2
+      cache_creation_input_token_cost: 3.75e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 1.5e-5
+    - region: us-east-1
+      cache_creation_input_token_cost: 3.75e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 1.5e-5
 limits:
     max_input_tokens: 200000
     max_output_tokens: 8192
-features: [function_calling, vision, chat, image]
+features:
+    - function_calling
+    - vision
+    - chat
+    - image
 params:
-    - key: max_tokens
-      maxValue: 8192
-    - key: tool_choice
-      type: non-view-manage-data
-      defaultValue: null
-      options:
-          - value: none
-            name: None
-          - value: auto
-            name: Auto
-          - value: required
-            name: Required
-          - value: custom
-            name: Custom
-            schema:
-                type: json
-      skipValues:
-          - null
-          - []
-      rule:
-          default:
-              condition: tools
-              then: auto
-              else: null
+    -
+        key: max_tokens
+        maxValue: 8192
+    -
+        key: tool_choice
+        type: non-view-manage-data
+        defaultValue: null
+        options:
+            -
+                value: none
+                name: None
+            -
+                value: auto
+                name: Auto
+            -
+                value: required
+                name: Required
+            -
+                value: custom
+                name: Custom
+                schema:
+                    type: json
+        skipValues:
+            - null
+            - []
+        rule:
+            default:
+                condition: tools
+                then: auto
+                else: null
 mode: chat

--- a/providers/aws-bedrock/us.anthropic.claude-3-5-sonnet-20241022-v2:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-3-5-sonnet-20241022-v2:0.yaml
@@ -24,34 +24,28 @@ features:
     - chat
     - image
 params:
-    -
-        key: max_tokens
-        maxValue: 8192
-    -
-        key: tool_choice
-        type: non-view-manage-data
-        defaultValue: null
-        options:
-            -
-                value: none
-                name: None
-            -
-                value: auto
-                name: Auto
-            -
-                value: required
-                name: Required
-            -
-                value: custom
-                name: Custom
-                schema:
-                    type: json
-        skipValues:
-            - null
-            - []
-        rule:
-            default:
-                condition: tools
-                then: auto
-                else: null
+    - key: max_tokens
+      maxValue: 8192
+    - key: tool_choice
+      type: non-view-manage-data
+      defaultValue: null
+      options:
+          - value: none
+            name: None
+          - value: auto
+            name: Auto
+          - value: required
+            name: Required
+          - value: custom
+            name: Custom
+            schema:
+                type: json
+      skipValues:
+          - null
+          - []
+      rule:
+          default:
+              condition: tools
+              then: auto
+              else: null
 mode: chat

--- a/providers/aws-bedrock/us.anthropic.claude-3-7-sonnet-20250219-v1:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-3-7-sonnet-20250219-v1:0.yaml
@@ -24,53 +24,46 @@ features:
     - chat
     - image
 params:
-    -
-        key: max_tokens
-        maxValue: 128000
-    -
-        key: thinking
-        properties:
-            type:
-                type: string
-                enum:
-                    - enabled
-                    - disabled
-            budget_tokens:
-                type: number
-                minValue: 1024
-                maxValue: 128000
-        defaultValue: null
-        withdrawParams:
-            - top_k
-            - top_p
-        skipValues:
-            - disabled
-            - null
-    -
-        key: tool_choice
-        type: non-view-manage-data
-        defaultValue: null
-        options:
-            -
-                value: none
-                name: None
-            -
-                value: auto
-                name: Auto
-            -
-                value: required
-                name: Required
-            -
-                value: custom
-                name: Custom
-                schema:
-                    type: json
-        skipValues:
-            - null
-            - []
-        rule:
-            default:
-                condition: tools
-                then: auto
-                else: null
+    - key: max_tokens
+      maxValue: 128000
+    - key: thinking
+      properties:
+          type:
+              type: string
+              enum:
+                  - enabled
+                  - disabled
+          budget_tokens:
+              type: number
+              minValue: 1024
+              maxValue: 128000
+      defaultValue: null
+      withdrawParams:
+          - top_k
+          - top_p
+      skipValues:
+          - disabled
+          - null
+    - key: tool_choice
+      type: non-view-manage-data
+      defaultValue: null
+      options:
+          - value: none
+            name: None
+          - value: auto
+            name: Auto
+          - value: required
+            name: Required
+          - value: custom
+            name: Custom
+            schema:
+                type: json
+      skipValues:
+          - null
+          - []
+      rule:
+          default:
+              condition: tools
+              then: auto
+              else: null
 mode: chat

--- a/providers/aws-bedrock/us.anthropic.claude-3-7-sonnet-20250219-v1:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-3-7-sonnet-20250219-v1:0.yaml
@@ -1,55 +1,76 @@
 model: us.anthropic.claude-3-7-sonnet-20250219-v1:0
 costs:
-    - region: "*"
-      input_cost_per_token: 0.000003
-      output_cost_per_token: 0.000015
-      cache_read_input_token_cost: 3.e-7
-      cache_creation_input_token_cost: 0.00000375
+    - region: us-west-2
+      cache_creation_input_token_cost: 3.75e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 1.5e-5
+    - region: us-east-2
+      cache_creation_input_token_cost: 3.75e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 1.5e-5
+    - region: us-east-1
+      cache_creation_input_token_cost: 3.75e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 1.5e-5
 limits:
     max_input_tokens: 200000
     max_output_tokens: 8192
-features: [function_calling, vision, chat, image]
+features:
+    - function_calling
+    - vision
+    - chat
+    - image
 params:
-    - key: max_tokens
-      maxValue: 128000
-    - key: thinking
-      properties:
-          type:
-              type: string
-              enum:
-                  - enabled
-                  - disabled
-          budget_tokens:
-              type: number
-              minValue: 1024
-              maxValue: 128000
-      defaultValue: null
-      withdrawParams:
-          - top_k
-          - top_p
-      skipValues:
-          - disabled
-          - null
-    - key: tool_choice
-      type: non-view-manage-data
-      defaultValue: null
-      options:
-          - value: none
-            name: None
-          - value: auto
-            name: Auto
-          - value: required
-            name: Required
-          - value: custom
-            name: Custom
-            schema:
-                type: json
-      skipValues:
-          - null
-          - []
-      rule:
-          default:
-              condition: tools
-              then: auto
-              else: null
+    -
+        key: max_tokens
+        maxValue: 128000
+    -
+        key: thinking
+        properties:
+            type:
+                type: string
+                enum:
+                    - enabled
+                    - disabled
+            budget_tokens:
+                type: number
+                minValue: 1024
+                maxValue: 128000
+        defaultValue: null
+        withdrawParams:
+            - top_k
+            - top_p
+        skipValues:
+            - disabled
+            - null
+    -
+        key: tool_choice
+        type: non-view-manage-data
+        defaultValue: null
+        options:
+            -
+                value: none
+                name: None
+            -
+                value: auto
+                name: Auto
+            -
+                value: required
+                name: Required
+            -
+                value: custom
+                name: Custom
+                schema:
+                    type: json
+        skipValues:
+            - null
+            - []
+        rule:
+            default:
+                condition: tools
+                then: auto
+                else: null
 mode: chat

--- a/providers/aws-bedrock/us.anthropic.claude-3-haiku-20240307-v1:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-3-haiku-20240307-v1:0.yaml
@@ -19,29 +19,24 @@ features:
     - chat
     - image
 params:
-    -
-        key: tool_choice
-        type: json
-        options:
-            -
-                value: none
-                name: None
-            -
-                value: auto
-                name: Auto
-            -
-                value: required
-                name: Required
-            -
-                value: custom
-                name: Custom
-                schema: null
-                type: json
-        skipValues:
-            - null
-        rule: null
-        default:
-            condition: tools
-            then: auto
-            else: null
+    - key: tool_choice
+      type: json
+      options:
+          - value: none
+            name: None
+          - value: auto
+            name: Auto
+          - value: required
+            name: Required
+          - value: custom
+            name: Custom
+            schema: null
+            type: json
+      skipValues:
+          - null
+      rule: null
+      default:
+          condition: tools
+          then: auto
+          else: null
 mode: chat

--- a/providers/aws-bedrock/us.anthropic.claude-3-haiku-20240307-v1:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-3-haiku-20240307-v1:0.yaml
@@ -1,7 +1,7 @@
 model: us.anthropic.claude-3-haiku-20240307-v1:0
 costs:
     - region: us-west-2
-      input_cost_per_token: 2.5e-7
+      input_cost_per_token: 2e-5
       output_cost_per_token: 6.25e-7
     - region: us-east-2
       input_cost_per_token: 2.5e-7

--- a/providers/aws-bedrock/us.anthropic.claude-3-haiku-20240307-v1:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-3-haiku-20240307-v1:0.yaml
@@ -2,43 +2,46 @@ model: us.anthropic.claude-3-haiku-20240307-v1:0
 costs:
     - region: us-west-2
       input_cost_per_token: 2.5e-7
-      input_cost_per_token_batches: 1.25e-7
-      output_cost_per_token: 1.25e-6
-      output_cost_per_token_batches: 6.25e-7
+      output_cost_per_token: 6.25e-7
     - region: us-east-2
       input_cost_per_token: 2.5e-7
-      input_cost_per_token_batches: 1.25e-7
       output_cost_per_token: 1.25e-6
-      output_cost_per_token_batches: 6.25e-7
     - region: us-east-1
-      input_cost_per_token: 2.5e-7
-      input_cost_per_token_batches: 1.25e-7
-      output_cost_per_token: 1.25e-6
-      output_cost_per_token_batches: 6.25e-7
+      input_cost_per_token: 1.25e-7
+      output_cost_per_token: 6.25e-7
 limits:
     max_tokens: 4096
     max_input_tokens: 200000
     max_output_tokens: 4096
-features: [function_calling, vision, chat, image]
+features:
+    - function_calling
+    - vision
+    - chat
+    - image
 params:
-    - key: tool_choice
-      type: json
-      options:
-          - value: none
-            name: None
-          - value: auto
-            name: Auto
-          - value: required
-            name: Required
-          - value: custom
-            name: Custom
-            schema:
-            type: json
-      skipValues:
-          - null
-      rule:
-      default:
-          condition: tools
-          then: auto
-          else: null
+    -
+        key: tool_choice
+        type: json
+        options:
+            -
+                value: none
+                name: None
+            -
+                value: auto
+                name: Auto
+            -
+                value: required
+                name: Required
+            -
+                value: custom
+                name: Custom
+                schema: null
+                type: json
+        skipValues:
+            - null
+        rule: null
+        default:
+            condition: tools
+            then: auto
+            else: null
 mode: chat

--- a/providers/aws-bedrock/us.anthropic.claude-3-opus-20240229-v1:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-3-opus-20240229-v1:0.yaml
@@ -16,31 +16,26 @@ features:
     - chat
     - image
 params:
-    -
-        key: tool_choice
-        type: non-view-manage-data
-        defaultValue: null
-        options:
-            -
-                value: none
-                name: None
-            -
-                value: auto
-                name: Auto
-            -
-                value: required
-                name: Required
-            -
-                value: custom
-                name: Custom
-                schema:
-                    type: json
-        skipValues:
-            - null
-            - []
-        rule:
-            default:
-                condition: tools
-                then: auto
-                else: null
+    - key: tool_choice
+      type: non-view-manage-data
+      defaultValue: null
+      options:
+          - value: none
+            name: None
+          - value: auto
+            name: Auto
+          - value: required
+            name: Required
+          - value: custom
+            name: Custom
+            schema:
+                type: json
+      skipValues:
+          - null
+          - []
+      rule:
+          default:
+              condition: tools
+              then: auto
+              else: null
 mode: chat

--- a/providers/aws-bedrock/us.anthropic.claude-3-opus-20240229-v1:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-3-opus-20240229-v1:0.yaml
@@ -1,34 +1,46 @@
 model: us.anthropic.claude-3-opus-20240229-v1:0
 costs:
-    - region: "*"
-      input_cost_per_token: 0.000015
-      output_cost_per_token: 0.000075
+    - region: us-west-2
+      input_cost_per_token: 7.5e-6
+      output_cost_per_token: 7.5e-5
+    - region: us-east-1
+      input_cost_per_token: 7.5e-6
+      output_cost_per_token: 7.5e-5
 limits:
     max_tokens: 4096
     max_input_tokens: 200000
     max_output_tokens: 4096
-features: [function_calling, vision, chat, image]
+features:
+    - function_calling
+    - vision
+    - chat
+    - image
 params:
-    - key: tool_choice
-      type: non-view-manage-data
-      defaultValue: null
-      options:
-          - value: none
-            name: None
-          - value: auto
-            name: Auto
-          - value: required
-            name: Required
-          - value: custom
-            name: Custom
-            schema:
-                type: json
-      skipValues:
-          - null
-          - []
-      rule:
-          default:
-              condition: tools
-              then: auto
-              else: null
+    -
+        key: tool_choice
+        type: non-view-manage-data
+        defaultValue: null
+        options:
+            -
+                value: none
+                name: None
+            -
+                value: auto
+                name: Auto
+            -
+                value: required
+                name: Required
+            -
+                value: custom
+                name: Custom
+                schema:
+                    type: json
+        skipValues:
+            - null
+            - []
+        rule:
+            default:
+                condition: tools
+                then: auto
+                else: null
 mode: chat

--- a/providers/aws-bedrock/us.anthropic.claude-3-sonnet-20240229-v1:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-3-sonnet-20240229-v1:0.yaml
@@ -16,31 +16,26 @@ features:
     - chat
     - image
 params:
-    -
-        key: tool_choice
-        type: non-view-manage-data
-        defaultValue: null
-        options:
-            -
-                value: none
-                name: None
-            -
-                value: auto
-                name: Auto
-            -
-                value: required
-                name: Required
-            -
-                value: custom
-                name: Custom
-                schema:
-                    type: json
-        skipValues:
-            - null
-            - []
-        rule:
-            default:
-                condition: tools
-                then: auto
-                else: null
+    - key: tool_choice
+      type: non-view-manage-data
+      defaultValue: null
+      options:
+          - value: none
+            name: None
+          - value: auto
+            name: Auto
+          - value: required
+            name: Required
+          - value: custom
+            name: Custom
+            schema:
+                type: json
+      skipValues:
+          - null
+          - []
+      rule:
+          default:
+              condition: tools
+              then: auto
+              else: null
 mode: chat

--- a/providers/aws-bedrock/us.anthropic.claude-3-sonnet-20240229-v1:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-3-sonnet-20240229-v1:0.yaml
@@ -1,34 +1,46 @@
 model: us.anthropic.claude-3-sonnet-20240229-v1:0
 costs:
-    - region: "*"
-      input_cost_per_token: 0.000003
-      output_cost_per_token: 0.000015
+    - region: us-west-2
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 1.5e-5
+    - region: us-east-1
+      input_cost_per_token: 1.5e-6
+      output_cost_per_token: 7.5e-6
 limits:
     max_tokens: 4096
     max_input_tokens: 200000
     max_output_tokens: 4096
-features: [function_calling, vision, chat, image]
+features:
+    - function_calling
+    - vision
+    - chat
+    - image
 params:
-    - key: tool_choice
-      type: non-view-manage-data
-      defaultValue: null
-      options:
-          - value: none
-            name: None
-          - value: auto
-            name: Auto
-          - value: required
-            name: Required
-          - value: custom
-            name: Custom
-            schema:
-                type: json
-      skipValues:
-          - null
-          - []
-      rule:
-          default:
-              condition: tools
-              then: auto
-              else: null
+    -
+        key: tool_choice
+        type: non-view-manage-data
+        defaultValue: null
+        options:
+            -
+                value: none
+                name: None
+            -
+                value: auto
+                name: Auto
+            -
+                value: required
+                name: Required
+            -
+                value: custom
+                name: Custom
+                schema:
+                    type: json
+        skipValues:
+            - null
+            - []
+        rule:
+            default:
+                condition: tools
+                then: auto
+                else: null
 mode: chat

--- a/providers/aws-bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0.yaml
@@ -4,53 +4,54 @@ costs:
       cache_creation_input_token_cost: 1.25e-6
       cache_read_input_token_cost: 1e-7
       input_cost_per_token: 1e-6
-      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 5e-6
-      output_cost_per_token_batches: 2.5e-6
     - region: us-west-1
       cache_creation_input_token_cost: 1.25e-6
       cache_read_input_token_cost: 1e-7
       input_cost_per_token: 1e-6
-      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 5e-6
-      output_cost_per_token_batches: 2.5e-6
     - region: us-east-2
       cache_creation_input_token_cost: 1.25e-6
       cache_read_input_token_cost: 1e-7
       input_cost_per_token: 1e-6
-      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 5e-6
-      output_cost_per_token_batches: 2.5e-6
     - region: us-east-1
       cache_creation_input_token_cost: 1.25e-6
       cache_read_input_token_cost: 1e-7
       input_cost_per_token: 1e-6
-      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 5e-6
-      output_cost_per_token_batches: 2.5e-6
     - region: ca-central-1
       cache_creation_input_token_cost: 1.25e-6
       cache_read_input_token_cost: 1e-7
       input_cost_per_token: 1e-6
-      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 5e-6
-      output_cost_per_token_batches: 2.5e-6
 limits:
     max_input_tokens: 200000
     max_output_tokens: 64000
     tool_use_system_prompt_tokens: 346
-features: [function_calling, vision, chat, image]
+features:
+    - function_calling
+    - vision
+    - chat
+    - image
 params:
-    - key: max_tokens
-      maxValue: 64000
-    - key: thinking
-      type: number
-      enum: [enabled, disabled]
-      minValue: 1024
-      maxValue: 128000
-      withdrawParams: [top_k, top_p]
-      skipValues:
-          - disabled
-          - null
-removeParams: [top_p]
+    -
+        key: max_tokens
+        maxValue: 64000
+    -
+        key: thinking
+        type: number
+        enum:
+            - enabled
+            - disabled
+        minValue: 1024
+        maxValue: 128000
+        withdrawParams:
+            - top_k
+            - top_p
+        skipValues:
+            - disabled
+            - null
+removeParams:
+    - top_p
 mode: chat

--- a/providers/aws-bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0.yaml
@@ -35,23 +35,21 @@ features:
     - chat
     - image
 params:
-    -
-        key: max_tokens
-        maxValue: 64000
-    -
-        key: thinking
-        type: number
-        enum:
-            - enabled
-            - disabled
-        minValue: 1024
-        maxValue: 128000
-        withdrawParams:
-            - top_k
-            - top_p
-        skipValues:
-            - disabled
-            - null
+    - key: max_tokens
+      maxValue: 64000
+    - key: thinking
+      type: number
+      enum:
+          - enabled
+          - disabled
+      minValue: 1024
+      maxValue: 128000
+      withdrawParams:
+          - top_k
+          - top_p
+      skipValues:
+          - disabled
+          - null
 removeParams:
     - top_p
 mode: chat

--- a/providers/aws-bedrock/us.anthropic.claude-opus-4-1-20250805-v1:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-opus-4-1-20250805-v1:0.yaml
@@ -1,61 +1,70 @@
 model: us.anthropic.claude-opus-4-1-20250805-v1:0
 costs:
     - region: us-west-2
-      cache_creation_input_token_cost: 1.875e-05
+      cache_creation_input_token_cost: 1.875e-5
       cache_read_input_token_cost: 1.5e-6
-      input_cost_per_token: 1.5e-05
-      input_cost_per_token_batches: 7.5e-6
-      output_cost_per_token: 7.5e-05
-      output_cost_per_token_batches: 3.75e-05
+      input_cost_per_token: 1.5e-5
+      output_cost_per_token: 7.5e-5
     - region: us-east-2
-      cache_creation_input_token_cost: 1.875e-05
+      cache_creation_input_token_cost: 1.875e-5
       cache_read_input_token_cost: 1.5e-6
-      input_cost_per_token: 1.5e-05
-      input_cost_per_token_batches: 7.5e-6
-      output_cost_per_token: 7.5e-05
-      output_cost_per_token_batches: 3.75e-05
+      input_cost_per_token: 1.5e-5
+      output_cost_per_token: 7.5e-5
     - region: us-east-1
-      cache_creation_input_token_cost: 1.875e-05
+      cache_creation_input_token_cost: 1.875e-5
       cache_read_input_token_cost: 1.5e-6
-      input_cost_per_token: 1.5e-05
-      input_cost_per_token_batches: 7.5e-6
-      output_cost_per_token: 7.5e-05
-      output_cost_per_token_batches: 3.75e-05
+      input_cost_per_token: 1.5e-5
+      output_cost_per_token: 7.5e-5
 limits:
     max_input_tokens: 200000
     max_output_tokens: 32000
     tool_use_system_prompt_tokens: 159
-features: [function_calling, vision, chat, image]
+features:
+    - function_calling
+    - vision
+    - chat
+    - image
 params:
-    - key: max_tokens
-      maxValue: 32000
-    - key: thinking
-      type: number
-      enum: [enabled, disabled]
-      minValue: 1024
-      maxValue: 128000
-      withdrawParams: [top_k, top_p]
-      skipValues:
-          - disabled
-          - null
-    - key: tool_choice
-      type: json
-      options:
-          - value: none
-            name: None
-          - value: auto
-            name: Auto
-          - value: required
-            name: Required
-          - value: custom
-            name: Custom
-            schema:
-            type: json
-      skipValues:
-          - null
-      rule:
-      default:
-          condition: tools
-          then: auto
-          else: null
+    -
+        key: max_tokens
+        maxValue: 32000
+    -
+        key: thinking
+        type: number
+        enum:
+            - enabled
+            - disabled
+        minValue: 1024
+        maxValue: 128000
+        withdrawParams:
+            - top_k
+            - top_p
+        skipValues:
+            - disabled
+            - null
+    -
+        key: tool_choice
+        type: json
+        options:
+            -
+                value: none
+                name: None
+            -
+                value: auto
+                name: Auto
+            -
+                value: required
+                name: Required
+            -
+                value: custom
+                name: Custom
+                schema: null
+                type: json
+        skipValues:
+            - null
+        rule: null
+        default:
+            condition: tools
+            then: auto
+            else: null
 mode: chat

--- a/providers/aws-bedrock/us.anthropic.claude-opus-4-1-20250805-v1:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-opus-4-1-20250805-v1:0.yaml
@@ -25,46 +25,39 @@ features:
     - chat
     - image
 params:
-    -
-        key: max_tokens
-        maxValue: 32000
-    -
-        key: thinking
-        type: number
-        enum:
-            - enabled
-            - disabled
-        minValue: 1024
-        maxValue: 128000
-        withdrawParams:
-            - top_k
-            - top_p
-        skipValues:
-            - disabled
-            - null
-    -
-        key: tool_choice
-        type: json
-        options:
-            -
-                value: none
-                name: None
-            -
-                value: auto
-                name: Auto
-            -
-                value: required
-                name: Required
-            -
-                value: custom
-                name: Custom
-                schema: null
-                type: json
-        skipValues:
-            - null
-        rule: null
-        default:
-            condition: tools
-            then: auto
-            else: null
+    - key: max_tokens
+      maxValue: 32000
+    - key: thinking
+      type: number
+      enum:
+          - enabled
+          - disabled
+      minValue: 1024
+      maxValue: 128000
+      withdrawParams:
+          - top_k
+          - top_p
+      skipValues:
+          - disabled
+          - null
+    - key: tool_choice
+      type: json
+      options:
+          - value: none
+            name: None
+          - value: auto
+            name: Auto
+          - value: required
+            name: Required
+          - value: custom
+            name: Custom
+            schema: null
+            type: json
+      skipValues:
+          - null
+      rule: null
+      default:
+          condition: tools
+          then: auto
+          else: null
 mode: chat

--- a/providers/aws-bedrock/us.anthropic.claude-opus-4-20250514-v1:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-opus-4-20250514-v1:0.yaml
@@ -25,53 +25,46 @@ features:
     - chat
     - image
 params:
-    -
-        key: max_tokens
-        maxValue: 128000
-    -
-        key: thinking
-        properties:
-            type:
-                type: string
-                enum:
-                    - enabled
-                    - disabled
-            budget_tokens:
-                type: number
-                minValue: 1024
-                maxValue: 128000
-        defaultValue: null
-        withdrawParams:
-            - top_k
-            - top_p
-        skipValues:
-            - disabled
-            - null
-    -
-        key: tool_choice
-        type: non-view-manage-data
-        defaultValue: null
-        options:
-            -
-                value: none
-                name: None
-            -
-                value: auto
-                name: Auto
-            -
-                value: required
-                name: Required
-            -
-                value: custom
-                name: Custom
-                schema:
-                    type: json
-        skipValues:
-            - null
-            - []
-        rule:
-            default:
-                condition: tools
-                then: auto
-                else: null
+    - key: max_tokens
+      maxValue: 128000
+    - key: thinking
+      properties:
+          type:
+              type: string
+              enum:
+                  - enabled
+                  - disabled
+          budget_tokens:
+              type: number
+              minValue: 1024
+              maxValue: 128000
+      defaultValue: null
+      withdrawParams:
+          - top_k
+          - top_p
+      skipValues:
+          - disabled
+          - null
+    - key: tool_choice
+      type: non-view-manage-data
+      defaultValue: null
+      options:
+          - value: none
+            name: None
+          - value: auto
+            name: Auto
+          - value: required
+            name: Required
+          - value: custom
+            name: Custom
+            schema:
+                type: json
+      skipValues:
+          - null
+          - []
+      rule:
+          default:
+              condition: tools
+              then: auto
+              else: null
 mode: chat

--- a/providers/aws-bedrock/us.anthropic.claude-opus-4-20250514-v1:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-opus-4-20250514-v1:0.yaml
@@ -1,56 +1,77 @@
 model: us.anthropic.claude-opus-4-20250514-v1:0
 costs:
-    - region: "*"
-      input_cost_per_token: 0.000015
-      output_cost_per_token: 0.000075
-      cache_read_input_token_cost: 0.0000015
-      cache_creation_input_token_cost: 0.00001875
+    - region: us-west-2
+      cache_creation_input_token_cost: 1.875e-5
+      cache_read_input_token_cost: 1.5e-6
+      input_cost_per_token: 1.5e-5
+      output_cost_per_token: 7.5e-5
+    - region: us-east-2
+      cache_creation_input_token_cost: 1.875e-5
+      cache_read_input_token_cost: 1.5e-6
+      input_cost_per_token: 1.5e-5
+      output_cost_per_token: 7.5e-5
+    - region: us-east-1
+      cache_creation_input_token_cost: 1.875e-5
+      cache_read_input_token_cost: 1.5e-6
+      input_cost_per_token: 1.5e-5
+      output_cost_per_token: 7.5e-5
 limits:
     max_input_tokens: 200000
     max_output_tokens: 32000
     tool_use_system_prompt_tokens: 159
-features: [function_calling, vision, chat, image]
+features:
+    - function_calling
+    - vision
+    - chat
+    - image
 params:
-    - key: max_tokens
-      maxValue: 128000
-    - key: thinking
-      properties:
-          type:
-              type: string
-              enum:
-                  - enabled
-                  - disabled
-          budget_tokens:
-              type: number
-              minValue: 1024
-              maxValue: 128000
-      defaultValue: null
-      withdrawParams:
-          - top_k
-          - top_p
-      skipValues:
-          - disabled
-          - null
-    - key: tool_choice
-      type: non-view-manage-data
-      defaultValue: null
-      options:
-          - value: none
-            name: None
-          - value: auto
-            name: Auto
-          - value: required
-            name: Required
-          - value: custom
-            name: Custom
-            schema:
-                type: json
-      skipValues:
-          - null
-          - []
-      rule:
-          default:
-              condition: tools
-              then: auto
-              else: null
+    -
+        key: max_tokens
+        maxValue: 128000
+    -
+        key: thinking
+        properties:
+            type:
+                type: string
+                enum:
+                    - enabled
+                    - disabled
+            budget_tokens:
+                type: number
+                minValue: 1024
+                maxValue: 128000
+        defaultValue: null
+        withdrawParams:
+            - top_k
+            - top_p
+        skipValues:
+            - disabled
+            - null
+    -
+        key: tool_choice
+        type: non-view-manage-data
+        defaultValue: null
+        options:
+            -
+                value: none
+                name: None
+            -
+                value: auto
+                name: Auto
+            -
+                value: required
+                name: Required
+            -
+                value: custom
+                name: Custom
+                schema:
+                    type: json
+        skipValues:
+            - null
+            - []
+        rule:
+            default:
+                condition: tools
+                then: auto
+                else: null
 mode: chat

--- a/providers/aws-bedrock/us.anthropic.claude-opus-4-5-20251101-v1:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-opus-4-5-20251101-v1:0.yaml
@@ -35,23 +35,21 @@ features:
     - chat
     - image
 params:
-    -
-        key: max_tokens
-        maxValue: 64000
-    -
-        key: thinking
-        type: number
-        enum:
-            - enabled
-            - disabled
-        minValue: 1024
-        maxValue: 128000
-        withdrawParams:
-            - top_k
-            - top_p
-        skipValues:
-            - disabled
-            - null
+    - key: max_tokens
+      maxValue: 64000
+    - key: thinking
+      type: number
+      enum:
+          - enabled
+          - disabled
+      minValue: 1024
+      maxValue: 128000
+      withdrawParams:
+          - top_k
+          - top_p
+      skipValues:
+          - disabled
+          - null
 removeParams:
     - temperature
     - top_p

--- a/providers/aws-bedrock/us.anthropic.claude-opus-4-5-20251101-v1:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-opus-4-5-20251101-v1:0.yaml
@@ -1,56 +1,58 @@
 model: us.anthropic.claude-opus-4-5-20251101-v1:0
 costs:
     - region: us-west-2
-      cache_creation_input_token_cost: 6.875e-6
-      cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 5.5e-6
-      input_cost_per_token_batches: 2.75e-6
-      output_cost_per_token: 2.75e-05
-      output_cost_per_token_batches: 1.375e-05
+      cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 2.5e-5
     - region: us-west-1
-      cache_creation_input_token_cost: 6.875e-6
-      cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 5.5e-6
-      input_cost_per_token_batches: 2.75e-6
-      output_cost_per_token: 2.75e-05
-      output_cost_per_token_batches: 1.375e-05
+      cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 2.5e-5
     - region: us-east-2
-      cache_creation_input_token_cost: 6.875e-6
-      cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 5.5e-6
-      input_cost_per_token_batches: 2.75e-6
-      output_cost_per_token: 2.75e-05
-      output_cost_per_token_batches: 1.375e-05
+      cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 2.5e-5
     - region: us-east-1
-      cache_creation_input_token_cost: 6.875e-6
-      cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 5.5e-6
-      input_cost_per_token_batches: 2.75e-6
-      output_cost_per_token: 2.75e-05
-      output_cost_per_token_batches: 1.375e-05
+      cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 2.5e-5
     - region: ca-central-1
-      cache_creation_input_token_cost: 6.875e-6
-      cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 5.5e-6
-      input_cost_per_token_batches: 2.75e-6
-      output_cost_per_token: 2.75e-05
-      output_cost_per_token_batches: 1.375e-05
+      cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 2.5e-5
 limits:
     max_input_tokens: 200000
     max_output_tokens: 64000
     tool_use_system_prompt_tokens: 159
-features: [function_calling, vision, chat, image]
+features:
+    - function_calling
+    - vision
+    - chat
+    - image
 params:
-    - key: max_tokens
-      maxValue: 64000
-    - key: thinking
-      type: number
-      enum: [enabled, disabled]
-      minValue: 1024
-      maxValue: 128000
-      withdrawParams: [top_k, top_p]
-      skipValues:
-          - disabled
-          - null
-removeParams: [temperature, top_p]
+    -
+        key: max_tokens
+        maxValue: 64000
+    -
+        key: thinking
+        type: number
+        enum:
+            - enabled
+            - disabled
+        minValue: 1024
+        maxValue: 128000
+        withdrawParams:
+            - top_k
+            - top_p
+        skipValues:
+            - disabled
+            - null
+removeParams:
+    - temperature
+    - top_p
 mode: chat

--- a/providers/aws-bedrock/us.anthropic.claude-opus-4-6-v1.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-opus-4-6-v1.yaml
@@ -1,44 +1,41 @@
 model: us.anthropic.claude-opus-4-6-v1
 costs:
     - region: us-west-2
-      cache_creation_input_token_cost: 6.875e-6
-      cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 5.5e-6
-      input_cost_per_token_batches: 2.75e-6
-      output_cost_per_token: 2.75e-05
-      output_cost_per_token_batches: 1.375e-05
+      cache_creation_input_token_cost: 1.25e-5
+      cache_read_input_token_cost: 1e-6
+      input_cost_per_token: 1e-5
+      output_cost_per_token: 2.5e-5
     - region: us-west-1
-      cache_creation_input_token_cost: 6.875e-6
-      cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 5.5e-6
-      input_cost_per_token_batches: 2.75e-6
-      output_cost_per_token: 2.75e-05
-      output_cost_per_token_batches: 1.375e-05
+      cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 1e-5
+      output_cost_per_token: 3.75e-5
     - region: us-east-2
-      cache_creation_input_token_cost: 6.875e-6
-      cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 5.5e-6
-      input_cost_per_token_batches: 2.75e-6
-      output_cost_per_token: 2.75e-05
-      output_cost_per_token_batches: 1.375e-05
+      cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 1e-5
+      output_cost_per_token: 3.75e-5
     - region: us-east-1
-      cache_creation_input_token_cost: 6.875e-6
-      cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 5.5e-6
-      input_cost_per_token_batches: 2.75e-6
-      output_cost_per_token: 2.75e-05
-      output_cost_per_token_batches: 1.375e-05
+      cache_creation_input_token_cost: 1.25e-5
+      cache_read_input_token_cost: 1e-6
+      input_cost_per_token: 1e-5
+      output_cost_per_token: 2.5e-5
+    - region: ca-west-1
+      cache_creation_input_token_cost: 1.25e-5
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 1e-5
+      output_cost_per_token: 3.75e-5
     - region: ca-central-1
-      cache_creation_input_token_cost: 6.875e-6
-      cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 5.5e-6
-      input_cost_per_token_batches: 2.75e-6
-      output_cost_per_token: 2.75e-05
-      output_cost_per_token_batches: 1.375e-05
+      cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 1e-6
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 2.5e-5
 limits:
     max_tokens: 128000
     max_input_tokens: 1000000
     max_output_tokens: 128000
     tool_use_system_prompt_tokens: 346
-features: [function_calling, vision]
+features:
+    - function_calling
+    - vision
 mode: chat

--- a/providers/aws-bedrock/us.anthropic.claude-sonnet-4-20250514-v1:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-sonnet-4-20250514-v1:0.yaml
@@ -30,46 +30,39 @@ features:
     - chat
     - image
 params:
-    -
-        key: max_tokens
-        maxValue: 128000
-    -
-        key: thinking
-        type: number
-        enum:
-            - enabled
-            - disabled
-        minValue: 1024
-        maxValue: 128000
-        withdrawParams:
-            - top_k
-            - top_p
-        skipValues:
-            - disabled
-            - null
-    -
-        key: tool_choice
-        type: json
-        options:
-            -
-                value: none
-                name: None
-            -
-                value: auto
-                name: Auto
-            -
-                value: required
-                name: Required
-            -
-                value: custom
-                name: Custom
-                schema: null
-                type: json
-        skipValues:
-            - null
-        rule: null
-        default:
-            condition: tools
-            then: auto
-            else: null
+    - key: max_tokens
+      maxValue: 128000
+    - key: thinking
+      type: number
+      enum:
+          - enabled
+          - disabled
+      minValue: 1024
+      maxValue: 128000
+      withdrawParams:
+          - top_k
+          - top_p
+      skipValues:
+          - disabled
+          - null
+    - key: tool_choice
+      type: json
+      options:
+          - value: none
+            name: None
+          - value: auto
+            name: Auto
+          - value: required
+            name: Required
+          - value: custom
+            name: Custom
+            schema: null
+            type: json
+      skipValues:
+          - null
+      rule: null
+      default:
+          condition: tools
+          then: auto
+          else: null
 mode: chat

--- a/providers/aws-bedrock/us.anthropic.claude-sonnet-4-20250514-v1:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-sonnet-4-20250514-v1:0.yaml
@@ -1,68 +1,75 @@
 model: us.anthropic.claude-sonnet-4-20250514-v1:0
 costs:
     - region: us-west-2
-      cache_creation_input_token_cost: 3.75e-6
+      cache_creation_input_token_cost: 7.5e-6
       cache_read_input_token_cost: 3e-7
       input_cost_per_token: 3e-6
-      input_cost_per_token_batches: 1.5e-6
-      output_cost_per_token: 1.5e-05
-      output_cost_per_token_batches: 7.5e-6
+      output_cost_per_token: 2.25e-5
     - region: us-west-1
       cache_creation_input_token_cost: 3.75e-6
       cache_read_input_token_cost: 3e-7
       input_cost_per_token: 3e-6
-      input_cost_per_token_batches: 1.5e-6
-      output_cost_per_token: 1.5e-05
-      output_cost_per_token_batches: 7.5e-6
+      output_cost_per_token: 1.5e-5
     - region: us-east-2
       cache_creation_input_token_cost: 3.75e-6
       cache_read_input_token_cost: 3e-7
-      input_cost_per_token: 3e-6
-      input_cost_per_token_batches: 1.5e-6
-      output_cost_per_token: 1.5e-05
-      output_cost_per_token_batches: 7.5e-6
+      input_cost_per_token: 6e-6
+      output_cost_per_token: 2.25e-5
     - region: us-east-1
-      cache_creation_input_token_cost: 3.75e-6
-      cache_read_input_token_cost: 3e-7
-      input_cost_per_token: 3e-6
-      input_cost_per_token_batches: 1.5e-6
-      output_cost_per_token: 1.5e-05
-      output_cost_per_token_batches: 7.5e-6
+      cache_creation_input_token_cost: 7.5e-6
+      cache_read_input_token_cost: 6e-7
+      input_cost_per_token: 6e-6
+      output_cost_per_token: 2.25e-5
 limits:
     max_input_tokens: 1000000
     max_output_tokens: 64000
     tool_use_system_prompt_tokens: 159
-features: [function_calling, vision, chat, image]
+features:
+    - function_calling
+    - vision
+    - chat
+    - image
 params:
-    - key: max_tokens
-      maxValue: 128000
-    - key: thinking
-      type: number
-      enum: [enabled, disabled]
-      minValue: 1024
-      maxValue: 128000
-      withdrawParams: [top_k, top_p]
-      skipValues:
-          - disabled
-          - null
-    - key: tool_choice
-      type: json
-      options:
-          - value: none
-            name: None
-          - value: auto
-            name: Auto
-          - value: required
-            name: Required
-          - value: custom
-            name: Custom
-            schema:
-            type: json
-      skipValues:
-          - null
-      rule:
-      default:
-          condition: tools
-          then: auto
-          else: null
+    -
+        key: max_tokens
+        maxValue: 128000
+    -
+        key: thinking
+        type: number
+        enum:
+            - enabled
+            - disabled
+        minValue: 1024
+        maxValue: 128000
+        withdrawParams:
+            - top_k
+            - top_p
+        skipValues:
+            - disabled
+            - null
+    -
+        key: tool_choice
+        type: json
+        options:
+            -
+                value: none
+                name: None
+            -
+                value: auto
+                name: Auto
+            -
+                value: required
+                name: Required
+            -
+                value: custom
+                name: Custom
+                schema: null
+                type: json
+        skipValues:
+            - null
+        rule: null
+        default:
+            condition: tools
+            then: auto
+            else: null
 mode: chat

--- a/providers/aws-bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
@@ -1,76 +1,82 @@
 model: us.anthropic.claude-sonnet-4-5-20250929-v1:0
 costs:
     - region: us-west-2
-      cache_creation_input_token_cost: 4.125e-6
-      cache_read_input_token_cost: 3.3e-7
-      input_cost_per_token: 3.3e-6
-      input_cost_per_token_batches: 1.65e-6
-      output_cost_per_token: 1.65e-05
-      output_cost_per_token_batches: 8.25e-6
+      cache_creation_input_token_cost: 7.5e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 2.25e-5
     - region: us-west-1
-      cache_creation_input_token_cost: 4.125e-6
-      cache_read_input_token_cost: 3.3e-7
-      input_cost_per_token: 3.3e-6
-      input_cost_per_token_batches: 1.65e-6
-      output_cost_per_token: 1.65e-05
-      output_cost_per_token_batches: 8.25e-6
+      cache_creation_input_token_cost: 7.5e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 2.25e-5
     - region: us-east-2
-      cache_creation_input_token_cost: 4.125e-6
-      cache_read_input_token_cost: 3.3e-7
-      input_cost_per_token: 3.3e-6
-      input_cost_per_token_batches: 1.65e-6
-      output_cost_per_token: 1.65e-05
-      output_cost_per_token_batches: 8.25e-6
+      cache_creation_input_token_cost: 7.5e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 1.5e-5
     - region: us-east-1
-      cache_creation_input_token_cost: 4.125e-6
-      cache_read_input_token_cost: 3.3e-7
-      input_cost_per_token: 3.3e-6
-      input_cost_per_token_batches: 1.65e-6
-      output_cost_per_token: 1.65e-05
-      output_cost_per_token_batches: 8.25e-6
+      cache_creation_input_token_cost: 3.75e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 6e-6
+      output_cost_per_token: 2.25e-5
     - region: ca-central-1
-      cache_creation_input_token_cost: 4.125e-6
-      cache_read_input_token_cost: 3.3e-7
-      input_cost_per_token: 3.3e-6
-      input_cost_per_token_batches: 1.65e-6
-      output_cost_per_token: 1.65e-05
-      output_cost_per_token_batches: 8.25e-6
+      cache_creation_input_token_cost: 7.5e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 6e-6
+      output_cost_per_token: 1.5e-5
 limits:
     max_input_tokens: 200000
     max_output_tokens: 64000
     tool_use_system_prompt_tokens: 346
-features: [function_calling, vision, chat, image]
+features:
+    - function_calling
+    - vision
+    - chat
+    - image
 params:
-    - key: max_tokens
-      maxValue: 64000
-    - key: thinking
-      type: number
-      enum: [enabled, disabled]
-      minValue: 1024
-      maxValue: 128000
-      withdrawParams: [top_k, top_p]
-      skipValues:
-          - disabled
-          - null
-    - key: tool_choice
-      type: json
-      options:
-          - value: none
-            name: None
-          - value: auto
-            name: Auto
-          - value: required
-            name: Required
-          - value: custom
-            name: Custom
-            schema:
-            type: json
-      skipValues:
-          - null
-      rule:
-      default:
-          condition: tools
-          then: auto
-          else: null
-removeParams: [top_p]
+    -
+        key: max_tokens
+        maxValue: 64000
+    -
+        key: thinking
+        type: number
+        enum:
+            - enabled
+            - disabled
+        minValue: 1024
+        maxValue: 128000
+        withdrawParams:
+            - top_k
+            - top_p
+        skipValues:
+            - disabled
+            - null
+    -
+        key: tool_choice
+        type: json
+        options:
+            -
+                value: none
+                name: None
+            -
+                value: auto
+                name: Auto
+            -
+                value: required
+                name: Required
+            -
+                value: custom
+                name: Custom
+                schema: null
+                type: json
+        skipValues:
+            - null
+        rule: null
+        default:
+            condition: tools
+            then: auto
+            else: null
+removeParams:
+    - top_p
 mode: chat

--- a/providers/aws-bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
@@ -35,48 +35,41 @@ features:
     - chat
     - image
 params:
-    -
-        key: max_tokens
-        maxValue: 64000
-    -
-        key: thinking
-        type: number
-        enum:
-            - enabled
-            - disabled
-        minValue: 1024
-        maxValue: 128000
-        withdrawParams:
-            - top_k
-            - top_p
-        skipValues:
-            - disabled
-            - null
-    -
-        key: tool_choice
-        type: json
-        options:
-            -
-                value: none
-                name: None
-            -
-                value: auto
-                name: Auto
-            -
-                value: required
-                name: Required
-            -
-                value: custom
-                name: Custom
-                schema: null
-                type: json
-        skipValues:
-            - null
-        rule: null
-        default:
-            condition: tools
-            then: auto
-            else: null
+    - key: max_tokens
+      maxValue: 64000
+    - key: thinking
+      type: number
+      enum:
+          - enabled
+          - disabled
+      minValue: 1024
+      maxValue: 128000
+      withdrawParams:
+          - top_k
+          - top_p
+      skipValues:
+          - disabled
+          - null
+    - key: tool_choice
+      type: json
+      options:
+          - value: none
+            name: None
+          - value: auto
+            name: Auto
+          - value: required
+            name: Required
+          - value: custom
+            name: Custom
+            schema: null
+            type: json
+      skipValues:
+          - null
+      rule: null
+      default:
+          condition: tools
+          then: auto
+          else: null
 removeParams:
     - top_p
 mode: chat

--- a/providers/aws-bedrock/us.cohere.embed-v4:0.yaml
+++ b/providers/aws-bedrock/us.cohere.embed-v4:0.yaml
@@ -1,0 +1,15 @@
+model: us.cohere.embed-v4:0
+costs:
+    - region: us-west-2
+      input_cost_per_token: 1.2e-7
+    - region: us-west-1
+      input_cost_per_token: 1.2e-7
+    - region: us-east-2
+      input_cost_per_token: 1.2e-7
+    - region: us-east-1
+      input_cost_per_token: 1.2e-7
+limits:
+    max_tokens: 128000
+    max_input_tokens: 128000
+    output_vector_size: 1536
+mode: embedding

--- a/providers/aws-bedrock/us.meta.llama3-1-405b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/us.meta.llama3-1-405b-instruct-v1:0.yaml
@@ -3,3 +3,9 @@ costs:
     - region: us-east-2
       input_cost_per_token: 2.4e-6
       output_cost_per_token: 2.4e-6
+limits:
+    max_tokens: 4096
+    max_input_tokens: 128000
+    max_output_tokens: 4096
+features: [function_calling, chat]
+mode: chat

--- a/providers/aws-bedrock/us.meta.llama3-1-405b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/us.meta.llama3-1-405b-instruct-v1:0.yaml
@@ -7,5 +7,7 @@ limits:
     max_tokens: 4096
     max_input_tokens: 128000
     max_output_tokens: 4096
-features: [function_calling, chat]
+features:
+    - function_calling
+    - chat
 mode: chat

--- a/providers/aws-bedrock/us.meta.llama3-1-405b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/us.meta.llama3-1-405b-instruct-v1:0.yaml
@@ -2,6 +2,4 @@ model: us.meta.llama3-1-405b-instruct-v1:0
 costs:
     - region: us-east-2
       input_cost_per_token: 2.4e-6
-      input_cost_per_token_batches: 1.2e-6
       output_cost_per_token: 2.4e-6
-      output_cost_per_token_batches: 1.2e-6

--- a/providers/aws-bedrock/us.meta.llama3-1-70b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/us.meta.llama3-1-70b-instruct-v1:0.yaml
@@ -2,22 +2,18 @@ model: us.meta.llama3-1-70b-instruct-v1:0
 costs:
     - region: us-west-2
       input_cost_per_token: 7.2e-7
-      input_cost_per_token_batches: 3.6e-7
       output_cost_per_token: 7.2e-7
-      output_cost_per_token_batches: 3.6e-7
     - region: us-east-2
       input_cost_per_token: 7.2e-7
-      input_cost_per_token_batches: 3.6e-7
       output_cost_per_token: 7.2e-7
-      output_cost_per_token_batches: 3.6e-7
     - region: us-east-1
       input_cost_per_token: 7.2e-7
-      input_cost_per_token_batches: 3.6e-7
       output_cost_per_token: 7.2e-7
-      output_cost_per_token_batches: 3.6e-7
 limits:
     max_tokens: 4096
     max_input_tokens: 128000
     max_output_tokens: 2048
-features: [function_calling, chat]
+features:
+    - function_calling
+    - chat
 mode: chat

--- a/providers/aws-bedrock/us.meta.llama3-1-8b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/us.meta.llama3-1-8b-instruct-v1:0.yaml
@@ -2,22 +2,18 @@ model: us.meta.llama3-1-8b-instruct-v1:0
 costs:
     - region: us-west-2
       input_cost_per_token: 2.2e-7
-      input_cost_per_token_batches: 1.1e-7
       output_cost_per_token: 2.2e-7
-      output_cost_per_token_batches: 1.1e-7
     - region: us-east-2
       input_cost_per_token: 2.2e-7
-      input_cost_per_token_batches: 1.1e-7
       output_cost_per_token: 2.2e-7
-      output_cost_per_token_batches: 1.1e-7
     - region: us-east-1
       input_cost_per_token: 2.2e-7
-      input_cost_per_token_batches: 1.1e-7
       output_cost_per_token: 2.2e-7
-      output_cost_per_token_batches: 1.1e-7
 limits:
     max_tokens: 4096
     max_input_tokens: 128000
     max_output_tokens: 2048
-features: [function_calling, chat]
+features:
+    - function_calling
+    - chat
 mode: chat

--- a/providers/aws-bedrock/us.meta.llama3-2-11b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/us.meta.llama3-2-11b-instruct-v1:0.yaml
@@ -9,3 +9,9 @@ costs:
     - region: us-east-1
       input_cost_per_token: 1.6e-7
       output_cost_per_token: 1.6e-7
+limits:
+    max_tokens: 4096
+    max_input_tokens: 128000
+    max_output_tokens: 4096
+features: [function_calling, vision]
+mode: chat

--- a/providers/aws-bedrock/us.meta.llama3-2-11b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/us.meta.llama3-2-11b-instruct-v1:0.yaml
@@ -13,5 +13,7 @@ limits:
     max_tokens: 4096
     max_input_tokens: 128000
     max_output_tokens: 4096
-features: [function_calling, vision]
+features:
+    - function_calling
+    - vision
 mode: chat

--- a/providers/aws-bedrock/us.meta.llama3-2-11b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/us.meta.llama3-2-11b-instruct-v1:0.yaml
@@ -2,9 +2,7 @@ model: us.meta.llama3-2-11b-instruct-v1:0
 costs:
     - region: us-west-2
       input_cost_per_token: 1.6e-7
-      input_cost_per_token_batches: 8e-8
       output_cost_per_token: 1.6e-7
-      output_cost_per_token_batches: 8e-8
     - region: us-east-2
       input_cost_per_token: 1.6e-7
       output_cost_per_token: 1.6e-7

--- a/providers/aws-bedrock/us.meta.llama3-2-1b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/us.meta.llama3-2-1b-instruct-v1:0.yaml
@@ -2,9 +2,7 @@ model: us.meta.llama3-2-1b-instruct-v1:0
 costs:
     - region: us-west-2
       input_cost_per_token: 1e-7
-      input_cost_per_token_batches: 5e-8
       output_cost_per_token: 1e-7
-      output_cost_per_token_batches: 5e-8
     - region: us-east-2
       input_cost_per_token: 1e-7
       output_cost_per_token: 1e-7
@@ -15,5 +13,7 @@ limits:
     max_tokens: 4096
     max_input_tokens: 128000
     max_output_tokens: 4096
-features: [function_calling, chat]
+features:
+    - function_calling
+    - chat
 mode: chat

--- a/providers/aws-bedrock/us.meta.llama3-2-3b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/us.meta.llama3-2-3b-instruct-v1:0.yaml
@@ -2,9 +2,7 @@ model: us.meta.llama3-2-3b-instruct-v1:0
 costs:
     - region: us-west-2
       input_cost_per_token: 1.5e-7
-      input_cost_per_token_batches: 7.5e-8
       output_cost_per_token: 1.5e-7
-      output_cost_per_token_batches: 7.5e-8
     - region: us-east-2
       input_cost_per_token: 1.5e-7
       output_cost_per_token: 1.5e-7
@@ -15,5 +13,7 @@ limits:
     max_tokens: 4096
     max_input_tokens: 128000
     max_output_tokens: 4096
-features: [function_calling, chat]
+features:
+    - function_calling
+    - chat
 mode: chat

--- a/providers/aws-bedrock/us.meta.llama3-2-90b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/us.meta.llama3-2-90b-instruct-v1:0.yaml
@@ -13,5 +13,7 @@ limits:
     max_tokens: 4096
     max_input_tokens: 128000
     max_output_tokens: 4096
-features: [function_calling, vision]
+features:
+    - function_calling
+    - vision
 mode: chat

--- a/providers/aws-bedrock/us.meta.llama3-2-90b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/us.meta.llama3-2-90b-instruct-v1:0.yaml
@@ -2,9 +2,7 @@ model: us.meta.llama3-2-90b-instruct-v1:0
 costs:
     - region: us-west-2
       input_cost_per_token: 7.2e-7
-      input_cost_per_token_batches: 3.6e-7
       output_cost_per_token: 7.2e-7
-      output_cost_per_token_batches: 3.6e-7
     - region: us-east-2
       input_cost_per_token: 7.2e-7
       output_cost_per_token: 7.2e-7

--- a/providers/aws-bedrock/us.meta.llama3-2-90b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/us.meta.llama3-2-90b-instruct-v1:0.yaml
@@ -9,3 +9,9 @@ costs:
     - region: us-east-1
       input_cost_per_token: 7.2e-7
       output_cost_per_token: 7.2e-7
+limits:
+    max_tokens: 4096
+    max_input_tokens: 128000
+    max_output_tokens: 4096
+features: [function_calling, vision]
+mode: chat

--- a/providers/aws-bedrock/us.meta.llama3-3-70b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/us.meta.llama3-3-70b-instruct-v1:0.yaml
@@ -2,22 +2,18 @@ model: us.meta.llama3-3-70b-instruct-v1:0
 costs:
     - region: us-west-2
       input_cost_per_token: 7.2e-7
-      input_cost_per_token_batches: 3.6e-7
       output_cost_per_token: 7.2e-7
-      output_cost_per_token_batches: 3.6e-7
     - region: us-east-2
       input_cost_per_token: 7.2e-7
-      input_cost_per_token_batches: 3.6e-7
       output_cost_per_token: 7.2e-7
-      output_cost_per_token_batches: 3.6e-7
     - region: us-east-1
       input_cost_per_token: 7.2e-7
-      input_cost_per_token_batches: 3.6e-7
       output_cost_per_token: 7.2e-7
-      output_cost_per_token_batches: 3.6e-7
 limits:
     max_tokens: 4096
     max_input_tokens: 128000
     max_output_tokens: 4096
-features: [function_calling, chat]
+features:
+    - function_calling
+    - chat
 mode: chat

--- a/providers/aws-bedrock/us.meta.llama4-maverick-17b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/us.meta.llama4-maverick-17b-instruct-v1:0.yaml
@@ -2,27 +2,21 @@ model: us.meta.llama4-maverick-17b-instruct-v1:0
 costs:
     - region: us-west-2
       input_cost_per_token: 2.4e-7
-      input_cost_per_token_batches: 1.2e-7
       output_cost_per_token: 9.7e-7
-      output_cost_per_token_batches: 4.85e-7
     - region: us-west-1
       input_cost_per_token: 2.4e-7
-      input_cost_per_token_batches: 1.2e-7
       output_cost_per_token: 9.7e-7
-      output_cost_per_token_batches: 4.85e-7
     - region: us-east-2
       input_cost_per_token: 2.4e-7
-      input_cost_per_token_batches: 1.2e-7
       output_cost_per_token: 9.7e-7
-      output_cost_per_token_batches: 4.85e-7
     - region: us-east-1
       input_cost_per_token: 2.4e-7
-      input_cost_per_token_batches: 1.2e-7
       output_cost_per_token: 9.7e-7
-      output_cost_per_token_batches: 4.85e-7
 limits:
     max_tokens: 4096
     max_input_tokens: 128000
     max_output_tokens: 4096
-features: [function_calling, chat]
+features:
+    - function_calling
+    - chat
 mode: chat

--- a/providers/aws-bedrock/us.meta.llama4-scout-17b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/us.meta.llama4-scout-17b-instruct-v1:0.yaml
@@ -2,27 +2,21 @@ model: us.meta.llama4-scout-17b-instruct-v1:0
 costs:
     - region: us-west-2
       input_cost_per_token: 1.7e-7
-      input_cost_per_token_batches: 8.5e-8
       output_cost_per_token: 6.6e-7
-      output_cost_per_token_batches: 3.3e-7
     - region: us-west-1
       input_cost_per_token: 1.7e-7
-      input_cost_per_token_batches: 8.5e-8
       output_cost_per_token: 6.6e-7
-      output_cost_per_token_batches: 3.3e-7
     - region: us-east-2
       input_cost_per_token: 1.7e-7
-      input_cost_per_token_batches: 8.5e-8
       output_cost_per_token: 6.6e-7
-      output_cost_per_token_batches: 3.3e-7
     - region: us-east-1
       input_cost_per_token: 1.7e-7
-      input_cost_per_token_batches: 8.5e-8
       output_cost_per_token: 6.6e-7
-      output_cost_per_token_batches: 3.3e-7
 limits:
     max_tokens: 4096
     max_input_tokens: 128000
     max_output_tokens: 4096
-features: [function_calling, chat]
+features:
+    - function_calling
+    - chat
 mode: chat

--- a/providers/aws-bedrock/us.mistral.pixtral-large-2502-v1:0.yaml
+++ b/providers/aws-bedrock/us.mistral.pixtral-large-2502-v1:0.yaml
@@ -3,15 +3,17 @@ costs:
     - region: us-west-2
       input_cost_per_token: 2e-6
       output_cost_per_token: 6e-6
-    - region: us-east-1
+    - region: us-east-2
       input_cost_per_token: 2e-6
       output_cost_per_token: 6e-6
-    - region: us-east-2
+    - region: us-east-1
       input_cost_per_token: 2e-6
       output_cost_per_token: 6e-6
 limits:
     max_tokens: 4096
     max_input_tokens: 128000
     max_output_tokens: 4096
-features: [function_calling, image]
+features:
+    - function_calling
+    - image
 mode: chat

--- a/providers/aws-bedrock/us.twelvelabs.marengo-embed-2-7-v1:0.yaml
+++ b/providers/aws-bedrock/us.twelvelabs.marengo-embed-2-7-v1:0.yaml
@@ -1,6 +1,8 @@
 model: us.twelvelabs.marengo-embed-2-7-v1:0
 costs:
     - region: us-east-1
+      input_cost_per_image: 1e-4
+      input_cost_per_second: 1.4e-4
       input_cost_per_token: 1e-10
 limits:
     max_tokens: 77

--- a/providers/aws-bedrock/us.twelvelabs.marengo-embed-2-7-v1:0.yaml
+++ b/providers/aws-bedrock/us.twelvelabs.marengo-embed-2-7-v1:0.yaml
@@ -1,10 +1,7 @@
 model: us.twelvelabs.marengo-embed-2-7-v1:0
 costs:
     - region: us-east-1
-      input_cost_per_audio_token: 0.00014
-      input_cost_per_image: 0.0001
-      input_cost_per_request: 7e-05
-      input_cost_per_second: 0.0007
+      input_cost_per_token: 1e-10
 limits:
     max_tokens: 77
     max_input_tokens: 77

--- a/providers/aws-bedrock/us.twelvelabs.marengo-embed-3-0-v1:0.yaml
+++ b/providers/aws-bedrock/us.twelvelabs.marengo-embed-3-0-v1:0.yaml
@@ -1,6 +1,8 @@
 model: us.twelvelabs.marengo-embed-3-0-v1:0
 costs:
     - region: us-east-1
+      input_cost_per_image: 1e-4
+      input_cost_per_second: 7e-4
       input_cost_per_token: 1e-10
 limits:
     max_tokens: 500

--- a/providers/aws-bedrock/us.twelvelabs.marengo-embed-3-0-v1:0.yaml
+++ b/providers/aws-bedrock/us.twelvelabs.marengo-embed-3-0-v1:0.yaml
@@ -1,7 +1,4 @@
 model: us.twelvelabs.marengo-embed-3-0-v1:0
 costs:
     - region: us-east-1
-      input_cost_per_audio_token: 0.00014
-      input_cost_per_image: 0.0001
-      input_cost_per_request: 7e-05
-      input_cost_per_second: 0.0007
+      input_cost_per_token: 1e-10

--- a/providers/aws-bedrock/us.twelvelabs.marengo-embed-3-0-v1:0.yaml
+++ b/providers/aws-bedrock/us.twelvelabs.marengo-embed-3-0-v1:0.yaml
@@ -4,6 +4,6 @@ costs:
       input_cost_per_token: 1e-10
 limits:
     max_tokens: 500
-    max_input_tokens: 500    
+    max_input_tokens: 500
     output_vector_size: 1024
 mode: embedding

--- a/providers/aws-bedrock/us.twelvelabs.marengo-embed-3-0-v1:0.yaml
+++ b/providers/aws-bedrock/us.twelvelabs.marengo-embed-3-0-v1:0.yaml
@@ -2,3 +2,8 @@ model: us.twelvelabs.marengo-embed-3-0-v1:0
 costs:
     - region: us-east-1
       input_cost_per_token: 1e-10
+limits:
+    max_tokens: 500
+    max_input_tokens: 500    
+    output_vector_size: 1024
+mode: embedding

--- a/providers/aws-bedrock/us.twelvelabs.pegasus-1-2-v1:0.yaml
+++ b/providers/aws-bedrock/us.twelvelabs.pegasus-1-2-v1:0.yaml
@@ -1,16 +1,16 @@
 model: us.twelvelabs.pegasus-1-2-v1:0
 costs:
+    - region: us-west-2
+      input_cost_per_token: 5e-10
+      output_cost_per_token: 7.5e-6
     - region: us-west-1
-      input_cost_per_second: 0.00049
+      input_cost_per_token: 5e-10
       output_cost_per_token: 7.5e-6
     - region: us-east-2
-      input_cost_per_second: 0.00049
+      input_cost_per_token: 5e-10
       output_cost_per_token: 7.5e-6
     - region: us-east-1
-      input_cost_per_second: 0.00049
-      output_cost_per_token: 7.5e-6
-    - region: us-west-2
-      input_cost_per_second: 0.00049
+      input_cost_per_token: 5e-10
       output_cost_per_token: 7.5e-6
 limits:
     max_tokens: 4096

--- a/providers/aws-bedrock/us.twelvelabs.pegasus-1-2-v1:0.yaml
+++ b/providers/aws-bedrock/us.twelvelabs.pegasus-1-2-v1:0.yaml
@@ -1,16 +1,16 @@
 model: us.twelvelabs.pegasus-1-2-v1:0
 costs:
     - region: us-west-2
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
     - region: us-west-1
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
     - region: us-east-2
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
     - region: us-east-1
-      input_cost_per_token: 5e-10
+      input_cost_per_second: 4.9e-4
       output_cost_per_token: 7.5e-6
 limits:
     max_tokens: 4096

--- a/providers/aws-bedrock/us.writer.palmyra-x4-v1:0.yaml
+++ b/providers/aws-bedrock/us.writer.palmyra-x4-v1:0.yaml
@@ -1,11 +1,21 @@
 model: us.writer.palmyra-x4-v1:0
 costs:
-    - region: "*"
-      input_cost_per_token: 0.0000025
-      output_cost_per_token: 0.00001
+    - region: us-west-2
+      input_cost_per_token: 2.5e-6
+      output_cost_per_token: 1e-5
+    - region: us-west-1
+      input_cost_per_token: 2.5e-6
+      output_cost_per_token: 1e-5
+    - region: us-east-2
+      input_cost_per_token: 2.5e-6
+      output_cost_per_token: 1e-5
+    - region: us-east-1
+      input_cost_per_token: 2.5e-6
+      output_cost_per_token: 1e-5
 limits:
     max_tokens: 4096
     max_input_tokens: 128000
     max_output_tokens: 8192
-features: [function_calling]
+features:
+    - function_calling
 mode: chat

--- a/providers/aws-bedrock/us.writer.palmyra-x5-v1:0.yaml
+++ b/providers/aws-bedrock/us.writer.palmyra-x5-v1:0.yaml
@@ -1,11 +1,21 @@
 model: us.writer.palmyra-x5-v1:0
 costs:
-    - region: "*"
-      input_cost_per_token: 6.e-7
-      output_cost_per_token: 0.000006
+    - region: us-west-2
+      input_cost_per_token: 6e-7
+      output_cost_per_token: 6e-6
+    - region: us-west-1
+      input_cost_per_token: 6e-7
+      output_cost_per_token: 6e-6
+    - region: us-east-2
+      input_cost_per_token: 6e-7
+      output_cost_per_token: 6e-6
+    - region: us-east-1
+      input_cost_per_token: 6e-7
+      output_cost_per_token: 6e-6
 limits:
     max_tokens: 4096
     max_input_tokens: 1000000
     max_output_tokens: 8192
-features: [function_calling]
+features:
+    - function_calling
 mode: chat

--- a/test/model.cue
+++ b/test/model.cue
@@ -36,6 +36,10 @@ package model
 	input_cost_per_query?:                   number
 	input_cost_per_image?:                   number
 	output_cost_per_image?:                  number
+	input_cost_per_image_token?:             number
+	output_cost_per_image_token?:            number
+	input_cost_per_video_token?:             number
+	output_cost_per_video_token?:            number
 	tiered_pricing?:                         #TieredPricing
 
 	// Resolution-based video pricing: matches fields like output_cost_per_second_480p, output_cost_per_second_4k, etc.


### PR DESCRIPTION
 Refined cost structures for ai21, amazon.nova, and anthropic.claude series, including the introduction of new models like amazon.nova-reel-v1 and anthropic.claude-3-7-sonnet-20250219-v1. Adjusted input and output costs across various regions for improved clarity and accuracy.