### PR TITLE
feat(cohere): add new models [bot]

### DIFF
--- a/providers/cohere/c4ai-aya-expanse-32b.yaml
+++ b/providers/cohere/c4ai-aya-expanse-32b.yaml
@@ -6,9 +6,9 @@ features:
     - system_messages
 limits:
     context_window: 128000
-    max_output_tokens: 4096
-    max_tokens: 4096
-mode: chat
+mode: completion
 model: c4ai-aya-expanse-32b
 sources:
     - https://docs.cohere.com/docs/aya-expanse
+supportedModes:
+    - chat

--- a/providers/cohere/c4ai-aya-vision-32b.yaml
+++ b/providers/cohere/c4ai-aya-vision-32b.yaml
@@ -3,9 +3,7 @@ costs:
       output_cost_per_token: 0
       region: "*"
 limits:
-    context_window: 16000
-    max_output_tokens: 4000
-    max_tokens: 4000
+    context_window: 16384
 modalities:
     input:
         - image

--- a/providers/cohere/command-a-03-2025.yaml
+++ b/providers/cohere/command-a-03-2025.yaml
@@ -3,17 +3,12 @@ costs:
       output_cost_per_token: 0.00001
       region: "*"
 features:
-    - function_calling
-    - tools
-    - tool_choice
     - structured_output
-    - system_messages
+    - tool_choice
+    - tools
 limits:
-    context_window: 256000
-    max_input_tokens: 256000
-    max_output_tokens: 8000
-    max_tokens: 8000
-mode: completion
+    context_window: 288000
+mode: chat
 model: command-a-03-2025
 params:
     - defaultValue: 256

--- a/providers/cohere/command-a-reasoning-08-2025.yaml
+++ b/providers/cohere/command-a-reasoning-08-2025.yaml
@@ -3,15 +3,12 @@ costs:
       output_cost_per_token: 0
       region: "*"
 features:
-    - function_calling
     - structured_output
-    - system_messages
+    - tool_choice
+    - tools
 limits:
-    context_window: 256000
-    max_input_tokens: 256000
-    max_output_tokens: 32000
-    max_tokens: 32000
-mode: completion
+    context_window: 288768
+mode: chat
 model: command-a-reasoning-08-2025
 params:
     - defaultValue: 256

--- a/providers/cohere/command-a-translate-08-2025.yaml
+++ b/providers/cohere/command-a-translate-08-2025.yaml
@@ -3,14 +3,11 @@ costs:
       output_cost_per_token: 0
       region: "*"
 features:
-    - function_calling
     - structured_output
+    - tools
 limits:
-    context_window: 16000
-    max_input_tokens: 8000
-    max_output_tokens: 8000
-    max_tokens: 8000
-mode: completion
+    context_window: 8992
+mode: chat
 model: command-a-translate-08-2025
 params:
     - defaultValue: 8000

--- a/providers/cohere/command-a-vision-07-2025.yaml
+++ b/providers/cohere/command-a-vision-07-2025.yaml
@@ -4,14 +4,13 @@ costs:
       region: "*"
 features:
     - structured_output
+    - tool_choice
 limits:
     context_window: 128000
-    max_output_tokens: 8000
-    max_tokens: 8000
 modalities:
     input:
         - image
-mode: completion
+mode: chat
 model: command-a-vision-07-2025
 params:
     - defaultValue: 256

--- a/providers/cohere/command-r-08-2024.yaml
+++ b/providers/cohere/command-r-08-2024.yaml
@@ -3,15 +3,14 @@ costs:
       output_cost_per_token: 6.e-7
       region: "*"
 features:
-    - function_calling
-    - tools
     - structured_output
+    - tool_choice
+    - tools
 limits:
-    context_window: 128000
-    max_input_tokens: 128000
-    max_output_tokens: 4000
-    max_tokens: 4000
+    context_window: 132096
 mode: completion
 model: command-r-08-2024
 sources:
     - https://docs.cohere.com/docs/command-r
+supportedModes:
+    - chat

--- a/providers/cohere/command-r-plus-08-2024.yaml
+++ b/providers/cohere/command-r-plus-08-2024.yaml
@@ -2,10 +2,14 @@ costs:
     - input_cost_per_token: 0.0000025
       output_cost_per_token: 0.00001
       region: "*"
+features:
+    - structured_output
+    - tool_choice
+    - tools
 isDeprecated: true
 limits:
-    max_input_tokens: 128000
-    max_output_tokens: 4000
-    max_tokens: 128000
+    context_window: 132096
 mode: completion
 model: command-r-plus-08-2024
+supportedModes:
+    - chat

--- a/providers/cohere/command-r7b-12-2024.yaml
+++ b/providers/cohere/command-r7b-12-2024.yaml
@@ -3,18 +3,15 @@ costs:
       output_cost_per_token: 1.5e-7
       region: "*"
 features:
-    - function_calling
-    - system_messages
-    - tool_choice
     - structured_output
+    - tool_choice
     - tools
 limits:
-    context_window: 128000
-    max_input_tokens: 128000
-    max_output_tokens: 4000
-    max_tokens: 4000
+    context_window: 132000
 mode: completion
 model: command-r7b-12-2024
 sources:
     - https://docs.cohere.com/docs/command-r7b
     - https://docs.cohere.com/reference/chat
+supportedModes:
+    - chat

--- a/providers/cohere/command-r7b-arabic-02-2025.yaml
+++ b/providers/cohere/command-r7b-arabic-02-2025.yaml
@@ -3,14 +3,14 @@ costs:
       output_cost_per_token: 1.5e-7
       region: "*"
 features:
-    - function_calling
-    - system_messages
     - structured_output
+    - tool_choice
+    - tools
 limits:
     context_window: 128000
-    max_output_tokens: 4000
-    max_tokens: 4000
-mode: chat
+mode: completion
 model: command-r7b-arabic-02-2025
 sources:
     - https://docs.cohere.com/docs/command-r7b
+supportedModes:
+    - chat

--- a/providers/cohere/embed-english-light-v3.0.yaml
+++ b/providers/cohere/embed-english-light-v3.0.yaml
@@ -4,7 +4,6 @@ costs:
       region: "*"
 limits:
     context_window: 512
-    max_input_tokens: 512
 modalities:
     input:
         - image

--- a/providers/cohere/embed-english-v3.0.yaml
+++ b/providers/cohere/embed-english-v3.0.yaml
@@ -5,7 +5,6 @@ costs:
       region: "*"
 limits:
     context_window: 512
-    max_input_tokens: 512
 modalities:
     input:
         - image

--- a/providers/cohere/embed-multilingual-light-v3.0.yaml
+++ b/providers/cohere/embed-multilingual-light-v3.0.yaml
@@ -4,7 +4,6 @@ costs:
       region: "*"
 limits:
     context_window: 512
-    max_input_tokens: 512
 modalities:
     input:
         - image

--- a/providers/cohere/embed-multilingual-v3.0.yaml
+++ b/providers/cohere/embed-multilingual-v3.0.yaml
@@ -4,7 +4,6 @@ costs:
       region: "*"
 limits:
     context_window: 512
-    max_input_tokens: 512
 modalities:
     input:
         - image

--- a/providers/cohere/embed-v4.0.yaml
+++ b/providers/cohere/embed-v4.0.yaml
@@ -3,9 +3,7 @@ costs:
       output_cost_per_token: 0
       region: "*"
 limits:
-    max_input_tokens: 128000
-    max_tokens: 128000
-    output_vector_size: 1536
+    context_window: 8192
 modalities:
     input:
         - image

--- a/providers/cohere/rerank-english-v3.0.yaml
+++ b/providers/cohere/rerank-english-v3.0.yaml
@@ -5,9 +5,6 @@ costs:
       region: "*"
 limits:
     context_window: 4096
-    max_input_tokens: 4096
-    max_output_tokens: 4096
-    max_tokens: 4096
 mode: rerank
 model: rerank-english-v3.0
 sources:

--- a/providers/cohere/rerank-multilingual-v3.0.yaml
+++ b/providers/cohere/rerank-multilingual-v3.0.yaml
@@ -4,9 +4,7 @@ costs:
       output_cost_per_token: 0
       region: "*"
 limits:
-    max_input_tokens: 4096
-    max_output_tokens: 4096
-    max_tokens: 4096
+    context_window: 4096
 mode: rerank
 model: rerank-multilingual-v3.0
 sources:

--- a/providers/cohere/rerank-v3.5.yaml
+++ b/providers/cohere/rerank-v3.5.yaml
@@ -5,7 +5,6 @@ costs:
       region: "*"
 limits:
     context_window: 4096
-    max_input_tokens: 4096
 mode: rerank
 model: rerank-v3.5
 removeParams:

--- a/providers/cohere/rerank-v4.0-fast.yaml
+++ b/providers/cohere/rerank-v4.0-fast.yaml
@@ -1,5 +1,5 @@
 limits:
-    context_window: 32000
+    context_window: 32768
 mode: rerank
 model: rerank-v4.0-fast
 removeParams:

--- a/providers/cohere/rerank-v4.0-pro.yaml
+++ b/providers/cohere/rerank-v4.0-pro.yaml
@@ -2,7 +2,7 @@ costs:
     - input_cost_per_query: 0.0025
       region: "*"
 limits:
-    context_window: 32000
+    context_window: 32768
 mode: rerank
 model: rerank-v4.0-pro
 removeParams:

--- a/providers/cohere/tiny-aya-earth.yaml
+++ b/providers/cohere/tiny-aya-earth.yaml
@@ -1,2 +1,8 @@
-mode: chat
+features:
+    - structured_output
+limits:
+    context_window: 8192
+mode: completion
 model: tiny-aya-earth
+supportedModes:
+    - chat

--- a/providers/cohere/tiny-aya-fire.yaml
+++ b/providers/cohere/tiny-aya-fire.yaml
@@ -1,2 +1,8 @@
-mode: chat
+features:
+    - structured_output
+limits:
+    context_window: 8192
+mode: completion
 model: tiny-aya-fire
+supportedModes:
+    - chat

--- a/providers/cohere/tiny-aya-global.yaml
+++ b/providers/cohere/tiny-aya-global.yaml
@@ -1,2 +1,8 @@
-mode: chat
+features:
+    - structured_output
+limits:
+    context_window: 8192
+mode: completion
 model: tiny-aya-global
+supportedModes:
+    - chat

--- a/providers/cohere/tiny-aya-water.yaml
+++ b/providers/cohere/tiny-aya-water.yaml
@@ -1,4 +1,10 @@
-mode: chat
+features:
+    - structured_output
+limits:
+    context_window: 8192
+mode: completion
 model: tiny-aya-water
 sources:
     - https://docs.cohere.com/docs/tiny-aya-water
+supportedModes:
+    - chat


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `cohere`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only changes, but mode/limit adjustments could affect routing and validation for Cohere models if clients rely on the previous `mode`/token limits.
> 
> **Overview**
> Updates Cohere model YAML configs to reflect new/adjusted capabilities and limits, including revised `context_window` values and cleanup of redundant max-token fields.
> 
> Several models change their primary `mode` (notably moving `command-a*` and `command-a-vision` to `chat`, and some Aya/Command variants to `completion`) and add `supportedModes` to indicate additional chat support.
> 
> Model feature flags are also refreshed (e.g., adding `tools`/`tool_choice`/`structured_output` where applicable), and the `tiny-aya-*` entries are expanded from minimal stubs to full configs with limits and features.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e1d6cb57ad2b7c7298ca033bb044ce959a2a6e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->