### PR TITLE
feat(openrouter): add new models [bot]

### DIFF
--- a/providers/openrouter/minimax/minimax-m2.5:free.yaml
+++ b/providers/openrouter/minimax/minimax-m2.5:free.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: minimax/minimax-m2.5:free

--- a/providers/openrouter/z-ai/glm-5-turbo.yaml
+++ b/providers/openrouter/z-ai/glm-5-turbo.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: z-ai/glm-5-turbo


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `openrouter`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds two new OpenRouter model definition YAML files with no changes to existing logic or security-sensitive code paths.
> 
> **Overview**
> Adds two new OpenRouter model config entries: `minimax/minimax-m2.5:free` and `z-ai/glm-5-turbo`, each declared with `mode: unknown` and the corresponding `model` identifier.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 235272b38eecd4671a9a6aa80777fc1bc66b0b84. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->