### PR TITLE
feat(mistral-ai): add new models [bot]

### DIFF
--- a/providers/mistral-ai/labs-leanstral-2603.yaml
+++ b/providers/mistral-ai/labs-leanstral-2603.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: labs-leanstral-2603

--- a/providers/mistral-ai/mistral-small-2603.yaml
+++ b/providers/mistral-ai/mistral-small-2603.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: mistral-small-2603

--- a/providers/mistral-ai/voxtral-mini-2602.yaml
+++ b/providers/mistral-ai/voxtral-mini-2602.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: voxtral-mini-2602

--- a/providers/mistral-ai/voxtral-mini-tts-260213.yaml
+++ b/providers/mistral-ai/voxtral-mini-tts-260213.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: voxtral-mini-tts-260213


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `mistral-ai`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adds new provider config files and does not modify runtime logic. Main risk is incorrect metadata (`mode: unknown`) affecting model selection/validation downstream.
> 
> **Overview**
> Adds four new `mistral-ai` model config entries: `labs-leanstral-2603`, `mistral-small-2603`, `voxtral-mini-2602`, and `voxtral-mini-tts-260213`.
> 
> Each new YAML currently sets `mode: unknown` and the corresponding `model` identifier, making these models available for discovery/configuration in the provider catalog.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9014e58c186ba93b77b54d56f9440841e13a63e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->