### PR TITLE
feat(deepinfra): add new models [bot]

### DIFF
--- a/providers/deepinfra/ByteDance/Seed-1.8.yaml
+++ b/providers/deepinfra/ByteDance/Seed-1.8.yaml
@@ -14,12 +14,10 @@ costs:
               - cost_per_token: 0.000004
                 from: 128000
 features:
-    - function_calling
-    - structured_output
-    - tool_choice
     - prompt_caching
 limits:
     context_window: 256000
+    max_tokens: 256000
 modalities:
     input:
         - image

--- a/providers/deepinfra/ByteDance/Seed-2.0-mini.yaml
+++ b/providers/deepinfra/ByteDance/Seed-2.0-mini.yaml
@@ -14,13 +14,10 @@ costs:
               - cost_per_token: 8.e-7
                 from: 128000
 features:
-    - function_calling
-    - structured_output
-    - tools
     - prompt_caching
-    - system_messages
 limits:
     context_window: 256000
+    max_tokens: 256000
 modalities:
     input:
         - image

--- a/providers/deepinfra/Gryphe/MythoMax-L2-13b.yaml
+++ b/providers/deepinfra/Gryphe/MythoMax-L2-13b.yaml
@@ -8,6 +8,7 @@ features:
 limits:
     context_window: 4096
     max_input_tokens: 4096
+    max_tokens: 4096
 mode: chat
 model: Gryphe/MythoMax-L2-13b
 sources:

--- a/providers/deepinfra/MiniMaxAI/MiniMax-M2.1.yaml
+++ b/providers/deepinfra/MiniMaxAI/MiniMax-M2.1.yaml
@@ -1,18 +1,14 @@
 costs:
-    - input_cost_per_token: 2.7e-7
+    - cache_read_input_token_cost: 2.90000007e-8
+      input_cost_per_token: 2.7e-7
       output_cost_per_token: 9.5e-7
       region: "*"
 features:
-    - function_calling
-    - tool_choice
-    - tools
-    - system_messages
-    - structured_output
     - prompt_caching
 limits:
     context_window: 196608
     max_output_tokens: 131072
-    max_tokens: 131072
+    max_tokens: 196608
 mode: chat
 model: MiniMaxAI/MiniMax-M2.1
 sources:

--- a/providers/deepinfra/MiniMaxAI/MiniMax-M2.5.yaml
+++ b/providers/deepinfra/MiniMaxAI/MiniMax-M2.5.yaml
@@ -1,17 +1,14 @@
 costs:
-    - input_cost_per_token: 2.7e-7
+    - cache_read_input_token_cost: 2.99999997e-8
+      input_cost_per_token: 2.7e-7
       output_cost_per_token: 9.5e-7
       region: "*"
 features:
-    - function_calling
-    - structured_output
-    - system_messages
-    - tool_choice
     - prompt_caching
 limits:
     context_window: 196608
     max_output_tokens: 131072
-    max_tokens: 131072
+    max_tokens: 196608
 mode: chat
 model: MiniMaxAI/MiniMax-M2.5
 sources:

--- a/providers/deepinfra/NousResearch/Hermes-3-Llama-3.1-70B.yaml
+++ b/providers/deepinfra/NousResearch/Hermes-3-Llama-3.1-70B.yaml
@@ -11,6 +11,7 @@ features:
 limits:
     context_window: 131072
     max_input_tokens: 131072
+    max_tokens: 131072
 mode: chat
 model: NousResearch/Hermes-3-Llama-3.1-70B
 sources:

--- a/providers/deepinfra/PaddlePaddle/PaddleOCR-VL-0.9B.yaml
+++ b/providers/deepinfra/PaddlePaddle/PaddleOCR-VL-0.9B.yaml
@@ -7,7 +7,7 @@ features:
 limits:
     context_window: 16384
     max_output_tokens: 8192
-    max_tokens: 8192
+    max_tokens: 16384
 modalities:
     input:
         - image

--- a/providers/deepinfra/Qwen/Qwen2.5-VL-32B-Instruct.yaml
+++ b/providers/deepinfra/Qwen/Qwen2.5-VL-32B-Instruct.yaml
@@ -9,6 +9,7 @@ features:
 limits:
     context_window: 128000
     max_input_tokens: 128000
+    max_tokens: 128000
 modalities:
     input:
         - image

--- a/providers/deepinfra/Qwen/Qwen3-14B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-14B.yaml
@@ -9,6 +9,7 @@ features:
     - structured_output
 limits:
     context_window: 40960
+    max_tokens: 40960
 mode: chat
 model: Qwen/Qwen3-14B
 sources:

--- a/providers/deepinfra/Qwen/Qwen3-235B-A22B-Instruct-2507.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-235B-A22B-Instruct-2507.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 7.1e-8
-      output_cost_per_token: 0.000001
+      output_cost_per_token: 1.e-7
       region: "*"
 features:
     - function_calling
@@ -18,3 +18,4 @@ sources:
     - https://deepinfra.com/Qwen/Qwen3-235B-A22B-Instruct-2507/api
     - https://api.deepinfra.com/models/Qwen/Qwen3-235B-A22B-Instruct-2507
     - https://huggingface.co/Qwen/Qwen3-235B-A22B-Instruct-2507
+thinking: true

--- a/providers/deepinfra/Qwen/Qwen3-235B-A22B-Thinking-2507.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-235B-A22B-Thinking-2507.yaml
@@ -1,12 +1,10 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2.000000006e-7
       input_cost_per_token: 2.3e-7
       output_cost_per_token: 0.0000023
       region: "*"
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
+    - prompt_caching
 limits:
     context_window: 262144
     max_input_tokens: 262144

--- a/providers/deepinfra/Qwen/Qwen3-30B-A3B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-30B-A3B.yaml
@@ -8,6 +8,7 @@ features:
     - structured_output
 limits:
     context_window: 40960
+    max_tokens: 40960
 mode: chat
 model: Qwen/Qwen3-30B-A3B
 sources:

--- a/providers/deepinfra/Qwen/Qwen3-32B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-32B.yaml
@@ -6,6 +6,7 @@ features:
     - function_calling
     - tool_choice
 limits:
+    context_window: 40960
     max_input_tokens: 40960
     max_output_tokens: 40960
     max_tokens: 40960

--- a/providers/deepinfra/Qwen/Qwen3-Coder-480B-A35B-Instruct-Turbo.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Coder-480B-A35B-Instruct-Turbo.yaml
@@ -4,12 +4,11 @@ costs:
       output_cost_per_token: 0.000001
       region: "*"
 features:
-    - function_calling
-    - tool_choice
+    - prompt_caching
 limits:
     context_window: 262144
     max_output_tokens: 16384
-    max_tokens: 16384
+    max_tokens: 262144
 mode: chat
 model: Qwen/Qwen3-Coder-480B-A35B-Instruct-Turbo
 sources:

--- a/providers/deepinfra/Qwen/Qwen3-Coder-480B-A35B-Instruct.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Coder-480B-A35B-Instruct.yaml
@@ -10,7 +10,7 @@ limits:
     context_window: 262144
     max_input_tokens: 262144
     max_output_tokens: 65536
-    max_tokens: 65536
+    max_tokens: 262144
 mode: chat
 model: Qwen/Qwen3-Coder-480B-A35B-Instruct
 sources:

--- a/providers/deepinfra/Qwen/Qwen3-Max-Thinking.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Max-Thinking.yaml
@@ -20,15 +20,11 @@ costs:
               - cost_per_token: 0.000015
                 from: 128000
 features:
-    - function_calling
-    - system_messages
-    - tool_choice
     - prompt_caching
-    - structured_output
 limits:
     context_window: 256000
     max_output_tokens: 16384
-    max_tokens: 16384
+    max_tokens: 256000
 mode: chat
 model: Qwen/Qwen3-Max-Thinking
 sources:

--- a/providers/deepinfra/Qwen/Qwen3-Max.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Max.yaml
@@ -18,18 +18,15 @@ costs:
               - cost_per_token: 0.000015
                 from: 128000
 features:
-    - function_calling
-    - tool_choice
-    - system_messages
     - prompt_caching
-    - tools
 limits:
-    context_window: 262144
+    context_window: 256000
     max_input_tokens: 258048
     max_output_tokens: 32768
-    max_tokens: 32768
+    max_tokens: 256000
 mode: chat
 model: Qwen/Qwen3-Max
 sources:
     - https://www.alibabacloud.com/help/en/model-studio/models
     - https://openrouter.ai/qwen/qwen3-max/api
+thinking: true

--- a/providers/deepinfra/Qwen/Qwen3-Next-80B-A3B-Instruct.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Next-80B-A3B-Instruct.yaml
@@ -6,12 +6,13 @@ features:
     - function_calling
     - tool_choice
 limits:
-    context_window: 262144
+    context_window: 131072
     max_input_tokens: 262144
     max_output_tokens: 262144
-    max_tokens: 262144
+    max_tokens: 131072
 mode: chat
 model: Qwen/Qwen3-Next-80B-A3B-Instruct
 sources:
     - https://deepinfra.com/Qwen/Qwen3-Next-80B-A3B-Instruct
     - https://huggingface.co/Qwen/Qwen3-Next-80B-A3B-Instruct
+thinking: true

--- a/providers/deepinfra/Qwen/Qwen3-VL-235B-A22B-Instruct.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-VL-235B-A22B-Instruct.yaml
@@ -1,12 +1,10 @@
 costs:
-    - input_cost_per_token: 2.e-7
+    - cache_read_input_token_cost: 1.1e-7
+      input_cost_per_token: 2.e-7
       output_cost_per_token: 8.8e-7
       region: "*"
 features:
-    - function_calling
-    - system_messages
-    - tool_choice
-    - structured_output
+    - prompt_caching
 limits:
     context_window: 262144
     max_input_tokens: 262144
@@ -21,3 +19,4 @@ sources:
     - https://deepinfra.com/Qwen/Qwen3-VL-235B-A22B-Instruct/api
     - https://openrouter.ai/qwen/qwen3-vl-235b-a22b-instruct/api
     - https://github.com/QwenLM/Qwen3-VL
+thinking: true

--- a/providers/deepinfra/Qwen/Qwen3-VL-30B-A3B-Instruct.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-VL-30B-A3B-Instruct.yaml
@@ -10,7 +10,7 @@ features:
 limits:
     context_window: 262144
     max_output_tokens: 16384
-    max_tokens: 16384
+    max_tokens: 262144
 modalities:
     input:
         - image
@@ -20,3 +20,4 @@ sources:
     - https://deepinfra.com/Qwen/Qwen3-VL-30B-A3B-Instruct/api
     - https://deepinfra.com/docs/advanced/max_tokens_limit
     - https://huggingface.co/Qwen/Qwen3-VL-30B-A3B-Instruct
+thinking: true

--- a/providers/deepinfra/Sao10K/L3.1-70B-Euryale-v2.2.yaml
+++ b/providers/deepinfra/Sao10K/L3.1-70B-Euryale-v2.2.yaml
@@ -7,6 +7,7 @@ features:
     - prompt_caching
 limits:
     context_window: 131072
+    max_tokens: 131072
 mode: chat
 model: Sao10K/L3.1-70B-Euryale-v2.2
 sources:

--- a/providers/deepinfra/allenai/olmOCR-2-7B-1025.yaml
+++ b/providers/deepinfra/allenai/olmOCR-2-7B-1025.yaml
@@ -3,7 +3,8 @@ costs:
       output_cost_per_token: 1.9e-7
       region: "*"
 limits:
-    context_window: 16000
+    context_window: 16384
+    max_tokens: 16384
 modalities:
     input:
         - image

--- a/providers/deepinfra/anthropic/claude-3-7-sonnet-latest.yaml
+++ b/providers/deepinfra/anthropic/claude-3-7-sonnet-latest.yaml
@@ -4,13 +4,10 @@ costs:
       output_cost_per_token: 0.0000165
       region: "*"
 features:
-    - function_calling
-    - tool_choice
-    - system_messages
-    - structured_output
     - prompt_caching
 limits:
     context_window: 200000
+    max_tokens: 200000
 modalities:
     input:
         - image

--- a/providers/deepinfra/anthropic/claude-4-opus.yaml
+++ b/providers/deepinfra/anthropic/claude-4-opus.yaml
@@ -11,7 +11,7 @@ limits:
     context_window: 200000
     max_input_tokens: 200000
     max_output_tokens: 32000
-    max_tokens: 32000
+    max_tokens: 200000
 modalities:
     input:
         - image

--- a/providers/deepinfra/anthropic/claude-4-sonnet.yaml
+++ b/providers/deepinfra/anthropic/claude-4-sonnet.yaml
@@ -11,7 +11,7 @@ limits:
     context_window: 200000
     max_input_tokens: 200000
     max_output_tokens: 64000
-    max_tokens: 64000
+    max_tokens: 200000
 modalities:
     input:
         - image

--- a/providers/deepinfra/deepseek-ai/DeepSeek-OCR.yaml
+++ b/providers/deepinfra/deepseek-ai/DeepSeek-OCR.yaml
@@ -10,7 +10,6 @@ limits:
 modalities:
     input:
         - image
-        - pdf
 mode: chat
 model: deepseek-ai/DeepSeek-OCR
 sources:

--- a/providers/deepinfra/deepseek-ai/DeepSeek-R1-0528-Turbo.yaml
+++ b/providers/deepinfra/deepseek-ai/DeepSeek-R1-0528-Turbo.yaml
@@ -7,6 +7,7 @@ features:
     - tool_choice
     - structured_output
 limits:
+    context_window: 32768
     max_output_tokens: 32768
     max_tokens: 32768
 mode: chat

--- a/providers/deepinfra/deepseek-ai/DeepSeek-R1-0528.yaml
+++ b/providers/deepinfra/deepseek-ai/DeepSeek-R1-0528.yaml
@@ -4,14 +4,12 @@ costs:
       output_cost_per_token: 0.00000215
       region: "*"
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
+    - prompt_caching
 limits:
     context_window: 163840
     max_input_tokens: 163840
     max_output_tokens: 32768
-    max_tokens: 32768
+    max_tokens: 163840
 mode: chat
 model: deepseek-ai/DeepSeek-R1-0528
 sources:

--- a/providers/deepinfra/deepseek-ai/DeepSeek-V3-0324.yaml
+++ b/providers/deepinfra/deepseek-ai/DeepSeek-V3-0324.yaml
@@ -4,13 +4,11 @@ costs:
       output_cost_per_token: 7.7e-7
       region: "*"
 features:
-    - function_calling
-    - tool_choice
     - prompt_caching
-    - structured_output
 limits:
     context_window: 163840
     max_input_tokens: 163840
+    max_tokens: 163840
 mode: chat
 model: deepseek-ai/DeepSeek-V3-0324
 sources:

--- a/providers/deepinfra/deepseek-ai/DeepSeek-V3.1-Terminus.yaml
+++ b/providers/deepinfra/deepseek-ai/DeepSeek-V3.1-Terminus.yaml
@@ -1,11 +1,10 @@
 costs:
-    - cache_read_input_token_cost: 1.3e-7
+    - cache_read_input_token_cost: 1.300000002e-7
       input_cost_per_token: 2.1e-7
       output_cost_per_token: 7.9e-7
       region: "*"
 features:
-    - function_calling
-    - tool_choice
+    - prompt_caching
 limits:
     context_window: 163840
     max_input_tokens: 163840

--- a/providers/deepinfra/deepseek-ai/DeepSeek-V3.1.yaml
+++ b/providers/deepinfra/deepseek-ai/DeepSeek-V3.1.yaml
@@ -1,19 +1,15 @@
 costs:
-    - cache_read_input_token_cost: 1.3e-7
+    - cache_read_input_token_cost: 1.300000002e-7
       input_cost_per_token: 2.1e-7
       output_cost_per_token: 7.9e-7
       region: "*"
 features:
-    - function_calling
-    - tool_choice
     - prompt_caching
-    - structured_output
-    - system_messages
 limits:
     context_window: 163840
     max_input_tokens: 163840
     max_output_tokens: 32768
-    max_tokens: 32768
+    max_tokens: 163840
 mode: chat
 model: deepseek-ai/DeepSeek-V3.1
 sources:

--- a/providers/deepinfra/deepseek-ai/DeepSeek-V3.2.yaml
+++ b/providers/deepinfra/deepseek-ai/DeepSeek-V3.2.yaml
@@ -4,16 +4,12 @@ costs:
       output_cost_per_token: 3.8e-7
       region: "*"
 features:
-    - function_calling
-    - system_messages
-    - tool_choice
     - prompt_caching
-    - structured_output
 limits:
     context_window: 163840
     max_input_tokens: 163840
     max_output_tokens: 16384
-    max_tokens: 16384
+    max_tokens: 163840
 mode: chat
 model: deepseek-ai/DeepSeek-V3.2
 sources:

--- a/providers/deepinfra/deepseek-ai/DeepSeek-V3.yaml
+++ b/providers/deepinfra/deepseek-ai/DeepSeek-V3.yaml
@@ -11,7 +11,7 @@ limits:
     context_window: 163840
     max_input_tokens: 163840
     max_output_tokens: 16384
-    max_tokens: 16384
+    max_tokens: 163840
 mode: chat
 model: deepseek-ai/DeepSeek-V3
 sources:

--- a/providers/deepinfra/deepseek-ai/Janus-Pro-7B.yaml
+++ b/providers/deepinfra/deepseek-ai/Janus-Pro-7B.yaml
@@ -7,7 +7,7 @@ modalities:
     input:
         - image
 mode: image
-model: ddeepseek-ai/Janus-Pro-7B
+model: deepseek-ai/Janus-Pro-7B
 sources:
     - https://deepinfra.com/deepseek-ai/Janus-Pro-7B/api
     - https://huggingface.co/deepseek-ai/Janus-Pro-7B

--- a/providers/deepinfra/google/gemini-1.5-flash-8b.yaml
+++ b/providers/deepinfra/google/gemini-1.5-flash-8b.yaml
@@ -1,3 +1,14 @@
+costs:
+    - input_cost_per_token: 3.75e-8
+      output_cost_per_token: 1.5e-7
+      region: "*"
 isDeprecated: true
+limits:
+    context_window: 1000000
+    max_tokens: 1000000
+modalities:
+    input:
+        - image
 mode: unknown
 model: google/gemini-1.5-flash-8b
+thinking: true

--- a/providers/deepinfra/google/gemini-1.5-flash.yaml
+++ b/providers/deepinfra/google/gemini-1.5-flash.yaml
@@ -1,3 +1,14 @@
+costs:
+    - input_cost_per_token: 7.5e-8
+      output_cost_per_token: 3.e-7
+      region: "*"
 isDeprecated: true
+limits:
+    context_window: 1000000
+    max_tokens: 1000000
+modalities:
+    input:
+        - image
 mode: unknown
 model: google/gemini-1.5-flash
+thinking: true

--- a/providers/deepinfra/google/gemini-2.5-flash.yaml
+++ b/providers/deepinfra/google/gemini-2.5-flash.yaml
@@ -13,7 +13,6 @@ limits:
     max_tokens: 1000000
 modalities:
     input:
-        - audio
         - image
 mode: chat
 model: google/gemini-2.5-flash

--- a/providers/deepinfra/google/gemini-2.5-pro.yaml
+++ b/providers/deepinfra/google/gemini-2.5-pro.yaml
@@ -11,15 +11,13 @@ features:
     - tool_choice
     - structured_output
 limits:
-    context_window: 1048576
+    context_window: 1000000
     max_input_tokens: 1048576
     max_output_tokens: 65536
-    max_tokens: 65536
+    max_tokens: 1000000
 modalities:
     input:
-        - audio
         - image
-        - pdf
 mode: chat
 model: google/gemini-2.5-pro
 sources:

--- a/providers/deepinfra/google/gemma-3-12b-it.yaml
+++ b/providers/deepinfra/google/gemma-3-12b-it.yaml
@@ -11,7 +11,7 @@ limits:
     context_window: 131072
     max_input_tokens: 131072
     max_output_tokens: 16384
-    max_tokens: 16384
+    max_tokens: 131072
 modalities:
     input:
         - image

--- a/providers/deepinfra/google/gemma-3-4b-it.yaml
+++ b/providers/deepinfra/google/gemma-3-4b-it.yaml
@@ -10,7 +10,7 @@ limits:
     context_window: 131072
     max_input_tokens: 131072
     max_output_tokens: 16384
-    max_tokens: 16384
+    max_tokens: 131072
 modalities:
     input:
         - image

--- a/providers/deepinfra/meta-llama/Llama-3.3-70B-Instruct-Turbo.yaml
+++ b/providers/deepinfra/meta-llama/Llama-3.3-70B-Instruct-Turbo.yaml
@@ -9,7 +9,7 @@ limits:
     context_window: 131072
     max_input_tokens: 131072
     max_output_tokens: 16384
-    max_tokens: 16384
+    max_tokens: 131072
 mode: chat
 model: meta-llama/Llama-3.3-70B-Instruct-Turbo
 sources:

--- a/providers/deepinfra/meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8.yaml
+++ b/providers/deepinfra/meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8.yaml
@@ -8,7 +8,7 @@ features:
 limits:
     context_window: 1048576
     max_output_tokens: 16384
-    max_tokens: 16384
+    max_tokens: 1048576
 modalities:
     input:
         - image

--- a/providers/deepinfra/meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo.yaml
+++ b/providers/deepinfra/meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo.yaml
@@ -10,7 +10,7 @@ limits:
     context_window: 131072
     max_input_tokens: 131072
     max_output_tokens: 16384
-    max_tokens: 16384
+    max_tokens: 131072
 mode: chat
 model: meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo
 sources:

--- a/providers/deepinfra/meta-llama/Meta-Llama-3.1-70B-Instruct.yaml
+++ b/providers/deepinfra/meta-llama/Meta-Llama-3.1-70B-Instruct.yaml
@@ -9,7 +9,7 @@ limits:
     context_window: 131072
     max_input_tokens: 131072
     max_output_tokens: 16384
-    max_tokens: 16384
+    max_tokens: 131072
 mode: chat
 model: meta-llama/Meta-Llama-3.1-70B-Instruct
 sources:

--- a/providers/deepinfra/meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo.yaml
+++ b/providers/deepinfra/meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo.yaml
@@ -9,7 +9,7 @@ limits:
     context_window: 131072
     max_input_tokens: 131072
     max_output_tokens: 16384
-    max_tokens: 16384
+    max_tokens: 131072
 mode: chat
 model: meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo
 sources:

--- a/providers/deepinfra/meta-llama/Meta-Llama-3.1-8B-Instruct.yaml
+++ b/providers/deepinfra/meta-llama/Meta-Llama-3.1-8B-Instruct.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 3.e-8
+    - input_cost_per_token: 2.e-8
       output_cost_per_token: 5.e-8
       region: "*"
 features:
@@ -9,7 +9,7 @@ limits:
     context_window: 131072
     max_input_tokens: 131072
     max_output_tokens: 16384
-    max_tokens: 16384
+    max_tokens: 131072
 mode: chat
 model: meta-llama/Meta-Llama-3.1-8B-Instruct
 sources:

--- a/providers/deepinfra/moonshotai/Kimi-K2-Instruct-0905.yaml
+++ b/providers/deepinfra/moonshotai/Kimi-K2-Instruct-0905.yaml
@@ -4,13 +4,9 @@ costs:
       output_cost_per_token: 0.000002
       region: "*"
 features:
-    - function_calling
-    - tool_choice
     - prompt_caching
-    - system_messages
-    - structured_output
 limits:
-    context_window: 262144
+    context_window: 131072
     max_input_tokens: 262144
     max_output_tokens: 131072
     max_tokens: 131072

--- a/providers/deepinfra/moonshotai/Kimi-K2-Thinking.yaml
+++ b/providers/deepinfra/moonshotai/Kimi-K2-Thinking.yaml
@@ -4,11 +4,9 @@ costs:
       output_cost_per_token: 0.000002
       region: "*"
 features:
-    - function_calling
-    - structured_output
     - prompt_caching
 limits:
-    context_window: 262144
+    context_window: 131072
     max_input_tokens: 262144
     max_output_tokens: 131072
     max_tokens: 131072

--- a/providers/deepinfra/moonshotai/Kimi-K2.5-Turbo.yaml
+++ b/providers/deepinfra/moonshotai/Kimi-K2.5-Turbo.yaml
@@ -1,18 +1,15 @@
 costs:
-    - input_cost_per_token: 5.e-7
-      output_cost_per_token: 0.0000028
+    - cache_read_input_token_cost: 1.00000002e-7
+      input_cost_per_token: 6.e-7
+      output_cost_per_token: 0.000003
       region: "*"
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
-    - system_messages
     - prompt_caching
 limits:
     context_window: 262144
     max_input_tokens: 262144
     max_output_tokens: 65535
-    max_tokens: 65535
+    max_tokens: 262144
 modalities:
     input:
         - image

--- a/providers/deepinfra/moonshotai/Kimi-K2.5.yaml
+++ b/providers/deepinfra/moonshotai/Kimi-K2.5.yaml
@@ -1,18 +1,14 @@
 costs:
-    - cache_read_input_token_cost: 7.e-8
+    - cache_read_input_token_cost: 7.0000002e-8
       input_cost_per_token: 4.5e-7
       output_cost_per_token: 0.00000225
       region: "*"
 features:
-    - function_calling
-    - tool_choice
-    - system_messages
-    - structured_output
     - prompt_caching
 limits:
     context_window: 262144
     max_output_tokens: 64000
-    max_tokens: 64000
+    max_tokens: 262144
 modalities:
     input:
         - image

--- a/providers/deepinfra/nvidia/Llama-3.1-Nemotron-70B-Instruct.yaml
+++ b/providers/deepinfra/nvidia/Llama-3.1-Nemotron-70B-Instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 6.e-7
-      output_cost_per_token: 6.e-7
+    - input_cost_per_token: 0.0000012
+      output_cost_per_token: 0.0000012
       region: "*"
 features:
     - tool_choice
@@ -8,7 +8,7 @@ limits:
     context_window: 131072
     max_input_tokens: 131072
     max_output_tokens: 4096
-    max_tokens: 4096
+    max_tokens: 131072
 mode: chat
 model: nvidia/Llama-3.1-Nemotron-70B-Instruct
 sources:

--- a/providers/deepinfra/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B.yaml
+++ b/providers/deepinfra/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B.yaml
@@ -4,14 +4,10 @@ costs:
       output_cost_per_token: 5.e-7
       region: "*"
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
-    - system_messages
     - prompt_caching
-    - tools
 limits:
     context_window: 262144
+    max_tokens: 262144
 mode: chat
 model: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B
 sources:

--- a/providers/deepinfra/nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL.yaml
+++ b/providers/deepinfra/nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL.yaml
@@ -6,10 +6,10 @@ features:
     - function_calling
     - system_messages
 limits:
-    context_window: 128000
+    context_window: 131072
     max_input_tokens: 128000
     max_output_tokens: 8192
-    max_tokens: 8192
+    max_tokens: 131072
 modalities:
     input:
         - image

--- a/providers/deepinfra/openai/gpt-oss-120b-Turbo.yaml
+++ b/providers/deepinfra/openai/gpt-oss-120b-Turbo.yaml
@@ -3,11 +3,13 @@ costs:
       output_cost_per_token: 6.e-7
       region: "*"
 limits:
+    context_window: 131072
     max_input_tokens: 131072
     max_output_tokens: 131072
     max_tokens: 131072
 mode: chat
-model: openai/gpt-oss-20b
+model: openai/gpt-oss-120b-Turbo
 sources:
     - https://deepinfra.com/openai/gpt-oss-20b/api
     - https://deepinfra.com/openai/gpt-oss-20b
+thinking: true

--- a/providers/deepinfra/zai-org/GLM-4.6.yaml
+++ b/providers/deepinfra/zai-org/GLM-4.6.yaml
@@ -1,19 +1,15 @@
 costs:
-    - cache_read_input_token_cost: 8.e-8
+    - cache_read_input_token_cost: 7.99999993e-8
       input_cost_per_token: 4.3e-7
       output_cost_per_token: 0.00000174
       region: "*"
 features:
-    - function_calling
-    - system_messages
-    - tool_choice
     - prompt_caching
-    - structured_output
 limits:
     context_window: 202752
     max_input_tokens: 202752
     max_output_tokens: 131072
-    max_tokens: 131072
+    max_tokens: 202752
 mode: chat
 model: zai-org/GLM-4.6
 sources:

--- a/providers/deepinfra/zai-org/GLM-4.6V.yaml
+++ b/providers/deepinfra/zai-org/GLM-4.6V.yaml
@@ -8,12 +8,10 @@ limits:
     context_window: 131072
     max_input_tokens: 131072
     max_output_tokens: 16384
-    max_tokens: 16384
+    max_tokens: 131072
 modalities:
     input:
-        - doc
         - image
-        - pdf
 mode: chat
 model: zai-org/GLM-4.6V
 sources:

--- a/providers/deepinfra/zai-org/GLM-4.7-Flash.yaml
+++ b/providers/deepinfra/zai-org/GLM-4.7-Flash.yaml
@@ -1,15 +1,14 @@
 costs:
-    - cache_read_input_token_cost: 1.e-8
+    - cache_read_input_token_cost: 1.00000002e-8
       input_cost_per_token: 6.e-8
       output_cost_per_token: 4.e-7
       region: "*"
 features:
-    - function_calling
-    - structured_output
+    - prompt_caching
 limits:
-    context_window: 200000
+    context_window: 202752
     max_output_tokens: 16384
-    max_tokens: 16384
+    max_tokens: 202752
 mode: chat
 model: zai-org/GLM-4.7-Flash
 sources:

--- a/providers/deepinfra/zai-org/GLM-4.7.yaml
+++ b/providers/deepinfra/zai-org/GLM-4.7.yaml
@@ -1,20 +1,17 @@
 costs:
-    - cache_read_input_token_cost: 1.e-8
-      input_cost_per_token: 6.e-8
-      output_cost_per_token: 4.e-7
+    - cache_read_input_token_cost: 8.e-8
+      input_cost_per_token: 4.e-7
+      output_cost_per_token: 0.00000175
       region: "*"
 features:
-    - function_calling
     - prompt_caching
-    - structured_output
-    - tools
 limits:
     context_window: 202752
     max_input_tokens: 202752
     max_output_tokens: 131072
-    max_tokens: 131072
+    max_tokens: 202752
 mode: chat
-model: zai-org/GLM-4.7-Flash
+model: zai-org/GLM-4.7
 sources:
     - https://docs.z.ai/guides/llm/glm-4.7
     - https://huggingface.co/zai-org/GLM-4.7-Flash

--- a/providers/deepinfra/zai-org/GLM-5.yaml
+++ b/providers/deepinfra/zai-org/GLM-5.yaml
@@ -4,14 +4,11 @@ costs:
       output_cost_per_token: 0.00000256
       region: "*"
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
     - prompt_caching
 limits:
     context_window: 202752
     max_output_tokens: 128000
-    max_tokens: 128000
+    max_tokens: 202752
 mode: chat
 model: zai-org/GLM-5
 sources:


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `deepinfra`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large set of DeepInfra model metadata changes that can affect request limits and pricing calculations if consumed by routing/billing logic, though no runtime code changes are involved.
> 
> **Overview**
> Updates many `providers/deepinfra/**.yaml` model definitions to better align declared capabilities and limits.
> 
> Most models now explicitly set `limits.max_tokens` (often matching `context_window`) and several entries adjust `context_window`, enable `prompt_caching`/`thinking`, and tweak token pricing fields (including cache-read costs). A few configs also correct model identifiers (e.g., `deepseek-ai/Janus-Pro-7B`, `openai/gpt-oss-120b-Turbo`) and add missing metadata for deprecated Gemini 1.5 models.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b6411dfa4d3d9db189b58d04a9f9ce2c455614fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->