### PR TITLE
feat(mistral-ai): add new models [bot]

### DIFF
--- a/providers/mistral-ai/mistral-squarepoint-2602.yaml
+++ b/providers/mistral-ai/mistral-squarepoint-2602.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: mistral-squarepoint-2602

--- a/providers/mistral-ai/voxtral-mini-realtime-2602.yaml
+++ b/providers/mistral-ai/voxtral-mini-realtime-2602.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: voxtral-mini-realtime-2602

--- a/providers/mistral-ai/voxtral-mini-realtime-latest.yaml
+++ b/providers/mistral-ai/voxtral-mini-realtime-latest.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: voxtral-mini-realtime-latest

--- a/providers/mistral-ai/voxtral-mini-transcribe-realtime-2602.yaml
+++ b/providers/mistral-ai/voxtral-mini-transcribe-realtime-2602.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: voxtral-mini-transcribe-realtime-2602


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `mistral-ai`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new Mistral model definition YAMLs with `mode: unknown`, which could break consumers/validation if a known mode is required, but the change is isolated to new config files.
> 
> **Overview**
> Registers four new `mistral-ai` model configs by adding YAML definition files for `mistral-squarepoint-2602`, `voxtral-mini-realtime-2602`, `voxtral-mini-realtime-latest`, and `voxtral-mini-transcribe-realtime-2602`.
> 
> Each new entry currently sets `mode: unknown` and defines the `model` identifier, without additional limits/features/cost metadata.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 83c5f495af8e083445bcb17bf05839237ba9fade. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->