### PR TITLE
feat(openrouter): add new models [bot]

### DIFF
--- a/providers/openrouter/mistralai/mistral-small-2603.yaml
+++ b/providers/openrouter/mistralai/mistral-small-2603.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: mistralai/mistral-small-2603

--- a/providers/openrouter/openai/gpt-5.4-mini.yaml
+++ b/providers/openrouter/openai/gpt-5.4-mini.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: openai/gpt-5.4-mini

--- a/providers/openrouter/openai/gpt-5.4-nano.yaml
+++ b/providers/openrouter/openai/gpt-5.4-nano.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: openai/gpt-5.4-nano


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `openrouter`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds three new OpenRouter model definition YAMLs without changing runtime code paths; impact is limited to making additional models selectable.
> 
> **Overview**
> Adds three new OpenRouter model config entries: `mistralai/mistral-small-2603`, `openai/gpt-5.4-mini`, and `openai/gpt-5.4-nano` (each with `mode: unknown`). This expands the set of available models via configuration only.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33e48683aade567398ae0d8a80399637785ecae2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->