### PR TITLE
feat: automate README updates with model counts

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -1,0 +1,48 @@
+name: Update README Model Counts
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'providers/**'
+
+jobs:
+  update-readme:
+    name: Update provider model counts
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Update README counts
+        run: npm run update:readme
+
+      - name: Check for changes
+        id: changes
+        run: |
+          if git diff --quiet README.md; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit and push
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add README.md
+          git commit -m "docs(readme): update provider model counts"
+          git push

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A comprehensive, community-maintained registry of AI/LLM model configurations. T
 
 LLM model configs change often — prices drop, features expand, limits shift. This repository provides up-to-date information across providers and makes updating stale data easy.
 
-- **Unified Schema** — Consistent model configuration format across 17 providers
+- **Unified Schema** — Consistent model configuration format across 19 providers
 - **Up-to-Date Pricing** — Current cost information for input/output tokens, batch processing, and caching
 - **Feature Tracking** — Know exactly what each model supports (vision, tools, structured output, etc.)
 - **Open Source** — Community-driven updates ensure accuracy and coverage
@@ -18,23 +18,25 @@ LLM model configs change often — prices drop, features expand, limits shift. T
 
 | Provider | Models | Description |
 |----------|--------|-------------|
-| OpenAI | 81 | GPT-4, GPT-4o, GPT-5, o1, o3, DALL-E, Whisper, TTS |
-| Anthropic | 21 | Claude 3, Claude 3.5, Claude 4 |
-| AWS Bedrock | 139 | Claude, Llama, Titan, Mistral on AWS |
-| Azure OpenAI | 77 | OpenAI models on Azure |
-| Azure AI Foundry | 65 | Azure AI models |
-| Google Vertex AI | 110 | Gemini, PaLM on GCP |
-| Google Gemini | 25 | Gemini Pro, Ultra, Flash |
-| Mistral AI | 37 | Mistral, Mixtral, Codestral |
-| Cohere | 16 | Command, Embed models |
-| Groq | 14 | Fast inference models |
-| Together AI | 39 | Open source model hosting |
-| DeepInfra | 67 | Open source model hosting |
-| Perplexity | 25 | Search-augmented models |
-| Cerebras | 8 | Fast inference models |
+| OpenRouter | 411 | Unified API for open source models |
+| AWS Bedrock | 211 | Claude, Llama, Titan, Mistral on AWS |
+| Google Vertex AI | 136 | Gemini, PaLM on GCP |
+| OpenAI | 111 | GPT-4, GPT-4o, GPT-5, o1, o3, DALL-E, Whisper, TTS |
+| DeepInfra | 87 | Open source model hosting |
+| Azure OpenAI | 78 | OpenAI models on Azure |
+| Azure AI Foundry | 68 | Azure AI models |
+| Together AI | 56 | Open source model hosting |
+| Mistral AI | 55 | Mistral, Mixtral, Codestral |
+| xAI | 42 | Grok models |
+| Google Gemini | 41 | Gemini Pro, Ultra, Flash |
+| Perplexity | 37 | Search-augmented models |
 | Databricks | 28 | Databricks-hosted models |
-| SambaNova | 16 | Enterprise AI models |
-| AI21 | 13 | Jamba models |
+| Anthropic | 23 | Claude 3, Claude 3.5, Claude 4 |
+| Cohere | 22 | Command, Embed models |
+| SambaNova | 22 | Enterprise AI models |
+| Groq | 15 | Fast inference models |
+| AI21 | 12 | Jamba models |
+| Cerebras | 7 | Fast inference models |
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint:yaml": "yamllint -c .yamllint.yml providers/",
     "sort:yaml": "ts-node --project scripts/tsconfig.json scripts/sort-yaml-keys.ts",
     "lint:yaml:fix": "npm run sort:yaml && prettier --write --tab-width 4 --print-width 256 'providers/**/*.yaml'",
+    "update:readme": "ts-node --project scripts/tsconfig.json scripts/update-readme-counts.ts",
     "prepare": "husky"
   },
   "devDependencies": {

--- a/scripts/update-readme-counts.ts
+++ b/scripts/update-readme-counts.ts
@@ -1,0 +1,114 @@
+import fs from 'fs';
+import path from 'path';
+
+const PROVIDERS_DIR = path.resolve(__dirname, '..', 'providers');
+const README_PATH = path.resolve(__dirname, '..', 'README.md');
+
+interface ProviderMeta {
+  name: string;
+  description: string;
+}
+
+const PROVIDER_META: Record<string, ProviderMeta> = {
+  'openai': { name: 'OpenAI', description: 'GPT-4, GPT-4o, GPT-5, o1, o3, DALL-E, Whisper, TTS' },
+  'anthropic': { name: 'Anthropic', description: 'Claude 3, Claude 3.5, Claude 4' },
+  'aws-bedrock': { name: 'AWS Bedrock', description: 'Claude, Llama, Titan, Mistral on AWS' },
+  'azure-open-ai': { name: 'Azure OpenAI', description: 'OpenAI models on Azure' },
+  'azure-ai-foundry': { name: 'Azure AI Foundry', description: 'Azure AI models' },
+  'google-vertex': { name: 'Google Vertex AI', description: 'Gemini, PaLM on GCP' },
+  'google-gemini': { name: 'Google Gemini', description: 'Gemini Pro, Ultra, Flash' },
+  'mistral-ai': { name: 'Mistral AI', description: 'Mistral, Mixtral, Codestral' },
+  'cohere': { name: 'Cohere', description: 'Command, Embed models' },
+  'groq': { name: 'Groq', description: 'Fast inference models' },
+  'together-ai': { name: 'Together AI', description: 'Open source model hosting' },
+  'deepinfra': { name: 'DeepInfra', description: 'Open source model hosting' },
+  'perplexity-ai': { name: 'Perplexity', description: 'Search-augmented models' },
+  'cerebras': { name: 'Cerebras', description: 'Fast inference models' },
+  'databricks': { name: 'Databricks', description: 'Databricks-hosted models' },
+  'sambanova': { name: 'SambaNova', description: 'Enterprise AI models' },
+  'ai21': { name: 'AI21', description: 'Jamba models' },
+  'openrouter': { name: 'OpenRouter', description: 'Unified API for open source models' },
+  'xai': { name: 'xAI', description: 'Grok models' },
+};
+
+function countModelFiles(dir: string): number {
+  let count = 0;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      count += countModelFiles(fullPath);
+    } else if (
+      entry.isFile() &&
+      entry.name.endsWith('.yaml') &&
+      entry.name !== 'default.yaml'
+    ) {
+      count++;
+    }
+  }
+  return count;
+}
+
+function formatDisplayName(dirName: string): string {
+  return dirName
+    .split('-')
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
+}
+
+function main(): void {
+  const providerDirs = fs
+    .readdirSync(PROVIDERS_DIR, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name);
+
+  const counts: { dir: string; meta: ProviderMeta; count: number }[] = [];
+
+  for (const dir of providerDirs) {
+    const providerPath = path.join(PROVIDERS_DIR, dir);
+    const count = countModelFiles(providerPath);
+    const meta = PROVIDER_META[dir] ?? {
+      name: formatDisplayName(dir),
+      description: '',
+    };
+    counts.push({ dir, meta, count });
+  }
+
+  counts.sort((a, b) => b.count - a.count);
+
+  const tableHeader = [
+    '| Provider | Models | Description |',
+    '|----------|--------|-------------|',
+  ];
+  const tableRows = counts.map(
+    ({ meta, count }) => `| ${meta.name} | ${count} | ${meta.description} |`,
+  );
+  const table = [...tableHeader, ...tableRows].join('\n');
+
+  let readme = fs.readFileSync(README_PATH, 'utf-8');
+
+  const tablePattern =
+    /\| Provider \| Models \| Description \|\n\|[-|]+\|\n(?:\|[^\n]+\|\n?)*/;
+  if (!tablePattern.test(readme)) {
+    console.error('Could not find the provider table in README.md');
+    process.exit(1);
+  }
+  readme = readme.replace(tablePattern, table + '\n');
+
+  const providerCountPattern =
+    /Consistent model configuration format across \d+ providers/;
+  if (providerCountPattern.test(readme)) {
+    readme = readme.replace(
+      providerCountPattern,
+      `Consistent model configuration format across ${counts.length} providers`,
+    );
+  }
+
+  fs.writeFileSync(README_PATH, readme, 'utf-8');
+
+  console.log(`Updated README.md with ${counts.length} providers:`);
+  for (const { meta, count } of counts) {
+    console.log(`  ${meta.name}: ${count} models`);
+  }
+}
+
+main();


### PR DESCRIPTION
- Added a new script to update the README with the latest model counts from providers.
- Introduced a GitHub Actions workflow to run the script on pushes to the main branch.
- Updated README to reflect the current number of providers and their respective model counts.
- Added a new npm script for manual README updates.