### PR TITLE
feat(deepinfra): add new models [bot]

### DIFF
--- a/providers/deepinfra/BAAI/bge-base-en-v1.5.yaml
+++ b/providers/deepinfra/BAAI/bge-base-en-v1.5.yaml
@@ -3,7 +3,7 @@ costs:
       region: "*"
 limits:
     max_input_tokens: 512
-mode: embedding
+mode: unknown
 model: BAAI/bge-base-en-v1.5
 sources:
     - https://deepinfra.com/BAAI/bge-base-en-v1.5/api

--- a/providers/deepinfra/BAAI/bge-en-icl.yaml
+++ b/providers/deepinfra/BAAI/bge-en-icl.yaml
@@ -1,7 +1,7 @@
 costs:
     - input_cost_per_token: 1.e-8
       region: "*"
-mode: embedding
+mode: unknown
 model: BAAI/bge-en-icl
 sources:
     - https://deepinfra.com/BAAI/bge-en-icl

--- a/providers/deepinfra/BAAI/bge-large-en-v1.5.yaml
+++ b/providers/deepinfra/BAAI/bge-large-en-v1.5.yaml
@@ -7,7 +7,7 @@ limits:
 modalities:
     input:
         - image
-mode: embedding
+mode: unknown
 model: BAAI/bge-large-en-v1.5
 sources:
     - https://deepinfra.com/BAAI/bge-large-en-v1.5/api

--- a/providers/deepinfra/BAAI/bge-m3-multi.yaml
+++ b/providers/deepinfra/BAAI/bge-m3-multi.yaml
@@ -3,7 +3,7 @@ costs:
       region: "*"
 limits:
     max_input_tokens: 8192
-mode: embedding
+mode: unknown
 model: BAAI/bge-m3-multi
 sources:
     - https://deepinfra.com/BAAI/bge-m3-multi/api

--- a/providers/deepinfra/BAAI/bge-m3.yaml
+++ b/providers/deepinfra/BAAI/bge-m3.yaml
@@ -4,7 +4,7 @@ costs:
 limits:
     max_input_tokens: 8192
     max_tokens: 8192
-mode: embedding
+mode: unknown
 model: BAAI/bge-m3
 sources:
     - https://deepinfra.com/BAAI/bge-m3/api

--- a/providers/deepinfra/Bria/Bria-3.2-vector.yaml
+++ b/providers/deepinfra/Bria/Bria-3.2-vector.yaml
@@ -4,7 +4,7 @@ costs:
 modalities:
     input:
         - image
-mode: image
+mode: unknown
 model: Bria/Bria-3.2-vector
 sources:
     - https://deepinfra.com/Bria/Bria-3.2-vector/api

--- a/providers/deepinfra/Bria/Bria-3.2.yaml
+++ b/providers/deepinfra/Bria/Bria-3.2.yaml
@@ -4,7 +4,7 @@ costs:
 modalities:
     input:
         - image
-mode: image
+mode: unknown
 model: Bria/Bria-3.2
 sources:
     - https://deepinfra.com/Bria/Bria-3.2/api

--- a/providers/deepinfra/Bria/blur_background.yaml
+++ b/providers/deepinfra/Bria/blur_background.yaml
@@ -4,7 +4,7 @@ costs:
 modalities:
     input:
         - image
-mode: image
+mode: unknown
 model: Bria/blur_background
 sources:
     - https://deepinfra.com/Bria/blur_background/api

--- a/providers/deepinfra/Bria/enhance.yaml
+++ b/providers/deepinfra/Bria/enhance.yaml
@@ -4,7 +4,7 @@ costs:
 modalities:
     input:
         - image
-mode: image
+mode: unknown
 model: Bria/enhance
 sources:
     - https://deepinfra.com/Bria/enhance/api

--- a/providers/deepinfra/Bria/erase.yaml
+++ b/providers/deepinfra/Bria/erase.yaml
@@ -1,7 +1,7 @@
 costs:
     - input_cost_per_image: 0.04
       region: "*"
-mode: image
+mode: unknown
 model: Bria/erase
 sources:
     - https://deepinfra.com/Bria/erase/api

--- a/providers/deepinfra/Bria/erase_foreground.yaml
+++ b/providers/deepinfra/Bria/erase_foreground.yaml
@@ -1,4 +1,4 @@
-mode: image
+mode: unknown
 model: Bria/erase_foreground
 sources:
     - https://deepinfra.com/Bria/erase_foreground

--- a/providers/deepinfra/Bria/expand.yaml
+++ b/providers/deepinfra/Bria/expand.yaml
@@ -4,7 +4,7 @@ costs:
 modalities:
     input:
         - image
-mode: image
+mode: unknown
 model: Bria/expand
 sources:
     - https://deepinfra.com/Bria/expand/api

--- a/providers/deepinfra/Bria/fibo.yaml
+++ b/providers/deepinfra/Bria/fibo.yaml
@@ -1,7 +1,7 @@
 modalities:
     input:
         - image
-mode: image
+mode: unknown
 model: Bria/fibo
 sources:
     - https://deepinfra.com/Bria/fibo/api

--- a/providers/deepinfra/Bria/fibo_edit.yaml
+++ b/providers/deepinfra/Bria/fibo_edit.yaml
@@ -1,7 +1,7 @@
 modalities:
     input:
         - image
-mode: image
+mode: unknown
 model: Bria/fibo_edit
 sources:
     - https://deepinfra.com/Bria/fibo_edit/api

--- a/providers/deepinfra/Bria/gen_fill.yaml
+++ b/providers/deepinfra/Bria/gen_fill.yaml
@@ -1,7 +1,7 @@
 modalities:
     input:
         - image
-mode: image
+mode: unknown
 model: Bria/gen_fill
 sources:
     - https://deepinfra.com/Bria/gen_fill

--- a/providers/deepinfra/Bria/remove_background.yaml
+++ b/providers/deepinfra/Bria/remove_background.yaml
@@ -1,7 +1,7 @@
 costs:
     - input_cost_per_image: 0
       region: "*"
-mode: image
+mode: unknown
 model: Bria/remove_background
 sources:
     - https://deepinfra.com/Bria/remove_background/api

--- a/providers/deepinfra/Bria/replace_background.yaml
+++ b/providers/deepinfra/Bria/replace_background.yaml
@@ -4,7 +4,7 @@ costs:
 modalities:
     input:
         - image
-mode: image
+mode: unknown
 model: Bria/replace_background
 sources:
     - https://deepinfra.com/Bria/replace_background/api

--- a/providers/deepinfra/ByteDance/Seed-1.8.yaml
+++ b/providers/deepinfra/ByteDance/Seed-1.8.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 5.e-8
+    - cache_read_input_token_cost: 5.0000000000000004e-8
       input_cost_per_token: 2.5e-7
       output_cost_per_token: 0.000002
       region: "*"
@@ -14,16 +14,14 @@ costs:
               - cost_per_token: 0.000004
                 from: 128000
 features:
-    - function_calling
-    - structured_output
-    - tool_choice
     - prompt_caching
 limits:
     context_window: 256000
+    max_tokens: 256000
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: ByteDance/Seed-1.8
 sources:
     - https://deepinfra.com/ByteDance/Seed-1.8/api

--- a/providers/deepinfra/ByteDance/Seed-2.0-mini.yaml
+++ b/providers/deepinfra/ByteDance/Seed-2.0-mini.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_token_cost: 2.e-8
-      input_cost_per_token: 1.e-7
-      output_cost_per_token: 4.e-7
+    - cache_read_input_token_cost: 2.0000000000000004e-8
+      input_cost_per_token: 1.0000000000000001e-7
+      output_cost_per_token: 4.0000000000000003e-7
       region: "*"
       tiered_pricing:
           cache_read:
@@ -14,17 +14,14 @@ costs:
               - cost_per_token: 8.e-7
                 from: 128000
 features:
-    - function_calling
-    - structured_output
-    - tools
     - prompt_caching
-    - system_messages
 limits:
     context_window: 256000
+    max_tokens: 256000
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: ByteDance/Seed-2.0-mini
 sources:
     - https://deepinfra.com/ByteDance/Seed-2.0-mini/api

--- a/providers/deepinfra/ByteDance/Seedream-4.5.yaml
+++ b/providers/deepinfra/ByteDance/Seedream-4.5.yaml
@@ -4,7 +4,7 @@ costs:
 modalities:
     input:
         - image
-mode: image
+mode: unknown
 model: ByteDance/Seedream-4.5
 sources:
     - https://deepinfra.com/ByteDance/Seedream-4.5/api

--- a/providers/deepinfra/ByteDance/Seedream-4.yaml
+++ b/providers/deepinfra/ByteDance/Seedream-4.yaml
@@ -4,7 +4,7 @@ costs:
 modalities:
     input:
         - image
-mode: image
+mode: unknown
 model: ByteDance/Seedream-4
 sources:
     - https://deepinfra.com/ByteDance/Seedream-4/api

--- a/providers/deepinfra/ClarityAI/creative.yaml
+++ b/providers/deepinfra/ClarityAI/creative.yaml
@@ -4,7 +4,7 @@ costs:
 modalities:
     input:
         - image
-mode: image
+mode: unknown
 model: ClarityAI/creative
 sources:
     - https://api.deepinfra.com/models/ClarityAI/creative

--- a/providers/deepinfra/ClarityAI/crystal.yaml
+++ b/providers/deepinfra/ClarityAI/crystal.yaml
@@ -4,7 +4,7 @@ costs:
 modalities:
     input:
         - image
-mode: image
+mode: unknown
 model: ClarityAI/crystal
 sources:
     - https://deepinfra.com/ClarityAI/crystal/voice

--- a/providers/deepinfra/ClarityAI/flux.yaml
+++ b/providers/deepinfra/ClarityAI/flux.yaml
@@ -4,7 +4,7 @@ costs:
 modalities:
     input:
         - image
-mode: image
+mode: unknown
 model: ClarityAI/flux
 sources:
     - https://deepinfra.com/ClarityAI/flux

--- a/providers/deepinfra/Gryphe/MythoMax-L2-13b.yaml
+++ b/providers/deepinfra/Gryphe/MythoMax-L2-13b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 4.e-7
-      output_cost_per_token: 4.e-7
+    - input_cost_per_token: 4.0000000000000003e-7
+      output_cost_per_token: 4.0000000000000003e-7
       region: "*"
 features:
     - tool_choice
@@ -8,7 +8,8 @@ features:
 limits:
     context_window: 4096
     max_input_tokens: 4096
-mode: chat
+    max_tokens: 4096
+mode: unknown
 model: Gryphe/MythoMax-L2-13b
 sources:
     - https://deepinfra.com/Gryphe/MythoMax-L2-13b/api

--- a/providers/deepinfra/MiniMaxAI/MiniMax-M2.1.yaml
+++ b/providers/deepinfra/MiniMaxAI/MiniMax-M2.1.yaml
@@ -1,19 +1,15 @@
 costs:
-    - input_cost_per_token: 2.7e-7
-      output_cost_per_token: 9.5e-7
+    - cache_read_input_token_cost: 2.90000007e-8
+      input_cost_per_token: 2.7e-7
+      output_cost_per_token: 9.499999999999999e-7
       region: "*"
 features:
-    - function_calling
-    - tool_choice
-    - tools
-    - system_messages
-    - structured_output
     - prompt_caching
 limits:
     context_window: 196608
     max_output_tokens: 131072
-    max_tokens: 131072
-mode: chat
+    max_tokens: 196608
+mode: unknown
 model: MiniMaxAI/MiniMax-M2.1
 sources:
     - https://deepinfra.com/MiniMaxAI/MiniMax-M2.1/api

--- a/providers/deepinfra/MiniMaxAI/MiniMax-M2.5.yaml
+++ b/providers/deepinfra/MiniMaxAI/MiniMax-M2.5.yaml
@@ -1,18 +1,15 @@
 costs:
-    - input_cost_per_token: 2.7e-7
-      output_cost_per_token: 9.5e-7
+    - cache_read_input_token_cost: 2.99999997e-8
+      input_cost_per_token: 2.7e-7
+      output_cost_per_token: 9.499999999999999e-7
       region: "*"
 features:
-    - function_calling
-    - structured_output
-    - system_messages
-    - tool_choice
     - prompt_caching
 limits:
     context_window: 196608
     max_output_tokens: 131072
-    max_tokens: 131072
-mode: chat
+    max_tokens: 196608
+mode: unknown
 model: MiniMaxAI/MiniMax-M2.5
 sources:
     - https://deepinfra.com/MiniMaxAI/MiniMax-M2.5/api

--- a/providers/deepinfra/NousResearch/Hermes-3-Llama-3.1-405B.yaml
+++ b/providers/deepinfra/NousResearch/Hermes-3-Llama-3.1-405B.yaml
@@ -11,7 +11,7 @@ limits:
     max_input_tokens: 131072
     max_output_tokens: 131072
     max_tokens: 131072
-mode: chat
+mode: unknown
 model: NousResearch/Hermes-3-Llama-3.1-405B
 sources:
     - https://deepinfra.com/NousResearch/Hermes-3-Llama-3.1-405B/api

--- a/providers/deepinfra/NousResearch/Hermes-3-Llama-3.1-70B.yaml
+++ b/providers/deepinfra/NousResearch/Hermes-3-Llama-3.1-70B.yaml
@@ -11,7 +11,8 @@ features:
 limits:
     context_window: 131072
     max_input_tokens: 131072
-mode: chat
+    max_tokens: 131072
+mode: unknown
 model: NousResearch/Hermes-3-Llama-3.1-70B
 sources:
     - https://deepinfra.com/NousResearch/Hermes-3-Llama-3.1-70B/api

--- a/providers/deepinfra/PaddlePaddle/PaddleOCR-VL-0.9B.yaml
+++ b/providers/deepinfra/PaddlePaddle/PaddleOCR-VL-0.9B.yaml
@@ -1,17 +1,17 @@
 costs:
     - input_cost_per_token: 1.4e-7
-      output_cost_per_token: 8.e-7
+      output_cost_per_token: 8.000000000000001e-7
       region: "*"
 features:
     - structured_output
 limits:
     context_window: 16384
     max_output_tokens: 8192
-    max_tokens: 8192
+    max_tokens: 16384
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: PaddlePaddle/PaddleOCR-VL-0.9B
 sources:
     - https://api.deepinfra.com/models/PaddlePaddle/PaddleOCR-VL-0.9B

--- a/providers/deepinfra/PrunaAI/p-image-Edit.yaml
+++ b/providers/deepinfra/PrunaAI/p-image-Edit.yaml
@@ -1,4 +1,4 @@
-mode: image
+mode: unknown
 model: PrunaAI/p-image-Edit
 sources:
     - https://deepinfra.com/PrunaAI/p-image-Edit

--- a/providers/deepinfra/PrunaAI/p-image.yaml
+++ b/providers/deepinfra/PrunaAI/p-image.yaml
@@ -1,7 +1,7 @@
 modalities:
     input:
         - image
-mode: image
+mode: unknown
 model: PrunaAI/p-image
 sources:
     - https://deepinfra.com/PrunaAI/p-image

--- a/providers/deepinfra/Qwen/Qwen-Image-Edit-Max.yaml
+++ b/providers/deepinfra/Qwen/Qwen-Image-Edit-Max.yaml
@@ -4,7 +4,7 @@ costs:
 modalities:
     input:
         - image
-mode: image
+mode: unknown
 model: Qwen/Qwen-Image-Edit-Max
 sources:
     - https://deepinfra.com/Qwen/Qwen-Image-Edit-Max

--- a/providers/deepinfra/Qwen/Qwen-Image-Edit.yaml
+++ b/providers/deepinfra/Qwen/Qwen-Image-Edit.yaml
@@ -4,7 +4,7 @@ costs:
 modalities:
     input:
         - image
-mode: image
+mode: unknown
 model: Qwen/Qwen-Image-Edit
 sources:
     - https://deepinfra.com/Qwen/Qwen-Image-Edit/api

--- a/providers/deepinfra/Qwen/Qwen-Image-Max.yaml
+++ b/providers/deepinfra/Qwen/Qwen-Image-Max.yaml
@@ -4,7 +4,7 @@ costs:
 modalities:
     input:
         - image
-mode: image
+mode: unknown
 model: Qwen/Qwen-Image-Max
 sources:
     - https://deepinfra.com/Qwen/Qwen-Image-Max/api

--- a/providers/deepinfra/Qwen/Qwen2.5-72B-Instruct.yaml
+++ b/providers/deepinfra/Qwen/Qwen2.5-72B-Instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 1.2e-7
-      output_cost_per_token: 3.9e-7
+    - input_cost_per_token: 1.2000000000000002e-7
+      output_cost_per_token: 3.8999999999999997e-7
       region: "*"
 features:
     - function_calling
@@ -10,7 +10,7 @@ limits:
     max_input_tokens: 32768
     max_output_tokens: 32768
     max_tokens: 32768
-mode: chat
+mode: unknown
 model: Qwen/Qwen2.5-72B-Instruct
 sources:
     - https://deepinfra.com/Qwen/Qwen2.5-72B-Instruct/api

--- a/providers/deepinfra/Qwen/Qwen2.5-VL-32B-Instruct.yaml
+++ b/providers/deepinfra/Qwen/Qwen2.5-VL-32B-Instruct.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 2.e-7
+    - input_cost_per_token: 2.0000000000000002e-7
       output_cost_per_token: 6.e-7
       region: "*"
 features:
@@ -9,10 +9,11 @@ features:
 limits:
     context_window: 128000
     max_input_tokens: 128000
+    max_tokens: 128000
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: Qwen/Qwen2.5-VL-32B-Instruct
 sources:
     - https://deepinfra.com/Qwen/Qwen2.5-VL-32B-Instruct/api

--- a/providers/deepinfra/Qwen/Qwen3-14B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-14B.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 1.2e-7
-      output_cost_per_token: 2.4e-7
+    - input_cost_per_token: 1.2000000000000002e-7
+      output_cost_per_token: 2.4000000000000003e-7
       region: "*"
 features:
     - function_calling
@@ -9,7 +9,8 @@ features:
     - structured_output
 limits:
     context_window: 40960
-mode: chat
+    max_tokens: 40960
+mode: unknown
 model: Qwen/Qwen3-14B
 sources:
     - https://deepinfra.com/Qwen/Qwen3-14B

--- a/providers/deepinfra/Qwen/Qwen3-235B-A22B-Instruct-2507.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-235B-A22B-Instruct-2507.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 7.1e-8
-      output_cost_per_token: 0.000001
+    - input_cost_per_token: 7.099999999999999e-8
+      output_cost_per_token: 1.0000000000000001e-7
       region: "*"
 features:
     - function_calling
@@ -12,9 +12,10 @@ limits:
     max_input_tokens: 262144
     max_output_tokens: 262144
     max_tokens: 262144
-mode: chat
+mode: unknown
 model: Qwen/Qwen3-235B-A22B-Instruct-2507
 sources:
     - https://deepinfra.com/Qwen/Qwen3-235B-A22B-Instruct-2507/api
     - https://api.deepinfra.com/models/Qwen/Qwen3-235B-A22B-Instruct-2507
     - https://huggingface.co/Qwen/Qwen3-235B-A22B-Instruct-2507
+thinking: true

--- a/providers/deepinfra/Qwen/Qwen3-235B-A22B-Thinking-2507.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-235B-A22B-Thinking-2507.yaml
@@ -1,18 +1,16 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2.000000006e-7
       input_cost_per_token: 2.3e-7
       output_cost_per_token: 0.0000023
       region: "*"
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
+    - prompt_caching
 limits:
     context_window: 262144
     max_input_tokens: 262144
     max_output_tokens: 262144
     max_tokens: 262144
-mode: chat
+mode: unknown
 model: Qwen/Qwen3-235B-A22B-Thinking-2507
 sources:
     - https://deepinfra.com/Qwen/Qwen3-235B-A22B-Thinking-2507

--- a/providers/deepinfra/Qwen/Qwen3-30B-A3B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-30B-A3B.yaml
@@ -8,7 +8,8 @@ features:
     - structured_output
 limits:
     context_window: 40960
-mode: chat
+    max_tokens: 40960
+mode: unknown
 model: Qwen/Qwen3-30B-A3B
 sources:
     - https://deepinfra.com/Qwen/Qwen3-30B-A3B/api

--- a/providers/deepinfra/Qwen/Qwen3-32B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-32B.yaml
@@ -6,10 +6,11 @@ features:
     - function_calling
     - tool_choice
 limits:
+    context_window: 40960
     max_input_tokens: 40960
     max_output_tokens: 40960
     max_tokens: 40960
-mode: chat
+mode: unknown
 model: Qwen/Qwen3-32B
 sources:
     - https://deepinfra.com/Qwen/Qwen3-32B

--- a/providers/deepinfra/Qwen/Qwen3-Coder-480B-A35B-Instruct-Turbo.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Coder-480B-A35B-Instruct-Turbo.yaml
@@ -1,16 +1,15 @@
 costs:
     - cache_read_input_token_cost: 2.2e-8
-      input_cost_per_token: 2.2e-7
+      input_cost_per_token: 2.1999999999999998e-7
       output_cost_per_token: 0.000001
       region: "*"
 features:
-    - function_calling
-    - tool_choice
+    - prompt_caching
 limits:
     context_window: 262144
     max_output_tokens: 16384
-    max_tokens: 16384
-mode: chat
+    max_tokens: 262144
+mode: unknown
 model: Qwen/Qwen3-Coder-480B-A35B-Instruct-Turbo
 sources:
     - https://deepinfra.com/Qwen/Qwen3-Coder-480B-A35B-Instruct-Turbo/api

--- a/providers/deepinfra/Qwen/Qwen3-Coder-480B-A35B-Instruct.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Coder-480B-A35B-Instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 4.e-7
-      output_cost_per_token: 0.0000016
+    - input_cost_per_token: 4.0000000000000003e-7
+      output_cost_per_token: 0.0000016000000000000001
       region: "*"
 features:
     - function_calling
@@ -10,8 +10,8 @@ limits:
     context_window: 262144
     max_input_tokens: 262144
     max_output_tokens: 65536
-    max_tokens: 65536
-mode: chat
+    max_tokens: 262144
+mode: unknown
 model: Qwen/Qwen3-Coder-480B-A35B-Instruct
 sources:
     - https://huggingface.co/Qwen/Qwen3-Coder-480B-A35B-Instruct

--- a/providers/deepinfra/Qwen/Qwen3-Embedding-0.6B-batch.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Embedding-0.6B-batch.yaml
@@ -4,7 +4,7 @@ costs:
 limits:
     context_window: 32768
     max_input_tokens: 8192
-mode: embedding
+mode: unknown
 model: Qwen/Qwen3-Embedding-0.6B-batch
 sources:
     - https://deepinfra.com/Qwen/Qwen3-Embedding-0.6B-batch/api

--- a/providers/deepinfra/Qwen/Qwen3-Embedding-0.6B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Embedding-0.6B.yaml
@@ -6,7 +6,7 @@ limits:
 modalities:
     input:
         - image
-mode: embedding
+mode: unknown
 model: Qwen/Qwen3-Embedding-0.6B
 sources:
     - https://deepinfra.com/Qwen/Qwen3-Embedding-0.6B/api

--- a/providers/deepinfra/Qwen/Qwen3-Embedding-4B-batch.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Embedding-4B-batch.yaml
@@ -6,7 +6,7 @@ limits:
 modalities:
     input:
         - image
-mode: embedding
+mode: unknown
 model: Qwen/Qwen3-Embedding-4B-batch
 sources:
     - https://deepinfra.com/Qwen/Qwen3-Embedding-4B-batch/api

--- a/providers/deepinfra/Qwen/Qwen3-Embedding-4B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Embedding-4B.yaml
@@ -6,7 +6,7 @@ limits:
 modalities:
     input:
         - image
-mode: embedding
+mode: unknown
 model: Qwen/Qwen3-Embedding-4B
 sources:
     - https://deepinfra.com/Qwen/Qwen3-Embedding-4B/api

--- a/providers/deepinfra/Qwen/Qwen3-Embedding-8B-batch.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Embedding-8B-batch.yaml
@@ -7,7 +7,7 @@ limits:
 modalities:
     input:
         - image
-mode: embedding
+mode: unknown
 model: Qwen/Qwen3-Embedding-8B-batch
 sources:
     - https://deepinfra.com/Qwen/Qwen3-Embedding-8B-batch/api

--- a/providers/deepinfra/Qwen/Qwen3-Embedding-8B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Embedding-8B.yaml
@@ -6,7 +6,7 @@ limits:
 modalities:
     input:
         - image
-mode: embedding
+mode: unknown
 model: Qwen/Qwen3-Embedding-8B
 sources:
     - https://deepinfra.com/Qwen/Qwen3-Embedding-8B/api

--- a/providers/deepinfra/Qwen/Qwen3-Max-Thinking.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Max-Thinking.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_read_input_token_cost: 2.4e-7
       input_cost_per_token: 0.0000012
-      output_cost_per_token: 0.000006
+      output_cost_per_token: 0.000005999999999999999
       region: "*"
       tiered_pricing:
           cache_read:
@@ -20,16 +20,12 @@ costs:
               - cost_per_token: 0.000015
                 from: 128000
 features:
-    - function_calling
-    - system_messages
-    - tool_choice
     - prompt_caching
-    - structured_output
 limits:
     context_window: 256000
     max_output_tokens: 16384
-    max_tokens: 16384
-mode: chat
+    max_tokens: 256000
+mode: unknown
 model: Qwen/Qwen3-Max-Thinking
 sources:
     - https://deepinfra.com/Qwen/Qwen3-Max-Thinking

--- a/providers/deepinfra/Qwen/Qwen3-Max.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Max.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_read_input_token_cost: 2.4e-7
       input_cost_per_token: 0.0000012
-      output_cost_per_token: 0.000006
+      output_cost_per_token: 0.000005999999999999999
       region: "*"
       tiered_pricing:
           cache_read:
@@ -18,18 +18,15 @@ costs:
               - cost_per_token: 0.000015
                 from: 128000
 features:
-    - function_calling
-    - tool_choice
-    - system_messages
     - prompt_caching
-    - tools
 limits:
-    context_window: 262144
+    context_window: 256000
     max_input_tokens: 258048
     max_output_tokens: 32768
-    max_tokens: 32768
-mode: chat
+    max_tokens: 256000
+mode: unknown
 model: Qwen/Qwen3-Max
 sources:
     - https://www.alibabacloud.com/help/en/model-studio/models
     - https://openrouter.ai/qwen/qwen3-max/api
+thinking: true

--- a/providers/deepinfra/Qwen/Qwen3-Next-80B-A3B-Instruct.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Next-80B-A3B-Instruct.yaml
@@ -6,12 +6,13 @@ features:
     - function_calling
     - tool_choice
 limits:
-    context_window: 262144
+    context_window: 131072
     max_input_tokens: 262144
     max_output_tokens: 262144
-    max_tokens: 262144
-mode: chat
+    max_tokens: 131072
+mode: unknown
 model: Qwen/Qwen3-Next-80B-A3B-Instruct
 sources:
     - https://deepinfra.com/Qwen/Qwen3-Next-80B-A3B-Instruct
     - https://huggingface.co/Qwen/Qwen3-Next-80B-A3B-Instruct
+thinking: true

--- a/providers/deepinfra/Qwen/Qwen3-VL-235B-A22B-Instruct.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-VL-235B-A22B-Instruct.yaml
@@ -1,12 +1,10 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 8.8e-7
+    - cache_read_input_token_cost: 1.1000000000000002e-7
+      input_cost_per_token: 2.0000000000000002e-7
+      output_cost_per_token: 8.799999999999999e-7
       region: "*"
 features:
-    - function_calling
-    - system_messages
-    - tool_choice
-    - structured_output
+    - prompt_caching
 limits:
     context_window: 262144
     max_input_tokens: 262144
@@ -15,9 +13,10 @@ limits:
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: Qwen/Qwen3-VL-235B-A22B-Instruct
 sources:
     - https://deepinfra.com/Qwen/Qwen3-VL-235B-A22B-Instruct/api
     - https://openrouter.ai/qwen/qwen3-vl-235b-a22b-instruct/api
     - https://github.com/QwenLM/Qwen3-VL
+thinking: true

--- a/providers/deepinfra/Qwen/Qwen3-VL-30B-A3B-Instruct.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-VL-30B-A3B-Instruct.yaml
@@ -10,13 +10,14 @@ features:
 limits:
     context_window: 262144
     max_output_tokens: 16384
-    max_tokens: 16384
+    max_tokens: 262144
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: Qwen/Qwen3-VL-30B-A3B-Instruct
 sources:
     - https://deepinfra.com/Qwen/Qwen3-VL-30B-A3B-Instruct/api
     - https://deepinfra.com/docs/advanced/max_tokens_limit
     - https://huggingface.co/Qwen/Qwen3-VL-30B-A3B-Instruct
+thinking: true

--- a/providers/deepinfra/Sao10K/L3-8B-Lunaris-v1-Turbo.yaml
+++ b/providers/deepinfra/Sao10K/L3-8B-Lunaris-v1-Turbo.yaml
@@ -1,13 +1,13 @@
 costs:
     - input_cost_per_token: 4.e-8
-      output_cost_per_token: 5.e-8
+      output_cost_per_token: 5.0000000000000004e-8
       region: "*"
 limits:
     context_window: 8192
     max_input_tokens: 8192
     max_output_tokens: 8192
     max_tokens: 8192
-mode: chat
+mode: unknown
 model: Sao10K/L3-8B-Lunaris-v1-Turbo
 sources:
     - https://deepinfra.com/Sao10K/L3-8B-Lunaris-v1-Turbo

--- a/providers/deepinfra/Sao10K/L3.1-70B-Euryale-v2.2.yaml
+++ b/providers/deepinfra/Sao10K/L3.1-70B-Euryale-v2.2.yaml
@@ -7,7 +7,8 @@ features:
     - prompt_caching
 limits:
     context_window: 131072
-mode: chat
+    max_tokens: 131072
+mode: unknown
 model: Sao10K/L3.1-70B-Euryale-v2.2
 sources:
     - https://deepinfra.com/Sao10K/L3.1-70B-Euryale-v2.2

--- a/providers/deepinfra/Sao10K/L3.3-70B-Euryale-v2.3.yaml
+++ b/providers/deepinfra/Sao10K/L3.3-70B-Euryale-v2.3.yaml
@@ -7,7 +7,7 @@ limits:
     max_input_tokens: 131072
     max_output_tokens: 131072
     max_tokens: 131072
-mode: chat
+mode: unknown
 model: Sao10K/L3.3-70B-Euryale-v2.3
 sources:
     - https://deepinfra.com/Sao10K/L3.3-70B-Euryale-v2.3

--- a/providers/deepinfra/Wan-AI/Wan2.6-Image-Edit.yaml
+++ b/providers/deepinfra/Wan-AI/Wan2.6-Image-Edit.yaml
@@ -4,7 +4,7 @@ costs:
 modalities:
     input:
         - image
-mode: image
+mode: unknown
 model: Wan-AI/Wan2.6-Image-Edit
 sources:
     - https://deepinfra.com/Wan-AI/Wan2.6-Image-Edit/api

--- a/providers/deepinfra/Wan-AI/Wan2.6-T2I.yaml
+++ b/providers/deepinfra/Wan-AI/Wan2.6-T2I.yaml
@@ -4,7 +4,7 @@ costs:
 modalities:
     input:
         - image
-mode: image
+mode: unknown
 model: Wan-AI/Wan2.6-T2I
 sources:
     - https://deepinfra.com/Wan-AI/Wan2.6-T2I/api

--- a/providers/deepinfra/allenai/Olmo-3.1-32B-Instruct.yaml
+++ b/providers/deepinfra/allenai/Olmo-3.1-32B-Instruct.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 2.e-7
+    - input_cost_per_token: 2.0000000000000002e-7
       output_cost_per_token: 6.e-7
       region: "*"
 limits:
@@ -7,7 +7,7 @@ limits:
     max_input_tokens: 65536
     max_output_tokens: 65536
     max_tokens: 65536
-mode: chat
+mode: unknown
 model: allenai/Olmo-3.1-32B-Instruct
 sources:
     - https://deepinfra.com/allenai/Olmo-3.1-32B-Instruct

--- a/providers/deepinfra/allenai/olmOCR-2-7B-1025.yaml
+++ b/providers/deepinfra/allenai/olmOCR-2-7B-1025.yaml
@@ -3,11 +3,12 @@ costs:
       output_cost_per_token: 1.9e-7
       region: "*"
 limits:
-    context_window: 16000
+    context_window: 16384
+    max_tokens: 16384
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: allenai/olmOCR-2-7B-1025
 sources:
     - https://deepinfra.com/allenai/olmOCR-2-7B-1025/api

--- a/providers/deepinfra/anthropic/claude-3-7-sonnet-latest.yaml
+++ b/providers/deepinfra/anthropic/claude-3-7-sonnet-latest.yaml
@@ -1,20 +1,17 @@
 costs:
-    - cache_read_input_token_cost: 3.3e-7
+    - cache_read_input_token_cost: 3.3000000000000007e-7
       input_cost_per_token: 0.0000033
       output_cost_per_token: 0.0000165
       region: "*"
 features:
-    - function_calling
-    - tool_choice
-    - system_messages
-    - structured_output
     - prompt_caching
 limits:
     context_window: 200000
+    max_tokens: 200000
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: anthropic/claude-3-7-sonnet-latest
 sources:
     - https://deepinfra.com/anthropic/claude-3-7-sonnet-latest/api

--- a/providers/deepinfra/anthropic/claude-4-opus.yaml
+++ b/providers/deepinfra/anthropic/claude-4-opus.yaml
@@ -11,11 +11,11 @@ limits:
     context_window: 200000
     max_input_tokens: 200000
     max_output_tokens: 32000
-    max_tokens: 32000
+    max_tokens: 200000
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: anthropic/claude-4-opus
 sources:
     - https://deepinfra.com/anthropic/claude-4-opus/api

--- a/providers/deepinfra/anthropic/claude-4-sonnet.yaml
+++ b/providers/deepinfra/anthropic/claude-4-sonnet.yaml
@@ -11,11 +11,11 @@ limits:
     context_window: 200000
     max_input_tokens: 200000
     max_output_tokens: 64000
-    max_tokens: 64000
+    max_tokens: 200000
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: anthropic/claude-4-sonnet
 sources:
     - https://deepinfra.com/anthropic/claude-4-sonnet

--- a/providers/deepinfra/black-forest-labs/FLUX-1-Redux-dev.yaml
+++ b/providers/deepinfra/black-forest-labs/FLUX-1-Redux-dev.yaml
@@ -4,7 +4,7 @@ costs:
 modalities:
     input:
         - image
-mode: image
+mode: unknown
 model: black-forest-labs/FLUX-1-Redux-dev
 sources:
     - https://deepinfra.com/black-forest-labs/FLUX-1-Redux-dev/api

--- a/providers/deepinfra/black-forest-labs/FLUX-1-dev.yaml
+++ b/providers/deepinfra/black-forest-labs/FLUX-1-dev.yaml
@@ -4,7 +4,7 @@ costs:
 modalities:
     input:
         - image
-mode: image
+mode: unknown
 model: black-forest-labs/FLUX-1-dev
 sources:
     - https://api.deepinfra.com/models/black-forest-labs/FLUX-1-dev

--- a/providers/deepinfra/black-forest-labs/FLUX-1-schnell.yaml
+++ b/providers/deepinfra/black-forest-labs/FLUX-1-schnell.yaml
@@ -4,7 +4,7 @@ costs:
 modalities:
     input:
         - image
-mode: image
+mode: unknown
 model: black-forest-labs/FLUX-1-schnell
 sources:
     - https://deepinfra.com/black-forest-labs/FLUX-1-schnell/api

--- a/providers/deepinfra/black-forest-labs/FLUX-1.1-pro.yaml
+++ b/providers/deepinfra/black-forest-labs/FLUX-1.1-pro.yaml
@@ -4,7 +4,7 @@ costs:
 modalities:
     input:
         - image
-mode: image
+mode: unknown
 model: black-forest-labs/FLUX-1.1-pro
 sources:
     - https://deepinfra.com/black-forest-labs/FLUX-1.1-pro/api

--- a/providers/deepinfra/black-forest-labs/FLUX-2-dev.yaml
+++ b/providers/deepinfra/black-forest-labs/FLUX-2-dev.yaml
@@ -4,7 +4,7 @@ costs:
 modalities:
     input:
         - image
-mode: image
+mode: unknown
 model: black-forest-labs/FLUX-2-dev
 sources:
     - https://deepinfra.com/black-forest-labs/FLUX-2-dev/api

--- a/providers/deepinfra/black-forest-labs/FLUX-2-klein-4b.yaml
+++ b/providers/deepinfra/black-forest-labs/FLUX-2-klein-4b.yaml
@@ -4,7 +4,7 @@ costs:
 modalities:
     input:
         - image
-mode: image
+mode: unknown
 model: black-forest-labs/FLUX-2-klein-4b
 sources:
     - https://deepinfra.com/black-forest-labs/FLUX-2-klein-4b/api

--- a/providers/deepinfra/black-forest-labs/FLUX-2-klein-9b.yaml
+++ b/providers/deepinfra/black-forest-labs/FLUX-2-klein-9b.yaml
@@ -4,7 +4,7 @@ costs:
 modalities:
     input:
         - image
-mode: image
+mode: unknown
 model: black-forest-labs/FLUX-2-klein-9b
 sources:
     - https://deepinfra.com/black-forest-labs/FLUX-2-klein-9b/api

--- a/providers/deepinfra/black-forest-labs/FLUX-2-max.yaml
+++ b/providers/deepinfra/black-forest-labs/FLUX-2-max.yaml
@@ -5,7 +5,7 @@ costs:
 modalities:
     input:
         - image
-mode: image
+mode: unknown
 model: black-forest-labs/FLUX-2-max
 sources:
     - https://deepinfra.com/black-forest-labs/FLUX-2-max/api

--- a/providers/deepinfra/black-forest-labs/FLUX-2-pro.yaml
+++ b/providers/deepinfra/black-forest-labs/FLUX-2-pro.yaml
@@ -4,7 +4,7 @@ costs:
 modalities:
     input:
         - image
-mode: image
+mode: unknown
 model: black-forest-labs/FLUX-2-pro
 sources:
     - https://api.deepinfra.com/models/black-forest-labs/FLUX-2-pro

--- a/providers/deepinfra/black-forest-labs/FLUX-pro.yaml
+++ b/providers/deepinfra/black-forest-labs/FLUX-pro.yaml
@@ -4,7 +4,7 @@ costs:
 modalities:
     input:
         - image
-mode: image
+mode: unknown
 model: black-forest-labs/FLUX-pro
 sources:
     - https://deepinfra.com/black-forest-labs/FLUX-pro/api

--- a/providers/deepinfra/black-forest-labs/FLUX.1-Kontext-dev.yaml
+++ b/providers/deepinfra/black-forest-labs/FLUX.1-Kontext-dev.yaml
@@ -4,7 +4,7 @@ costs:
 modalities:
     input:
         - image
-mode: image
+mode: unknown
 model: black-forest-labs/FLUX.1-Kontext-dev
 sources:
     - https://deepinfra.com/black-forest-labs/FLUX.1-Kontext-dev/api

--- a/providers/deepinfra/deepseek-ai/DeepSeek-OCR.yaml
+++ b/providers/deepinfra/deepseek-ai/DeepSeek-OCR.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 3.e-8
-      output_cost_per_token: 1.e-7
+    - input_cost_per_token: 3.0000000000000004e-8
+      output_cost_per_token: 1.0000000000000001e-7
       region: "*"
 limits:
     context_window: 8192
@@ -10,8 +10,7 @@ limits:
 modalities:
     input:
         - image
-        - pdf
-mode: chat
+mode: unknown
 model: deepseek-ai/DeepSeek-OCR
 sources:
     - https://deepinfra.com/deepseek-ai/DeepSeek-OCR

--- a/providers/deepinfra/deepseek-ai/DeepSeek-R1-0528-Turbo.yaml
+++ b/providers/deepinfra/deepseek-ai/DeepSeek-R1-0528-Turbo.yaml
@@ -1,15 +1,16 @@
 costs:
     - input_cost_per_token: 0.000001
-      output_cost_per_token: 0.000003
+      output_cost_per_token: 0.0000029999999999999997
       region: "*"
 features:
     - function_calling
     - tool_choice
     - structured_output
 limits:
+    context_window: 32768
     max_output_tokens: 32768
     max_tokens: 32768
-mode: chat
+mode: unknown
 model: deepseek-ai/DeepSeek-R1-0528-Turbo
 sources:
     - https://deepinfra.com/deepseek-ai/DeepSeek-R1-0528-Turbo/api

--- a/providers/deepinfra/deepseek-ai/DeepSeek-R1-0528.yaml
+++ b/providers/deepinfra/deepseek-ai/DeepSeek-R1-0528.yaml
@@ -1,18 +1,16 @@
 costs:
     - cache_read_input_token_cost: 3.5e-7
       input_cost_per_token: 5.e-7
-      output_cost_per_token: 0.00000215
+      output_cost_per_token: 0.0000021499999999999997
       region: "*"
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
+    - prompt_caching
 limits:
     context_window: 163840
     max_input_tokens: 163840
     max_output_tokens: 32768
-    max_tokens: 32768
-mode: chat
+    max_tokens: 163840
+mode: unknown
 model: deepseek-ai/DeepSeek-R1-0528
 sources:
     - https://deepinfra.com/deepseek-ai/DeepSeek-R1-0528/api

--- a/providers/deepinfra/deepseek-ai/DeepSeek-R1-Distill-Llama-70B.yaml
+++ b/providers/deepinfra/deepseek-ai/DeepSeek-R1-Distill-Llama-70B.yaml
@@ -1,13 +1,13 @@
 costs:
     - input_cost_per_token: 7.e-7
-      output_cost_per_token: 8.e-7
+      output_cost_per_token: 8.000000000000001e-7
       region: "*"
 limits:
     context_window: 131072
     max_input_tokens: 131072
     max_output_tokens: 131072
     max_tokens: 131072
-mode: chat
+mode: unknown
 model: deepseek-ai/DeepSeek-R1-Distill-Llama-70B
 sources:
     - https://deepinfra.com/deepseek-ai/DeepSeek-R1-Distill-Llama-70B/api

--- a/providers/deepinfra/deepseek-ai/DeepSeek-V3-0324.yaml
+++ b/providers/deepinfra/deepseek-ai/DeepSeek-V3-0324.yaml
@@ -1,17 +1,15 @@
 costs:
     - cache_read_input_token_cost: 1.35e-7
-      input_cost_per_token: 2.e-7
+      input_cost_per_token: 2.0000000000000002e-7
       output_cost_per_token: 7.7e-7
       region: "*"
 features:
-    - function_calling
-    - tool_choice
     - prompt_caching
-    - structured_output
 limits:
     context_window: 163840
     max_input_tokens: 163840
-mode: chat
+    max_tokens: 163840
+mode: unknown
 model: deepseek-ai/DeepSeek-V3-0324
 sources:
     - https://deepinfra.com/deepseek-ai/DeepSeek-V3-0324/api

--- a/providers/deepinfra/deepseek-ai/DeepSeek-V3.1-Terminus.yaml
+++ b/providers/deepinfra/deepseek-ai/DeepSeek-V3.1-Terminus.yaml
@@ -1,17 +1,16 @@
 costs:
-    - cache_read_input_token_cost: 1.3e-7
+    - cache_read_input_token_cost: 1.300000002e-7
       input_cost_per_token: 2.1e-7
       output_cost_per_token: 7.9e-7
       region: "*"
 features:
-    - function_calling
-    - tool_choice
+    - prompt_caching
 limits:
     context_window: 163840
     max_input_tokens: 163840
     max_output_tokens: 163840
     max_tokens: 163840
-mode: chat
+mode: unknown
 model: deepseek-ai/DeepSeek-V3.1-Terminus
 sources:
     - https://deepinfra.com/deepseek-ai/DeepSeek-V3.1-Terminus/api

--- a/providers/deepinfra/deepseek-ai/DeepSeek-V3.1.yaml
+++ b/providers/deepinfra/deepseek-ai/DeepSeek-V3.1.yaml
@@ -1,20 +1,16 @@
 costs:
-    - cache_read_input_token_cost: 1.3e-7
+    - cache_read_input_token_cost: 1.300000002e-7
       input_cost_per_token: 2.1e-7
       output_cost_per_token: 7.9e-7
       region: "*"
 features:
-    - function_calling
-    - tool_choice
     - prompt_caching
-    - structured_output
-    - system_messages
 limits:
     context_window: 163840
     max_input_tokens: 163840
     max_output_tokens: 32768
-    max_tokens: 32768
-mode: chat
+    max_tokens: 163840
+mode: unknown
 model: deepseek-ai/DeepSeek-V3.1
 sources:
     - https://deepinfra.com/deepseek-ai/DeepSeek-V3.1/api

--- a/providers/deepinfra/deepseek-ai/DeepSeek-V3.2.yaml
+++ b/providers/deepinfra/deepseek-ai/DeepSeek-V3.2.yaml
@@ -4,17 +4,13 @@ costs:
       output_cost_per_token: 3.8e-7
       region: "*"
 features:
-    - function_calling
-    - system_messages
-    - tool_choice
     - prompt_caching
-    - structured_output
 limits:
     context_window: 163840
     max_input_tokens: 163840
     max_output_tokens: 16384
-    max_tokens: 16384
-mode: chat
+    max_tokens: 163840
+mode: unknown
 model: deepseek-ai/DeepSeek-V3.2
 sources:
     - https://deepinfra.com/deepseek-ai/DeepSeek-V3.2/api

--- a/providers/deepinfra/deepseek-ai/DeepSeek-V3.yaml
+++ b/providers/deepinfra/deepseek-ai/DeepSeek-V3.yaml
@@ -11,8 +11,8 @@ limits:
     context_window: 163840
     max_input_tokens: 163840
     max_output_tokens: 16384
-    max_tokens: 16384
-mode: chat
+    max_tokens: 163840
+mode: unknown
 model: deepseek-ai/DeepSeek-V3
 sources:
     - https://deepinfra.com/deepseek-ai/DeepSeek-V3/api

--- a/providers/deepinfra/deepseek-ai/Janus-Pro-1B.yaml
+++ b/providers/deepinfra/deepseek-ai/Janus-Pro-1B.yaml
@@ -6,7 +6,7 @@ limits:
 modalities:
     input:
         - image
-mode: image
+mode: unknown
 model: deepseek-ai/Janus-Pro-1B
 sources:
     - https://deepinfra.com/deepseek-ai/Janus-Pro-1B/api

--- a/providers/deepinfra/deepseek-ai/Janus-Pro-7B.yaml
+++ b/providers/deepinfra/deepseek-ai/Janus-Pro-7B.yaml
@@ -6,8 +6,8 @@ limits:
 modalities:
     input:
         - image
-mode: image
-model: ddeepseek-ai/Janus-Pro-7B
+mode: unknown
+model: deepseek-ai/Janus-Pro-7B
 sources:
     - https://deepinfra.com/deepseek-ai/Janus-Pro-7B/api
     - https://huggingface.co/deepseek-ai/Janus-Pro-7B

--- a/providers/deepinfra/google/embeddinggemma-300m.yaml
+++ b/providers/deepinfra/google/embeddinggemma-300m.yaml
@@ -3,7 +3,7 @@ costs:
       region: "*"
 limits:
     max_input_tokens: 2048
-mode: embedding
+mode: unknown
 model: google/embeddinggemma-300m
 sources:
     - https://deepinfra.com/google/embeddinggemma-300m/api

--- a/providers/deepinfra/google/gemini-1.5-flash-8b.yaml
+++ b/providers/deepinfra/google/gemini-1.5-flash-8b.yaml
@@ -1,3 +1,14 @@
+costs:
+    - input_cost_per_token: 3.75e-8
+      output_cost_per_token: 1.5e-7
+      region: "*"
 isDeprecated: true
+limits:
+    context_window: 1000000
+    max_tokens: 1000000
+modalities:
+    input:
+        - image
 mode: unknown
 model: google/gemini-1.5-flash-8b
+thinking: true

--- a/providers/deepinfra/google/gemini-1.5-flash.yaml
+++ b/providers/deepinfra/google/gemini-1.5-flash.yaml
@@ -1,3 +1,14 @@
+costs:
+    - input_cost_per_token: 7.5e-8
+      output_cost_per_token: 3.e-7
+      region: "*"
 isDeprecated: true
+limits:
+    context_window: 1000000
+    max_tokens: 1000000
+modalities:
+    input:
+        - image
 mode: unknown
 model: google/gemini-1.5-flash
+thinking: true

--- a/providers/deepinfra/google/gemini-2.5-flash.yaml
+++ b/providers/deepinfra/google/gemini-2.5-flash.yaml
@@ -13,9 +13,8 @@ limits:
     max_tokens: 1000000
 modalities:
     input:
-        - audio
         - image
-mode: chat
+mode: unknown
 model: google/gemini-2.5-flash
 sources:
     - https://deepinfra.com/google/gemini-2.5-flash

--- a/providers/deepinfra/google/gemini-2.5-pro.yaml
+++ b/providers/deepinfra/google/gemini-2.5-pro.yaml
@@ -11,16 +11,14 @@ features:
     - tool_choice
     - structured_output
 limits:
-    context_window: 1048576
+    context_window: 1000000
     max_input_tokens: 1048576
     max_output_tokens: 65536
-    max_tokens: 65536
+    max_tokens: 1000000
 modalities:
     input:
-        - audio
         - image
-        - pdf
-mode: chat
+mode: unknown
 model: google/gemini-2.5-pro
 sources:
     - https://deepinfra.com/google/gemini-2.5-pro/api

--- a/providers/deepinfra/google/gemma-3-12b-it.yaml
+++ b/providers/deepinfra/google/gemma-3-12b-it.yaml
@@ -11,11 +11,11 @@ limits:
     context_window: 131072
     max_input_tokens: 131072
     max_output_tokens: 16384
-    max_tokens: 16384
+    max_tokens: 131072
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: google/gemma-3-12b-it
 sources:
     - https://deepinfra.com/google/gemma-3-12b-it/api

--- a/providers/deepinfra/google/gemma-3-27b-it.yaml
+++ b/providers/deepinfra/google/gemma-3-27b-it.yaml
@@ -13,7 +13,7 @@ limits:
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: google/gemma-3-27b-it
 sources:
     - https://deepinfra.com/google/gemma-3-27b-it/api

--- a/providers/deepinfra/google/gemma-3-4b-it.yaml
+++ b/providers/deepinfra/google/gemma-3-4b-it.yaml
@@ -10,11 +10,11 @@ limits:
     context_window: 131072
     max_input_tokens: 131072
     max_output_tokens: 16384
-    max_tokens: 16384
+    max_tokens: 131072
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: google/gemma-3-4b-it
 sources:
     - https://deepinfra.com/google/gemma-3-4b-it/api

--- a/providers/deepinfra/intfloat/e5-base-v2.yaml
+++ b/providers/deepinfra/intfloat/e5-base-v2.yaml
@@ -7,7 +7,7 @@ limits:
 modalities:
     input:
         - image
-mode: embedding
+mode: unknown
 model: intfloat/e5-base-v2
 sources:
     - https://deepinfra.com/intfloat/e5-base-v2/api

--- a/providers/deepinfra/intfloat/e5-large-v2.yaml
+++ b/providers/deepinfra/intfloat/e5-large-v2.yaml
@@ -4,7 +4,7 @@ costs:
 limits:
     max_input_tokens: 512
     max_tokens: 512
-mode: embedding
+mode: unknown
 model: intfloat/e5-large-v2
 sources:
     - https://deepinfra.com/intfloat/e5-large-v2/api

--- a/providers/deepinfra/intfloat/multilingual-e5-large-instruct.yaml
+++ b/providers/deepinfra/intfloat/multilingual-e5-large-instruct.yaml
@@ -6,7 +6,7 @@ limits:
 modalities:
     input:
         - image
-mode: embedding
+mode: unknown
 model: intfloat/multilingual-e5-large-instruct
 sources:
     - https://deepinfra.com/intfloat/multilingual-e5-large-instruct/api

--- a/providers/deepinfra/intfloat/multilingual-e5-large.yaml
+++ b/providers/deepinfra/intfloat/multilingual-e5-large.yaml
@@ -4,7 +4,7 @@ costs:
 limits:
     max_input_tokens: 512
     max_tokens: 512
-mode: embedding
+mode: unknown
 model: intfloat/multilingual-e5-large
 sources:
     - https://deepinfra.com/intfloat/multilingual-e5-large/api

--- a/providers/deepinfra/meta-llama/Llama-3.2-11B-Vision-Instruct.yaml
+++ b/providers/deepinfra/meta-llama/Llama-3.2-11B-Vision-Instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 4.9e-8
-      output_cost_per_token: 4.9e-8
+    - input_cost_per_token: 4.8999999999999995e-8
+      output_cost_per_token: 4.8999999999999995e-8
       region: "*"
 limits:
     context_window: 131072
@@ -10,7 +10,7 @@ limits:
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: meta-llama/Llama-3.2-11B-Vision-Instruct
 sources:
     - https://deepinfra.com/meta-llama/Llama-3.2-11B-Vision-Instruct/api

--- a/providers/deepinfra/meta-llama/Llama-3.3-70B-Instruct-Turbo.yaml
+++ b/providers/deepinfra/meta-llama/Llama-3.3-70B-Instruct-Turbo.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 1.e-7
+    - input_cost_per_token: 1.0000000000000001e-7
       output_cost_per_token: 3.2e-7
       region: "*"
 features:
@@ -9,8 +9,8 @@ limits:
     context_window: 131072
     max_input_tokens: 131072
     max_output_tokens: 16384
-    max_tokens: 16384
-mode: chat
+    max_tokens: 131072
+mode: unknown
 model: meta-llama/Llama-3.3-70B-Instruct-Turbo
 sources:
     - https://deepinfra.com/meta-llama/Llama-3.3-70B-Instruct-Turbo/api

--- a/providers/deepinfra/meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8.yaml
+++ b/providers/deepinfra/meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8.yaml
@@ -8,11 +8,11 @@ features:
 limits:
     context_window: 1048576
     max_output_tokens: 16384
-    max_tokens: 16384
+    max_tokens: 1048576
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8
 sources:
     - https://deepinfra.com/meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8/api

--- a/providers/deepinfra/meta-llama/Llama-4-Scout-17B-16E-Instruct.yaml
+++ b/providers/deepinfra/meta-llama/Llama-4-Scout-17B-16E-Instruct.yaml
@@ -14,7 +14,7 @@ limits:
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: meta-llama/Llama-4-Scout-17B-16E-Instruct
 sources:
     - https://deepinfra.com/meta-llama/Llama-4-Scout-17B-16E-Instruct/api

--- a/providers/deepinfra/meta-llama/Llama-Guard-4-12B.yaml
+++ b/providers/deepinfra/meta-llama/Llama-Guard-4-12B.yaml
@@ -10,7 +10,7 @@ limits:
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: meta-llama/Llama-Guard-4-12B
 sources:
     - https://deepinfra.com/meta-llama/Llama-Guard-4-12B/api

--- a/providers/deepinfra/meta-llama/Meta-Llama-3-8B-Instruct.yaml
+++ b/providers/deepinfra/meta-llama/Meta-Llama-3-8B-Instruct.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 3.e-8
+    - input_cost_per_token: 3.0000000000000004e-8
       output_cost_per_token: 4.e-8
       region: "*"
 features:
@@ -10,7 +10,7 @@ limits:
     max_input_tokens: 8192
     max_output_tokens: 8192
     max_tokens: 8192
-mode: chat
+mode: unknown
 model: meta-llama/Meta-Llama-3-8B-Instruct
 sources:
     - https://deepinfra.com/meta-llama/Meta-Llama-3-8B-Instruct

--- a/providers/deepinfra/meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo.yaml
+++ b/providers/deepinfra/meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 4.e-7
-      output_cost_per_token: 4.e-7
+    - input_cost_per_token: 4.0000000000000003e-7
+      output_cost_per_token: 4.0000000000000003e-7
       region: "*"
 features:
     - function_calling
@@ -10,8 +10,8 @@ limits:
     context_window: 131072
     max_input_tokens: 131072
     max_output_tokens: 16384
-    max_tokens: 16384
-mode: chat
+    max_tokens: 131072
+mode: unknown
 model: meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo
 sources:
     - https://deepinfra.com/meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo/api

--- a/providers/deepinfra/meta-llama/Meta-Llama-3.1-70B-Instruct.yaml
+++ b/providers/deepinfra/meta-llama/Meta-Llama-3.1-70B-Instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 4.e-7
-      output_cost_per_token: 4.e-7
+    - input_cost_per_token: 4.0000000000000003e-7
+      output_cost_per_token: 4.0000000000000003e-7
       region: "*"
 features:
     - function_calling
@@ -9,8 +9,8 @@ limits:
     context_window: 131072
     max_input_tokens: 131072
     max_output_tokens: 16384
-    max_tokens: 16384
-mode: chat
+    max_tokens: 131072
+mode: unknown
 model: meta-llama/Meta-Llama-3.1-70B-Instruct
 sources:
     - https://deepinfra.com/meta-llama/Meta-Llama-3.1-70B-Instruct/api

--- a/providers/deepinfra/meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo.yaml
+++ b/providers/deepinfra/meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 2.e-8
-      output_cost_per_token: 3.e-8
+      output_cost_per_token: 3.0000000000000004e-8
       region: "*"
 features:
     - function_calling
@@ -9,8 +9,8 @@ limits:
     context_window: 131072
     max_input_tokens: 131072
     max_output_tokens: 16384
-    max_tokens: 16384
-mode: chat
+    max_tokens: 131072
+mode: unknown
 model: meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo
 sources:
     - https://deepinfra.com/meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo/api

--- a/providers/deepinfra/meta-llama/Meta-Llama-3.1-8B-Instruct.yaml
+++ b/providers/deepinfra/meta-llama/Meta-Llama-3.1-8B-Instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 3.e-8
-      output_cost_per_token: 5.e-8
+    - input_cost_per_token: 2.e-8
+      output_cost_per_token: 5.0000000000000004e-8
       region: "*"
 features:
     - function_calling
@@ -9,8 +9,8 @@ limits:
     context_window: 131072
     max_input_tokens: 131072
     max_output_tokens: 16384
-    max_tokens: 16384
-mode: chat
+    max_tokens: 131072
+mode: unknown
 model: meta-llama/Meta-Llama-3.1-8B-Instruct
 sources:
     - https://deepinfra.com/meta-llama/Meta-Llama-3.1-8B-Instruct/api

--- a/providers/deepinfra/microsoft/phi-4.yaml
+++ b/providers/deepinfra/microsoft/phi-4.yaml
@@ -9,7 +9,7 @@ limits:
     max_input_tokens: 16384
     max_output_tokens: 16384
     max_tokens: 16384
-mode: chat
+mode: unknown
 model: microsoft/phi-4
 sources:
     - https://deepinfra.com/microsoft/phi-4/api

--- a/providers/deepinfra/mistralai/Mistral-Nemo-Instruct-2407.yaml
+++ b/providers/deepinfra/mistralai/Mistral-Nemo-Instruct-2407.yaml
@@ -11,7 +11,7 @@ limits:
     max_input_tokens: 131072
     max_output_tokens: 131072
     max_tokens: 131072
-mode: chat
+mode: unknown
 model: mistralai/Mistral-Nemo-Instruct-2407
 sources:
     - https://deepinfra.com/mistralai/Mistral-Nemo-Instruct-2407/api

--- a/providers/deepinfra/mistralai/Mistral-Small-24B-Instruct-2501.yaml
+++ b/providers/deepinfra/mistralai/Mistral-Small-24B-Instruct-2501.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-8
+    - input_cost_per_token: 5.0000000000000004e-8
       output_cost_per_token: 8.e-8
       region: "*"
 features:
@@ -11,7 +11,7 @@ limits:
     max_input_tokens: 32768
     max_output_tokens: 32768
     max_tokens: 32768
-mode: chat
+mode: unknown
 model: mistralai/Mistral-Small-24B-Instruct-2501
 sources:
     - https://deepinfra.com/mistralai/Mistral-Small-24B-Instruct-2501

--- a/providers/deepinfra/mistralai/Mistral-Small-3.2-24B-Instruct-2506.yaml
+++ b/providers/deepinfra/mistralai/Mistral-Small-3.2-24B-Instruct-2506.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 7.5e-8
-      output_cost_per_token: 2.e-7
+      output_cost_per_token: 2.0000000000000002e-7
       region: "*"
 features:
     - function_calling
@@ -14,7 +14,7 @@ limits:
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: mistralai/Mistral-Small-3.2-24B-Instruct-2506
 sources:
     - https://docs.mistral.ai/models/mistral-small-3-2-25-06

--- a/providers/deepinfra/mistralai/Mixtral-8x7B-Instruct-v0.1.yaml
+++ b/providers/deepinfra/mistralai/Mixtral-8x7B-Instruct-v0.1.yaml
@@ -10,7 +10,7 @@ limits:
     max_input_tokens: 32768
     max_output_tokens: 32768
     max_tokens: 32768
-mode: chat
+mode: unknown
 model: mistralai/Mixtral-8x7B-Instruct-v0.1
 sources:
     - https://deepinfra.com/mistralai/Mixtral-8x7B-Instruct-v0.1/api

--- a/providers/deepinfra/moonshotai/Kimi-K2-Instruct-0905.yaml
+++ b/providers/deepinfra/moonshotai/Kimi-K2-Instruct-0905.yaml
@@ -1,20 +1,16 @@
 costs:
-    - cache_read_input_token_cost: 1.5e-7
-      input_cost_per_token: 4.e-7
+    - cache_read_input_token_cost: 1.5000000000000002e-7
+      input_cost_per_token: 4.0000000000000003e-7
       output_cost_per_token: 0.000002
       region: "*"
 features:
-    - function_calling
-    - tool_choice
     - prompt_caching
-    - system_messages
-    - structured_output
 limits:
-    context_window: 262144
+    context_window: 131072
     max_input_tokens: 262144
     max_output_tokens: 131072
     max_tokens: 131072
-mode: chat
+mode: unknown
 model: moonshotai/Kimi-K2-Instruct-0905
 sources:
     - https://deepinfra.com/moonshotai/Kimi-K2-Instruct-0905/api

--- a/providers/deepinfra/moonshotai/Kimi-K2-Thinking.yaml
+++ b/providers/deepinfra/moonshotai/Kimi-K2-Thinking.yaml
@@ -1,18 +1,16 @@
 costs:
-    - cache_read_input_token_cost: 1.41e-7
-      input_cost_per_token: 4.7e-7
+    - cache_read_input_token_cost: 1.4099999999999998e-7
+      input_cost_per_token: 4.6999999999999995e-7
       output_cost_per_token: 0.000002
       region: "*"
 features:
-    - function_calling
-    - structured_output
     - prompt_caching
 limits:
-    context_window: 262144
+    context_window: 131072
     max_input_tokens: 262144
     max_output_tokens: 131072
     max_tokens: 131072
-mode: chat
+mode: unknown
 model: moonshotai/Kimi-K2-Thinking
 sources:
     - https://deepinfra.com/moonshotai/Kimi-K2-Thinking

--- a/providers/deepinfra/moonshotai/Kimi-K2.5-Turbo.yaml
+++ b/providers/deepinfra/moonshotai/Kimi-K2.5-Turbo.yaml
@@ -1,22 +1,19 @@
 costs:
-    - input_cost_per_token: 5.e-7
-      output_cost_per_token: 0.0000028
+    - cache_read_input_token_cost: 1.0000000199999999e-7
+      input_cost_per_token: 6.e-7
+      output_cost_per_token: 0.0000029999999999999997
       region: "*"
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
-    - system_messages
     - prompt_caching
 limits:
     context_window: 262144
     max_input_tokens: 262144
     max_output_tokens: 65535
-    max_tokens: 65535
+    max_tokens: 262144
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: moonshotai/Kimi-K2.5-Turbo
 sources:
     - https://deepinfra.com/moonshotai/Kimi-K2.5/api

--- a/providers/deepinfra/moonshotai/Kimi-K2.5.yaml
+++ b/providers/deepinfra/moonshotai/Kimi-K2.5.yaml
@@ -1,22 +1,18 @@
 costs:
-    - cache_read_input_token_cost: 7.e-8
-      input_cost_per_token: 4.5e-7
+    - cache_read_input_token_cost: 7.000000200000001e-8
+      input_cost_per_token: 4.5000000000000003e-7
       output_cost_per_token: 0.00000225
       region: "*"
 features:
-    - function_calling
-    - tool_choice
-    - system_messages
-    - structured_output
     - prompt_caching
 limits:
     context_window: 262144
     max_output_tokens: 64000
-    max_tokens: 64000
+    max_tokens: 262144
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: moonshotai/Kimi-K2.5
 sources:
     - https://deepinfra.com/moonshotai/Kimi-K2.5/api

--- a/providers/deepinfra/nvidia/Llama-3.1-Nemotron-70B-Instruct.yaml
+++ b/providers/deepinfra/nvidia/Llama-3.1-Nemotron-70B-Instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 6.e-7
-      output_cost_per_token: 6.e-7
+    - input_cost_per_token: 0.0000012
+      output_cost_per_token: 0.0000012
       region: "*"
 features:
     - tool_choice
@@ -8,8 +8,8 @@ limits:
     context_window: 131072
     max_input_tokens: 131072
     max_output_tokens: 4096
-    max_tokens: 4096
-mode: chat
+    max_tokens: 131072
+mode: unknown
 model: nvidia/Llama-3.1-Nemotron-70B-Instruct
 sources:
     - https://deepinfra.com/nvidia/Llama-3.1-Nemotron-70B-Instruct/api

--- a/providers/deepinfra/nvidia/Llama-3.3-Nemotron-Super-49B-v1.5.yaml
+++ b/providers/deepinfra/nvidia/Llama-3.3-Nemotron-Super-49B-v1.5.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 4.e-7
+    - input_cost_per_token: 1.0000000000000001e-7
+      output_cost_per_token: 4.0000000000000003e-7
       region: "*"
 features:
     - function_calling
@@ -11,7 +11,7 @@ limits:
     max_input_tokens: 131072
     max_output_tokens: 131072
     max_tokens: 131072
-mode: chat
+mode: unknown
 model: nvidia/Llama-3.3-Nemotron-Super-49B-v1.5
 sources:
     - https://deepinfra.com/nvidia/Llama-3.3-Nemotron-Super-49B-v1.5

--- a/providers/deepinfra/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B.yaml
+++ b/providers/deepinfra/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B.yaml
@@ -1,18 +1,14 @@
 costs:
-    - cache_read_input_token_cost: 4.e-8
-      input_cost_per_token: 1.e-7
+    - cache_read_input_token_cost: 4.000000000000001e-8
+      input_cost_per_token: 1.0000000000000001e-7
       output_cost_per_token: 5.e-7
       region: "*"
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
-    - system_messages
     - prompt_caching
-    - tools
 limits:
     context_window: 262144
-mode: chat
+    max_tokens: 262144
+mode: unknown
 model: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B
 sources:
     - https://deepinfra.com/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B/api

--- a/providers/deepinfra/nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL.yaml
+++ b/providers/deepinfra/nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL.yaml
@@ -1,19 +1,19 @@
 costs:
-    - input_cost_per_token: 2.e-7
+    - input_cost_per_token: 2.0000000000000002e-7
       output_cost_per_token: 6.e-7
       region: "*"
 features:
     - function_calling
     - system_messages
 limits:
-    context_window: 128000
+    context_window: 131072
     max_input_tokens: 128000
     max_output_tokens: 8192
-    max_tokens: 8192
+    max_tokens: 131072
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL
 sources:
     - https://deepinfra.com/nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL

--- a/providers/deepinfra/nvidia/NVIDIA-Nemotron-Nano-9B-v2.yaml
+++ b/providers/deepinfra/nvidia/NVIDIA-Nemotron-Nano-9B-v2.yaml
@@ -10,7 +10,7 @@ limits:
     max_input_tokens: 131072
     max_output_tokens: 131072
     max_tokens: 131072
-mode: chat
+mode: unknown
 model: nvidia/NVIDIA-Nemotron-Nano-9B-v2
 sources:
     - https://deepinfra.com/nvidia/NVIDIA-Nemotron-Nano-9B-v2/api

--- a/providers/deepinfra/nvidia/Nemotron-3-Nano-30B-A3B.yaml
+++ b/providers/deepinfra/nvidia/Nemotron-3-Nano-30B-A3B.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 5.e-8
-      output_cost_per_token: 2.e-7
+    - input_cost_per_token: 5.0000000000000004e-8
+      output_cost_per_token: 2.0000000000000002e-7
       region: "*"
 features:
     - function_calling
@@ -10,7 +10,7 @@ limits:
     max_input_tokens: 262144
     max_output_tokens: 262144
     max_tokens: 262144
-mode: chat
+mode: unknown
 model: nvidia/Nemotron-3-Nano-30B-A3B
 sources:
     - https://deepinfra.com/nvidia/Nemotron-3-Nano-30B-A3B/api

--- a/providers/deepinfra/nvidia/llama-nemotron-embed-vl-1b-v2.yaml
+++ b/providers/deepinfra/nvidia/llama-nemotron-embed-vl-1b-v2.yaml
@@ -7,7 +7,7 @@ limits:
 modalities:
     input:
         - image
-mode: embedding
+mode: unknown
 model: nvidia/llama-nemotron-embed-vl-1b-v2
 sources:
     - https://deepinfra.com/nvidia/llama-nemotron-embed-vl-1b-v2/api

--- a/providers/deepinfra/openai/gpt-oss-120b-Turbo.yaml
+++ b/providers/deepinfra/openai/gpt-oss-120b-Turbo.yaml
@@ -3,11 +3,13 @@ costs:
       output_cost_per_token: 6.e-7
       region: "*"
 limits:
+    context_window: 131072
     max_input_tokens: 131072
     max_output_tokens: 131072
     max_tokens: 131072
-mode: chat
-model: openai/gpt-oss-20b
+mode: unknown
+model: openai/gpt-oss-120b-Turbo
 sources:
     - https://deepinfra.com/openai/gpt-oss-20b/api
     - https://deepinfra.com/openai/gpt-oss-20b
+thinking: true

--- a/providers/deepinfra/openai/gpt-oss-120b.yaml
+++ b/providers/deepinfra/openai/gpt-oss-120b.yaml
@@ -11,7 +11,7 @@ limits:
     max_input_tokens: 131072
     max_output_tokens: 131072
     max_tokens: 131072
-mode: chat
+mode: unknown
 model: openai/gpt-oss-120b
 sources:
     - https://developers.openai.com/api/docs/models/gpt-oss-120b

--- a/providers/deepinfra/openai/gpt-oss-20b.yaml
+++ b/providers/deepinfra/openai/gpt-oss-20b.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 3.e-8
+    - input_cost_per_token: 3.0000000000000004e-8
       output_cost_per_token: 1.4e-7
       region: "*"
 features:
@@ -11,7 +11,7 @@ limits:
     max_input_tokens: 131072
     max_output_tokens: 131072
     max_tokens: 131072
-mode: chat
+mode: unknown
 model: openai/gpt-oss-20b
 sources:
     - https://developers.openai.com/api/docs/models/gpt-oss-20b

--- a/providers/deepinfra/sentence-transformers/all-MiniLM-L12-v2.yaml
+++ b/providers/deepinfra/sentence-transformers/all-MiniLM-L12-v2.yaml
@@ -6,7 +6,7 @@ limits:
 modalities:
     input:
         - image
-mode: embedding
+mode: unknown
 model: sentence-transformers/all-MiniLM-L12-v2
 sources:
     - https://deepinfra.com/sentence-transformers/all-MiniLM-L12-v2/api

--- a/providers/deepinfra/sentence-transformers/all-MiniLM-L6-v2.yaml
+++ b/providers/deepinfra/sentence-transformers/all-MiniLM-L6-v2.yaml
@@ -1,4 +1,4 @@
-mode: embedding
+mode: unknown
 model: sentence-transformers/all-MiniLM-L6-v2
 sources:
     - https://deepinfra.com/sentence-transformers/all-MiniLM-L6-v2/api

--- a/providers/deepinfra/sentence-transformers/all-mpnet-base-v2.yaml
+++ b/providers/deepinfra/sentence-transformers/all-mpnet-base-v2.yaml
@@ -3,7 +3,7 @@ costs:
       region: "*"
 limits:
     max_input_tokens: 512
-mode: embedding
+mode: unknown
 model: sentence-transformers/all-mpnet-base-v2
 sources:
     - https://deepinfra.com/sentence-transformers/all-mpnet-base-v2

--- a/providers/deepinfra/sentence-transformers/clip-ViT-B-32-multilingual-v1.yaml
+++ b/providers/deepinfra/sentence-transformers/clip-ViT-B-32-multilingual-v1.yaml
@@ -1,7 +1,7 @@
 modalities:
     input:
         - image
-mode: embedding
+mode: unknown
 model: sentence-transformers/clip-ViT-B-32-multilingual-v1
 sources:
     - https://deepinfra.com/sentence-transformers/clip-ViT-B-32-multilingual-v1

--- a/providers/deepinfra/sentence-transformers/clip-ViT-B-32.yaml
+++ b/providers/deepinfra/sentence-transformers/clip-ViT-B-32.yaml
@@ -1,7 +1,7 @@
 modalities:
     input:
         - image
-mode: embedding
+mode: unknown
 model: sentence-transformers/clip-ViT-B-32
 sources:
     - https://deepinfra.com/sentence-transformers/clip-ViT-B-32/api

--- a/providers/deepinfra/sentence-transformers/multi-qa-mpnet-base-dot-v1.yaml
+++ b/providers/deepinfra/sentence-transformers/multi-qa-mpnet-base-dot-v1.yaml
@@ -1,7 +1,7 @@
 costs:
     - input_cost_per_token: 5.e-9
       region: "*"
-mode: embedding
+mode: unknown
 model: sentence-transformers/multi-qa-mpnet-base-dot-v1
 sources:
     - https://deepinfra.com/sentence-transformers/multi-qa-mpnet-base-dot-v1/api

--- a/providers/deepinfra/sentence-transformers/paraphrase-MiniLM-L6-v2.yaml
+++ b/providers/deepinfra/sentence-transformers/paraphrase-MiniLM-L6-v2.yaml
@@ -3,7 +3,7 @@ costs:
       region: "*"
 limits:
     max_input_tokens: 512
-mode: embedding
+mode: unknown
 model: sentence-transformers/paraphrase-MiniLM-L6-v2
 sources:
     - https://deepinfra.com/sentence-transformers/paraphrase-MiniLM-L6-v2/api

--- a/providers/deepinfra/shibing624/text2vec-base-chinese.yaml
+++ b/providers/deepinfra/shibing624/text2vec-base-chinese.yaml
@@ -1,4 +1,4 @@
-mode: embedding
+mode: unknown
 model: shibing624/text2vec-base-chinese
 sources:
     - https://deepinfra.com/shibing624/text2vec-base-chinese/api

--- a/providers/deepinfra/stabilityai/sdxl-turbo.yaml
+++ b/providers/deepinfra/stabilityai/sdxl-turbo.yaml
@@ -4,7 +4,7 @@ costs:
 modalities:
     input:
         - image
-mode: image
+mode: unknown
 model: stabilityai/sdxl-turbo
 sources:
     - https://deepinfra.com/stabilityai/sdxl-turbo/api

--- a/providers/deepinfra/thenlper/gte-base.yaml
+++ b/providers/deepinfra/thenlper/gte-base.yaml
@@ -3,7 +3,7 @@ costs:
       region: "*"
 limits:
     max_input_tokens: 512
-mode: embedding
+mode: unknown
 model: thenlper/gte-base
 sources:
     - https://deepinfra.com/thenlper/gte-base

--- a/providers/deepinfra/thenlper/gte-large.yaml
+++ b/providers/deepinfra/thenlper/gte-large.yaml
@@ -3,7 +3,7 @@ costs:
       region: "*"
 limits:
     max_input_tokens: 512
-mode: embedding
+mode: unknown
 model: thenlper/gte-large
 sources:
     - https://deepinfra.com/thenlper/gte-large/api

--- a/providers/deepinfra/zai-org/GLM-4.6.yaml
+++ b/providers/deepinfra/zai-org/GLM-4.6.yaml
@@ -1,20 +1,16 @@
 costs:
-    - cache_read_input_token_cost: 8.e-8
+    - cache_read_input_token_cost: 7.99999993e-8
       input_cost_per_token: 4.3e-7
       output_cost_per_token: 0.00000174
       region: "*"
 features:
-    - function_calling
-    - system_messages
-    - tool_choice
     - prompt_caching
-    - structured_output
 limits:
     context_window: 202752
     max_input_tokens: 202752
     max_output_tokens: 131072
-    max_tokens: 131072
-mode: chat
+    max_tokens: 202752
+mode: unknown
 model: zai-org/GLM-4.6
 sources:
     - https://deepinfra.com/zai-org/GLM-4.6/api

--- a/providers/deepinfra/zai-org/GLM-4.6V.yaml
+++ b/providers/deepinfra/zai-org/GLM-4.6V.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 3.e-7
-      output_cost_per_token: 9.e-7
+      output_cost_per_token: 9.000000000000001e-7
       region: "*"
 features:
     - function_calling
@@ -8,13 +8,11 @@ limits:
     context_window: 131072
     max_input_tokens: 131072
     max_output_tokens: 16384
-    max_tokens: 16384
+    max_tokens: 131072
 modalities:
     input:
-        - doc
         - image
-        - pdf
-mode: chat
+mode: unknown
 model: zai-org/GLM-4.6V
 sources:
     - https://deepinfra.com/zai-org/GLM-4.6V/api

--- a/providers/deepinfra/zai-org/GLM-4.7-Flash.yaml
+++ b/providers/deepinfra/zai-org/GLM-4.7-Flash.yaml
@@ -1,16 +1,15 @@
 costs:
-    - cache_read_input_token_cost: 1.e-8
-      input_cost_per_token: 6.e-8
-      output_cost_per_token: 4.e-7
+    - cache_read_input_token_cost: 1.0000000199999999e-8
+      input_cost_per_token: 6.000000000000001e-8
+      output_cost_per_token: 4.0000000000000003e-7
       region: "*"
 features:
-    - function_calling
-    - structured_output
+    - prompt_caching
 limits:
-    context_window: 200000
+    context_window: 202752
     max_output_tokens: 16384
-    max_tokens: 16384
-mode: chat
+    max_tokens: 202752
+mode: unknown
 model: zai-org/GLM-4.7-Flash
 sources:
     - https://docs.z.ai/guides/llm/glm-4.7

--- a/providers/deepinfra/zai-org/GLM-4.7.yaml
+++ b/providers/deepinfra/zai-org/GLM-4.7.yaml
@@ -1,20 +1,17 @@
 costs:
-    - cache_read_input_token_cost: 1.e-8
-      input_cost_per_token: 6.e-8
-      output_cost_per_token: 4.e-7
+    - cache_read_input_token_cost: 8.000000000000001e-8
+      input_cost_per_token: 4.0000000000000003e-7
+      output_cost_per_token: 0.00000175
       region: "*"
 features:
-    - function_calling
     - prompt_caching
-    - structured_output
-    - tools
 limits:
     context_window: 202752
     max_input_tokens: 202752
     max_output_tokens: 131072
-    max_tokens: 131072
-mode: chat
-model: zai-org/GLM-4.7-Flash
+    max_tokens: 202752
+mode: unknown
+model: zai-org/GLM-4.7
 sources:
     - https://docs.z.ai/guides/llm/glm-4.7
     - https://huggingface.co/zai-org/GLM-4.7-Flash

--- a/providers/deepinfra/zai-org/GLM-5.yaml
+++ b/providers/deepinfra/zai-org/GLM-5.yaml
@@ -1,18 +1,15 @@
 costs:
-    - cache_read_input_token_cost: 1.6e-7
-      input_cost_per_token: 8.e-7
+    - cache_read_input_token_cost: 1.6000000000000003e-7
+      input_cost_per_token: 8.000000000000001e-7
       output_cost_per_token: 0.00000256
       region: "*"
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
     - prompt_caching
 limits:
     context_window: 202752
     max_output_tokens: 128000
-    max_tokens: 128000
-mode: chat
+    max_tokens: 202752
+mode: unknown
 model: zai-org/GLM-5
 sources:
     - https://deepinfra.com/zai-org/GLM-5/api


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `deepinfra`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Bulk updates DeepInfra model YAML metadata (modes, token limits, costs, and feature flags), which can affect model discovery/routing and limit enforcement despite being config-only. Main risk is incorrect `mode`/`max_tokens` values causing consumers to select the wrong capability or mis-handle token limits.
> 
> **Overview**
> Updates a large set of `providers/deepinfra/*/*.yaml` model definitions, primarily changing `mode` values to `unknown` and normalizing/adjusting model metadata.
> 
> Also refreshes per-model pricing and limits (notably adding/updating `limits.max_tokens`/`context_window` and small float-precision tweaks), toggles some capability flags like `prompt_caching`/`thinking`, and fixes a few incorrect model identifiers (e.g., `deepseek-ai/Janus-Pro-7B`, `openai/gpt-oss-120b-Turbo`, `zai-org/GLM-4.7`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 44e38203960ecaddd951ec51b7e17f7a69e86619. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->