### PR TITLE
feat(openrouter): update model YAMLs [bot]

### DIFF
--- a/providers/openrouter/ai21/jamba-large-1.7.yaml
+++ b/providers/openrouter/ai21/jamba-large-1.7.yaml
@@ -1,2 +1,17 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0.000002
+      output_cost_per_token: 0.000008
+      region: "*"
+features:
+    - function_calling
+    - tool_choice
+    - system_messages
+    - text
+limits:
+    context_window: 256000
+    max_output_tokens: 4096
+    max_tokens: 4096
+mode: chat
 model: ai21/jamba-large-1.7
+sources:
+    - https://openrouter.ai/ai21/jamba-large-1.7/api

--- a/providers/openrouter/aion-labs/aion-1.0-mini.yaml
+++ b/providers/openrouter/aion-labs/aion-1.0-mini.yaml
@@ -1,2 +1,18 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 7.e-7
+      output_cost_per_token: 0.0000014
+      region: "*"
+features:
+    - chat
+    - text
+    - tool_choice
+    - system_messages
+limits:
+    context_window: 131072
+    max_output_tokens: 32768
+    max_tokens: 32768
+mode: chat
 model: aion-labs/aion-1.0-mini
+sources:
+    - https://openrouter.ai/aion-labs/aion-1.0-mini/api
+thinking: true

--- a/providers/openrouter/aion-labs/aion-1.0.yaml
+++ b/providers/openrouter/aion-labs/aion-1.0.yaml
@@ -1,2 +1,20 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0.000004
+      output_cost_per_token: 0.000008
+      region: "*"
+features:
+    - function_calling
+    - tool_choice
+    - chat
+    - text
+    - code
+    - tools
+limits:
+    context_window: 131072
+    max_output_tokens: 32768
+    max_tokens: 32768
+mode: chat
 model: aion-labs/aion-1.0
+sources:
+    - https://openrouter.ai/aion-labs/aion-1.0/api
+thinking: true

--- a/providers/openrouter/aion-labs/aion-2.0.yaml
+++ b/providers/openrouter/aion-labs/aion-2.0.yaml
@@ -1,2 +1,18 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 2.e-7
+      input_cost_per_token: 8.e-7
+      output_cost_per_token: 0.0000016
+      region: "*"
+features:
+    - chat
+    - tool_choice
+    - prompt_caching
+limits:
+    context_window: 131072
+    max_output_tokens: 32768
+    max_tokens: 32768
+mode: chat
 model: aion-labs/aion-2.0
+sources:
+    - https://openrouter.ai/aion-labs/aion-2.0/api
+thinking: true

--- a/providers/openrouter/aion-labs/aion-rp-llama-3.1-8b.yaml
+++ b/providers/openrouter/aion-labs/aion-rp-llama-3.1-8b.yaml
@@ -1,2 +1,18 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 8.e-7
+      output_cost_per_token: 0.0000016
+      region: "*"
+features:
+    - function_calling
+    - tool_choice
+    - chat
+    - text
+    - tools
+limits:
+    context_window: 32768
+    max_output_tokens: 32768
+    max_tokens: 32768
+mode: chat
 model: aion-labs/aion-rp-llama-3.1-8b
+sources:
+    - https://openrouter.ai/aion-labs/aion-rp-llama-3.1-8b/api

--- a/providers/openrouter/alfredpros/codellama-7b-instruct-solidity.yaml
+++ b/providers/openrouter/alfredpros/codellama-7b-instruct-solidity.yaml
@@ -1,2 +1,16 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 8.e-7
+      output_cost_per_token: 0.0000012
+      region: "*"
+features:
+    - chat
+    - text
+    - code
+limits:
+    context_window: 4096
+    max_output_tokens: 4096
+    max_tokens: 4096
+mode: chat
 model: alfredpros/codellama-7b-instruct-solidity
+sources:
+    - https://openrouter.ai/alfredpros/codellama-7b-instruct-solidity/api

--- a/providers/openrouter/alibaba/tongyi-deepresearch-30b-a3b.yaml
+++ b/providers/openrouter/alibaba/tongyi-deepresearch-30b-a3b.yaml
@@ -1,2 +1,19 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 9.e-8
+      output_cost_per_token: 4.5e-7
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tools
+    - text
+    - code
+    - system_messages
+limits:
+    context_window: 131072
+    max_tokens: 131072
+mode: chat
 model: alibaba/tongyi-deepresearch-30b-a3b
+sources:
+    - https://openrouter.ai/alibaba/tongyi-deepresearch-30b-a3b/api
+thinking: true

--- a/providers/openrouter/allenai/olmo-2-0325-32b-instruct.yaml
+++ b/providers/openrouter/allenai/olmo-2-0325-32b-instruct.yaml
@@ -1,2 +1,13 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 5.e-8
+      output_cost_per_token: 2.e-7
+      region: "*"
+features:
+    - chat
+    - text
+limits:
+    context_window: 128000
+mode: chat
 model: allenai/olmo-2-0325-32b-instruct
+sources:
+    - https://openrouter.ai/allenai/olmo-2-0325-32b-instruct/api

--- a/providers/openrouter/allenai/olmo-3-32b-think.yaml
+++ b/providers/openrouter/allenai/olmo-3-32b-think.yaml
@@ -1,2 +1,19 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 1.5e-7
+      output_cost_per_token: 5.e-7
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - response_schema
+    - text
+limits:
+    context_window: 65536
+    max_output_tokens: 65536
+    max_tokens: 65536
+mode: chat
 model: allenai/olmo-3-32b-think
+sources:
+    - https://openrouter.ai/allenai/olmo-3-32b-think/api
+thinking: true

--- a/providers/openrouter/allenai/olmo-3.1-32b-instruct.yaml
+++ b/providers/openrouter/allenai/olmo-3.1-32b-instruct.yaml
@@ -1,2 +1,15 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 2.e-7
+      output_cost_per_token: 6.e-7
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - response_schema
+limits:
+    context_window: 65536
+mode: chat
 model: allenai/olmo-3.1-32b-instruct
+sources:
+    - https://openrouter.ai/allenai/olmo-3.1-32b-instruct/api

--- a/providers/openrouter/allenai/olmo-3.1-32b-think.yaml
+++ b/providers/openrouter/allenai/olmo-3.1-32b-think.yaml
@@ -1,2 +1,17 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 1.5e-7
+      output_cost_per_token: 5.e-7
+      region: "*"
+features:
+    - chat
+    - text
+    - response_schema
+limits:
+    context_window: 65536
+    max_output_tokens: 65536
+    max_tokens: 65536
+mode: chat
 model: allenai/olmo-3.1-32b-think
+sources:
+    - https://openrouter.ai/allenai/olmo-3.1-32b-think/api
+thinking: true

--- a/providers/openrouter/alpindale/goliath-120b.yaml
+++ b/providers/openrouter/alpindale/goliath-120b.yaml
@@ -1,2 +1,15 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0.00000375
+      output_cost_per_token: 0.0000075
+      region: "*"
+features:
+    - chat
+    - text
+limits:
+    context_window: 6144
+    max_output_tokens: 1024
+    max_tokens: 1024
+mode: chat
 model: alpindale/goliath-120b
+sources:
+    - https://openrouter.ai/alpindale/goliath-120b/api

--- a/providers/openrouter/amazon/nova-2-lite-v1.yaml
+++ b/providers/openrouter/amazon/nova-2-lite-v1.yaml
@@ -1,2 +1,26 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 3.e-7
+      output_cost_per_token: 0.0000025
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - vision
+    - image_input
+    - tool_choice
+    - tools
+    - text
+limits:
+    context_window: 1000000
+    max_output_tokens: 65535
+    max_tokens: 65535
+mode: chat
 model: amazon/nova-2-lite-v1
+params:
+    - defaultValue: 128
+      key: max_tokens
+      maxValue: 65535
+      minValue: 1
+sources:
+    - https://openrouter.ai/amazon/nova-2-lite-v1/api
+thinking: true

--- a/providers/openrouter/amazon/nova-lite-v1.yaml
+++ b/providers/openrouter/amazon/nova-lite-v1.yaml
@@ -1,2 +1,21 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 6.e-8
+      output_cost_per_token: 2.4e-7
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - vision
+    - image_input
+    - tool_choice
+    - system_messages
+    - text
+limits:
+    context_window: 300000
+    max_input_tokens: 294880
+    max_output_tokens: 5120
+    max_tokens: 5120
+mode: chat
 model: amazon/nova-lite-v1
+sources:
+    - https://openrouter.ai/amazon/nova-lite-v1/api

--- a/providers/openrouter/amazon/nova-micro-v1.yaml
+++ b/providers/openrouter/amazon/nova-micro-v1.yaml
@@ -1,2 +1,18 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 3.5e-8
+      output_cost_per_token: 1.4e-7
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - text
+    - code
+limits:
+    context_window: 128000
+    max_output_tokens: 5120
+    max_tokens: 5120
+mode: chat
 model: amazon/nova-micro-v1
+sources:
+    - https://openrouter.ai/amazon/nova-micro-v1/api

--- a/providers/openrouter/amazon/nova-premier-v1.yaml
+++ b/providers/openrouter/amazon/nova-premier-v1.yaml
@@ -1,2 +1,23 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 6.25e-7
+      input_cost_per_token: 0.0000025
+      output_cost_per_token: 0.0000125
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - vision
+    - image_input
+    - system_messages
+    - tool_choice
+    - text
+    - tools
+limits:
+    context_window: 1000000
+    max_input_tokens: 968000
+    max_output_tokens: 32000
+    max_tokens: 32000
+mode: chat
 model: amazon/nova-premier-v1
+sources:
+    - https://openrouter.ai/amazon/nova-premier-v1/api

--- a/providers/openrouter/amazon/nova-pro-v1.yaml
+++ b/providers/openrouter/amazon/nova-pro-v1.yaml
@@ -1,2 +1,19 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 8.e-7
+      output_cost_per_token: 0.0000032
+      region: "*"
+features:
+    - chat
+    - vision
+    - image_input
+    - function_calling
+    - tool_choice
+    - text
+limits:
+    context_window: 300000
+    max_output_tokens: 5120
+    max_tokens: 5120
+mode: chat
 model: amazon/nova-pro-v1
+sources:
+    - https://openrouter.ai/amazon/nova-pro-v1/api

--- a/providers/openrouter/anthracite-org/magnum-v4-72b.yaml
+++ b/providers/openrouter/anthracite-org/magnum-v4-72b.yaml
@@ -1,2 +1,16 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0.000003
+      output_cost_per_token: 0.000005
+      region: "*"
+features:
+    - chat
+    - text
+limits:
+    context_window: 16384
+    max_input_tokens: 14336
+    max_output_tokens: 2048
+    max_tokens: 2048
+mode: chat
 model: anthracite-org/magnum-v4-72b
+sources:
+    - https://openrouter.ai/anthracite-org/magnum-v4-72b/api

--- a/providers/openrouter/anthropic/claude-3.5-haiku.yaml
+++ b/providers/openrouter/anthropic/claude-3.5-haiku.yaml
@@ -1,2 +1,24 @@
-mode: unknown
+costs:
+    - cache_creation_input_token_cost: 0.000001
+      cache_read_input_token_cost: 8.e-8
+      input_cost_per_token: 8.e-7
+      output_cost_per_token: 0.000004
+      region: "*"
+features:
+    - chat
+    - text
+    - vision
+    - image_input
+    - function_calling
+    - tool_choice
+    - prompt_caching
+limits:
+    context_window: 200000
+    max_input_tokens: 191808
+    max_output_tokens: 8192
+    max_tokens: 8192
+mode: chat
 model: anthropic/claude-3.5-haiku
+sources:
+    - https://openrouter.ai/anthropic/claude-3.5-haiku/api
+thinking: false

--- a/providers/openrouter/anthropic/claude-opus-4.6.yaml
+++ b/providers/openrouter/anthropic/claude-opus-4.6.yaml
@@ -1,2 +1,47 @@
-mode: unknown
+costs:
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: "*"
+      tiered_pricing:
+          cache_read:
+              - cost_per_token: 0.000001
+                from: 200000
+          cache_write:
+              - cost_per_token: 0.0000125
+                from: 200000
+          input:
+              - cost_per_token: 0.00001
+                from: 200000
+          output:
+              - cost_per_token: 0.0000375
+                from: 200000
+features:
+    - chat
+    - text
+    - vision
+    - image_input
+    - function_calling
+    - tool_choice
+    - tools
+    - response_schema
+    - prompt_caching
+    - system_messages
+limits:
+    context_window: 1000000
+    max_output_tokens: 128000
+    max_tokens: 128000
+mode: chat
 model: anthropic/claude-opus-4.6
+params:
+    - defaultValue: 128
+      key: max_tokens
+      maxValue: 128000
+      minValue: 1
+    - defaultValue: null
+      key: top_k
+      minValue: 0
+sources:
+    - https://openrouter.ai/anthropic/claude-opus-4.6/api
+thinking: true

--- a/providers/openrouter/anthropic/claude-sonnet-4.6.yaml
+++ b/providers/openrouter/anthropic/claude-sonnet-4.6.yaml
@@ -1,2 +1,32 @@
-mode: unknown
+costs:
+    - cache_creation_input_token_cost: 0.00000375
+      cache_read_input_token_cost: 3.e-7
+      input_cost_per_token: 0.000003
+      output_cost_per_token: 0.000015
+      region: "*"
+features:
+    - chat
+    - text
+    - code
+    - vision
+    - image_input
+    - function_calling
+    - tool_choice
+    - tools
+    - system_messages
+    - response_schema
+    - prompt_caching
+limits:
+    context_window: 1000000
+    max_output_tokens: 128000
+    max_tokens: 128000
+mode: chat
 model: anthropic/claude-sonnet-4.6
+params:
+    - defaultValue: 128
+      key: max_tokens
+      maxValue: 128000
+      minValue: 1
+sources:
+    - https://openrouter.ai/anthropic/claude-sonnet-4.6/api
+thinking: true

--- a/providers/openrouter/arcee-ai/coder-large.yaml
+++ b/providers/openrouter/arcee-ai/coder-large.yaml
@@ -1,2 +1,16 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 5.e-7
+      output_cost_per_token: 8.e-7
+      region: "*"
+features:
+    - chat
+    - text
+    - code
+    - tool_choice
+    - function_calling
+limits:
+    context_window: 32768
+mode: chat
 model: arcee-ai/coder-large
+sources:
+    - https://openrouter.ai/arcee-ai/coder-large/api

--- a/providers/openrouter/arcee-ai/maestro-reasoning.yaml
+++ b/providers/openrouter/arcee-ai/maestro-reasoning.yaml
@@ -1,2 +1,16 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 9.e-7
+      output_cost_per_token: 0.0000033
+      region: "*"
+features:
+    - chat
+    - text
+limits:
+    context_window: 131072
+    max_output_tokens: 32000
+    max_tokens: 32000
+mode: chat
 model: arcee-ai/maestro-reasoning
+sources:
+    - https://openrouter.ai/arcee-ai/maestro-reasoning/api
+thinking: true

--- a/providers/openrouter/arcee-ai/spotlight.yaml
+++ b/providers/openrouter/arcee-ai/spotlight.yaml
@@ -1,2 +1,16 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 1.8e-7
+      output_cost_per_token: 1.8e-7
+      region: "*"
+features:
+    - chat
+    - vision
+    - image_input
+limits:
+    context_window: 131072
+    max_output_tokens: 65537
+    max_tokens: 65537
+mode: chat
 model: arcee-ai/spotlight
+sources:
+    - https://openrouter.ai/arcee-ai/spotlight/api

--- a/providers/openrouter/arcee-ai/trinity-large-preview:free.yaml
+++ b/providers/openrouter/arcee-ai/trinity-large-preview:free.yaml
@@ -1,2 +1,20 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0
+      output_cost_per_token: 0
+      region: "*"
+features:
+    - function_calling
+    - tool_choice
+    - response_schema
+    - system_messages
+    - chat
+    - text
+    - code
+    - tools
+limits:
+    context_window: 131000
+mode: chat
 model: arcee-ai/trinity-large-preview:free
+sources:
+    - https://openrouter.ai/arcee-ai/trinity-large-preview:free/api
+    - https://openrouter.ai/arcee-ai/trinity-large-preview/api

--- a/providers/openrouter/arcee-ai/trinity-mini.yaml
+++ b/providers/openrouter/arcee-ai/trinity-mini.yaml
@@ -1,2 +1,21 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 4.5e-8
+      output_cost_per_token: 1.5e-7
+      region: "*"
+features:
+    - function_calling
+    - tool_choice
+    - response_schema
+    - chat
+    - text
+    - code
+    - tools
+limits:
+    context_window: 131072
+    max_output_tokens: 131072
+    max_tokens: 131072
+mode: chat
 model: arcee-ai/trinity-mini
+sources:
+    - https://openrouter.ai/arcee-ai/trinity-mini/api
+thinking: true

--- a/providers/openrouter/arcee-ai/trinity-mini:free.yaml
+++ b/providers/openrouter/arcee-ai/trinity-mini:free.yaml
@@ -1,2 +1,21 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0
+      output_cost_per_token: 0
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - response_schema
+    - text
+    - tools
+limits:
+    context_window: 131072
+    max_output_tokens: 131072
+    max_tokens: 131072
+mode: chat
 model: arcee-ai/trinity-mini:free
+sources:
+    - https://openrouter.ai/arcee-ai/trinity-mini:free/api
+    - https://openrouter.ai/arcee-ai/trinity-mini/api
+thinking: true

--- a/providers/openrouter/arcee-ai/virtuoso-large.yaml
+++ b/providers/openrouter/arcee-ai/virtuoso-large.yaml
@@ -1,2 +1,20 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 7.5e-7
+      output_cost_per_token: 0.0000012
+      region: "*"
+features:
+    - function_calling
+    - tool_choice
+    - chat
+    - text
+    - code
+    - tools
+limits:
+    context_window: 131072
+    max_input_tokens: 131072
+    max_output_tokens: 64000
+    max_tokens: 64000
+mode: chat
 model: arcee-ai/virtuoso-large
+sources:
+    - https://openrouter.ai/arcee-ai/virtuoso-large/api

--- a/providers/openrouter/baidu/ernie-4.5-21b-a3b-thinking.yaml
+++ b/providers/openrouter/baidu/ernie-4.5-21b-a3b-thinking.yaml
@@ -1,2 +1,16 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 7.e-8
+      output_cost_per_token: 2.8e-7
+      region: "*"
+features:
+    - chat
+    - text
+limits:
+    context_window: 131072
+    max_output_tokens: 65536
+    max_tokens: 65536
+mode: chat
 model: baidu/ernie-4.5-21b-a3b-thinking
+sources:
+    - https://openrouter.ai/baidu/ernie-4.5-21b-a3b-thinking/api
+thinking: true

--- a/providers/openrouter/baidu/ernie-4.5-300b-a47b.yaml
+++ b/providers/openrouter/baidu/ernie-4.5-300b-a47b.yaml
@@ -1,2 +1,22 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 2.8e-7
+      output_cost_per_token: 0.0000011
+      region: "*"
+features:
+    - chat
+    - response_schema
+limits:
+    context_window: 131072
+    max_output_tokens: 12000
+    max_tokens: 12000
+mode: chat
 model: baidu/ernie-4.5-300b-a47b
+params:
+    - defaultValue: 128
+      key: max_tokens
+      maxValue: 12000
+      minValue: 1
+removeParams:
+    - "n"
+sources:
+    - https://openrouter.ai/baidu/ernie-4.5-300b-a47b/api

--- a/providers/openrouter/baidu/ernie-4.5-vl-28b-a3b.yaml
+++ b/providers/openrouter/baidu/ernie-4.5-vl-28b-a3b.yaml
@@ -1,2 +1,20 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 1.4e-7
+      output_cost_per_token: 5.6e-7
+      region: "*"
+features:
+    - chat
+    - vision
+    - image_input
+    - function_calling
+    - tool_choice
+    - tools
+    - text
+limits:
+    context_window: 131072
+    max_output_tokens: 8000
+    max_tokens: 8000
+mode: chat
 model: baidu/ernie-4.5-vl-28b-a3b
+sources:
+    - https://openrouter.ai/baidu/ernie-4.5-vl-28b-a3b/api

--- a/providers/openrouter/baidu/ernie-4.5-vl-424b-a47b.yaml
+++ b/providers/openrouter/baidu/ernie-4.5-vl-424b-a47b.yaml
@@ -1,2 +1,18 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 4.2e-7
+      output_cost_per_token: 0.00000125
+      region: "*"
+features:
+    - chat
+    - vision
+    - image_input
+    - text
+limits:
+    context_window: 123000
+    max_output_tokens: 16000
+    max_tokens: 16000
+mode: chat
 model: baidu/ernie-4.5-vl-424b-a47b
+sources:
+    - https://openrouter.ai/baidu/ernie-4.5-vl-424b-a47b/api
+thinking: true

--- a/providers/openrouter/bytedance-seed/seed-1.6-flash.yaml
+++ b/providers/openrouter/bytedance-seed/seed-1.6-flash.yaml
@@ -1,2 +1,29 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 7.5e-8
+      output_cost_per_token: 3.e-7
+      region: "*"
+      tiered_pricing:
+          input:
+              - cost_per_token: 1.e-7
+                from: 128000
+          output:
+              - cost_per_token: 8.e-7
+                from: 128000
+features:
+    - chat
+    - function_calling
+    - vision
+    - image_input
+    - tool_choice
+    - response_schema
+    - tools
+    - text
+limits:
+    context_window: 262144
+    max_output_tokens: 32768
+    max_tokens: 32768
+mode: chat
 model: bytedance-seed/seed-1.6-flash
+sources:
+    - https://openrouter.ai/bytedance-seed/seed-1.6-flash/api
+thinking: true

--- a/providers/openrouter/bytedance-seed/seed-1.6.yaml
+++ b/providers/openrouter/bytedance-seed/seed-1.6.yaml
@@ -1,2 +1,30 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 2.5e-7
+      output_cost_per_token: 0.000002
+      region: "*"
+      tiered_pricing:
+          input:
+              - cost_per_token: 5.e-7
+                from: 128000
+          output:
+              - cost_per_token: 0.000004
+                from: 128000
+features:
+    - chat
+    - text
+    - vision
+    - image_input
+    - function_calling
+    - tool_choice
+    - tools
+    - response_schema
+    - system_messages
+limits:
+    context_window: 262144
+    max_output_tokens: 32768
+    max_tokens: 32768
+mode: chat
 model: bytedance-seed/seed-1.6
+sources:
+    - https://openrouter.ai/bytedance-seed/seed-1.6/api
+thinking: true

--- a/providers/openrouter/bytedance-seed/seed-2.0-mini.yaml
+++ b/providers/openrouter/bytedance-seed/seed-2.0-mini.yaml
@@ -1,2 +1,30 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 1.e-7
+      output_cost_per_token: 4.e-7
+      region: "*"
+      tiered_pricing:
+          input:
+              - cost_per_token: 2.e-7
+                from: 128000
+          output:
+              - cost_per_token: 8.e-7
+                from: 128000
+features:
+    - chat
+    - function_calling
+    - vision
+    - image_input
+    - tool_choice
+    - response_schema
+    - prompt_caching
+    - text
+    - tools
+limits:
+    context_window: 262144
+    max_output_tokens: 131072
+    max_tokens: 131072
+mode: chat
 model: bytedance-seed/seed-2.0-mini
+sources:
+    - https://openrouter.ai/bytedance-seed/seed-2.0-mini/api
+thinking: true

--- a/providers/openrouter/cognitivecomputations/dolphin-mistral-24b-venice-edition:free.yaml
+++ b/providers/openrouter/cognitivecomputations/dolphin-mistral-24b-venice-edition:free.yaml
@@ -1,2 +1,15 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0
+      output_cost_per_token: 0
+      region: "*"
+features:
+    - chat
+    - text
+    - response_schema
+limits:
+    context_window: 32768
+    max_tokens: 32768
+mode: chat
 model: cognitivecomputations/dolphin-mistral-24b-venice-edition:free
+sources:
+    - https://openrouter.ai/cognitivecomputations/dolphin-mistral-24b-venice-edition:free/api

--- a/providers/openrouter/cohere/command-a.yaml
+++ b/providers/openrouter/cohere/command-a.yaml
@@ -1,2 +1,21 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0.0000025
+      output_cost_per_token: 0.00001
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - response_schema
+    - text
+    - code
+    - tools
+limits:
+    context_window: 256000
+    max_output_tokens: 8192
+    max_tokens: 8192
+mode: chat
 model: cohere/command-a
+sources:
+    - https://openrouter.ai/cohere/command-a/api
+    - https://docs.cohere.com/docs/command-a

--- a/providers/openrouter/cohere/command-r-08-2024.yaml
+++ b/providers/openrouter/cohere/command-r-08-2024.yaml
@@ -1,2 +1,21 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 1.5e-7
+      output_cost_per_token: 6.e-7
+      region: "*"
+features:
+    - chat
+    - text
+    - function_calling
+    - tools
+    - tool_choice
+    - system_messages
+    - response_schema
+limits:
+    context_window: 128000
+    max_output_tokens: 4000
+    max_tokens: 4000
+mode: chat
 model: cohere/command-r-08-2024
+sources:
+    - https://openrouter.ai/cohere/command-r-08-2024/api
+    - https://docs.cohere.com/docs/command-r

--- a/providers/openrouter/cohere/command-r-plus-08-2024.yaml
+++ b/providers/openrouter/cohere/command-r-plus-08-2024.yaml
@@ -1,2 +1,22 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0.0000025
+      output_cost_per_token: 0.00001
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - system_messages
+    - response_schema
+    - text
+    - code
+    - tools
+limits:
+    context_window: 128000
+    max_output_tokens: 4000
+    max_tokens: 4000
+mode: chat
 model: cohere/command-r-plus-08-2024
+sources:
+    - https://openrouter.ai/cohere/command-r-plus-08-2024/api
+    - https://docs.cohere.com/docs/command-r-plus

--- a/providers/openrouter/cohere/command-r7b-12-2024.yaml
+++ b/providers/openrouter/cohere/command-r7b-12-2024.yaml
@@ -1,2 +1,20 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 3.75e-8
+      output_cost_per_token: 1.5e-7
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - response_schema
+    - text
+    - code
+    - tools
+limits:
+    context_window: 128000
+    max_output_tokens: 4000
+    max_tokens: 4000
+mode: chat
 model: cohere/command-r7b-12-2024
+sources:
+    - https://openrouter.ai/cohere/command-r7b-12-2024/api

--- a/providers/openrouter/deepcogito/cogito-v2.1-671b.yaml
+++ b/providers/openrouter/deepcogito/cogito-v2.1-671b.yaml
@@ -1,2 +1,20 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0.00000125
+      output_cost_per_token: 0.00000125
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - tools
+    - response_schema
+    - text
+    - code
+    - system_messages
+limits:
+    context_window: 128000
+mode: chat
 model: deepcogito/cogito-v2.1-671b
+sources:
+    - https://openrouter.ai/deepcogito/cogito-v2.1-671b/api
+thinking: true

--- a/providers/openrouter/deepseek/deepseek-r1-distill-llama-70b.yaml
+++ b/providers/openrouter/deepseek/deepseek-r1-distill-llama-70b.yaml
@@ -1,2 +1,17 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 7.e-7
+      output_cost_per_token: 8.e-7
+      region: "*"
+features:
+    - chat
+    - text
+    - code
+limits:
+    context_window: 131072
+    max_output_tokens: 16384
+    max_tokens: 16384
+mode: chat
 model: deepseek/deepseek-r1-distill-llama-70b
+sources:
+    - https://openrouter.ai/deepseek/deepseek-r1-distill-llama-70b/api
+thinking: true

--- a/providers/openrouter/deepseek/deepseek-r1-distill-qwen-32b.yaml
+++ b/providers/openrouter/deepseek/deepseek-r1-distill-qwen-32b.yaml
@@ -1,2 +1,18 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 2.9e-7
+      output_cost_per_token: 2.9e-7
+      region: "*"
+features:
+    - chat
+    - text
+    - code
+    - response_schema
+limits:
+    context_window: 32768
+    max_output_tokens: 32768
+    max_tokens: 32768
+mode: chat
 model: deepseek/deepseek-r1-distill-qwen-32b
+sources:
+    - https://openrouter.ai/deepseek/deepseek-r1-distill-qwen-32b/api
+thinking: true

--- a/providers/openrouter/deepseek/deepseek-v3.1-terminus.yaml
+++ b/providers/openrouter/deepseek/deepseek-v3.1-terminus.yaml
@@ -1,2 +1,18 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 2.1e-7
+      output_cost_per_token: 7.9e-7
+      region: "*"
+features:
+    - function_calling
+    - chat
+    - text
+    - code
+    - tools
+    - system_messages
+limits:
+    context_window: 163840
+mode: chat
 model: deepseek/deepseek-v3.1-terminus
+sources:
+    - https://openrouter.ai/deepseek/deepseek-v3.1-terminus/api
+thinking: true

--- a/providers/openrouter/deepseek/deepseek-v3.1-terminus:exacto.yaml
+++ b/providers/openrouter/deepseek/deepseek-v3.1-terminus:exacto.yaml
@@ -1,2 +1,18 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 2.1e-7
+      output_cost_per_token: 7.9e-7
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - text
+    - code
+    - tools
+limits:
+    context_window: 163840
+    max_input_tokens: 163840
+mode: chat
 model: deepseek/deepseek-v3.1-terminus:exacto
+sources:
+    - https://openrouter.ai/deepseek/deepseek-v3.1-terminus:exacto/api
+thinking: true

--- a/providers/openrouter/deepseek/deepseek-v3.2-exp.yaml
+++ b/providers/openrouter/deepseek/deepseek-v3.2-exp.yaml
@@ -1,2 +1,22 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 2.7e-7
+      output_cost_per_token: 4.1e-7
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - response_schema
+    - system_messages
+    - text
+    - code
+    - tools
+limits:
+    context_window: 163840
+    max_output_tokens: 65536
+    max_tokens: 65536
+mode: chat
 model: deepseek/deepseek-v3.2-exp
+sources:
+    - https://openrouter.ai/deepseek/deepseek-v3.2-exp/api
+thinking: true

--- a/providers/openrouter/eleutherai/llemma_7b.yaml
+++ b/providers/openrouter/eleutherai/llemma_7b.yaml
@@ -1,2 +1,12 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 8.e-7
+      output_cost_per_token: 0.0000012
+      region: "*"
+limits:
+    context_window: 4096
+    max_output_tokens: 4096
+    max_tokens: 4096
+mode: chat
 model: eleutherai/llemma_7b
+sources:
+    - https://openrouter.ai/eleutherai/llemma_7b/api

--- a/providers/openrouter/essentialai/rnj-1-instruct.yaml
+++ b/providers/openrouter/essentialai/rnj-1-instruct.yaml
@@ -1,2 +1,17 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 1.5e-7
+      output_cost_per_token: 1.5e-7
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - response_schema
+    - text
+    - code
+    - tools
+limits:
+    context_window: 32768
+mode: chat
 model: essentialai/rnj-1-instruct
+sources:
+    - https://openrouter.ai/essentialai/rnj-1-instruct/api

--- a/providers/openrouter/gemma-3-27b-it.yaml
+++ b/providers/openrouter/gemma-3-27b-it.yaml
@@ -1,8 +1,24 @@
+costs:
+    - input_cost_per_token: 3.e-8
+      output_cost_per_token: 1.1e-7
+      region: "*"
 features:
     - chat
-    - image
+    - vision
+    - image_input
+    - function_calling
+    - tool_choice
+    - tools
+    - response_schema
+    - system_messages
+limits:
+    context_window: 128000
+    max_output_tokens: 65536
+    max_tokens: 65536
 mode: chat
 model: gemma-3-27b-it
 params:
     - key: max_tokens
-      maxValue: 16384
+      maxValue: 65536
+sources:
+    - https://openrouter.ai/google/gemma-3-27b-it/api

--- a/providers/openrouter/google/gemini-2.5-flash-image.yaml
+++ b/providers/openrouter/google/gemini-2.5-flash-image.yaml
@@ -1,2 +1,23 @@
-mode: unknown
+costs:
+    - input_cost_per_audio_token: 0.000001
+      input_cost_per_token: 3.e-7
+      output_cost_per_image_token: 0.00003
+      output_cost_per_token: 0.0000025
+      region: "*"
+features:
+    - vision
+    - image
+    - image_input
+    - chat
+    - text
+    - response_schema
+    - system_messages
+limits:
+    context_window: 32768
+    max_output_tokens: 32768
+    max_tokens: 32768
+mode: chat
 model: google/gemini-2.5-flash-image
+sources:
+    - https://openrouter.ai/google/gemini-2.5-flash-image/api
+thinking: false

--- a/providers/openrouter/google/gemini-2.5-flash-lite-preview-09-2025.yaml
+++ b/providers/openrouter/google/gemini-2.5-flash-lite-preview-09-2025.yaml
@@ -1,2 +1,24 @@
-mode: unknown
+costs:
+    - input_cost_per_audio_token: 3.e-7
+      input_cost_per_token: 1.e-7
+      output_cost_per_token: 4.e-7
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - vision
+    - image_input
+    - audio_input
+    - tool_choice
+    - response_schema
+    - text
+    - tools
+limits:
+    context_window: 1048576
+    max_output_tokens: 65536
+    max_tokens: 65536
+mode: chat
 model: google/gemini-2.5-flash-lite-preview-09-2025
+sources:
+    - https://openrouter.ai/google/gemini-2.5-flash-lite-preview-09-2025/api
+thinking: true

--- a/providers/openrouter/google/gemini-2.5-flash-lite.yaml
+++ b/providers/openrouter/google/gemini-2.5-flash-lite.yaml
@@ -1,2 +1,28 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 1.e-8
+      cache_storage_cost_per_token_per_hour: 8.33e-8
+      input_cost_per_audio_token: 3.e-7
+      input_cost_per_image_token: 1.e-7
+      input_cost_per_token: 1.e-7
+      output_cost_per_token: 4.e-7
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - vision
+    - image_input
+    - audio_input
+    - tool_choice
+    - prompt_caching
+    - response_schema
+    - text
+    - tools
+limits:
+    context_window: 1048576
+    max_output_tokens: 65535
+    max_tokens: 65535
+mode: chat
 model: google/gemini-2.5-flash-lite
+sources:
+    - https://openrouter.ai/google/gemini-2.5-flash-lite/api
+thinking: true

--- a/providers/openrouter/google/gemini-2.5-pro-preview-05-06.yaml
+++ b/providers/openrouter/google/gemini-2.5-pro-preview-05-06.yaml
@@ -1,2 +1,43 @@
-mode: unknown
+costs:
+    - cache_creation_input_token_cost: 3.75e-7
+      cache_read_input_token_cost: 1.25e-7
+      input_cost_per_audio_token: 0.00000125
+      input_cost_per_image_token: 0.00000125
+      input_cost_per_token: 0.00000125
+      output_cost_per_token: 0.00001
+      region: "*"
+      tiered_pricing:
+          cache_read:
+              - cost_per_token: 2.5e-7
+                from: 200000
+          cache_write:
+              - cost_per_token: 7.5e-7
+                from: 200000
+          input:
+              - cost_per_token: 0.0000025
+                from: 200000
+          output:
+              - cost_per_token: 0.000015
+                from: 200000
+features:
+    - chat
+    - function_calling
+    - vision
+    - image_input
+    - audio_input
+    - system_messages
+    - tool_choice
+    - response_schema
+    - prompt_caching
+    - text
+    - code
+    - tools
+limits:
+    context_window: 1048576
+    max_output_tokens: 65536
+    max_tokens: 65536
+mode: chat
 model: google/gemini-2.5-pro-preview-05-06
+sources:
+    - https://openrouter.ai/google/gemini-2.5-pro-preview-05-06/api
+thinking: true

--- a/providers/openrouter/google/gemini-2.5-pro-preview.yaml
+++ b/providers/openrouter/google/gemini-2.5-pro-preview.yaml
@@ -1,2 +1,41 @@
-mode: unknown
+costs:
+    - cache_creation_input_token_cost: 3.75e-7
+      cache_read_input_token_cost: 1.25e-7
+      input_cost_per_audio_token: 0.00000125
+      input_cost_per_token: 0.00000125
+      output_cost_per_token: 0.00001
+      region: "*"
+      tiered_pricing:
+          cache_read:
+              - cost_per_token: 2.5e-7
+                from: 200000
+          cache_write:
+              - cost_per_token: 7.5e-7
+                from: 200000
+          input:
+              - cost_per_token: 0.0000025
+                from: 200000
+          output:
+              - cost_per_token: 0.000015
+                from: 200000
+features:
+    - chat
+    - function_calling
+    - vision
+    - image_input
+    - audio_input
+    - tool_choice
+    - response_schema
+    - system_messages
+    - text
+    - code
+    - tools
+limits:
+    context_window: 1048576
+    max_output_tokens: 65536
+    max_tokens: 65536
+mode: chat
 model: google/gemini-2.5-pro-preview
+sources:
+    - https://openrouter.ai/google/gemini-2.5-pro-preview/api
+thinking: true

--- a/providers/openrouter/google/gemini-3-flash-preview.yaml
+++ b/providers/openrouter/google/gemini-3-flash-preview.yaml
@@ -1,2 +1,30 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 5.e-8
+      cache_storage_cost_per_token_per_hour: 0.000001
+      input_cost_per_audio_token: 0.000001
+      input_cost_per_token: 5.e-7
+      output_cost_per_token: 0.000003
+      region: "*"
+features:
+    - chat
+    - text
+    - code
+    - vision
+    - image_input
+    - audio_input
+    - pdf_input
+    - function_calling
+    - tools
+    - tool_choice
+    - system_messages
+    - response_schema
+    - prompt_caching
+limits:
+    context_window: 1048576
+    max_output_tokens: 65536
+    max_tokens: 65536
+mode: chat
 model: google/gemini-3-flash-preview
+sources:
+    - https://openrouter.ai/google/gemini-3-flash-preview/api
+thinking: true

--- a/providers/openrouter/google/gemini-3-pro-image-preview.yaml
+++ b/providers/openrouter/google/gemini-3-pro-image-preview.yaml
@@ -1,2 +1,29 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 2.e-7
+      cache_storage_cost_per_token_per_hour: 0.0000045
+      input_cost_per_audio_token: 0.000002
+      input_cost_per_image_token: 0.000002
+      input_cost_per_token: 0.000002
+      output_cost_per_image_token: 0.00012
+      output_cost_per_token: 0.000012
+      region: "*"
+features:
+    - chat
+    - text
+    - vision
+    - image_input
+    - image
+    - function_calling
+    - tool_choice
+    - system_messages
+    - prompt_caching
+    - response_schema
+limits:
+    context_window: 65536
+    max_output_tokens: 32768
+    max_tokens: 32768
+mode: chat
 model: google/gemini-3-pro-image-preview
+sources:
+    - https://openrouter.ai/google/gemini-3-pro-image-preview/api
+thinking: true

--- a/providers/openrouter/google/gemini-3.1-flash-image-preview.yaml
+++ b/providers/openrouter/google/gemini-3.1-flash-image-preview.yaml
@@ -1,2 +1,25 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 5.e-7
+      output_cost_per_image_token: 0.00006
+      output_cost_per_token: 0.000003
+      region: "*"
+features:
+    - chat
+    - text
+    - vision
+    - image_input
+    - image
+    - function_calling
+    - tool_choice
+    - tools
+    - response_schema
+    - system_messages
+limits:
+    context_window: 65536
+    max_output_tokens: 65536
+    max_tokens: 65536
+mode: chat
 model: google/gemini-3.1-flash-image-preview
+sources:
+    - https://openrouter.ai/google/gemini-3.1-flash-image-preview/api
+thinking: true

--- a/providers/openrouter/google/gemini-3.1-pro-preview-customtools.yaml
+++ b/providers/openrouter/google/gemini-3.1-pro-preview-customtools.yaml
@@ -1,2 +1,39 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 2.e-7
+      cache_storage_cost_per_token_per_hour: 0.0000045
+      input_cost_per_audio_token: 0.000002
+      input_cost_per_token: 0.000002
+      output_cost_per_token: 0.000012
+      region: "*"
+      tiered_pricing:
+          cache_read:
+              - cost_per_token: 4.e-7
+                from: 200000
+          input:
+              - cost_per_token: 0.000004
+                from: 200000
+          output:
+              - cost_per_token: 0.000018
+                from: 200000
+features:
+    - chat
+    - function_calling
+    - vision
+    - image_input
+    - audio_input
+    - tool_choice
+    - response_schema
+    - system_messages
+    - prompt_caching
+    - tools
+    - text
+    - code
+limits:
+    context_window: 1048576
+    max_output_tokens: 65536
+    max_tokens: 65536
+mode: chat
 model: google/gemini-3.1-pro-preview-customtools
+sources:
+    - https://openrouter.ai/google/gemini-3.1-pro-preview-customtools/api
+thinking: true

--- a/providers/openrouter/google/gemini-3.1-pro-preview.yaml
+++ b/providers/openrouter/google/gemini-3.1-pro-preview.yaml
@@ -1,2 +1,27 @@
-mode: unknown
+costs:
+    - input_cost_per_audio_token: 0.000002
+      input_cost_per_token: 0.000002
+      output_cost_per_token: 0.000012
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - vision
+    - image_input
+    - audio_input
+    - pdf_input
+    - tool_choice
+    - response_schema
+    - system_messages
+    - text
+    - code
+    - tools
+limits:
+    context_window: 1048576
+    max_output_tokens: 65536
+    max_tokens: 65536
+mode: chat
 model: google/gemini-3.1-pro-preview
+sources:
+    - https://openrouter.ai/google/gemini-3.1-pro-preview/api
+thinking: true

--- a/providers/openrouter/google/gemma-2-27b-it.yaml
+++ b/providers/openrouter/google/gemma-2-27b-it.yaml
@@ -1,2 +1,21 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 6.5e-7
+      output_cost_per_token: 6.5e-7
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - response_schema
+    - system_messages
+    - text
+    - code
+    - tools
+limits:
+    context_window: 8192
+    max_output_tokens: 2048
+    max_tokens: 2048
+mode: chat
 model: google/gemma-2-27b-it
+sources:
+    - https://openrouter.ai/google/gemma-2-27b-it/api

--- a/providers/openrouter/google/gemma-2-9b-it.yaml
+++ b/providers/openrouter/google/gemma-2-9b-it.yaml
@@ -1,2 +1,15 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 3.e-8
+      output_cost_per_token: 9.e-8
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - response_schema
+limits:
+    context_window: 8192
+mode: chat
 model: google/gemma-2-9b-it
+sources:
+    - https://openrouter.ai/google/gemma-2-9b-it/api

--- a/providers/openrouter/google/gemma-3-12b-it.yaml
+++ b/providers/openrouter/google/gemma-3-12b-it.yaml
@@ -1,2 +1,17 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 4.e-8
+      output_cost_per_token: 1.3e-7
+      region: "*"
+features:
+    - chat
+    - vision
+    - image_input
+    - function_calling
+    - response_schema
+    - system_messages
+limits:
+    context_window: 131072
+mode: chat
 model: google/gemma-3-12b-it
+sources:
+    - https://openrouter.ai/google/gemma-3-12b-it/api

--- a/providers/openrouter/google/gemma-3-12b-it:free.yaml
+++ b/providers/openrouter/google/gemma-3-12b-it:free.yaml
@@ -1,2 +1,20 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0
+      output_cost_per_token: 0
+      region: "*"
+features:
+    - chat
+    - vision
+    - image_input
+    - function_calling
+    - response_schema
+    - text
+    - tools
+limits:
+    context_window: 32768
+    max_output_tokens: 8192
+    max_tokens: 8192
+mode: chat
 model: google/gemma-3-12b-it:free
+sources:
+    - https://openrouter.ai/google/gemma-3-12b-it:free/api

--- a/providers/openrouter/google/gemma-3-27b-it:free.yaml
+++ b/providers/openrouter/google/gemma-3-27b-it:free.yaml
@@ -1,2 +1,21 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0
+      output_cost_per_token: 0
+      region: "*"
+features:
+    - chat
+    - vision
+    - image_input
+    - function_calling
+    - tool_choice
+    - response_schema
+    - system_messages
+    - text
+limits:
+    context_window: 131072
+    max_output_tokens: 8192
+    max_tokens: 8192
+mode: chat
 model: google/gemma-3-27b-it:free
+sources:
+    - https://openrouter.ai/google/gemma-3-27b-it:free/api

--- a/providers/openrouter/google/gemma-3-4b-it.yaml
+++ b/providers/openrouter/google/gemma-3-4b-it.yaml
@@ -1,2 +1,15 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 4.e-8
+      output_cost_per_token: 8.e-8
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - vision
+    - image_input
+limits:
+    context_window: 131072
+mode: chat
 model: google/gemma-3-4b-it
+sources:
+    - https://openrouter.ai/google/gemma-3-4b-it/api

--- a/providers/openrouter/google/gemma-3-4b-it:free.yaml
+++ b/providers/openrouter/google/gemma-3-4b-it:free.yaml
@@ -1,2 +1,18 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0
+      output_cost_per_token: 0
+      region: "*"
+features:
+    - chat
+    - vision
+    - image_input
+    - text
+    - code
+limits:
+    context_window: 32768
+    max_output_tokens: 8192
+    max_tokens: 8192
+mode: chat
 model: google/gemma-3-4b-it:free
+sources:
+    - https://openrouter.ai/google/gemma-3-4b-it:free/api

--- a/providers/openrouter/google/gemma-3n-e2b-it:free.yaml
+++ b/providers/openrouter/google/gemma-3n-e2b-it:free.yaml
@@ -1,2 +1,15 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0
+      output_cost_per_token: 0
+      region: "*"
+features:
+    - chat
+    - system_messages
+limits:
+    context_window: 8192
+    max_output_tokens: 2048
+    max_tokens: 2048
+mode: chat
 model: google/gemma-3n-e2b-it:free
+sources:
+    - https://openrouter.ai/google/gemma-3n-e2b-it:free/api

--- a/providers/openrouter/google/gemma-3n-e4b-it.yaml
+++ b/providers/openrouter/google/gemma-3n-e4b-it.yaml
@@ -1,2 +1,16 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 2.e-8
+      output_cost_per_token: 4.e-8
+      region: "*"
+features:
+    - chat
+    - vision
+    - image_input
+limits:
+    context_window: 32768
+    max_output_tokens: 4096
+    max_tokens: 4096
+mode: chat
 model: google/gemma-3n-e4b-it
+sources:
+    - https://openrouter.ai/google/gemma-3n-e4b-it/api

--- a/providers/openrouter/google/gemma-3n-e4b-it:free.yaml
+++ b/providers/openrouter/google/gemma-3n-e4b-it:free.yaml
@@ -1,2 +1,25 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0
+      output_cost_per_token: 0
+      region: "*"
+features:
+    - chat
+    - system_messages
+limits:
+    context_window: 8192
+    max_output_tokens: 2048
+    max_tokens: 2048
+mode: chat
 model: google/gemma-3n-e4b-it:free
+params:
+    - defaultValue: 2048
+      key: max_tokens
+      maxValue: 2048
+      minValue: 1
+removeParams:
+    - frequency_penalty
+    - presence_penalty
+    - "n"
+    - response_format
+sources:
+    - https://openrouter.ai/google/gemma-3n-e4b-it:free/api

--- a/providers/openrouter/ibm-granite/granite-4.0-h-micro.yaml
+++ b/providers/openrouter/ibm-granite/granite-4.0-h-micro.yaml
@@ -1,2 +1,16 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 1.7e-8
+      output_cost_per_token: 1.1e-7
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - tools
+    - system_messages
+limits:
+    context_window: 131000
+mode: chat
 model: ibm-granite/granite-4.0-h-micro
+sources:
+    - https://openrouter.ai/ibm-granite/granite-4.0-h-micro/api

--- a/providers/openrouter/inception/mercury-2.yaml
+++ b/providers/openrouter/inception/mercury-2.yaml
@@ -1,2 +1,21 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 2.5e-8
+      input_cost_per_token: 2.5e-7
+      output_cost_per_token: 7.5e-7
+      region: "*"
+features:
+    - function_calling
+    - tool_choice
+    - response_schema
+    - chat
+    - text
+    - tools
+limits:
+    context_window: 128000
+    max_output_tokens: 50000
+    max_tokens: 50000
+mode: chat
 model: inception/mercury-2
+sources:
+    - https://openrouter.ai/inception/mercury-2/api
+thinking: true

--- a/providers/openrouter/inception/mercury-coder.yaml
+++ b/providers/openrouter/inception/mercury-coder.yaml
@@ -1,2 +1,21 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 2.5e-8
+      input_cost_per_token: 2.5e-7
+      output_cost_per_token: 7.5e-7
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - response_schema
+    - tool_choice
+    - tools
+    - text
+    - code
+limits:
+    context_window: 128000
+    max_output_tokens: 32000
+    max_tokens: 32000
+mode: chat
 model: inception/mercury-coder
+sources:
+    - https://openrouter.ai/inception/mercury-coder/api

--- a/providers/openrouter/inception/mercury.yaml
+++ b/providers/openrouter/inception/mercury.yaml
@@ -1,2 +1,3 @@
+isDeprecated: true
 mode: unknown
 model: inception/mercury

--- a/providers/openrouter/inflection/inflection-3-pi.yaml
+++ b/providers/openrouter/inflection/inflection-3-pi.yaml
@@ -1,2 +1,16 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0.0000025
+      output_cost_per_token: 0.00001
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+limits:
+    context_window: 8000
+    max_output_tokens: 1024
+    max_tokens: 1024
+mode: chat
 model: inflection/inflection-3-pi
+sources:
+    - https://openrouter.ai/inflection/inflection-3-pi/api

--- a/providers/openrouter/inflection/inflection-3-productivity.yaml
+++ b/providers/openrouter/inflection/inflection-3-productivity.yaml
@@ -1,2 +1,16 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0.0000025
+      output_cost_per_token: 0.00001
+      region: "*"
+features:
+    - chat
+    - tool_choice
+    - function_calling
+limits:
+    context_window: 8000
+    max_output_tokens: 1024
+    max_tokens: 1024
+mode: chat
 model: inflection/inflection-3-productivity
+sources:
+    - https://openrouter.ai/inflection/inflection-3-productivity/api

--- a/providers/openrouter/kimi-vl-a3b-thinking:free.yaml
+++ b/providers/openrouter/kimi-vl-a3b-thinking:free.yaml
@@ -1,7 +1,17 @@
+costs:
+    - input_cost_per_token: 0
+      output_cost_per_token: 0
+      region: "*"
 features:
     - chat
-    - image
+    - vision
+    - image_input
 limits:
+    context_window: 131072
     max_tokens: 4096
 mode: chat
 model: kimi-vl-a3b-thinking:free
+sources:
+    - https://openrouter.ai/moonshotai/kimi-vl-a3b-thinking:free/api
+    - https://openrouter.ai/moonshotai/kimi-vl-a3b-thinking:free
+thinking: true

--- a/providers/openrouter/kwaipilot/kat-coder-pro.yaml
+++ b/providers/openrouter/kwaipilot/kat-coder-pro.yaml
@@ -1,2 +1,21 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 4.14e-8
+      input_cost_per_token: 2.07e-7
+      output_cost_per_token: 8.28e-7
+      region: "*"
+features:
+    - chat
+    - text
+    - code
+    - function_calling
+    - tool_choice
+    - response_schema
+    - tools
+limits:
+    context_window: 256000
+    max_output_tokens: 128000
+    max_tokens: 128000
+mode: chat
 model: kwaipilot/kat-coder-pro
+sources:
+    - https://openrouter.ai/kwaipilot/kat-coder-pro/api

--- a/providers/openrouter/liquid/lfm-2-24b-a2b.yaml
+++ b/providers/openrouter/liquid/lfm-2-24b-a2b.yaml
@@ -1,2 +1,15 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 3.e-8
+      output_cost_per_token: 1.2e-7
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+limits:
+    context_window: 32768
+    max_tokens: 32768
+mode: chat
 model: liquid/lfm-2-24b-a2b
+sources:
+    - https://openrouter.ai/liquid/lfm-2-24b-a2b/api

--- a/providers/openrouter/liquid/lfm-2.2-6b.yaml
+++ b/providers/openrouter/liquid/lfm-2.2-6b.yaml
@@ -1,2 +1,13 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 1.e-8
+      output_cost_per_token: 2.e-8
+      region: "*"
+features:
+    - chat
+    - text
+limits:
+    context_window: 32768
+mode: chat
 model: liquid/lfm-2.2-6b
+sources:
+    - https://openrouter.ai/liquid/lfm-2.2-6b/api

--- a/providers/openrouter/liquid/lfm-2.5-1.2b-instruct:free.yaml
+++ b/providers/openrouter/liquid/lfm-2.5-1.2b-instruct:free.yaml
@@ -1,2 +1,14 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0
+      output_cost_per_token: 0
+      region: "*"
+features:
+    - chat
+    - text
+    - code
+limits:
+    context_window: 32768
+mode: chat
 model: liquid/lfm-2.5-1.2b-instruct:free
+sources:
+    - https://openrouter.ai/liquid/lfm-2.5-1.2b-instruct:free/api

--- a/providers/openrouter/liquid/lfm-2.5-1.2b-thinking:free.yaml
+++ b/providers/openrouter/liquid/lfm-2.5-1.2b-thinking:free.yaml
@@ -1,2 +1,14 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0
+      output_cost_per_token: 0
+      region: "*"
+features:
+    - chat
+    - system_messages
+limits:
+    context_window: 32768
+mode: chat
 model: liquid/lfm-2.5-1.2b-thinking:free
+sources:
+    - https://openrouter.ai/liquid/lfm-2.5-1.2b-thinking:free/api
+thinking: true

--- a/providers/openrouter/liquid/lfm2-8b-a1b.yaml
+++ b/providers/openrouter/liquid/lfm2-8b-a1b.yaml
@@ -1,2 +1,14 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 1.e-8
+      output_cost_per_token: 2.e-8
+      region: "*"
+features:
+    - chat
+    - text
+limits:
+    context_window: 32768
+    max_tokens: 32768
+mode: chat
 model: liquid/lfm2-8b-a1b
+sources:
+    - https://openrouter.ai/liquid/lfm2-8b-a1b/api

--- a/providers/openrouter/llama-3-lumimaid-70b.yaml
+++ b/providers/openrouter/llama-3-lumimaid-70b.yaml
@@ -1,7 +1,12 @@
 features:
     - chat
+limits:
+    context_window: 8192
 mode: chat
 model: llama-3-lumimaid-70b
 params:
     - key: max_tokens
       maxValue: 4096
+sources:
+    - https://openrouter.ai/neversleep/llama-3-lumimaid-70b/api
+    - https://openrouter.ai/neversleep/llama-3-lumimaid-70b

--- a/providers/openrouter/llama-3.2-90b-vision-instruct.yaml
+++ b/providers/openrouter/llama-3.2-90b-vision-instruct.yaml
@@ -1,8 +1,14 @@
 features:
     - chat
-    - image
+    - vision
+    - image_input
+limits:
+    context_window: 131072
 mode: chat
 model: llama-3.2-90b-vision-instruct
 params:
     - key: max_tokens
       maxValue: 2048
+sources:
+    - https://openrouter.ai/meta-llama/llama-3.2-90b-vision-instruct/api
+    - https://openrouter.ai/meta-llama/llama-3.2-90b-vision-instruct

--- a/providers/openrouter/meituan/longcat-flash-chat.yaml
+++ b/providers/openrouter/meituan/longcat-flash-chat.yaml
@@ -1,2 +1,18 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 2.e-7
+      input_cost_per_token: 2.e-7
+      output_cost_per_token: 8.e-7
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - tools
+limits:
+    context_window: 131072
+    max_output_tokens: 131072
+    max_tokens: 131072
+mode: chat
 model: meituan/longcat-flash-chat
+sources:
+    - https://openrouter.ai/meituan/longcat-flash-chat/api

--- a/providers/openrouter/meta-llama/llama-3-8b-instruct.yaml
+++ b/providers/openrouter/meta-llama/llama-3-8b-instruct.yaml
@@ -1,2 +1,19 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 3.e-8
+      output_cost_per_token: 4.e-8
+      region: "*"
+features:
+    - chat
+    - text
+    - function_calling
+    - tool_choice
+    - tools
+    - system_messages
+limits:
+    context_window: 8192
+    max_output_tokens: 16384
+    max_tokens: 16384
+mode: chat
 model: meta-llama/llama-3-8b-instruct
+sources:
+    - https://openrouter.ai/meta-llama/llama-3-8b-instruct/api

--- a/providers/openrouter/meta-llama/llama-3.1-405b-instruct.yaml
+++ b/providers/openrouter/meta-llama/llama-3.1-405b-instruct.yaml
@@ -1,2 +1,13 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0.000004
+      output_cost_per_token: 0.000004
+      region: "*"
+features:
+    - chat
+    - system_messages
+limits:
+    context_window: 131000
+mode: chat
 model: meta-llama/llama-3.1-405b-instruct
+sources:
+    - https://openrouter.ai/meta-llama/llama-3.1-405b-instruct/api

--- a/providers/openrouter/meta-llama/llama-3.1-405b.yaml
+++ b/providers/openrouter/meta-llama/llama-3.1-405b.yaml
@@ -1,2 +1,15 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0.000004
+      output_cost_per_token: 0.000004
+      region: "*"
+features:
+    - chat
+    - text
+limits:
+    context_window: 32768
+    max_output_tokens: 32768
+    max_tokens: 32768
+mode: chat
 model: meta-llama/llama-3.1-405b
+sources:
+    - https://openrouter.ai/meta-llama/llama-3.1-405b/api

--- a/providers/openrouter/meta-llama/llama-3.1-70b-instruct.yaml
+++ b/providers/openrouter/meta-llama/llama-3.1-70b-instruct.yaml
@@ -1,2 +1,20 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 4.e-7
+      output_cost_per_token: 4.e-7
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - tools
+    - system_messages
+    - response_schema
+    - text
+    - code
+limits:
+    context_window: 131072
+    max_tokens: 131072
+mode: chat
 model: meta-llama/llama-3.1-70b-instruct
+sources:
+    - https://openrouter.ai/meta-llama/llama-3.1-70b-instruct/api

--- a/providers/openrouter/meta-llama/llama-3.1-8b-instruct.yaml
+++ b/providers/openrouter/meta-llama/llama-3.1-8b-instruct.yaml
@@ -1,2 +1,19 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 2.e-8
+      output_cost_per_token: 5.e-8
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - text
+    - code
+    - tools
+limits:
+    context_window: 16384
+    max_output_tokens: 16384
+    max_tokens: 16384
+mode: chat
 model: meta-llama/llama-3.1-8b-instruct
+sources:
+    - https://openrouter.ai/meta-llama/llama-3.1-8b-instruct/api

--- a/providers/openrouter/meta-llama/llama-3.2-11b-vision-instruct.yaml
+++ b/providers/openrouter/meta-llama/llama-3.2-11b-vision-instruct.yaml
@@ -1,2 +1,21 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 4.9e-8
+      output_cost_per_token: 4.9e-8
+      region: "*"
+features:
+    - chat
+    - vision
+    - image_input
+    - function_calling
+    - tool_choice
+    - system_messages
+    - text
+    - code
+limits:
+    context_window: 131072
+    max_output_tokens: 16384
+    max_tokens: 16384
+mode: chat
 model: meta-llama/llama-3.2-11b-vision-instruct
+sources:
+    - https://openrouter.ai/meta-llama/llama-3.2-11b-vision-instruct/api

--- a/providers/openrouter/meta-llama/llama-3.2-1b-instruct.yaml
+++ b/providers/openrouter/meta-llama/llama-3.2-1b-instruct.yaml
@@ -1,2 +1,15 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 2.7e-8
+      output_cost_per_token: 2.e-7
+      region: "*"
+features:
+    - chat
+    - system_messages
+limits:
+    context_window: 60000
+    max_output_tokens: 4096
+    max_tokens: 4096
+mode: chat
 model: meta-llama/llama-3.2-1b-instruct
+sources:
+    - https://openrouter.ai/meta-llama/llama-3.2-1b-instruct/api

--- a/providers/openrouter/meta-llama/llama-3.2-3b-instruct.yaml
+++ b/providers/openrouter/meta-llama/llama-3.2-3b-instruct.yaml
@@ -1,2 +1,15 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 5.1e-8
+      output_cost_per_token: 3.4e-7
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - text
+    - system_messages
+limits:
+    context_window: 80000
+mode: chat
 model: meta-llama/llama-3.2-3b-instruct
+sources:
+    - https://openrouter.ai/meta-llama/llama-3.2-3b-instruct/api

--- a/providers/openrouter/meta-llama/llama-3.2-3b-instruct:free.yaml
+++ b/providers/openrouter/meta-llama/llama-3.2-3b-instruct:free.yaml
@@ -1,2 +1,16 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0
+      output_cost_per_token: 0
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - text
+    - code
+    - system_messages
+limits:
+    context_window: 131072
+mode: chat
 model: meta-llama/llama-3.2-3b-instruct:free
+sources:
+    - https://openrouter.ai/meta-llama/llama-3.2-3b-instruct:free/api

--- a/providers/openrouter/meta-llama/llama-3.3-70b-instruct.yaml
+++ b/providers/openrouter/meta-llama/llama-3.3-70b-instruct.yaml
@@ -1,2 +1,19 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 1.e-7
+      output_cost_per_token: 3.2e-7
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - text
+    - code
+limits:
+    context_window: 131072
+    max_input_tokens: 131072
+    max_output_tokens: 16384
+    max_tokens: 16384
+mode: chat
 model: meta-llama/llama-3.3-70b-instruct
+sources:
+    - https://openrouter.ai/meta-llama/llama-3.3-70b-instruct/api

--- a/providers/openrouter/meta-llama/llama-3.3-70b-instruct:free.yaml
+++ b/providers/openrouter/meta-llama/llama-3.3-70b-instruct:free.yaml
@@ -1,2 +1,19 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0
+      output_cost_per_token: 0
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - system_messages
+    - text
+    - code
+limits:
+    context_window: 128000
+    max_output_tokens: 128000
+    max_tokens: 128000
+mode: chat
 model: meta-llama/llama-3.3-70b-instruct:free
+sources:
+    - https://openrouter.ai/meta-llama/llama-3.3-70b-instruct:free/api

--- a/providers/openrouter/meta-llama/llama-4-maverick.yaml
+++ b/providers/openrouter/meta-llama/llama-4-maverick.yaml
@@ -1,2 +1,19 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 1.5e-7
+      output_cost_per_token: 6.e-7
+      region: "*"
+features:
+    - chat
+    - text
+    - vision
+    - image_input
+    - system_messages
+    - response_schema
+limits:
+    context_window: 1048576
+    max_output_tokens: 16384
+    max_tokens: 16384
+mode: chat
 model: meta-llama/llama-4-maverick
+sources:
+    - https://openrouter.ai/meta-llama/llama-4-maverick/api

--- a/providers/openrouter/meta-llama/llama-4-scout.yaml
+++ b/providers/openrouter/meta-llama/llama-4-scout.yaml
@@ -1,2 +1,23 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 8.e-8
+      output_cost_per_token: 3.e-7
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - vision
+    - image_input
+    - system_messages
+    - tool_choice
+    - tools
+    - response_schema
+    - text
+    - code
+limits:
+    context_window: 327680
+    max_output_tokens: 16384
+    max_tokens: 16384
+mode: chat
 model: meta-llama/llama-4-scout
+sources:
+    - https://openrouter.ai/meta-llama/llama-4-scout/api

--- a/providers/openrouter/meta-llama/llama-guard-3-8b.yaml
+++ b/providers/openrouter/meta-llama/llama-guard-3-8b.yaml
@@ -1,2 +1,14 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 2.e-8
+      output_cost_per_token: 6.e-8
+      region: "*"
+features:
+    - chat
+    - system_messages
+    - tool_choice
+limits:
+    context_window: 131072
+mode: chat
 model: meta-llama/llama-guard-3-8b
+sources:
+    - https://openrouter.ai/meta-llama/llama-guard-3-8b/api

--- a/providers/openrouter/meta-llama/llama-guard-4-12b.yaml
+++ b/providers/openrouter/meta-llama/llama-guard-4-12b.yaml
@@ -1,2 +1,15 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 1.8e-7
+      output_cost_per_token: 1.8e-7
+      region: "*"
+features:
+    - chat
+    - vision
+    - image_input
+    - system_messages
+limits:
+    context_window: 163840
+mode: chat
 model: meta-llama/llama-guard-4-12b
+sources:
+    - https://openrouter.ai/meta-llama/llama-guard-4-12b/api

--- a/providers/openrouter/microsoft/phi-4.yaml
+++ b/providers/openrouter/microsoft/phi-4.yaml
@@ -1,2 +1,15 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 6.e-8
+      output_cost_per_token: 1.4e-7
+      region: "*"
+features:
+    - chat
+    - response_schema
+limits:
+    context_window: 16384
+    max_output_tokens: 16384
+    max_tokens: 16384
+mode: chat
 model: microsoft/phi-4
+sources:
+    - https://openrouter.ai/microsoft/phi-4/api

--- a/providers/openrouter/microsoft/wizardlm-2-8x22b.yaml
+++ b/providers/openrouter/microsoft/wizardlm-2-8x22b.yaml
@@ -1,2 +1,17 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 6.2e-7
+      output_cost_per_token: 6.2e-7
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - system_messages
+limits:
+    context_window: 65535
+    max_output_tokens: 8000
+    max_tokens: 8000
+mode: chat
 model: microsoft/wizardlm-2-8x22b
+sources:
+    - https://openrouter.ai/microsoft/wizardlm-2-8x22b/api

--- a/providers/openrouter/minimax/minimax-01.yaml
+++ b/providers/openrouter/minimax/minimax-01.yaml
@@ -1,2 +1,16 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 2.e-7
+      output_cost_per_token: 0.0000011
+      region: "*"
+features:
+    - chat
+    - vision
+    - image_input
+limits:
+    context_window: 1000192
+    max_output_tokens: 1000192
+    max_tokens: 1000192
+mode: chat
 model: minimax/minimax-01
+sources:
+    - https://openrouter.ai/minimax/minimax-01/api

--- a/providers/openrouter/minimax/minimax-m1.yaml
+++ b/providers/openrouter/minimax/minimax-m1.yaml
@@ -1,2 +1,23 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 4.e-7
+      output_cost_per_token: 0.0000022
+      region: "*"
+      tiered_pricing:
+          input:
+              - cost_per_token: 0.0000013
+                from: 200000
+features:
+    - chat
+    - function_calling
+    - system_messages
+    - tools
+    - text
+limits:
+    context_window: 1000000
+    max_output_tokens: 40000
+    max_tokens: 40000
+mode: chat
 model: minimax/minimax-m1
+sources:
+    - https://openrouter.ai/minimax/minimax-m1/api
+thinking: true

--- a/providers/openrouter/minimax/minimax-m2-her.yaml
+++ b/providers/openrouter/minimax/minimax-m2-her.yaml
@@ -1,2 +1,15 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 3.e-7
+      output_cost_per_token: 0.0000012
+      region: "*"
+features:
+    - chat
+    - system_messages
+limits:
+    context_window: 65536
+    max_output_tokens: 2048
+    max_tokens: 2048
+mode: chat
 model: minimax/minimax-m2-her
+sources:
+    - https://openrouter.ai/minimax/minimax-m2-her/api

--- a/providers/openrouter/minimax/minimax-m2.5.yaml
+++ b/providers/openrouter/minimax/minimax-m2.5.yaml
@@ -1,2 +1,17 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 3.e-8
+      input_cost_per_token: 2.7e-7
+      output_cost_per_token: 9.5e-7
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - response_schema
+limits:
+    context_window: 196608
+mode: chat
 model: minimax/minimax-m2.5
+sources:
+    - https://openrouter.ai/minimax/minimax-m2.5/api
+thinking: true

--- a/providers/openrouter/mistralai/codestral-2508.yaml
+++ b/providers/openrouter/mistralai/codestral-2508.yaml
@@ -1,2 +1,19 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 3.e-7
+      output_cost_per_token: 9.e-7
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - response_schema
+    - text
+    - code
+    - tools
+limits:
+    context_window: 256000
+mode: chat
 model: mistralai/codestral-2508
+sources:
+    - https://openrouter.ai/mistralai/codestral-2508/api
+    - https://docs.mistral.ai/models/codestral-25-08

--- a/providers/openrouter/mistralai/devstral-medium.yaml
+++ b/providers/openrouter/mistralai/devstral-medium.yaml
@@ -1,2 +1,21 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 4.e-7
+      output_cost_per_token: 0.000002
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - response_schema
+    - system_messages
+    - text
+    - code
+    - tools
+limits:
+    context_window: 131072
+mode: chat
 model: mistralai/devstral-medium
+sources:
+    - https://openrouter.ai/mistralai/devstral-medium/api
+    - https://docs.mistral.ai/models/devstral-medium-1-0-25-07
+thinking: false

--- a/providers/openrouter/mistralai/devstral-small.yaml
+++ b/providers/openrouter/mistralai/devstral-small.yaml
@@ -1,2 +1,17 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 1.e-7
+      output_cost_per_token: 3.e-7
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - text
+    - code
+    - tools
+limits:
+    context_window: 131072
+mode: chat
 model: mistralai/devstral-small
+sources:
+    - https://openrouter.ai/mistralai/devstral-small/api

--- a/providers/openrouter/mistralai/mistral-7b-instruct-v0.1.yaml
+++ b/providers/openrouter/mistralai/mistral-7b-instruct-v0.1.yaml
@@ -1,2 +1,13 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 1.1e-7
+      output_cost_per_token: 1.9e-7
+      region: "*"
+features:
+    - chat
+    - text
+limits:
+    context_window: 2824
+mode: chat
 model: mistralai/mistral-7b-instruct-v0.1
+sources:
+    - https://openrouter.ai/mistralai/mistral-7b-instruct-v0.1/api

--- a/providers/openrouter/mistralai/mistral-large-2407.yaml
+++ b/providers/openrouter/mistralai/mistral-large-2407.yaml
@@ -1,2 +1,20 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0.000002
+      output_cost_per_token: 0.000006
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - response_schema
+    - text
+    - code
+    - tools
+limits:
+    context_window: 131072
+    max_output_tokens: 4096
+    max_tokens: 4096
+mode: chat
 model: mistralai/mistral-large-2407
+sources:
+    - https://openrouter.ai/mistralai/mistral-large-2407/api

--- a/providers/openrouter/mistralai/mistral-large-2411.yaml
+++ b/providers/openrouter/mistralai/mistral-large-2411.yaml
@@ -1,2 +1,19 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0.000002
+      output_cost_per_token: 0.000006
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tools
+    - tool_choice
+    - response_schema
+    - system_messages
+    - text
+    - code
+limits:
+    context_window: 131072
+mode: chat
 model: mistralai/mistral-large-2411
+sources:
+    - https://openrouter.ai/mistralai/mistral-large-2411/api

--- a/providers/openrouter/mistralai/mistral-medium-3.1.yaml
+++ b/providers/openrouter/mistralai/mistral-medium-3.1.yaml
@@ -1,2 +1,23 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 4.e-7
+      output_cost_per_token: 0.000002
+      region: "*"
+features:
+    - function_calling
+    - vision
+    - image_input
+    - chat
+    - response_schema
+    - system_messages
+    - tool_choice
+    - tools
+    - text
+    - code
+limits:
+    context_window: 131072
+    max_output_tokens: 131072
+mode: chat
 model: mistralai/mistral-medium-3.1
+sources:
+    - https://openrouter.ai/mistralai/mistral-medium-3.1/api
+    - https://docs.mistral.ai/models/mistral-medium-3-1-25-08

--- a/providers/openrouter/mistralai/mistral-medium-3.yaml
+++ b/providers/openrouter/mistralai/mistral-medium-3.yaml
@@ -1,2 +1,20 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 4.e-7
+      output_cost_per_token: 0.000002
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - vision
+    - image_input
+    - response_schema
+    - tool_choice
+    - text
+    - tools
+limits:
+    context_window: 131072
+mode: chat
 model: mistralai/mistral-medium-3
+sources:
+    - https://openrouter.ai/mistralai/mistral-medium-3/api
+    - https://docs.mistral.ai/getting-started/models/

--- a/providers/openrouter/mistralai/mistral-nemo.yaml
+++ b/providers/openrouter/mistralai/mistral-nemo.yaml
@@ -1,2 +1,21 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 2.e-8
+      output_cost_per_token: 4.e-8
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - system_messages
+    - text
+    - code
+    - tools
+    - response_schema
+limits:
+    context_window: 131072
+    max_output_tokens: 16384
+    max_tokens: 16384
+mode: chat
 model: mistralai/mistral-nemo
+sources:
+    - https://openrouter.ai/mistralai/mistral-nemo/api

--- a/providers/openrouter/mistralai/mistral-saba.yaml
+++ b/providers/openrouter/mistralai/mistral-saba.yaml
@@ -1,2 +1,20 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 2.e-7
+      output_cost_per_token: 6.e-7
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - response_schema
+    - system_messages
+    - text
+    - code
+    - tools
+limits:
+    context_window: 32768
+    max_tokens: 32768
+mode: chat
 model: mistralai/mistral-saba
+sources:
+    - https://openrouter.ai/mistralai/mistral-saba/api

--- a/providers/openrouter/mistralai/mistral-small-24b-instruct-2501.yaml
+++ b/providers/openrouter/mistralai/mistral-small-24b-instruct-2501.yaml
@@ -1,2 +1,21 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 5.e-8
+      output_cost_per_token: 8.e-8
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - response_schema
+    - system_messages
+    - tool_choice
+    - tools
+    - text
+    - code
+limits:
+    context_window: 32768
+    max_output_tokens: 16384
+    max_tokens: 16384
+mode: chat
 model: mistralai/mistral-small-24b-instruct-2501
+sources:
+    - https://openrouter.ai/mistralai/mistral-small-24b-instruct-2501/api

--- a/providers/openrouter/mistralai/mistral-small-3.1-24b-instruct:free.yaml
+++ b/providers/openrouter/mistralai/mistral-small-3.1-24b-instruct:free.yaml
@@ -1,2 +1,21 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0
+      output_cost_per_token: 0
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - vision
+    - image_input
+    - tool_choice
+    - response_schema
+    - system_messages
+    - text
+    - code
+    - tools
+limits:
+    context_window: 128000
+mode: chat
 model: mistralai/mistral-small-3.1-24b-instruct:free
+sources:
+    - https://openrouter.ai/mistralai/mistral-small-3.1-24b-instruct:free/api

--- a/providers/openrouter/mistralai/mistral-small-creative.yaml
+++ b/providers/openrouter/mistralai/mistral-small-creative.yaml
@@ -1,2 +1,19 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 1.e-7
+      output_cost_per_token: 3.e-7
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - system_messages
+    - text
+    - code
+limits:
+    context_window: 32768
+    max_output_tokens: 32768
+    max_tokens: 32768
+mode: chat
 model: mistralai/mistral-small-creative
+sources:
+    - https://openrouter.ai/mistralai/mistral-small-creative/api

--- a/providers/openrouter/mistralai/mixtral-8x7b-instruct.yaml
+++ b/providers/openrouter/mistralai/mixtral-8x7b-instruct.yaml
@@ -1,2 +1,21 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 5.4e-7
+      output_cost_per_token: 5.4e-7
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - system_messages
+    - response_schema
+    - text
+    - code
+    - tools
+limits:
+    context_window: 32768
+    max_output_tokens: 16384
+    max_tokens: 16384
+mode: chat
 model: mistralai/mixtral-8x7b-instruct
+sources:
+    - https://openrouter.ai/mistralai/mixtral-8x7b-instruct/api

--- a/providers/openrouter/mistralai/pixtral-large-2411.yaml
+++ b/providers/openrouter/mistralai/pixtral-large-2411.yaml
@@ -1,2 +1,24 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0.000002
+      output_cost_per_token: 0.000006
+      region: "*"
+features:
+    - chat
+    - vision
+    - image_input
+    - function_calling
+    - tool_choice
+    - response_schema
+    - system_messages
+    - text
+    - code
+    - tools
+limits:
+    context_window: 131072
+    max_output_tokens: 4096
+    max_tokens: 4096
+mode: chat
 model: mistralai/pixtral-large-2411
+sources:
+    - https://openrouter.ai/mistralai/pixtral-large-2411/api
+thinking: false

--- a/providers/openrouter/mistralai/voxtral-small-24b-2507.yaml
+++ b/providers/openrouter/mistralai/voxtral-small-24b-2507.yaml
@@ -1,2 +1,17 @@
-mode: unknown
+costs:
+    - input_cost_per_audio_token: 0.0001
+      input_cost_per_token: 1.e-7
+      output_cost_per_token: 3.e-7
+      region: "*"
+features:
+    - chat
+    - audio_input
+    - function_calling
+    - tool_choice
+    - response_schema
+limits:
+    context_window: 32000
+mode: chat
 model: mistralai/voxtral-small-24b-2507
+sources:
+    - https://openrouter.ai/mistralai/voxtral-small-24b-2507/api

--- a/providers/openrouter/moonshotai/kimi-k2-0905.yaml
+++ b/providers/openrouter/moonshotai/kimi-k2-0905.yaml
@@ -1,2 +1,19 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 1.5e-7
+      input_cost_per_token: 4.e-7
+      output_cost_per_token: 0.000002
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - tools
+    - text
+    - response_schema
+    - system_messages
+limits:
+    context_window: 131072
+mode: chat
 model: moonshotai/kimi-k2-0905
+sources:
+    - https://openrouter.ai/moonshotai/kimi-k2-0905/api

--- a/providers/openrouter/moonshotai/kimi-k2-0905:exacto.yaml
+++ b/providers/openrouter/moonshotai/kimi-k2-0905:exacto.yaml
@@ -1,2 +1,21 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 1.5e-7
+      input_cost_per_token: 4.e-7
+      output_cost_per_token: 0.000002
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - text
+    - code
+    - tools
+limits:
+    context_window: 131072
+mode: chat
 model: moonshotai/kimi-k2-0905:exacto
+params:
+    - defaultValue: 0.7
+      key: temperature
+sources:
+    - https://openrouter.ai/moonshotai/kimi-k2-0905:exacto/api

--- a/providers/openrouter/moonshotai/kimi-k2-thinking.yaml
+++ b/providers/openrouter/moonshotai/kimi-k2-thinking.yaml
@@ -1,2 +1,24 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 1.41e-7
+      input_cost_per_token: 4.7e-7
+      output_cost_per_token: 0.000002
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - tools
+    - text
+    - system_messages
+    - response_schema
+limits:
+    context_window: 131072
+mode: chat
 model: moonshotai/kimi-k2-thinking
+params:
+    - defaultValue: null
+      key: reasoning
+      type: object
+sources:
+    - https://openrouter.ai/moonshotai/kimi-k2-thinking/api
+thinking: true

--- a/providers/openrouter/moonshotai/kimi-k2.yaml
+++ b/providers/openrouter/moonshotai/kimi-k2.yaml
@@ -1,2 +1,19 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 5.5e-7
+      output_cost_per_token: 0.0000022
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - tools
+    - text
+    - code
+limits:
+    context_window: 131000
+    max_output_tokens: 131000
+    max_tokens: 131000
+mode: chat
 model: moonshotai/kimi-k2
+sources:
+    - https://openrouter.ai/moonshotai/kimi-k2/api

--- a/providers/openrouter/morph-v2.yaml
+++ b/providers/openrouter/morph-v2.yaml
@@ -1,7 +1,13 @@
 features:
     - chat
+    - code
+limits:
+    context_window: 32000
 mode: chat
 model: morph-v2
 params:
     - key: max_tokens
       maxValue: 16000
+sources:
+    - https://openrouter.ai/morph/morph-v2/api
+    - https://docs.morphllm.com/

--- a/providers/openrouter/morph/morph-v3-fast.yaml
+++ b/providers/openrouter/morph/morph-v3-fast.yaml
@@ -1,2 +1,16 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 8.e-7
+      output_cost_per_token: 0.0000012
+      region: "*"
+features:
+    - chat
+    - text
+    - code
+limits:
+    context_window: 81920
+    max_output_tokens: 38000
+    max_tokens: 38000
+mode: chat
 model: morph/morph-v3-fast
+sources:
+    - https://openrouter.ai/morph/morph-v3-fast/api

--- a/providers/openrouter/morph/morph-v3-large.yaml
+++ b/providers/openrouter/morph/morph-v3-large.yaml
@@ -1,2 +1,16 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 9.e-7
+      output_cost_per_token: 0.0000019
+      region: "*"
+features:
+    - chat
+    - text
+    - code
+limits:
+    context_window: 262144
+    max_output_tokens: 131072
+    max_tokens: 131072
+mode: chat
 model: morph/morph-v3-large
+sources:
+    - https://openrouter.ai/morph/morph-v3-large/api

--- a/providers/openrouter/neversleep/llama-3.1-lumimaid-8b.yaml
+++ b/providers/openrouter/neversleep/llama-3.1-lumimaid-8b.yaml
@@ -1,2 +1,9 @@
-mode: unknown
+features:
+    - chat
+    - text
+limits:
+    context_window: 131072
+mode: chat
 model: neversleep/llama-3.1-lumimaid-8b
+sources:
+    - https://openrouter.ai/neversleep/llama-3.1-lumimaid-8b/api

--- a/providers/openrouter/neversleep/noromaid-20b.yaml
+++ b/providers/openrouter/neversleep/noromaid-20b.yaml
@@ -1,2 +1,11 @@
-mode: unknown
+features:
+    - chat
+    - text
+limits:
+    context_window: 8192
+    max_output_tokens: 4096
+    max_tokens: 4096
+mode: chat
 model: neversleep/noromaid-20b
+sources:
+    - https://openrouter.ai/neversleep/noromaid-20b/api

--- a/providers/openrouter/nex-agi/deepseek-v3.1-nex-n1.yaml
+++ b/providers/openrouter/nex-agi/deepseek-v3.1-nex-n1.yaml
@@ -1,2 +1,20 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 2.7e-7
+      output_cost_per_token: 0.000001
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - response_schema
+    - text
+    - code
+    - tools
+limits:
+    context_window: 131072
+    max_output_tokens: 163840
+    max_tokens: 163840
+mode: chat
 model: nex-agi/deepseek-v3.1-nex-n1
+sources:
+    - https://openrouter.ai/nex-agi/deepseek-v3.1-nex-n1/api

--- a/providers/openrouter/nousresearch/hermes-2-pro-llama-3-8b.yaml
+++ b/providers/openrouter/nousresearch/hermes-2-pro-llama-3-8b.yaml
@@ -1,2 +1,19 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 1.4e-7
+      output_cost_per_token: 1.4e-7
+      region: "*"
+features:
+    - function_calling
+    - response_schema
+    - chat
+    - text
+    - code
+    - tools
+limits:
+    context_window: 8192
+    max_output_tokens: 8192
+    max_tokens: 8192
+mode: chat
 model: nousresearch/hermes-2-pro-llama-3-8b
+sources:
+    - https://openrouter.ai/nousresearch/hermes-2-pro-llama-3-8b/api

--- a/providers/openrouter/nousresearch/hermes-3-llama-3.1-405b.yaml
+++ b/providers/openrouter/nousresearch/hermes-3-llama-3.1-405b.yaml
@@ -1,2 +1,19 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0.000001
+      output_cost_per_token: 0.000001
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - system_messages
+    - text
+    - code
+limits:
+    context_window: 131072
+    max_output_tokens: 16384
+    max_tokens: 16384
+mode: chat
 model: nousresearch/hermes-3-llama-3.1-405b
+sources:
+    - https://openrouter.ai/nousresearch/hermes-3-llama-3.1-405b/api

--- a/providers/openrouter/nousresearch/hermes-3-llama-3.1-405b:free.yaml
+++ b/providers/openrouter/nousresearch/hermes-3-llama-3.1-405b:free.yaml
@@ -1,2 +1,15 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0
+      output_cost_per_token: 0
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - system_messages
+limits:
+    context_window: 131072
+mode: chat
 model: nousresearch/hermes-3-llama-3.1-405b:free
+sources:
+    - https://openrouter.ai/nousresearch/hermes-3-llama-3.1-405b:free/api

--- a/providers/openrouter/nousresearch/hermes-3-llama-3.1-70b.yaml
+++ b/providers/openrouter/nousresearch/hermes-3-llama-3.1-70b.yaml
@@ -1,2 +1,18 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 3.e-7
+      output_cost_per_token: 3.e-7
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - response_schema
+    - system_messages
+    - text
+    - tools
+    - tool_choice
+limits:
+    context_window: 131072
+mode: chat
 model: nousresearch/hermes-3-llama-3.1-70b
+sources:
+    - https://openrouter.ai/nousresearch/hermes-3-llama-3.1-70b/api

--- a/providers/openrouter/nousresearch/hermes-4-405b.yaml
+++ b/providers/openrouter/nousresearch/hermes-4-405b.yaml
@@ -1,2 +1,20 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0.000001
+      output_cost_per_token: 0.000003
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - response_schema
+    - tools
+    - text
+    - code
+    - system_messages
+limits:
+    context_window: 131072
+mode: chat
 model: nousresearch/hermes-4-405b
+sources:
+    - https://openrouter.ai/nousresearch/hermes-4-405b/api
+thinking: true

--- a/providers/openrouter/nousresearch/hermes-4-70b.yaml
+++ b/providers/openrouter/nousresearch/hermes-4-70b.yaml
@@ -1,2 +1,17 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 1.3e-7
+      output_cost_per_token: 4.e-7
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tools
+    - response_schema
+    - system_messages
+limits:
+    context_window: 131072
+mode: chat
 model: nousresearch/hermes-4-70b
+sources:
+    - https://openrouter.ai/nousresearch/hermes-4-70b/api
+thinking: true

--- a/providers/openrouter/nvidia/llama-3.1-nemotron-70b-instruct.yaml
+++ b/providers/openrouter/nvidia/llama-3.1-nemotron-70b-instruct.yaml
@@ -1,2 +1,16 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0.0000012
+      output_cost_per_token: 0.0000012
+      region: "*"
+features:
+    - function_calling
+    - tool_choice
+    - tools
+limits:
+    context_window: 131072
+    max_output_tokens: 16384
+    max_tokens: 16384
+mode: chat
 model: nvidia/llama-3.1-nemotron-70b-instruct
+sources:
+    - https://openrouter.ai/nvidia/llama-3.1-nemotron-70b-instruct/api

--- a/providers/openrouter/nvidia/llama-3.3-nemotron-super-49b-v1.5.yaml
+++ b/providers/openrouter/nvidia/llama-3.3-nemotron-super-49b-v1.5.yaml
@@ -1,2 +1,17 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 1.e-7
+      output_cost_per_token: 4.e-7
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tools
+    - text
+    - code
+limits:
+    context_window: 131072
+mode: chat
 model: nvidia/llama-3.3-nemotron-super-49b-v1.5
+sources:
+    - https://openrouter.ai/nvidia/llama-3.3-nemotron-super-49b-v1.5/api
+thinking: true

--- a/providers/openrouter/nvidia/nemotron-3-nano-30b-a3b.yaml
+++ b/providers/openrouter/nvidia/nemotron-3-nano-30b-a3b.yaml
@@ -1,2 +1,19 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 5.e-8
+      output_cost_per_token: 2.e-7
+      region: "*"
+features:
+    - chat
+    - text
+    - function_calling
+    - tool_choice
+    - tools
+    - response_schema
+    - system_messages
+limits:
+    context_window: 262144
+mode: chat
 model: nvidia/nemotron-3-nano-30b-a3b
+sources:
+    - https://openrouter.ai/nvidia/nemotron-3-nano-30b-a3b/api
+thinking: true

--- a/providers/openrouter/nvidia/nemotron-3-nano-30b-a3b:free.yaml
+++ b/providers/openrouter/nvidia/nemotron-3-nano-30b-a3b:free.yaml
@@ -1,2 +1,19 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0
+      output_cost_per_token: 0
+      region: "*"
+features:
+    - chat
+    - text
+    - function_calling
+    - tool_choice
+    - response_schema
+    - tools
+limits:
+    context_window: 256000
+mode: chat
 model: nvidia/nemotron-3-nano-30b-a3b:free
+sources:
+    - https://openrouter.ai/nvidia/nemotron-3-nano-30b-a3b:free/api
+    - https://openrouter.ai/nvidia/nemotron-3-nano-30b-a3b/api
+thinking: true

--- a/providers/openrouter/nvidia/nemotron-nano-12b-v2-vl.yaml
+++ b/providers/openrouter/nvidia/nemotron-nano-12b-v2-vl.yaml
@@ -1,2 +1,16 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 2.e-7
+      output_cost_per_token: 6.e-7
+      region: "*"
+features:
+    - chat
+    - vision
+    - image_input
+    - text
+limits:
+    context_window: 131072
+mode: chat
 model: nvidia/nemotron-nano-12b-v2-vl
+sources:
+    - https://openrouter.ai/nvidia/nemotron-nano-12b-v2-vl/api
+thinking: true

--- a/providers/openrouter/nvidia/nemotron-nano-12b-v2-vl:free.yaml
+++ b/providers/openrouter/nvidia/nemotron-nano-12b-v2-vl:free.yaml
@@ -1,2 +1,16 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0
+      output_cost_per_token: 0
+      region: "*"
+features:
+    - chat
+    - vision
+    - image_input
+    - text
+limits:
+    context_window: 128000
+mode: chat
 model: nvidia/nemotron-nano-12b-v2-vl:free
+sources:
+    - https://openrouter.ai/nvidia/nemotron-nano-12b-v2-vl:free/api
+thinking: true

--- a/providers/openrouter/nvidia/nemotron-nano-9b-v2.yaml
+++ b/providers/openrouter/nvidia/nemotron-nano-9b-v2.yaml
@@ -1,2 +1,16 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 4.e-8
+      output_cost_per_token: 1.6e-7
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tools
+    - text
+limits:
+    context_window: 131072
+mode: chat
 model: nvidia/nemotron-nano-9b-v2
+sources:
+    - https://openrouter.ai/nvidia/nemotron-nano-9b-v2/api
+thinking: true

--- a/providers/openrouter/nvidia/nemotron-nano-9b-v2:free.yaml
+++ b/providers/openrouter/nvidia/nemotron-nano-9b-v2:free.yaml
@@ -1,2 +1,20 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0
+      output_cost_per_token: 0
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - response_schema
+    - system_messages
+    - text
+    - tools
+limits:
+    context_window: 128000
+mode: chat
 model: nvidia/nemotron-nano-9b-v2:free
+sources:
+    - https://openrouter.ai/nvidia/nemotron-nano-9b-v2:free/api
+    - https://openrouter.ai/nvidia/nemotron-nano-9b-v2/api
+thinking: true

--- a/providers/openrouter/openai/gpt-3.5-turbo-0613.yaml
+++ b/providers/openrouter/openai/gpt-3.5-turbo-0613.yaml
@@ -1,2 +1,21 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0.000001
+      output_cost_per_token: 0.000002
+      region: "*"
+features:
+    - function_calling
+    - chat
+    - system_messages
+    - tool_choice
+    - response_schema
+    - text
+    - code
+    - tools
+limits:
+    context_window: 4095
+    max_output_tokens: 4096
+    max_tokens: 4096
+mode: chat
 model: openai/gpt-3.5-turbo-0613
+sources:
+    - https://openrouter.ai/openai/gpt-3.5-turbo-0613/api

--- a/providers/openrouter/openai/gpt-3.5-turbo-instruct.yaml
+++ b/providers/openrouter/openai/gpt-3.5-turbo-instruct.yaml
@@ -1,2 +1,14 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0.0000015
+      output_cost_per_token: 0.000002
+      region: "*"
+features:
+    - text
+limits:
+    context_window: 4095
+    max_output_tokens: 4096
+    max_tokens: 4096
+mode: completion
 model: openai/gpt-3.5-turbo-instruct
+sources:
+    - https://openrouter.ai/openai/gpt-3.5-turbo-instruct/api

--- a/providers/openrouter/openai/gpt-4-0314.yaml
+++ b/providers/openrouter/openai/gpt-4-0314.yaml
@@ -1,2 +1,3 @@
+isDeprecated: true
 mode: unknown
 model: openai/gpt-4-0314

--- a/providers/openrouter/openai/gpt-4-1106-preview.yaml
+++ b/providers/openrouter/openai/gpt-4-1106-preview.yaml
@@ -1,2 +1,18 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0.00001
+      output_cost_per_token: 0.00003
+      region: "*"
+features:
+    - function_calling
+    - chat
+    - system_messages
+    - tool_choice
+    - response_schema
+limits:
+    context_window: 128000
+    max_output_tokens: 4096
+    max_tokens: 4096
+mode: chat
 model: openai/gpt-4-1106-preview
+sources:
+    - https://openrouter.ai/openai/gpt-4-1106-preview/api

--- a/providers/openrouter/openai/gpt-4-turbo-preview.yaml
+++ b/providers/openrouter/openai/gpt-4-turbo-preview.yaml
@@ -1,2 +1,22 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0.00001
+      output_cost_per_token: 0.00003
+      region: "*"
+features:
+    - function_calling
+    - parallel_function_calling
+    - chat
+    - system_messages
+    - tool_choice
+    - response_schema
+    - tools
+    - text
+    - code
+limits:
+    context_window: 128000
+    max_output_tokens: 4096
+    max_tokens: 4096
+mode: chat
 model: openai/gpt-4-turbo-preview
+sources:
+    - https://openrouter.ai/openai/gpt-4-turbo-preview/api

--- a/providers/openrouter/openai/gpt-4-turbo.yaml
+++ b/providers/openrouter/openai/gpt-4-turbo.yaml
@@ -1,2 +1,22 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0.00001
+      output_cost_per_token: 0.00003
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - vision
+    - image_input
+    - system_messages
+    - tool_choice
+    - response_schema
+    - text
+    - tools
+limits:
+    context_window: 128000
+    max_output_tokens: 4096
+    max_tokens: 4096
+mode: chat
 model: openai/gpt-4-turbo
+sources:
+    - https://openrouter.ai/openai/gpt-4-turbo/api

--- a/providers/openrouter/openai/gpt-4o-2024-08-06.yaml
+++ b/providers/openrouter/openai/gpt-4o-2024-08-06.yaml
@@ -1,2 +1,25 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 0.00000125
+      input_cost_per_token: 0.0000025
+      output_cost_per_token: 0.00001
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - parallel_function_calling
+    - vision
+    - image_input
+    - tool_choice
+    - response_schema
+    - system_messages
+    - text
+    - code
+    - tools
+limits:
+    context_window: 128000
+    max_output_tokens: 16384
+    max_tokens: 16384
+mode: chat
 model: openai/gpt-4o-2024-08-06
+sources:
+    - https://openrouter.ai/openai/gpt-4o-2024-08-06/api

--- a/providers/openrouter/openai/gpt-4o-2024-11-20.yaml
+++ b/providers/openrouter/openai/gpt-4o-2024-11-20.yaml
@@ -1,2 +1,22 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 0.00000125
+      input_cost_per_token: 0.0000025
+      output_cost_per_token: 0.00001
+      region: "*"
+features:
+    - function_calling
+    - vision
+    - image_input
+    - chat
+    - text
+    - tools
+    - tool_choice
+    - system_messages
+limits:
+    context_window: 128000
+    max_output_tokens: 16384
+    max_tokens: 16384
+mode: chat
 model: openai/gpt-4o-2024-11-20
+sources:
+    - https://openrouter.ai/openai/gpt-4o-2024-11-20/api

--- a/providers/openrouter/openai/gpt-4o-audio-preview.yaml
+++ b/providers/openrouter/openai/gpt-4o-audio-preview.yaml
@@ -1,2 +1,25 @@
-mode: unknown
+costs:
+    - input_cost_per_audio_token: 0.00004
+      input_cost_per_token: 0.0000025
+      output_cost_per_audio_token: 0.00008
+      output_cost_per_token: 0.00001
+      region: "*"
+features:
+    - chat
+    - text
+    - audio_input
+    - audio_output
+    - function_calling
+    - tool_choice
+    - response_schema
+    - system_messages
+    - tools
+limits:
+    context_window: 128000
+    max_output_tokens: 16384
+    max_tokens: 16384
+mode: chat
 model: openai/gpt-4o-audio-preview
+sources:
+    - https://openrouter.ai/openai/gpt-4o-audio-preview/api
+thinking: false

--- a/providers/openrouter/openai/gpt-4o-mini-2024-07-18.yaml
+++ b/providers/openrouter/openai/gpt-4o-mini-2024-07-18.yaml
@@ -1,2 +1,25 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 7.5e-8
+      input_cost_per_token: 1.5e-7
+      output_cost_per_token: 6.e-7
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - vision
+    - image_input
+    - tool_choice
+    - response_schema
+    - system_messages
+    - text
+    - code
+    - tools
+limits:
+    context_window: 128000
+    max_input_tokens: 128000
+    max_output_tokens: 16384
+    max_tokens: 16384
+mode: chat
 model: openai/gpt-4o-mini-2024-07-18
+sources:
+    - https://openrouter.ai/openai/gpt-4o-mini-2024-07-18/api

--- a/providers/openrouter/openai/gpt-4o-mini-search-preview.yaml
+++ b/providers/openrouter/openai/gpt-4o-mini-search-preview.yaml
@@ -1,2 +1,17 @@
-mode: unknown
+costs:
+    - input_cost_per_query: 0.0275
+      input_cost_per_token: 1.5e-7
+      output_cost_per_token: 6.e-7
+      region: "*"
+features:
+    - chat
+    - system_messages
+    - response_schema
+limits:
+    context_window: 128000
+    max_output_tokens: 16384
+    max_tokens: 16384
+mode: chat
 model: openai/gpt-4o-mini-search-preview
+sources:
+    - https://openrouter.ai/openai/gpt-4o-mini-search-preview/api

--- a/providers/openrouter/openai/gpt-4o-mini.yaml
+++ b/providers/openrouter/openai/gpt-4o-mini.yaml
@@ -1,2 +1,22 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 7.5e-8
+      input_cost_per_token: 1.5e-7
+      output_cost_per_token: 6.e-7
+      region: "*"
+features:
+    - function_calling
+    - vision
+    - image_input
+    - chat
+    - tool_choice
+    - response_schema
+    - system_messages
+    - prompt_caching
+limits:
+    context_window: 128000
+    max_output_tokens: 16384
+    max_tokens: 16384
+mode: chat
 model: openai/gpt-4o-mini
+sources:
+    - https://openrouter.ai/openai/gpt-4o-mini/api

--- a/providers/openrouter/openai/gpt-4o-search-preview.yaml
+++ b/providers/openrouter/openai/gpt-4o-search-preview.yaml
@@ -1,2 +1,20 @@
-mode: unknown
+costs:
+    - input_cost_per_query: 0.035
+      input_cost_per_token: 0.0000025
+      output_cost_per_token: 0.00001
+      region: "*"
+features:
+    - chat
+    - text
+    - system_messages
+    - response_schema
+limits:
+    context_window: 128000
+    max_input_tokens: 128000
+    max_output_tokens: 16384
+    max_tokens: 16384
+mode: chat
 model: openai/gpt-4o-search-preview
+sources:
+    - https://openrouter.ai/openai/gpt-4o-search-preview/api
+thinking: false

--- a/providers/openrouter/openai/gpt-4o:extended.yaml
+++ b/providers/openrouter/openai/gpt-4o:extended.yaml
@@ -1,2 +1,26 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0.000006
+      output_cost_per_token: 0.000018
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - vision
+    - image_input
+    - system_messages
+    - tool_choice
+    - response_schema
+    - text
+limits:
+    context_window: 128000
+    max_output_tokens: 64000
+    max_tokens: 64000
+mode: chat
 model: openai/gpt-4o:extended
+params:
+    - defaultValue: 128
+      key: max_tokens
+      maxValue: 64000
+      minValue: 1
+sources:
+    - https://openrouter.ai/openai/gpt-4o:extended/api

--- a/providers/openrouter/openai/gpt-5-image-mini.yaml
+++ b/providers/openrouter/openai/gpt-5-image-mini.yaml
@@ -1,2 +1,29 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 2.5e-7
+      input_cost_per_query: 0.01
+      input_cost_per_token: 0.0000025
+      output_cost_per_image_token: 0.000008
+      output_cost_per_token: 0.000002
+      region: "*"
+features:
+    - chat
+    - text
+    - vision
+    - image_input
+    - image
+    - function_calling
+    - tools
+    - tool_choice
+    - response_schema
+    - system_messages
+    - prompt_caching
+limits:
+    context_window: 400000
+    max_input_tokens: 272000
+    max_output_tokens: 128000
+    max_tokens: 128000
+mode: chat
 model: openai/gpt-5-image-mini
+sources:
+    - https://openrouter.ai/openai/gpt-5-image-mini/api
+thinking: true

--- a/providers/openrouter/openai/gpt-5-image.yaml
+++ b/providers/openrouter/openai/gpt-5-image.yaml
@@ -1,2 +1,28 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 0.00000125
+      input_cost_per_token: 0.00001
+      output_cost_per_image_token: 0.00004
+      output_cost_per_token: 0.00001
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - vision
+    - image_input
+    - image
+    - text
+    - code
+    - tools
+    - tool_choice
+    - system_messages
+    - response_schema
+limits:
+    context_window: 400000
+    max_input_tokens: 272000
+    max_output_tokens: 128000
+    max_tokens: 128000
+mode: chat
 model: openai/gpt-5-image
+sources:
+    - https://openrouter.ai/openai/gpt-5-image/api
+thinking: true

--- a/providers/openrouter/openai/gpt-5-pro.yaml
+++ b/providers/openrouter/openai/gpt-5-pro.yaml
@@ -1,2 +1,25 @@
-mode: unknown
+costs:
+    - input_cost_per_query: 0.01
+      input_cost_per_token: 0.000015
+      output_cost_per_token: 0.00012
+      region: "*"
+features:
+    - chat
+    - text
+    - vision
+    - image_input
+    - function_calling
+    - tool_choice
+    - tools
+    - response_schema
+    - system_messages
+limits:
+    context_window: 400000
+    max_input_tokens: 272000
+    max_output_tokens: 128000
+    max_tokens: 128000
+mode: chat
 model: openai/gpt-5-pro
+sources:
+    - https://openrouter.ai/openai/gpt-5-pro/api
+thinking: true

--- a/providers/openrouter/openai/gpt-5.1-chat.yaml
+++ b/providers/openrouter/openai/gpt-5.1-chat.yaml
@@ -1,2 +1,23 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 1.25e-7
+      input_cost_per_token: 0.00000125
+      output_cost_per_token: 0.00001
+      region: "*"
+features:
+    - chat
+    - text
+    - vision
+    - image_input
+    - function_calling
+    - tool_choice
+    - tools
+    - response_schema
+    - system_messages
+limits:
+    context_window: 128000
+    max_output_tokens: 16384
+    max_tokens: 16384
+mode: chat
 model: openai/gpt-5.1-chat
+sources:
+    - https://openrouter.ai/openai/gpt-5.1-chat/api

--- a/providers/openrouter/openai/gpt-5.1-codex-max.yaml
+++ b/providers/openrouter/openai/gpt-5.1-codex-max.yaml
@@ -1,2 +1,32 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 1.25e-7
+      input_cost_per_query: 0.01
+      input_cost_per_token: 0.00000125
+      output_cost_per_token: 0.00001
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - vision
+    - image_input
+    - tool_choice
+    - response_schema
+    - system_messages
+    - text
+    - code
+    - tools
+limits:
+    context_window: 400000
+    max_input_tokens: 272000
+    max_output_tokens: 128000
+    max_tokens: 128000
+mode: chat
 model: openai/gpt-5.1-codex-max
+params:
+    - defaultValue: 128
+      key: max_tokens
+      maxValue: 128000
+      minValue: 1
+sources:
+    - https://openrouter.ai/openai/gpt-5.1-codex-max/api
+thinking: true

--- a/providers/openrouter/openai/gpt-5.1-codex-mini.yaml
+++ b/providers/openrouter/openai/gpt-5.1-codex-mini.yaml
@@ -1,2 +1,27 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 2.5e-8
+      input_cost_per_token: 2.5e-7
+      output_cost_per_token: 0.000002
+      region: "*"
+features:
+    - chat
+    - text
+    - code
+    - vision
+    - image_input
+    - function_calling
+    - tool_choice
+    - tools
+    - response_schema
+    - system_messages
+limits:
+    context_window: 400000
+    max_input_tokens: 300000
+    max_output_tokens: 100000
+    max_tokens: 100000
+mode: chat
 model: openai/gpt-5.1-codex-mini
+sources:
+    - https://openrouter.ai/openai/gpt-5.1-codex-mini/api
+    - https://developers.openai.com/docs/models/gpt-5.1-codex-mini
+thinking: true

--- a/providers/openrouter/openai/gpt-5.1-codex.yaml
+++ b/providers/openrouter/openai/gpt-5.1-codex.yaml
@@ -1,2 +1,25 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 1.25e-7
+      input_cost_per_token: 0.00000125
+      output_cost_per_token: 0.00001
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - vision
+    - image_input
+    - tool_choice
+    - response_schema
+    - text
+    - code
+    - tools
+limits:
+    context_window: 400000
+    max_input_tokens: 272000
+    max_output_tokens: 128000
+    max_tokens: 128000
+mode: chat
 model: openai/gpt-5.1-codex
+sources:
+    - https://openrouter.ai/openai/gpt-5.1-codex/api
+thinking: true

--- a/providers/openrouter/openai/gpt-5.1.yaml
+++ b/providers/openrouter/openai/gpt-5.1.yaml
@@ -1,2 +1,28 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 1.25e-7
+      input_cost_per_token: 0.00000125
+      output_cost_per_token: 0.00001
+      region: "*"
+features:
+    - chat
+    - text
+    - vision
+    - image_input
+    - function_calling
+    - tools
+    - tool_choice
+    - system_messages
+    - response_schema
+    - prompt_caching
+    - pdf
+    - pdf_input
+limits:
+    context_window: 400000
+    max_input_tokens: 272000
+    max_output_tokens: 128000
+    max_tokens: 128000
+mode: chat
 model: openai/gpt-5.1
+sources:
+    - https://openrouter.ai/openai/gpt-5.1/api
+thinking: true

--- a/providers/openrouter/openai/gpt-5.3-chat.yaml
+++ b/providers/openrouter/openai/gpt-5.3-chat.yaml
@@ -1,2 +1,24 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 1.75e-7
+      input_cost_per_token: 0.00000175
+      output_cost_per_token: 0.000014
+      region: "*"
+features:
+    - chat
+    - text
+    - vision
+    - image_input
+    - function_calling
+    - tool_choice
+    - prompt_caching
+    - system_messages
+    - pdf_input
+limits:
+    context_window: 128000
+    max_input_tokens: 111616
+    max_output_tokens: 16384
+    max_tokens: 16384
+mode: chat
 model: openai/gpt-5.3-chat
+sources:
+    - https://openrouter.ai/openai/gpt-5.3-chat/api

--- a/providers/openrouter/openai/gpt-5.3-codex.yaml
+++ b/providers/openrouter/openai/gpt-5.3-codex.yaml
@@ -1,2 +1,47 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 1.75e-7
+      input_cost_per_query: 0.01
+      input_cost_per_token: 0.00000175
+      output_cost_per_token: 0.000014
+      region: "*"
+features:
+    - chat
+    - text
+    - code
+    - vision
+    - image_input
+    - function_calling
+    - tool_choice
+    - response_schema
+    - tools
+    - system_messages
+limits:
+    context_window: 400000
+    max_input_tokens: 272000
+    max_output_tokens: 128000
+    max_tokens: 128000
+mode: chat
 model: openai/gpt-5.3-codex
+params:
+    - defaultValue: 128
+      key: max_tokens
+      maxValue: 128000
+      minValue: 1
+    - defaultValue: medium
+      key: reasoning_effort
+      options:
+          - name: None
+            value: none
+          - name: Low
+            value: low
+          - name: Medium
+            value: medium
+          - name: High
+            value: high
+          - name: Extra High
+            value: xhigh
+      type: string
+sources:
+    - https://openrouter.ai/openai/gpt-5.3-codex/api
+    - https://openrouter.ai/openai/gpt-5.3-codex
+thinking: true

--- a/providers/openrouter/openai/gpt-5.4-pro.yaml
+++ b/providers/openrouter/openai/gpt-5.4-pro.yaml
@@ -1,2 +1,37 @@
-mode: unknown
+costs:
+    - input_cost_per_query: 0.01
+      input_cost_per_token: 0.00003
+      output_cost_per_token: 0.00018
+      region: "*"
+      tiered_pricing:
+          input:
+              - cost_per_token: 0.00006
+                from: 272000
+          output:
+              - cost_per_token: 0.00027
+                from: 272000
+features:
+    - chat
+    - vision
+    - image_input
+    - function_calling
+    - tool_choice
+    - response_schema
+    - system_messages
+    - text
+    - tools
+limits:
+    context_window: 1050000
+    max_input_tokens: 922000
+    max_output_tokens: 128000
+    max_tokens: 128000
+mode: chat
 model: openai/gpt-5.4-pro
+params:
+    - defaultValue: 128
+      key: max_tokens
+      maxValue: 128000
+      minValue: 1
+sources:
+    - https://openrouter.ai/openai/gpt-5.4-pro/api
+thinking: true

--- a/providers/openrouter/openai/gpt-5.4.yaml
+++ b/providers/openrouter/openai/gpt-5.4.yaml
@@ -1,2 +1,35 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 2.5e-7
+      input_cost_per_token: 0.0000025
+      output_cost_per_token: 0.000015
+      region: "*"
+      tiered_pricing:
+          cache_read:
+              - cost_per_token: 5.e-7
+                from: 272000
+          input:
+              - cost_per_token: 0.000005
+                from: 272000
+          output:
+              - cost_per_token: 0.0000225
+                from: 272000
+features:
+    - chat
+    - function_calling
+    - vision
+    - image_input
+    - tool_choice
+    - response_schema
+    - system_messages
+    - text
+    - pdf_input
+limits:
+    context_window: 1050000
+    max_input_tokens: 922000
+    max_output_tokens: 128000
+    max_tokens: 128000
+mode: chat
 model: openai/gpt-5.4
+sources:
+    - https://openrouter.ai/openai/gpt-5.4/api
+thinking: true

--- a/providers/openrouter/openai/gpt-audio-mini.yaml
+++ b/providers/openrouter/openai/gpt-audio-mini.yaml
@@ -1,2 +1,22 @@
-mode: unknown
+costs:
+    - input_cost_per_audio_token: 6.e-7
+      input_cost_per_token: 6.e-7
+      output_cost_per_audio_token: 0.0000024
+      output_cost_per_token: 0.0000024
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - response_schema
+    - audio_input
+    - audio_output
+    - system_messages
+limits:
+    context_window: 128000
+    max_output_tokens: 16384
+    max_tokens: 16384
+mode: chat
 model: openai/gpt-audio-mini
+sources:
+    - https://openrouter.ai/openai/gpt-audio-mini/api

--- a/providers/openrouter/openai/gpt-audio.yaml
+++ b/providers/openrouter/openai/gpt-audio.yaml
@@ -1,2 +1,21 @@
-mode: unknown
+costs:
+    - input_cost_per_audio_token: 0.000032
+      input_cost_per_token: 0.0000025
+      output_cost_per_audio_token: 0.000064
+      output_cost_per_token: 0.00001
+      region: "*"
+features:
+    - audio_input
+    - audio_output
+    - chat
+    - response_schema
+    - system_messages
+    - text
+limits:
+    context_window: 128000
+    max_output_tokens: 16384
+    max_tokens: 16384
+mode: chat
 model: openai/gpt-audio
+sources:
+    - https://openrouter.ai/openai/gpt-audio/api

--- a/providers/openrouter/openai/gpt-oss-120b:exacto.yaml
+++ b/providers/openrouter/openai/gpt-oss-120b:exacto.yaml
@@ -1,2 +1,20 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 3.9e-8
+      output_cost_per_token: 1.9e-7
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - response_schema
+    - system_messages
+    - text
+    - code
+    - tools
+limits:
+    context_window: 131072
+mode: chat
 model: openai/gpt-oss-120b:exacto
+sources:
+    - https://openrouter.ai/openai/gpt-oss-120b:exacto/api
+thinking: true

--- a/providers/openrouter/openai/gpt-oss-120b:free.yaml
+++ b/providers/openrouter/openai/gpt-oss-120b:free.yaml
@@ -1,2 +1,21 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0
+      output_cost_per_token: 0
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - response_schema
+    - tools
+    - text
+    - code
+    - system_messages
+limits:
+    context_window: 131072
+    max_output_tokens: 131072
+    max_tokens: 131072
 model: openai/gpt-oss-120b:free
+sources:
+    - https://openrouter.ai/openai/gpt-oss-120b:free/api
+thinking: true

--- a/providers/openrouter/openai/gpt-oss-120b:free.yaml
+++ b/providers/openrouter/openai/gpt-oss-120b:free.yaml
@@ -15,6 +15,7 @@ limits:
     context_window: 131072
     max_output_tokens: 131072
     max_tokens: 131072
+mode: chat
 model: openai/gpt-oss-120b:free
 sources:
     - https://openrouter.ai/openai/gpt-oss-120b:free/api

--- a/providers/openrouter/openai/gpt-oss-20b:free.yaml
+++ b/providers/openrouter/openai/gpt-oss-20b:free.yaml
@@ -1,2 +1,22 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0
+      output_cost_per_token: 0
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tools
+    - tool_choice
+    - response_schema
+    - text
+    - code
+    - system_messages
+limits:
+    context_window: 131072
+    max_output_tokens: 131072
+    max_tokens: 131072
+mode: chat
 model: openai/gpt-oss-20b:free
+sources:
+    - https://openrouter.ai/openai/gpt-oss-20b:free/api
+thinking: true

--- a/providers/openrouter/openai/gpt-oss-safeguard-20b.yaml
+++ b/providers/openrouter/openai/gpt-oss-safeguard-20b.yaml
@@ -1,2 +1,26 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 3.7e-8
+      input_cost_per_token: 7.5e-8
+      output_cost_per_token: 3.e-7
+      region: "*"
+features:
+    - chat
+    - text
+    - function_calling
+    - tool_choice
+    - tools
+    - response_schema
+limits:
+    context_window: 131072
+    max_output_tokens: 65536
+    max_tokens: 65536
+mode: chat
 model: openai/gpt-oss-safeguard-20b
+params:
+    - defaultValue: 128
+      key: max_tokens
+      maxValue: 65536
+      minValue: 1
+sources:
+    - https://openrouter.ai/openai/gpt-oss-safeguard-20b/api
+thinking: true

--- a/providers/openrouter/openai/o1-pro.yaml
+++ b/providers/openrouter/openai/o1-pro.yaml
@@ -1,2 +1,19 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0.00015
+      output_cost_per_token: 0.0006
+      region: "*"
+features:
+    - chat
+    - vision
+    - image_input
+    - response_schema
+    - text
+limits:
+    context_window: 200000
+    max_output_tokens: 100000
+    max_tokens: 100000
+mode: chat
 model: openai/o1-pro
+sources:
+    - https://openrouter.ai/openai/o1-pro/api
+thinking: true

--- a/providers/openrouter/openai/o3-deep-research.yaml
+++ b/providers/openrouter/openai/o3-deep-research.yaml
@@ -1,2 +1,24 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 0.0000025
+      input_cost_per_token: 0.00001
+      output_cost_per_token: 0.00004
+      region: "*"
+features:
+    - chat
+    - text
+    - vision
+    - image_input
+    - function_calling
+    - tools
+    - tool_choice
+    - response_schema
+    - system_messages
+limits:
+    context_window: 200000
+    max_output_tokens: 100000
+    max_tokens: 100000
+mode: chat
 model: openai/o3-deep-research
+sources:
+    - https://openrouter.ai/openai/o3-deep-research/api
+thinking: true

--- a/providers/openrouter/openai/o3-pro.yaml
+++ b/providers/openrouter/openai/o3-pro.yaml
@@ -1,2 +1,22 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0.00002
+      output_cost_per_token: 0.00008
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - vision
+    - image_input
+    - tool_choice
+    - response_schema
+    - text
+    - tools
+limits:
+    context_window: 200000
+    max_output_tokens: 100000
+    max_tokens: 100000
+mode: chat
 model: openai/o3-pro
+sources:
+    - https://openrouter.ai/openai/o3-pro/api
+thinking: true

--- a/providers/openrouter/openai/o3.yaml
+++ b/providers/openrouter/openai/o3.yaml
@@ -1,2 +1,25 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000002
+      output_cost_per_token: 0.000008
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - vision
+    - image_input
+    - tool_choice
+    - response_schema
+    - system_messages
+    - text
+    - code
+    - tools
+limits:
+    context_window: 200000
+    max_output_tokens: 100000
+    max_tokens: 100000
+mode: chat
 model: openai/o3
+sources:
+    - https://openrouter.ai/openai/o3/api
+thinking: true

--- a/providers/openrouter/openai/o4-mini-deep-research.yaml
+++ b/providers/openrouter/openai/o4-mini-deep-research.yaml
@@ -1,2 +1,26 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 5.e-7
+      input_cost_per_query: 0.01
+      input_cost_per_token: 0.000002
+      output_cost_per_token: 0.000008
+      region: "*"
+features:
+    - vision
+    - image_input
+    - function_calling
+    - tool_choice
+    - tools
+    - response_schema
+    - chat
+    - text
+    - code
+    - system_messages
+limits:
+    context_window: 200000
+    max_output_tokens: 100000
+    max_tokens: 100000
+mode: chat
 model: openai/o4-mini-deep-research
+sources:
+    - https://openrouter.ai/openai/o4-mini-deep-research/api
+thinking: true

--- a/providers/openrouter/openai/o4-mini-high.yaml
+++ b/providers/openrouter/openai/o4-mini-high.yaml
@@ -1,2 +1,23 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 2.75e-7
+      input_cost_per_token: 0.0000011
+      output_cost_per_token: 0.0000044
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tools
+    - tool_choice
+    - vision
+    - image_input
+    - response_schema
+    - system_messages
+limits:
+    context_window: 200000
+    max_output_tokens: 100000
+    max_tokens: 100000
+mode: chat
 model: openai/o4-mini-high
+sources:
+    - https://openrouter.ai/openai/o4-mini-high/api
+thinking: true

--- a/providers/openrouter/openai/o4-mini.yaml
+++ b/providers/openrouter/openai/o4-mini.yaml
@@ -1,2 +1,25 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 2.75e-7
+      input_cost_per_token: 0.0000011
+      output_cost_per_token: 0.0000044
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - vision
+    - image_input
+    - response_schema
+    - text
+    - code
+    - tools
+    - tool_choice
+    - system_messages
+limits:
+    context_window: 200000
+    max_output_tokens: 100000
+    max_tokens: 100000
+mode: chat
 model: openai/o4-mini
+sources:
+    - https://openrouter.ai/openai/o4-mini/api
+thinking: true

--- a/providers/openrouter/openrouter/auto.yaml
+++ b/providers/openrouter/openrouter/auto.yaml
@@ -1,2 +1,12 @@
-mode: unknown
+features:
+    - chat
+    - vision
+    - image_input
+    - audio_input
+    - text
+limits:
+    context_window: 2000000
+mode: chat
 model: openrouter/auto
+sources:
+    - https://openrouter.ai/openrouter/auto/api

--- a/providers/openrouter/openrouter/bodybuilder.yaml
+++ b/providers/openrouter/openrouter/bodybuilder.yaml
@@ -1,2 +1,14 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0
+      output_cost_per_token: 0
+      region: "*"
+features:
+    - chat
+    - text
+    - system_messages
+limits:
+    context_window: 128000
+mode: chat
 model: openrouter/bodybuilder
+sources:
+    - https://openrouter.ai/openrouter/bodybuilder/api

--- a/providers/openrouter/openrouter/free.yaml
+++ b/providers/openrouter/openrouter/free.yaml
@@ -1,2 +1,17 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0
+      output_cost_per_token: 0
+      region: "*"
+features:
+    - chat
+    - vision
+    - image_input
+    - function_calling
+    - tool_choice
+    - text
+limits:
+    context_window: 200000
+mode: chat
 model: openrouter/free
+sources:
+    - https://openrouter.ai/openrouter/free/api

--- a/providers/openrouter/perplexity/sonar-deep-research.yaml
+++ b/providers/openrouter/perplexity/sonar-deep-research.yaml
@@ -1,2 +1,17 @@
-mode: unknown
+costs:
+    - input_cost_per_query: 0.005
+      input_cost_per_token: 0.000002
+      output_cost_per_token: 0.000008
+      region: "*"
+features:
+    - chat
+    - system_messages
+    - tool_choice
+    - text
+limits:
+    context_window: 128000
+mode: chat
 model: perplexity/sonar-deep-research
+sources:
+    - https://openrouter.ai/perplexity/sonar-deep-research/api
+thinking: true

--- a/providers/openrouter/perplexity/sonar-pro-search.yaml
+++ b/providers/openrouter/perplexity/sonar-pro-search.yaml
@@ -1,2 +1,26 @@
-mode: unknown
+costs:
+    - input_cost_per_request: 0.018
+      input_cost_per_token: 0.000003
+      output_cost_per_token: 0.000015
+      region: "*"
+features:
+    - chat
+    - vision
+    - image_input
+    - function_calling
+    - tool_choice
+    - response_schema
+limits:
+    context_window: 200000
+    max_output_tokens: 8000
+    max_tokens: 8000
+mode: chat
 model: perplexity/sonar-pro-search
+params:
+    - defaultValue: 128
+      key: max_tokens
+      maxValue: 8000
+      minValue: 1
+sources:
+    - https://openrouter.ai/perplexity/sonar-pro-search/api
+thinking: true

--- a/providers/openrouter/perplexity/sonar-pro.yaml
+++ b/providers/openrouter/perplexity/sonar-pro.yaml
@@ -1,2 +1,19 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0.000003
+      output_cost_per_token: 0.000015
+      region: "*"
+features:
+    - chat
+    - vision
+    - image_input
+    - function_calling
+    - tool_choice
+limits:
+    context_window: 200000
+    max_output_tokens: 8000
+    max_tokens: 8000
+mode: chat
 model: perplexity/sonar-pro
+sources:
+    - https://openrouter.ai/perplexity/sonar-pro/api
+thinking: false

--- a/providers/openrouter/perplexity/sonar-reasoning-pro.yaml
+++ b/providers/openrouter/perplexity/sonar-reasoning-pro.yaml
@@ -1,2 +1,19 @@
-mode: unknown
+costs:
+    - input_cost_per_query: 0.005
+      input_cost_per_token: 0.000002
+      output_cost_per_token: 0.000008
+      region: "*"
+features:
+    - chat
+    - text
+    - vision
+    - image_input
+limits:
+    context_window: 128000
+    max_output_tokens: 128000
+    max_tokens: 128000
+mode: chat
 model: perplexity/sonar-reasoning-pro
+sources:
+    - https://openrouter.ai/perplexity/sonar-reasoning-pro/api
+thinking: true

--- a/providers/openrouter/perplexity/sonar.yaml
+++ b/providers/openrouter/perplexity/sonar.yaml
@@ -1,2 +1,23 @@
-mode: unknown
+costs:
+    - input_cost_per_query: 0.005
+      input_cost_per_token: 0.000001
+      output_cost_per_token: 0.000001
+      region: "*"
+features:
+    - chat
+    - text
+    - vision
+    - image_input
+    - function_calling
+    - tool_choice
+    - tools
+limits:
+    context_window: 127072
+mode: chat
 model: perplexity/sonar
+params:
+    - defaultValue: 0
+      key: top_k
+      minValue: 0
+sources:
+    - https://openrouter.ai/perplexity/sonar/api

--- a/providers/openrouter/phi-3-mini-128k-instruct.yaml
+++ b/providers/openrouter/phi-3-mini-128k-instruct.yaml
@@ -1,7 +1,8 @@
 features:
     - chat
-    - tools
 limits:
-    max_tokens: 4096
+    context_window: 128000
 mode: chat
 model: phi-3-mini-128k-instruct
+sources:
+    - https://openrouter.ai/microsoft/phi-3-mini-128k-instruct/api

--- a/providers/openrouter/phi-4-reasoning-plus.yaml
+++ b/providers/openrouter/phi-4-reasoning-plus.yaml
@@ -1,6 +1,11 @@
 features:
     - chat
 limits:
-    max_tokens: 4096
+    context_window: 32768
 mode: chat
 model: phi-4-reasoning-plus
+sources:
+    - https://openrouter.ai/microsoft/phi-4-reasoning-plus/api
+    - https://openrouter.ai/microsoft/phi-4-reasoning-plus/providers
+    - https://huggingface.co/microsoft/Phi-4-reasoning-plus
+thinking: true

--- a/providers/openrouter/prime-intellect/intellect-3.yaml
+++ b/providers/openrouter/prime-intellect/intellect-3.yaml
@@ -1,2 +1,25 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 2.e-7
+      output_cost_per_token: 0.0000011
+      region: "*"
+features:
+    - chat
+    - text
+    - function_calling
+    - tools
+    - tool_choice
+    - response_schema
+limits:
+    context_window: 131072
+    max_output_tokens: 131072
+    max_tokens: 131072
+mode: chat
 model: prime-intellect/intellect-3
+params:
+    - defaultValue: 128
+      key: max_tokens
+      maxValue: 131072
+      minValue: 1
+sources:
+    - https://openrouter.ai/prime-intellect/intellect-3/api
+thinking: true

--- a/providers/openrouter/qwen/qwen-2.5-72b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen-2.5-72b-instruct.yaml
@@ -1,2 +1,21 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 1.2e-7
+      output_cost_per_token: 3.9e-7
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - tools
+    - text
+    - code
+    - system_messages
+    - response_schema
+limits:
+    context_window: 32768
+    max_output_tokens: 16384
+    max_tokens: 16384
+mode: chat
 model: qwen/qwen-2.5-72b-instruct
+sources:
+    - https://openrouter.ai/qwen/qwen-2.5-72b-instruct/api

--- a/providers/openrouter/qwen/qwen-2.5-7b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen-2.5-7b-instruct.yaml
@@ -1,2 +1,17 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 4.e-8
+      output_cost_per_token: 1.e-7
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - system_messages
+limits:
+    context_window: 32768
+    max_output_tokens: 8000
+    max_tokens: 8000
+mode: chat
 model: qwen/qwen-2.5-7b-instruct
+sources:
+    - https://openrouter.ai/qwen/qwen-2.5-7b-instruct/api

--- a/providers/openrouter/qwen/qwen-2.5-vl-7b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen-2.5-vl-7b-instruct.yaml
@@ -1,2 +1,15 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 2.e-7
+      output_cost_per_token: 2.e-7
+      region: "*"
+features:
+    - chat
+    - vision
+    - image_input
+limits:
+    context_window: 32768
+    max_output_tokens: 32768
+mode: chat
 model: qwen/qwen-2.5-vl-7b-instruct
+sources:
+    - https://openrouter.ai/qwen/qwen-2.5-vl-7b-instruct/api

--- a/providers/openrouter/qwen/qwen-max.yaml
+++ b/providers/openrouter/qwen/qwen-max.yaml
@@ -1,2 +1,19 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 2.08e-7
+      input_cost_per_token: 0.00000104
+      output_cost_per_token: 0.00000416
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - tools
+    - text
+limits:
+    context_window: 32768
+    max_output_tokens: 8192
+    max_tokens: 8192
+mode: chat
 model: qwen/qwen-max
+sources:
+    - https://openrouter.ai/qwen/qwen-max/api

--- a/providers/openrouter/qwen/qwen-plus-2025-07-28.yaml
+++ b/providers/openrouter/qwen/qwen-plus-2025-07-28.yaml
@@ -1,2 +1,32 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 2.6e-7
+      output_cost_per_token: 7.8e-7
+      region: "*"
+      tiered_pricing:
+          input:
+              - cost_per_token: 7.8e-7
+                from: 256000
+          output:
+              - cost_per_token: 0.00000234
+                from: 256000
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - response_schema
+    - text
+limits:
+    context_window: 1000000
+    max_input_tokens: 995904
+    max_output_tokens: 32768
+    max_tokens: 32768
+mode: chat
 model: qwen/qwen-plus-2025-07-28
+params:
+    - defaultValue: 128
+      key: max_tokens
+      maxValue: 32768
+      minValue: 1
+sources:
+    - https://openrouter.ai/qwen/qwen-plus-2025-07-28/api
+thinking: true

--- a/providers/openrouter/qwen/qwen-plus-2025-07-28:thinking.yaml
+++ b/providers/openrouter/qwen/qwen-plus-2025-07-28:thinking.yaml
@@ -1,2 +1,29 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 2.6e-7
+      output_cost_per_token: 7.8e-7
+      region: "*"
+      tiered_pricing:
+          input:
+              - cost_per_token: 0.0000012
+                from: 256000
+          output:
+              - cost_per_token: 0.0000036
+                from: 256000
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - response_schema
+    - system_messages
+    - tools
+    - text
+limits:
+    context_window: 1000000
+    max_input_tokens: 995904
+    max_output_tokens: 32768
+    max_tokens: 32768
+mode: chat
 model: qwen/qwen-plus-2025-07-28:thinking
+sources:
+    - https://openrouter.ai/qwen/qwen-plus-2025-07-28:thinking/api
+thinking: true

--- a/providers/openrouter/qwen/qwen-plus.yaml
+++ b/providers/openrouter/qwen/qwen-plus.yaml
@@ -1,2 +1,30 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 8.e-8
+      input_cost_per_token: 4.e-7
+      output_cost_per_token: 0.0000012
+      region: "*"
+      tiered_pricing:
+          cache_read:
+              - cost_per_token: 2.4e-7
+                from: 256000
+          input:
+              - cost_per_token: 0.0000012
+                from: 256000
+          output:
+              - cost_per_token: 0.0000036
+                from: 256000
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - response_schema
+    - text
+limits:
+    context_window: 1000000
+    max_input_tokens: 995904
+    max_output_tokens: 32768
+    max_tokens: 32768
+mode: chat
 model: qwen/qwen-plus
+sources:
+    - https://openrouter.ai/qwen/qwen-plus/api

--- a/providers/openrouter/qwen/qwen-turbo.yaml
+++ b/providers/openrouter/qwen/qwen-turbo.yaml
@@ -1,2 +1,19 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 3.25e-8
+      output_cost_per_token: 1.3e-7
+      region: "*"
+features:
+    - function_calling
+    - tool_choice
+    - tools
+    - chat
+    - text
+limits:
+    context_window: 131072
+    max_input_tokens: 98304
+    max_output_tokens: 8192
+    max_tokens: 8192
+mode: chat
 model: qwen/qwen-turbo
+sources:
+    - https://openrouter.ai/qwen/qwen-turbo/api

--- a/providers/openrouter/qwen/qwen-vl-max.yaml
+++ b/providers/openrouter/qwen/qwen-vl-max.yaml
@@ -1,2 +1,19 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 8.e-7
+      output_cost_per_token: 0.0000032
+      region: "*"
+features:
+    - chat
+    - vision
+    - image_input
+    - function_calling
+    - text
+    - response_schema
+limits:
+    context_window: 131072
+    max_output_tokens: 32768
+    max_tokens: 32768
+mode: chat
 model: qwen/qwen-vl-max
+sources:
+    - https://openrouter.ai/qwen/qwen-vl-max/api

--- a/providers/openrouter/qwen/qwen2.5-coder-7b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen2.5-coder-7b-instruct.yaml
@@ -1,2 +1,18 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 3.e-8
+      output_cost_per_token: 9.e-8
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - response_schema
+    - text
+    - code
+    - tools
+limits:
+    context_window: 32768
+mode: chat
 model: qwen/qwen2.5-coder-7b-instruct
+sources:
+    - https://openrouter.ai/qwen/qwen2.5-coder-7b-instruct/api

--- a/providers/openrouter/qwen/qwen2.5-vl-32b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen2.5-vl-32b-instruct.yaml
@@ -1,2 +1,14 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 2.e-7
+      output_cost_per_token: 6.e-7
+      region: "*"
+features:
+    - chat
+    - vision
+    - image_input
+limits:
+    context_window: 128000
+mode: chat
 model: qwen/qwen2.5-vl-32b-instruct
+sources:
+    - https://openrouter.ai/qwen/qwen2.5-vl-32b-instruct/api

--- a/providers/openrouter/qwen/qwen2.5-vl-72b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen2.5-vl-72b-instruct.yaml
@@ -1,2 +1,17 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 8.e-7
+      output_cost_per_token: 8.e-7
+      region: "*"
+features:
+    - chat
+    - vision
+    - image_input
+    - text
+limits:
+    context_window: 32768
+    max_output_tokens: 32768
+    max_tokens: 32768
+mode: chat
 model: qwen/qwen2.5-vl-72b-instruct
+sources:
+    - https://openrouter.ai/qwen/qwen2.5-vl-72b-instruct/api

--- a/providers/openrouter/qwen/qwen3-14b.yaml
+++ b/providers/openrouter/qwen/qwen3-14b.yaml
@@ -1,2 +1,22 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 6.e-8
+      output_cost_per_token: 2.4e-7
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tools
+    - tool_choice
+    - response_schema
+    - system_messages
+    - text
+    - code
+limits:
+    context_window: 40960
+    max_output_tokens: 40960
+    max_tokens: 40960
+mode: chat
 model: qwen/qwen3-14b
+sources:
+    - https://openrouter.ai/qwen/qwen3-14b/api
+thinking: true

--- a/providers/openrouter/qwen/qwen3-235b-a22b.yaml
+++ b/providers/openrouter/qwen/qwen3-235b-a22b.yaml
@@ -1,2 +1,28 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 4.55e-7
+      output_cost_per_token: 0.00000182
+      region: "*"
+features:
+    - chat
+    - text
+    - code
+    - function_calling
+    - tool_choice
+    - vision
+    - image_input
+    - response_schema
+limits:
+    context_window: 131072
+    max_input_tokens: 98304
+    max_output_tokens: 8192
+    max_tokens: 8192
+mode: chat
 model: qwen/qwen3-235b-a22b
+params:
+    - defaultValue: 128
+      key: max_tokens
+      maxValue: 8192
+      minValue: 1
+sources:
+    - https://openrouter.ai/qwen/qwen3-235b-a22b/api
+thinking: true

--- a/providers/openrouter/qwen/qwen3-30b-a3b-instruct-2507.yaml
+++ b/providers/openrouter/qwen/qwen3-30b-a3b-instruct-2507.yaml
@@ -1,2 +1,19 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 9.e-8
+      output_cost_per_token: 3.e-7
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - text
+    - code
+    - tools
+limits:
+    context_window: 262144
+    max_output_tokens: 262144
+    max_tokens: 262144
+mode: chat
 model: qwen/qwen3-30b-a3b-instruct-2507
+sources:
+    - https://openrouter.ai/qwen/qwen3-30b-a3b-instruct-2507/api

--- a/providers/openrouter/qwen/qwen3-30b-a3b-thinking-2507.yaml
+++ b/providers/openrouter/qwen/qwen3-30b-a3b-thinking-2507.yaml
@@ -1,2 +1,17 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 5.1e-8
+      output_cost_per_token: 3.4e-7
+      region: "*"
+features:
+    - chat
+    - text
+    - function_calling
+    - tool_choice
+    - tools
+limits:
+    context_window: 32768
+mode: chat
 model: qwen/qwen3-30b-a3b-thinking-2507
+sources:
+    - https://openrouter.ai/qwen/qwen3-30b-a3b-thinking-2507/api
+thinking: true

--- a/providers/openrouter/qwen/qwen3-30b-a3b.yaml
+++ b/providers/openrouter/qwen/qwen3-30b-a3b.yaml
@@ -1,2 +1,21 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 8.e-8
+      output_cost_per_token: 2.8e-7
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - tools
+    - text
+    - code
+    - response_schema
+limits:
+    context_window: 40960
+    max_output_tokens: 40960
+    max_tokens: 40960
+mode: chat
 model: qwen/qwen3-30b-a3b
+sources:
+    - https://openrouter.ai/qwen/qwen3-30b-a3b/api
+thinking: true

--- a/providers/openrouter/qwen/qwen3-32b.yaml
+++ b/providers/openrouter/qwen/qwen3-32b.yaml
@@ -1,2 +1,25 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 4.e-8
+      input_cost_per_token: 8.e-8
+      output_cost_per_token: 2.4e-7
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - text
+    - tools
+limits:
+    context_window: 40960
+    max_output_tokens: 40960
+    max_tokens: 40960
+mode: chat
 model: qwen/qwen3-32b
+params:
+    - defaultValue: 40960
+      key: max_tokens
+      maxValue: 40960
+      minValue: 1
+sources:
+    - https://openrouter.ai/qwen/qwen3-32b/api
+thinking: true

--- a/providers/openrouter/qwen/qwen3-4b:free.yaml
+++ b/providers/openrouter/qwen/qwen3-4b:free.yaml
@@ -1,2 +1,22 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0
+      output_cost_per_token: 0
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - response_schema
+    - tools
+    - text
+    - code
+    - system_messages
+limits:
+    context_window: 40960
+    max_output_tokens: 40960
+    max_tokens: 40960
+mode: chat
 model: qwen/qwen3-4b:free
+sources:
+    - https://openrouter.ai/qwen/qwen3-4b:free/api
+thinking: true

--- a/providers/openrouter/qwen/qwen3-8b.yaml
+++ b/providers/openrouter/qwen/qwen3-8b.yaml
@@ -1,2 +1,23 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 5.e-8
+      input_cost_per_token: 5.e-8
+      output_cost_per_token: 4.e-7
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - tools
+    - text
+    - code
+    - response_schema
+    - system_messages
+limits:
+    context_window: 40960
+    max_output_tokens: 8192
+    max_tokens: 8192
+mode: chat
 model: qwen/qwen3-8b
+sources:
+    - https://openrouter.ai/qwen/qwen3-8b/api
+thinking: true

--- a/providers/openrouter/qwen/qwen3-coder-30b-a3b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen3-coder-30b-a3b-instruct.yaml
@@ -1,2 +1,21 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 7.e-8
+      output_cost_per_token: 2.7e-7
+      region: "*"
+features:
+    - function_calling
+    - tool_choice
+    - tools
+    - chat
+    - text
+    - code
+    - system_messages
+    - response_schema
+limits:
+    context_window: 160000
+    max_output_tokens: 32768
+    max_tokens: 32768
+mode: chat
 model: qwen/qwen3-coder-30b-a3b-instruct
+sources:
+    - https://openrouter.ai/qwen/qwen3-coder-30b-a3b-instruct/api

--- a/providers/openrouter/qwen/qwen3-coder-flash.yaml
+++ b/providers/openrouter/qwen/qwen3-coder-flash.yaml
@@ -1,2 +1,36 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 3.9e-8
+      input_cost_per_token: 1.95e-7
+      output_cost_per_token: 9.75e-7
+      region: "*"
+      tiered_pricing:
+          cache_read:
+              - cost_per_token: 1.e-7
+                from: 32000
+          input:
+              - cost_per_token: 3.25e-7
+                from: 32000
+              - cost_per_token: 5.e-7
+                from: 128000
+          output:
+              - cost_per_token: 0.000001625
+                from: 32000
+              - cost_per_token: 0.0000025
+                from: 128000
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - response_schema
+    - text
+    - code
+    - tools
+limits:
+    context_window: 1000000
+    max_input_tokens: 997952
+    max_output_tokens: 65536
+    max_tokens: 65536
+mode: chat
 model: qwen/qwen3-coder-flash
+sources:
+    - https://openrouter.ai/qwen/qwen3-coder-flash/api

--- a/providers/openrouter/qwen/qwen3-coder-next.yaml
+++ b/providers/openrouter/qwen/qwen3-coder-next.yaml
@@ -1,2 +1,22 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 6.e-8
+      input_cost_per_token: 1.2e-7
+      output_cost_per_token: 7.5e-7
+      region: "*"
+features:
+    - function_calling
+    - tool_choice
+    - response_schema
+    - chat
+    - text
+    - code
+    - tools
+limits:
+    context_window: 262144
+    max_output_tokens: 65536
+    max_tokens: 65536
+mode: chat
 model: qwen/qwen3-coder-next
+sources:
+    - https://openrouter.ai/qwen/qwen3-coder-next/api
+thinking: false

--- a/providers/openrouter/qwen/qwen3-coder-plus.yaml
+++ b/providers/openrouter/qwen/qwen3-coder-plus.yaml
@@ -1,2 +1,40 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 1.3e-7
+      input_cost_per_token: 6.5e-7
+      output_cost_per_token: 0.00000325
+      region: "*"
+      tiered_pricing:
+          cache_read:
+              - cost_per_token: 3.6e-7
+                from: 32000
+              - cost_per_token: 6.e-7
+                from: 128000
+          input:
+              - cost_per_token: 0.0000018
+                from: 32000
+              - cost_per_token: 0.000003
+                from: 128000
+          output:
+              - cost_per_token: 0.000009
+                from: 32000
+              - cost_per_token: 0.000015
+                from: 128000
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - response_schema
+    - prompt_caching
+    - text
+    - code
+    - tools
+limits:
+    context_window: 1000000
+    max_input_tokens: 997952
+    max_output_tokens: 65536
+    max_tokens: 65536
+mode: chat
 model: qwen/qwen3-coder-plus
+sources:
+    - https://openrouter.ai/qwen/qwen3-coder-plus/api
+thinking: true

--- a/providers/openrouter/qwen/qwen3-coder:exacto.yaml
+++ b/providers/openrouter/qwen/qwen3-coder:exacto.yaml
@@ -1,2 +1,17 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 2.2e-8
+      input_cost_per_token: 2.2e-7
+      output_cost_per_token: 0.000001
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - text
+    - code
+limits:
+    context_window: 262144
+mode: chat
 model: qwen/qwen3-coder:exacto
+sources:
+    - https://openrouter.ai/qwen/qwen3-coder:exacto/api

--- a/providers/openrouter/qwen/qwen3-coder:free.yaml
+++ b/providers/openrouter/qwen/qwen3-coder:free.yaml
@@ -1,2 +1,21 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0
+      output_cost_per_token: 0
+      region: "*"
+features:
+    - chat
+    - text
+    - code
+    - function_calling
+    - tools
+    - tool_choice
+    - system_messages
+    - response_schema
+limits:
+    context_window: 262000
+    max_output_tokens: 262000
+    max_tokens: 262000
+mode: chat
 model: qwen/qwen3-coder:free
+sources:
+    - https://openrouter.ai/qwen/qwen3-coder:free/api

--- a/providers/openrouter/qwen/qwen3-max-thinking.yaml
+++ b/providers/openrouter/qwen/qwen3-max-thinking.yaml
@@ -1,2 +1,36 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 7.8e-7
+      output_cost_per_token: 0.0000039
+      region: "*"
+      tiered_pricing:
+          input:
+              - cost_per_token: 0.0000024
+                from: 32000
+              - cost_per_token: 0.000003
+                from: 128000
+          output:
+              - cost_per_token: 0.000012
+                from: 32000
+              - cost_per_token: 0.000015
+                from: 128000
+features:
+    - chat
+    - text
+    - function_calling
+    - tool_choice
+    - response_schema
+limits:
+    context_window: 262144
+    max_input_tokens: 258048
+    max_output_tokens: 32768
+    max_tokens: 32768
+mode: chat
 model: qwen/qwen3-max-thinking
+params:
+    - defaultValue: 128
+      key: max_tokens
+      maxValue: 32768
+      minValue: 1
+sources:
+    - https://openrouter.ai/qwen/qwen3-max-thinking/api
+thinking: true

--- a/providers/openrouter/qwen/qwen3-next-80b-a3b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen3-next-80b-a3b-instruct.yaml
@@ -1,2 +1,18 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 9.e-8
+      output_cost_per_token: 0.0000011
+      region: "*"
+features:
+    - chat
+    - text
+    - code
+    - system_messages
+limits:
+    context_window: 131072
+    max_output_tokens: 131072
+    max_tokens: 131072
+mode: chat
 model: qwen/qwen3-next-80b-a3b-instruct
+sources:
+    - https://openrouter.ai/qwen/qwen3-next-80b-a3b-instruct/api
+    - https://openrouter.ai/qwen/qwen3-next-80b-a3b-instruct

--- a/providers/openrouter/qwen/qwen3-next-80b-a3b-instruct:free.yaml
+++ b/providers/openrouter/qwen/qwen3-next-80b-a3b-instruct:free.yaml
@@ -1,2 +1,19 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0
+      output_cost_per_token: 0
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - system_messages
+    - text
+    - code
+    - tools
+limits:
+    context_window: 262144
+mode: chat
 model: qwen/qwen3-next-80b-a3b-instruct:free
+sources:
+    - https://openrouter.ai/qwen/qwen3-next-80b-a3b-instruct:free/api
+    - https://openrouter.ai/qwen/qwen3-next-80b-a3b-instruct/api

--- a/providers/openrouter/qwen/qwen3-next-80b-a3b-thinking.yaml
+++ b/providers/openrouter/qwen/qwen3-next-80b-a3b-thinking.yaml
@@ -1,2 +1,22 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 9.75e-8
+      output_cost_per_token: 7.8e-7
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - response_schema
+    - text
+    - code
+    - tools
+limits:
+    context_window: 131072
+    max_input_tokens: 126976
+    max_output_tokens: 32768
+    max_tokens: 32768
+mode: chat
 model: qwen/qwen3-next-80b-a3b-thinking
+sources:
+    - https://openrouter.ai/qwen/qwen3-next-80b-a3b-thinking/api
+thinking: true

--- a/providers/openrouter/qwen/qwen3-vl-235b-a22b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen3-vl-235b-a22b-instruct.yaml
@@ -1,2 +1,16 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 2.e-7
+      output_cost_per_token: 8.8e-7
+      region: "*"
+features:
+    - chat
+    - vision
+    - image_input
+    - function_calling
+    - tools
+limits:
+    context_window: 262144
+mode: chat
 model: qwen/qwen3-vl-235b-a22b-instruct
+sources:
+    - https://openrouter.ai/qwen/qwen3-vl-235b-a22b-instruct/api

--- a/providers/openrouter/qwen/qwen3-vl-235b-a22b-thinking.yaml
+++ b/providers/openrouter/qwen/qwen3-vl-235b-a22b-thinking.yaml
@@ -1,2 +1,20 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 2.6e-7
+      output_cost_per_token: 0.0000026
+      region: "*"
+features:
+    - chat
+    - vision
+    - image_input
+    - function_calling
+    - text
+    - code
+    - tools
+    - tool_choice
+limits:
+    context_window: 131072
+mode: chat
 model: qwen/qwen3-vl-235b-a22b-thinking
+sources:
+    - https://openrouter.ai/qwen/qwen3-vl-235b-a22b-thinking/api
+thinking: true

--- a/providers/openrouter/qwen/qwen3-vl-30b-a3b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen3-vl-30b-a3b-instruct.yaml
@@ -1,2 +1,20 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 1.3e-7
+      output_cost_per_token: 5.2e-7
+      region: "*"
+features:
+    - chat
+    - vision
+    - image_input
+    - function_calling
+    - tool_choice
+    - text
+limits:
+    context_window: 131072
+    max_input_tokens: 129024
+    max_output_tokens: 32768
+    max_tokens: 32768
+mode: chat
 model: qwen/qwen3-vl-30b-a3b-instruct
+sources:
+    - https://openrouter.ai/qwen/qwen3-vl-30b-a3b-instruct/api

--- a/providers/openrouter/qwen/qwen3-vl-30b-a3b-thinking.yaml
+++ b/providers/openrouter/qwen/qwen3-vl-30b-a3b-thinking.yaml
@@ -1,2 +1,22 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 1.3e-7
+      output_cost_per_token: 0.00000156
+      region: "*"
+features:
+    - chat
+    - vision
+    - image_input
+    - function_calling
+    - tool_choice
+    - tools
+    - text
+limits:
+    context_window: 131072
+    max_input_tokens: 126976
+    max_output_tokens: 32768
+    max_tokens: 32768
+mode: chat
 model: qwen/qwen3-vl-30b-a3b-thinking
+sources:
+    - https://openrouter.ai/qwen/qwen3-vl-30b-a3b-thinking/api
+thinking: true

--- a/providers/openrouter/qwen/qwen3-vl-8b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen3-vl-8b-instruct.yaml
@@ -1,2 +1,21 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 8.e-8
+      output_cost_per_token: 5.e-7
+      region: "*"
+features:
+    - chat
+    - text
+    - vision
+    - image_input
+    - function_calling
+    - tool_choice
+    - tools
+    - response_schema
+limits:
+    context_window: 131072
+    max_output_tokens: 32768
+    max_tokens: 32768
+mode: chat
 model: qwen/qwen3-vl-8b-instruct
+sources:
+    - https://openrouter.ai/qwen/qwen3-vl-8b-instruct/api

--- a/providers/openrouter/qwen/qwen3-vl-8b-thinking.yaml
+++ b/providers/openrouter/qwen/qwen3-vl-8b-thinking.yaml
@@ -1,2 +1,24 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 1.17e-7
+      output_cost_per_token: 0.000001365
+      region: "*"
+features:
+    - chat
+    - vision
+    - image_input
+    - function_calling
+    - tool_choice
+    - response_schema
+    - text
+    - code
+    - tools
+limits:
+    context_window: 131072
+    max_input_tokens: 126976
+    max_output_tokens: 32768
+    max_tokens: 32768
+mode: chat
 model: qwen/qwen3-vl-8b-thinking
+sources:
+    - https://openrouter.ai/qwen/qwen3-vl-8b-thinking/api
+thinking: true

--- a/providers/openrouter/qwen/qwen3.5-122b-a10b.yaml
+++ b/providers/openrouter/qwen/qwen3.5-122b-a10b.yaml
@@ -1,2 +1,23 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 2.6e-7
+      output_cost_per_token: 0.00000208
+      region: "*"
+features:
+    - function_calling
+    - vision
+    - image_input
+    - chat
+    - tool_choice
+    - tools
+    - response_schema
+    - text
+    - code
+limits:
+    context_window: 262144
+    max_input_tokens: 258048
+    max_output_tokens: 65536
+    max_tokens: 65536
 model: qwen/qwen3.5-122b-a10b
+sources:
+    - https://openrouter.ai/qwen/qwen3.5-122b-a10b/api
+thinking: true

--- a/providers/openrouter/qwen/qwen3.5-122b-a10b.yaml
+++ b/providers/openrouter/qwen/qwen3.5-122b-a10b.yaml
@@ -17,6 +17,7 @@ limits:
     max_input_tokens: 258048
     max_output_tokens: 65536
     max_tokens: 65536
+mode: chat
 model: qwen/qwen3.5-122b-a10b
 sources:
     - https://openrouter.ai/qwen/qwen3.5-122b-a10b/api

--- a/providers/openrouter/qwen/qwen3.5-27b.yaml
+++ b/providers/openrouter/qwen/qwen3.5-27b.yaml
@@ -1,2 +1,24 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 1.95e-7
+      output_cost_per_token: 0.00000156
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - vision
+    - image_input
+    - tools
+    - tool_choice
+    - response_schema
+    - text
+    - code
+    - system_messages
+limits:
+    context_window: 262144
+    max_output_tokens: 65536
+    max_tokens: 65536
+mode: chat
 model: qwen/qwen3.5-27b
+sources:
+    - https://openrouter.ai/qwen/qwen3.5-27b/api
+thinking: true

--- a/providers/openrouter/qwen/qwen3.5-35b-a3b.yaml
+++ b/providers/openrouter/qwen/qwen3.5-35b-a3b.yaml
@@ -16,6 +16,7 @@ limits:
     max_input_tokens: 258048
     max_output_tokens: 65536
     max_tokens: 65536
+mode: chat
 model: qwen/qwen3.5-35b-a3b
 sources:
     - https://openrouter.ai/qwen/qwen3.5-35b-a3b/api

--- a/providers/openrouter/qwen/qwen3.5-35b-a3b.yaml
+++ b/providers/openrouter/qwen/qwen3.5-35b-a3b.yaml
@@ -1,2 +1,22 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 1.625e-7
+      output_cost_per_token: 0.0000013
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - vision
+    - image_input
+    - tool_choice
+    - response_schema
+    - text
+    - tools
+limits:
+    context_window: 262144
+    max_input_tokens: 258048
+    max_output_tokens: 65536
+    max_tokens: 65536
 model: qwen/qwen3.5-35b-a3b
+sources:
+    - https://openrouter.ai/qwen/qwen3.5-35b-a3b/api
+thinking: true

--- a/providers/openrouter/qwen/qwen3.5-397b-a17b.yaml
+++ b/providers/openrouter/qwen/qwen3.5-397b-a17b.yaml
@@ -1,2 +1,23 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 3.9e-7
+      output_cost_per_token: 0.00000234
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - vision
+    - image_input
+    - tool_choice
+    - tools
+    - text
+    - code
+limits:
+    context_window: 262144
+    max_input_tokens: 258048
+    max_output_tokens: 65536
+    max_tokens: 65536
+mode: chat
 model: qwen/qwen3.5-397b-a17b
+sources:
+    - https://openrouter.ai/qwen/qwen3.5-397b-a17b/api
+thinking: true

--- a/providers/openrouter/qwen/qwen3.5-flash-02-23.yaml
+++ b/providers/openrouter/qwen/qwen3.5-flash-02-23.yaml
@@ -1,2 +1,23 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 1.e-7
+      output_cost_per_token: 4.e-7
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - vision
+    - image_input
+    - tool_choice
+    - response_schema
+    - tools
+    - text
+limits:
+    context_window: 1000000
+    max_input_tokens: 983616
+    max_output_tokens: 65536
+    max_tokens: 65536
+mode: chat
 model: qwen/qwen3.5-flash-02-23
+sources:
+    - https://openrouter.ai/qwen/qwen3.5-flash-02-23/api
+thinking: true

--- a/providers/openrouter/qwen/qwen3.5-plus-02-15.yaml
+++ b/providers/openrouter/qwen/qwen3.5-plus-02-15.yaml
@@ -1,2 +1,34 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 2.6e-7
+      output_cost_per_token: 0.00000156
+      region: "*"
+      tiered_pricing:
+          input:
+              - cost_per_token: 3.25e-7
+                from: 256000
+          output:
+              - cost_per_token: 0.00000195
+                from: 256000
+features:
+    - chat
+    - text
+    - vision
+    - image_input
+    - function_calling
+    - tool_choice
+    - response_schema
+    - tools
+limits:
+    context_window: 1000000
+    max_output_tokens: 65536
+    max_tokens: 65536
+mode: chat
 model: qwen/qwen3.5-plus-02-15
+params:
+    - defaultValue: 65536
+      key: max_tokens
+      maxValue: 65536
+      minValue: 1
+sources:
+    - https://openrouter.ai/qwen/qwen3.5-plus-02-15/api
+thinking: true

--- a/providers/openrouter/qwen/qwq-32b.yaml
+++ b/providers/openrouter/qwen/qwq-32b.yaml
@@ -1,2 +1,18 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 1.5e-7
+      output_cost_per_token: 4.e-7
+      region: "*"
+features:
+    - chat
+    - text
+    - code
+    - response_schema
+limits:
+    context_window: 32768
+    max_output_tokens: 32768
+    max_tokens: 32768
+mode: chat
 model: qwen/qwq-32b
+sources:
+    - https://openrouter.ai/qwen/qwq-32b/api
+thinking: true

--- a/providers/openrouter/raifle/sorcererlm-8x22b.yaml
+++ b/providers/openrouter/raifle/sorcererlm-8x22b.yaml
@@ -1,2 +1,9 @@
-mode: unknown
+features:
+    - chat
+    - text
+limits:
+    context_window: 16000
+mode: chat
 model: raifle/sorcererlm-8x22b
+sources:
+    - https://openrouter.ai/raifle/sorcererlm-8x22b/api

--- a/providers/openrouter/relace/relace-apply-3.yaml
+++ b/providers/openrouter/relace/relace-apply-3.yaml
@@ -1,2 +1,27 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 8.5e-7
+      output_cost_per_token: 0.00000125
+      region: "*"
+features:
+    - code
+    - text
+limits:
+    context_window: 256000
+    max_output_tokens: 128000
+    max_tokens: 128000
+mode: chat
 model: relace/relace-apply-3
+params:
+    - defaultValue: 128
+      key: max_tokens
+      maxValue: 128000
+      minValue: 1
+removeParams:
+    - temperature
+    - top_p
+    - "n"
+    - frequency_penalty
+    - presence_penalty
+    - response_format
+sources:
+    - https://openrouter.ai/relace/relace-apply-3/api

--- a/providers/openrouter/relace/relace-search.yaml
+++ b/providers/openrouter/relace/relace-search.yaml
@@ -1,2 +1,20 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0.000001
+      output_cost_per_token: 0.000003
+      region: "*"
+features:
+    - function_calling
+    - tool_choice
+    - tools
+    - text
+    - code
+    - system_messages
+limits:
+    context_window: 256000
+    max_input_tokens: 128000
+    max_output_tokens: 128000
+    max_tokens: 128000
+mode: chat
 model: relace/relace-search
+sources:
+    - https://openrouter.ai/relace/relace-search/api

--- a/providers/openrouter/sao10k/l3-euryale-70b.yaml
+++ b/providers/openrouter/sao10k/l3-euryale-70b.yaml
@@ -1,2 +1,17 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0.00000148
+      output_cost_per_token: 0.00000148
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - system_messages
+limits:
+    context_window: 8192
+    max_output_tokens: 8192
+    max_tokens: 8192
+mode: chat
 model: sao10k/l3-euryale-70b
+sources:
+    - https://openrouter.ai/sao10k/l3-euryale-70b/api

--- a/providers/openrouter/sao10k/l3-lunaris-8b.yaml
+++ b/providers/openrouter/sao10k/l3-lunaris-8b.yaml
@@ -1,2 +1,13 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 4.e-8
+      output_cost_per_token: 5.e-8
+      region: "*"
+features:
+    - chat
+    - text
+limits:
+    context_window: 8192
+mode: chat
 model: sao10k/l3-lunaris-8b
+sources:
+    - https://openrouter.ai/sao10k/l3-lunaris-8b/api

--- a/providers/openrouter/sao10k/l3.1-70b-hanami-x1.yaml
+++ b/providers/openrouter/sao10k/l3.1-70b-hanami-x1.yaml
@@ -1,2 +1,14 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0.000003
+      output_cost_per_token: 0.000003
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - system_messages
+limits:
+    context_window: 16000
 model: sao10k/l3.1-70b-hanami-x1
+sources:
+    - https://openrouter.ai/sao10k/l3.1-70b-hanami-x1/api

--- a/providers/openrouter/sao10k/l3.1-70b-hanami-x1.yaml
+++ b/providers/openrouter/sao10k/l3.1-70b-hanami-x1.yaml
@@ -9,6 +9,7 @@ features:
     - system_messages
 limits:
     context_window: 16000
+mode: chat
 model: sao10k/l3.1-70b-hanami-x1
 sources:
     - https://openrouter.ai/sao10k/l3.1-70b-hanami-x1/api

--- a/providers/openrouter/sao10k/l3.1-euryale-70b.yaml
+++ b/providers/openrouter/sao10k/l3.1-euryale-70b.yaml
@@ -1,2 +1,15 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 8.5e-7
+      output_cost_per_token: 8.5e-7
+      region: "*"
+features:
+    - chat
+    - tool_choice
+limits:
+    context_window: 131072
+    max_output_tokens: 16384
+    max_tokens: 16384
+mode: chat
 model: sao10k/l3.1-euryale-70b
+sources:
+    - https://openrouter.ai/sao10k/l3.1-euryale-70b/api

--- a/providers/openrouter/sao10k/l3.3-euryale-70b.yaml
+++ b/providers/openrouter/sao10k/l3.3-euryale-70b.yaml
@@ -1,2 +1,16 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 6.5e-7
+      output_cost_per_token: 7.5e-7
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - text
+limits:
+    context_window: 131072
+    max_output_tokens: 16384
+    max_tokens: 16384
+mode: chat
 model: sao10k/l3.3-euryale-70b
+sources:
+    - https://openrouter.ai/sao10k/l3.3-euryale-70b/api

--- a/providers/openrouter/stepfun/step-3.5-flash.yaml
+++ b/providers/openrouter/stepfun/step-3.5-flash.yaml
@@ -1,2 +1,20 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 2.e-8
+      input_cost_per_token: 1.e-7
+      output_cost_per_token: 3.e-7
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - system_messages
+    - text
+limits:
+    context_window: 256000
+    max_output_tokens: 256000
+    max_tokens: 256000
+mode: chat
 model: stepfun/step-3.5-flash
+sources:
+    - https://openrouter.ai/stepfun/step-3.5-flash/api
+thinking: true

--- a/providers/openrouter/stepfun/step-3.5-flash:free.yaml
+++ b/providers/openrouter/stepfun/step-3.5-flash:free.yaml
@@ -1,2 +1,20 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0
+      output_cost_per_token: 0
+      region: "*"
+features:
+    - function_calling
+    - tool_choice
+    - chat
+    - text
+    - tools
+limits:
+    context_window: 256000
+    max_output_tokens: 256000
+    max_tokens: 256000
+mode: chat
 model: stepfun/step-3.5-flash:free
+sources:
+    - https://openrouter.ai/stepfun/step-3.5-flash:free/api
+    - https://openrouter.ai/stepfun/step-3.5-flash/api
+thinking: true

--- a/providers/openrouter/tencent/hunyuan-a13b-instruct.yaml
+++ b/providers/openrouter/tencent/hunyuan-a13b-instruct.yaml
@@ -11,6 +11,7 @@ limits:
     context_window: 131072
     max_output_tokens: 131072
     max_tokens: 131072
+mode: chat
 model: tencent/hunyuan-a13b-instruct
 sources:
     - https://openrouter.ai/tencent/hunyuan-a13b-instruct/api

--- a/providers/openrouter/tencent/hunyuan-a13b-instruct.yaml
+++ b/providers/openrouter/tencent/hunyuan-a13b-instruct.yaml
@@ -1,2 +1,17 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 1.4e-7
+      output_cost_per_token: 5.7e-7
+      region: "*"
+features:
+    - chat
+    - text
+    - code
+    - response_schema
+limits:
+    context_window: 131072
+    max_output_tokens: 131072
+    max_tokens: 131072
 model: tencent/hunyuan-a13b-instruct
+sources:
+    - https://openrouter.ai/tencent/hunyuan-a13b-instruct/api
+thinking: true

--- a/providers/openrouter/thedrummer/cydonia-24b-v4.1.yaml
+++ b/providers/openrouter/thedrummer/cydonia-24b-v4.1.yaml
@@ -1,2 +1,17 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 3.e-7
+      output_cost_per_token: 5.e-7
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - system_messages
+limits:
+    context_window: 131072
+    max_output_tokens: 131072
+    max_tokens: 131072
+mode: chat
 model: thedrummer/cydonia-24b-v4.1
+sources:
+    - https://openrouter.ai/thedrummer/cydonia-24b-v4.1/api

--- a/providers/openrouter/thedrummer/rocinante-12b.yaml
+++ b/providers/openrouter/thedrummer/rocinante-12b.yaml
@@ -1,2 +1,17 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 1.7e-7
+      output_cost_per_token: 4.3e-7
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - response_schema
+limits:
+    context_window: 32768
+    max_output_tokens: 32768
+    max_tokens: 32768
+mode: chat
 model: thedrummer/rocinante-12b
+sources:
+    - https://openrouter.ai/thedrummer/rocinante-12b/api

--- a/providers/openrouter/thedrummer/skyfall-36b-v2.yaml
+++ b/providers/openrouter/thedrummer/skyfall-36b-v2.yaml
@@ -1,2 +1,19 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 5.5e-7
+      output_cost_per_token: 8.e-7
+      region: "*"
+features:
+    - function_calling
+    - tool_choice
+    - chat
+    - text
+    - code
+    - tools
+limits:
+    context_window: 32768
+    max_output_tokens: 32768
+    max_tokens: 32768
+mode: chat
 model: thedrummer/skyfall-36b-v2
+sources:
+    - https://openrouter.ai/thedrummer/skyfall-36b-v2/api

--- a/providers/openrouter/thedrummer/unslopnemo-12b.yaml
+++ b/providers/openrouter/thedrummer/unslopnemo-12b.yaml
@@ -1,2 +1,18 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 4.e-7
+      output_cost_per_token: 4.e-7
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - response_schema
+    - text
+limits:
+    context_window: 32768
+    max_output_tokens: 32768
+    max_tokens: 32768
+mode: chat
 model: thedrummer/unslopnemo-12b
+sources:
+    - https://openrouter.ai/thedrummer/unslopnemo-12b/api

--- a/providers/openrouter/tngtech/deepseek-r1t2-chimera.yaml
+++ b/providers/openrouter/tngtech/deepseek-r1t2-chimera.yaml
@@ -1,2 +1,21 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 1.25e-7
+      input_cost_per_token: 2.5e-7
+      output_cost_per_token: 8.5e-7
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - response_schema
+    - text
+    - tools
+    - tool_choice
+limits:
+    context_window: 163840
+    max_output_tokens: 163840
+    max_tokens: 163840
+mode: chat
 model: tngtech/deepseek-r1t2-chimera
+sources:
+    - https://openrouter.ai/tngtech/deepseek-r1t2-chimera/api
+thinking: true

--- a/providers/openrouter/upstage/solar-pro-3.yaml
+++ b/providers/openrouter/upstage/solar-pro-3.yaml
@@ -1,2 +1,17 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 1.5e-8
+      input_cost_per_token: 1.5e-7
+      output_cost_per_token: 6.e-7
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - response_schema
+limits:
+    context_window: 128000
+mode: chat
 model: upstage/solar-pro-3
+sources:
+    - https://openrouter.ai/upstage/solar-pro-3/api
+thinking: true

--- a/providers/openrouter/writer/palmyra-x5.yaml
+++ b/providers/openrouter/writer/palmyra-x5.yaml
@@ -1,2 +1,22 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 6.e-7
+      output_cost_per_token: 0.000006
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - text
+limits:
+    context_window: 1040000
+    max_output_tokens: 8192
+    max_tokens: 8192
+mode: chat
 model: writer/palmyra-x5
+params:
+    - defaultValue: 128
+      key: max_tokens
+      maxValue: 8192
+      minValue: 1
+sources:
+    - https://openrouter.ai/writer/palmyra-x5/api

--- a/providers/openrouter/x-ai/grok-3-beta.yaml
+++ b/providers/openrouter/x-ai/grok-3-beta.yaml
@@ -1,2 +1,20 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 7.5e-7
+      input_cost_per_token: 0.000003
+      output_cost_per_token: 0.000015
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - response_schema
+    - system_messages
+    - text
+    - tools
+limits:
+    context_window: 131072
+mode: chat
 model: x-ai/grok-3-beta
+sources:
+    - https://openrouter.ai/x-ai/grok-3-beta/api
+    - https://docs.x.ai/developers/models#models-and-pricing

--- a/providers/openrouter/x-ai/grok-3-mini-beta.yaml
+++ b/providers/openrouter/x-ai/grok-3-mini-beta.yaml
@@ -1,2 +1,19 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 7.5e-8
+      input_cost_per_token: 3.e-7
+      output_cost_per_token: 5.e-7
+      region: "*"
+features:
+    - chat
+    - text
+    - function_calling
+    - tool_choice
+    - response_schema
+limits:
+    context_window: 131072
+mode: chat
 model: x-ai/grok-3-mini-beta
+sources:
+    - https://openrouter.ai/x-ai/grok-3-mini-beta/api
+    - https://docs.x.ai/developers/models#models-and-pricing
+thinking: true

--- a/providers/openrouter/x-ai/grok-3-mini.yaml
+++ b/providers/openrouter/x-ai/grok-3-mini.yaml
@@ -1,2 +1,21 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 7.5e-8
+      input_cost_per_token: 3.e-7
+      output_cost_per_token: 5.e-7
+      region: "*"
+features:
+    - function_calling
+    - tool_choice
+    - response_schema
+    - system_messages
+    - chat
+    - text
+limits:
+    context_window: 131072
+    max_tokens: 131072
+mode: chat
 model: x-ai/grok-3-mini
+sources:
+    - https://openrouter.ai/x-ai/grok-3-mini/api
+    - https://docs.x.ai/developers/models#models-and-pricing
+thinking: true

--- a/providers/openrouter/x-ai/grok-3.yaml
+++ b/providers/openrouter/x-ai/grok-3.yaml
@@ -1,2 +1,21 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 7.5e-7
+      input_cost_per_token: 0.000003
+      output_cost_per_token: 0.000015
+      region: "*"
+features:
+    - chat
+    - text
+    - function_calling
+    - tool_choice
+    - response_schema
+    - system_messages
+    - tools
+    - prompt_caching
+limits:
+    context_window: 131072
+mode: chat
 model: x-ai/grok-3
+sources:
+    - https://openrouter.ai/x-ai/grok-3/api
+    - https://docs.x.ai/developers/models#models-and-pricing

--- a/providers/openrouter/x-ai/grok-4-fast.yaml
+++ b/providers/openrouter/x-ai/grok-4-fast.yaml
@@ -1,2 +1,27 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 5.e-8
+      input_cost_per_token: 2.e-7
+      output_cost_per_token: 5.e-7
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - vision
+    - image_input
+    - system_messages
+    - tool_choice
+    - tools
+    - response_schema
+    - prompt_caching
+    - text
+    - code
+limits:
+    context_window: 2000000
+    max_output_tokens: 30000
+    max_tokens: 30000
+mode: chat
 model: x-ai/grok-4-fast
+sources:
+    - https://openrouter.ai/x-ai/grok-4-fast/api
+    - https://docs.x.ai/developers/models#models-and-pricing
+thinking: true

--- a/providers/openrouter/x-ai/grok-4.1-fast.yaml
+++ b/providers/openrouter/x-ai/grok-4.1-fast.yaml
@@ -1,2 +1,38 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 5.e-8
+      input_cost_per_token: 2.e-7
+      output_cost_per_token: 5.e-7
+      region: "*"
+      tiered_pricing:
+          input:
+              - cost_per_token: 4.e-7
+                from: 128000
+          output:
+              - cost_per_token: 0.000001
+                from: 128000
+features:
+    - chat
+    - text
+    - vision
+    - image_input
+    - function_calling
+    - tool_choice
+    - tools
+    - response_schema
+    - prompt_caching
+    - system_messages
+limits:
+    context_window: 2000000
+    max_output_tokens: 30000
+    max_tokens: 30000
+mode: chat
 model: x-ai/grok-4.1-fast
+params:
+    - defaultValue: 128
+      key: max_tokens
+      maxValue: 30000
+      minValue: 1
+sources:
+    - https://openrouter.ai/x-ai/grok-4.1-fast/api
+    - https://docs.x.ai/developers/models#models-and-pricing
+thinking: true

--- a/providers/openrouter/x-ai/grok-code-fast-1.yaml
+++ b/providers/openrouter/x-ai/grok-code-fast-1.yaml
@@ -1,2 +1,24 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 2.e-8
+      input_cost_per_token: 2.e-7
+      output_cost_per_token: 0.0000015
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - response_schema
+    - system_messages
+    - text
+    - code
+    - tools
+limits:
+    context_window: 256000
+    max_output_tokens: 10000
+    max_tokens: 10000
+mode: chat
 model: x-ai/grok-code-fast-1
+sources:
+    - https://openrouter.ai/x-ai/grok-code-fast-1/api
+    - https://docs.x.ai/developers/models#models-and-pricing
+thinking: true

--- a/providers/openrouter/z-ai/glm-4-32b.yaml
+++ b/providers/openrouter/z-ai/glm-4-32b.yaml
@@ -1,2 +1,16 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 1.e-7
+      output_cost_per_token: 1.e-7
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - tools
+    - text
+limits:
+    context_window: 128000
+mode: chat
 model: z-ai/glm-4-32b
+sources:
+    - https://openrouter.ai/z-ai/glm-4-32b/api

--- a/providers/openrouter/z-ai/glm-4.5-air.yaml
+++ b/providers/openrouter/z-ai/glm-4.5-air.yaml
@@ -1,2 +1,20 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 2.5e-8
+      input_cost_per_token: 1.3e-7
+      output_cost_per_token: 8.5e-7
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - system_messages
+    - text
+limits:
+    context_window: 131072
+    max_output_tokens: 98304
+    max_tokens: 98304
+mode: chat
 model: z-ai/glm-4.5-air
+sources:
+    - https://openrouter.ai/z-ai/glm-4.5-air/api
+thinking: true

--- a/providers/openrouter/z-ai/glm-4.5-air:free.yaml
+++ b/providers/openrouter/z-ai/glm-4.5-air:free.yaml
@@ -1,2 +1,20 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0
+      output_cost_per_token: 0
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - system_messages
+    - text
+    - tools
+limits:
+    context_window: 131072
+    max_output_tokens: 96000
+    max_tokens: 96000
+mode: chat
 model: z-ai/glm-4.5-air:free
+sources:
+    - https://openrouter.ai/z-ai/glm-4.5-air:free/api
+thinking: true

--- a/providers/openrouter/z-ai/glm-4.5.yaml
+++ b/providers/openrouter/z-ai/glm-4.5.yaml
@@ -1,2 +1,20 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 1.1e-7
+      input_cost_per_token: 6.e-7
+      output_cost_per_token: 0.0000022
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tool_choice
+    - tools
+    - system_messages
+limits:
+    context_window: 131072
+    max_output_tokens: 98304
+    max_tokens: 98304
+mode: chat
 model: z-ai/glm-4.5
+sources:
+    - https://openrouter.ai/z-ai/glm-4.5/api
+thinking: true

--- a/providers/openrouter/z-ai/glm-4.5v.yaml
+++ b/providers/openrouter/z-ai/glm-4.5v.yaml
@@ -1,2 +1,23 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 1.1e-7
+      input_cost_per_token: 6.e-7
+      output_cost_per_token: 0.0000018
+      region: "*"
+features:
+    - chat
+    - vision
+    - image_input
+    - function_calling
+    - tool_choice
+    - response_schema
+    - prompt_caching
+    - text
+limits:
+    context_window: 65536
+    max_output_tokens: 16384
+    max_tokens: 16384
+mode: chat
 model: z-ai/glm-4.5v
+sources:
+    - https://openrouter.ai/z-ai/glm-4.5v/api
+thinking: true

--- a/providers/openrouter/z-ai/glm-4.6v.yaml
+++ b/providers/openrouter/z-ai/glm-4.6v.yaml
@@ -1,2 +1,29 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 3.e-7
+      output_cost_per_token: 9.e-7
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - vision
+    - image_input
+    - system_messages
+    - tool_choice
+    - text
+    - tools
+limits:
+    context_window: 131072
+    max_output_tokens: 131072
+    max_tokens: 131072
+mode: chat
 model: z-ai/glm-4.6v
+params:
+    - defaultValue: 0.6
+      key: top_p
+    - defaultValue: 128
+      key: max_tokens
+      maxValue: 131072
+      minValue: 1
+sources:
+    - https://openrouter.ai/z-ai/glm-4.6v/api
+thinking: true

--- a/providers/openrouter/z-ai/glm-5.yaml
+++ b/providers/openrouter/z-ai/glm-5.yaml
@@ -1,2 +1,21 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 7.2e-7
+      output_cost_per_token: 0.0000023
+      region: "*"
+features:
+    - chat
+    - function_calling
+    - tools
+    - text
+    - system_messages
+    - tool_choice
+limits:
+    context_window: 202752
+    max_input_tokens: 71680
+    max_output_tokens: 131072
+    max_tokens: 131072
+mode: chat
 model: z-ai/glm-5
+sources:
+    - https://openrouter.ai/z-ai/glm-5/api
+thinking: true


### PR DESCRIPTION
Auto-generated by poc-agent for provider `openrouter`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large, auto-generated update across many OpenRouter model YAMLs that changes pricing, capability flags, and token limits; mistakes here can impact model selection, feature gating, and cost calculations.
> 
> **Overview**
> Updates the OpenRouter provider’s model catalog by adding and refreshing many model YAMLs with **cost metadata**, **supported features** (e.g., tools/function calling, vision/audio/PDF, caching), and **token/context limits**, plus `sources` links and `thinking`/`isDeprecated` flags.
> 
> Includes a few notable metadata corrections (e.g., replacing legacy `image` with `vision`/`image_input`, increasing some `max_tokens` caps, and marking certain legacy models like `inception/mercury` and `openai/gpt-4-0314` as deprecated).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3096e4107a84b2b35513a323c44cceb9010e55b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->