### PR TITLE
feat(mistral-ai): update model YAMLs [bot]

### DIFF
--- a/providers/mistral-ai/mistral-squarepoint-2602.yaml
+++ b/providers/mistral-ai/mistral-squarepoint-2602.yaml
@@ -1,2 +1,2 @@
-mode: unknown
+mode: chat
 model: mistral-squarepoint-2602

--- a/providers/mistral-ai/voxtral-mini-realtime-2602.yaml
+++ b/providers/mistral-ai/voxtral-mini-realtime-2602.yaml
@@ -1,2 +1,18 @@
-mode: unknown
+costs:
+    - input_cost_per_second: 0.0001
+      region: "*"
+features:
+    - audio_input
+    - chat
+    - function_calling
+    - response_schema
+    - assistant_prefill
+    - tools
+    - tool_choice
+    - text
+    - system_messages
+mode: chat
 model: voxtral-mini-realtime-2602
+sources:
+    - https://docs.mistral.ai/models/voxtral-mini-transcribe-realtime-26-02
+    - https://docs.mistral.ai/capabilities/audio_transcription

--- a/providers/mistral-ai/voxtral-mini-realtime-latest.yaml
+++ b/providers/mistral-ai/voxtral-mini-realtime-latest.yaml
@@ -1,2 +1,17 @@
-mode: unknown
+costs:
+    - input_cost_per_second: 0.0001
+      region: "*"
+features:
+    - audio_input
+    - function_calling
+    - response_schema
+mode: audio_transcription
 model: voxtral-mini-realtime-latest
+params:
+    - defaultValue: null
+      key: temperature
+removeParams:
+    - top_p
+    - safe_prompt
+sources:
+    - https://docs.mistral.ai/models/voxtral-mini-transcribe-realtime-26-02

--- a/providers/mistral-ai/voxtral-mini-transcribe-realtime-2602.yaml
+++ b/providers/mistral-ai/voxtral-mini-transcribe-realtime-2602.yaml
@@ -1,2 +1,9 @@
-mode: unknown
+costs:
+    - input_cost_per_second: 0.0001
+      region: "*"
+features:
+    - audio_input
+mode: audio_transcription
 model: voxtral-mini-transcribe-realtime-2602
+sources:
+    - https://docs.mistral.ai/models/voxtral-mini-transcribe-realtime-26-02


### PR DESCRIPTION
Auto-generated by poc-agent for provider `mistral-ai`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk YAML metadata updates that affect model capability/parameter declarations and may change how clients route requests to these models.
> 
> **Overview**
> Updates Mistral model YAMLs to reflect current capabilities and usage.
> 
> `mistral-squarepoint-2602` is set to `mode: chat`. The Voxtral realtime/transcribe models add pricing metadata (`input_cost_per_second`), feature flags, and documentation `sources`; `voxtral-mini-realtime-latest` is clarified as `mode: audio_transcription` with `temperature` allowed and `top_p`/`safe_prompt` removed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6175cee9a18ca2efcf6d08f5d10bb4bff0447234. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->