### PR TITLE
fix

### DIFF
--- a/.github/workflows/trigger-sync.yml
+++ b/.github/workflows/trigger-sync.yml
@@ -13,9 +13,26 @@ env:
   S3_IAM_ROLE_ARN: ${{ secrets.S3_IAM_ROLE_ARN }}
 
 jobs:
+  validate:
+    name: Validate before build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Validate (yamllint)
+        run: pip install yamllint && yamllint -c .yamllint.yml providers/
+
+      - name: Set up CUE
+        uses: cue-lang/setup-cue@v1.0.1
+      - name: Validate (CUE)
+        run: ./test/validate.sh
+
   build:
     name: Build unified JSON
     runs-on: ubuntu-latest
+    needs: validate
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,9 +1,6 @@
 name: Validate Model Configs
 
 on:
-  push:
-    branches:
-      - '**'
   pull_request:
     branches:
       - '**'

--- a/.github/workflows/yaml-lint-fix.yml
+++ b/.github/workflows/yaml-lint-fix.yml
@@ -31,6 +31,14 @@ jobs:
       - name: Run YAML fix
         run: npm run lint:yaml:fix
 
+      - name: Validate (yamllint)
+        run: pip install yamllint && yamllint -c .yamllint.yml providers/
+
+      - name: Set up CUE
+        uses: cue-lang/setup-cue@v1.0.1
+      - name: Validate (CUE)
+        run: ./test/validate.sh
+
       - name: Commit and push if changed
         run: |
           git config user.name "github-actions[bot]"
@@ -39,11 +47,3 @@ jobs:
           if ! git diff --staged --quiet; then
             git commit -m "chore: fix YAML format" && git push
           fi
-
-      - name: Validate (yamllint)
-        run: pip install yamllint && yamllint -c .yamllint.yml providers/
-
-      - name: Set up CUE
-        uses: cue-lang/setup-cue@v1.0.1
-      - name: Validate (CUE)
-        run: ./test/validate.sh


### PR DESCRIPTION
Workflow involves this:
On pull request: run validate.yml (simple validation check for linting and cue) (for forks)

On push: without any validation, run yaml:lint:fix, followed by lint:check and cue check (same as validation).
Separate jobs since `yaml-lint-fix.yml needs contents: write to commit and push back. If you add pull_request to it, fork PRs would trigger the workflow but the commit+push step would fail because it doesn't have write access.`

On push to main: same as on push followed by building the JSON and pushing to s3 