### PR TITLE
param class to model param

### DIFF
--- a/.github/test/common.cue
+++ b/.github/test/common.cue
@@ -2,7 +2,7 @@ package model
 
 // Shared definitions for model and default schemas
 
-#ParamKey:
+#ModelParamKey:
 	"max_tokens" |
 	"max_completion_tokens" |
 	"temperature" |
@@ -22,17 +22,17 @@ package model
 	"min_tokens" |
 	"parallel_tool_calls"
 
-#ParamType:
+#ModelParamType:
 	"string" |
 	"boolean" |
 	"array-of-strings" |
 	"json" |
 	"number"
 
-#Param: {
-	key:             #ParamKey
+#ModelParam: {
+	key:             #ModelParamKey
 	defaultValue?:   string | number | bool | null
 	minValue?:       number
 	maxValue?:       number
-	type?:           #ParamType
+	type?:           #ModelParamType
 }

--- a/.github/test/default.cue
+++ b/.github/test/default.cue
@@ -4,7 +4,7 @@ package model
 
 #DefaultConfig: {
 	// Configurable parameters with defaults
-	params?: [...#Param]
+	params?: [...#ModelParam]
 
 	// Message types supported
 	messages?: {

--- a/.github/test/model.cue
+++ b/.github/test/model.cue
@@ -171,11 +171,11 @@ package model
 	// Input/output modality support (e.g. text, image, audio)
 	modalities?: #Modalities
 	// Param overrides or additions relative to the provider default
-	params?: [...#Param]
+	params?: [...#ModelParam]
 	// Param keys to remove from the provider default
-	removeParams?: [...#ParamKey]
+	removeParams?: [...#ModelParamKey]
 	// Param keys that must always be provided by callers
-	requiredParams?: [...#ParamKey]
+	requiredParams?: [...#ModelParamKey]
 	// Whether the model is deprecated
 	isDeprecated?: bool
 	// Date after which the model is considered deprecated (YYYY-MM-DD)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk schema refactor that renames parameter-related CUE definitions; main risk is breaking downstream references expecting the old `#Param*` names.
> 
> **Overview**
> Renames the shared parameter schema types in `.github/test/common.cue` from `#ParamKey`/`#ParamType`/`#Param` to `#ModelParamKey`/`#ModelParamType`/`#ModelParam`.
> 
> Updates `.github/test/default.cue` and `.github/test/model.cue` to reference the new `#ModelParam*` names for `params`, `removeParams`, and `requiredParams`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 180a6e8c26871ec6e086a904b79c7cbcd208d68d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->