### PR TITLE
fix(openai): align GPT-5 token param keys in OpenAI YAMLs

### DIFF
--- a/providers/openai/gpt-5-codex.yaml
+++ b/providers/openai/gpt-5-codex.yaml
@@ -23,9 +23,11 @@ mode: chat
 model: gpt-5-codex
 params:
     - defaultValue: 128
-      key: max_tokens
+      key: max_completion_tokens
       maxValue: 128000
       minValue: 1
+removeParams:
+    - max_tokens
 sources:
     - https://developers.openai.com/docs/models/gpt-5-codex
     - https://developers.openai.com/docs/pricing

--- a/providers/openai/gpt-5-pro-2025-10-06.yaml
+++ b/providers/openai/gpt-5-pro-2025-10-06.yaml
@@ -21,9 +21,11 @@ mode: chat
 model: gpt-5-pro-2025-10-06
 params:
     - defaultValue: 128
-      key: max_tokens
+      key: max_completion_tokens
       maxValue: 272000
       minValue: 1
+removeParams:
+    - max_tokens
 sources:
     - https://developers.openai.com/api/docs/models/gpt-5-pro
     - https://developers.openai.com/api/docs/pricing

--- a/providers/openai/gpt-5-pro.yaml
+++ b/providers/openai/gpt-5-pro.yaml
@@ -16,7 +16,7 @@ mode: chat
 model: gpt-5-pro
 params:
     - defaultValue: 128
-      key: max_tokens
+      key: max_completion_tokens
       maxValue: 272000
       minValue: 1
 removeParams:
@@ -24,6 +24,7 @@ removeParams:
     - top_p
     - "n"
     - parallel_tool_calls
+    - max_tokens
 sources:
     - https://developers.openai.com/api/docs/models/gpt-5-pro
 thinking: true

--- a/providers/openai/gpt-5-search-api-2025-10-14.yaml
+++ b/providers/openai/gpt-5-search-api-2025-10-14.yaml
@@ -23,9 +23,11 @@ mode: chat
 model: gpt-5-search-api-2025-10-14
 params:
     - defaultValue: 128
-      key: max_tokens
+      key: max_completion_tokens
       maxValue: 128000
       minValue: 1
+removeParams:
+    - max_tokens
 sources:
     - https://developers.openai.com/api/docs/pricing
     - https://developers.openai.com/api/docs/models/gpt-5

--- a/providers/openai/gpt-5.1-chat-latest.yaml
+++ b/providers/openai/gpt-5.1-chat-latest.yaml
@@ -23,8 +23,10 @@ mode: chat
 model: gpt-5.1-chat-latest
 params:
     - defaultValue: 128
-      key: max_tokens
+      key: max_completion_tokens
       maxValue: 16384
       minValue: 1
+removeParams:
+    - max_tokens
 sources:
     - https://developers.openai.com/api/docs/models/gpt-5.1-chat-latest

--- a/providers/openai/gpt-5.1-codex-mini.yaml
+++ b/providers/openai/gpt-5.1-codex-mini.yaml
@@ -22,9 +22,11 @@ mode: chat
 model: gpt-5.1-codex-mini
 params:
     - defaultValue: 128
-      key: max_tokens
+      key: max_completion_tokens
       maxValue: 128000
       minValue: 1
+removeParams:
+    - max_tokens
 sources:
     - https://developers.openai.com/api/docs/models/gpt-5.1-codex-mini
     - https://developers.openai.com/api/docs/pricing

--- a/providers/openai/gpt-5.2-codex.yaml
+++ b/providers/openai/gpt-5.2-codex.yaml
@@ -22,11 +22,13 @@ mode: chat
 model: gpt-5.2-codex
 params:
     - defaultValue: 128
-      key: max_tokens
+      key: max_completion_tokens
       maxValue: 128000
       minValue: 1
     - defaultValue: high
       key: reasoning_effort
+removeParams:
+    - max_tokens
 sources:
     - https://developers.openai.com/api/docs/models/gpt-5.2-codex
     - https://developers.openai.com/api/docs/pricing

--- a/providers/openai/gpt-5.2-pro-2025-12-11.yaml
+++ b/providers/openai/gpt-5.2-pro-2025-12-11.yaml
@@ -19,9 +19,11 @@ mode: chat
 model: gpt-5.2-pro-2025-12-11
 params:
     - defaultValue: 128000
-      key: max_tokens
+      key: max_completion_tokens
       maxValue: 128000
       minValue: 1
+removeParams:
+    - max_tokens
 sources:
     - https://developers.openai.com/api/docs/models/gpt-5.2-pro
 thinking: true

--- a/providers/openai/gpt-5.3-chat-latest.yaml
+++ b/providers/openai/gpt-5.3-chat-latest.yaml
@@ -21,8 +21,10 @@ mode: chat
 model: gpt-5.3-chat-latest
 params:
     - defaultValue: 128
-      key: max_tokens
+      key: max_completion_tokens
       maxValue: 16384
       minValue: 1
+removeParams:
+    - max_tokens
 sources:
     - https://developers.openai.com/api/docs/models/gpt-5.3-chat-latest

--- a/providers/openai/gpt-5.3-codex.yaml
+++ b/providers/openai/gpt-5.3-codex.yaml
@@ -22,11 +22,13 @@ mode: chat
 model: gpt-5.3-codex
 params:
     - defaultValue: 128
-      key: max_tokens
+      key: max_completion_tokens
       maxValue: 128000
       minValue: 1
     - defaultValue: medium
       key: reasoning_effort
+removeParams:
+    - max_tokens
 sources:
     - https://developers.openai.com/api/docs/models/gpt-5.3-codex
     - https://developers.openai.com/api/docs/pricing

--- a/providers/openai/gpt-5.4-2026-03-05.yaml
+++ b/providers/openai/gpt-5.4-2026-03-05.yaml
@@ -31,9 +31,11 @@ mode: chat
 model: gpt-5.4-2026-03-05
 params:
     - defaultValue: 128000
-      key: max_tokens
+      key: max_completion_tokens
       maxValue: 128000
       minValue: 1
+removeParams:
+    - max_tokens
 sources:
     - https://developers.openai.com/api/docs/models/gpt-5.4
     - https://developers.openai.com/api/docs/pricing

--- a/providers/openai/gpt-5.4-pro-2026-03-05.yaml
+++ b/providers/openai/gpt-5.4-pro-2026-03-05.yaml
@@ -26,12 +26,14 @@ mode: chat
 model: gpt-5.4-pro-2026-03-05
 params:
     - defaultValue: 128
-      key: max_tokens
+      key: max_completion_tokens
       maxValue: 128000
       minValue: 1
     - defaultValue: medium
       key: reasoning_effort
       type: string
+removeParams:
+    - max_tokens
 sources:
     - https://developers.openai.com/api/docs/models/gpt-5.4-pro
     - https://developers.openai.com/api/docs/pricing

--- a/providers/openai/gpt-5.4-pro.yaml
+++ b/providers/openai/gpt-5.4-pro.yaml
@@ -26,7 +26,7 @@ mode: chat
 model: gpt-5.4-pro
 params:
     - defaultValue: 128000
-      key: max_tokens
+      key: max_completion_tokens
       maxValue: 128000
       minValue: 1
     - defaultValue: high
@@ -37,6 +37,7 @@ removeParams:
     - top_p
     - "n"
     - stop
+    - max_tokens
 sources:
     - https://developers.openai.com/api/docs/models/gpt-5.4-pro
     - https://developers.openai.com/api/docs/pricing

--- a/providers/openai/gpt-5.4.yaml
+++ b/providers/openai/gpt-5.4.yaml
@@ -33,12 +33,14 @@ mode: chat
 model: gpt-5.4
 params:
     - defaultValue: 128
-      key: max_tokens
+      key: max_completion_tokens
       maxValue: 128000
       minValue: 1
     - defaultValue: none
       key: reasoning_effort
       type: string
+removeParams:
+    - max_tokens
 sources:
     - https://developers.openai.com/api/docs/models/gpt-5.4
     - https://developers.openai.com/api/docs/pricing


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- updated `providers/openai/gpt-5.4.yaml` to use `max_completion_tokens` in `params`
- added `removeParams: [max_tokens]` for `gpt-5.4.yaml`
- audited GPT-5 model YAMLs under `providers/openai` and normalized remaining files that still used `key: max_tokens`
- ensured all affected GPT-5 YAMLs remove inherited `max_tokens` via `removeParams`

## Files updated
- `providers/openai/gpt-5-pro.yaml`
- `providers/openai/gpt-5-pro-2025-10-06.yaml`
- `providers/openai/gpt-5-search-api-2025-10-14.yaml`
- `providers/openai/gpt-5-codex.yaml`
- `providers/openai/gpt-5.2-codex.yaml`
- `providers/openai/gpt-5.1-codex-mini.yaml`
- `providers/openai/gpt-5.3-chat-latest.yaml`
- `providers/openai/gpt-5.2-pro-2025-12-11.yaml`
- `providers/openai/gpt-5.1-chat-latest.yaml`
- `providers/openai/gpt-5.3-codex.yaml`
- `providers/openai/gpt-5.4-pro.yaml`
- `providers/openai/gpt-5.4-pro-2026-03-05.yaml`
- `providers/openai/gpt-5.4-2026-03-05.yaml`
- `providers/openai/gpt-5.4.yaml`

## Validation
- validated all files in `providers/openai/*.yaml` with `./.github/test/validate.sh` (after installing `cue`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e35477b1-0e18-4c45-8d9b-fd915e29cf00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e35477b1-0e18-4c45-8d9b-fd915e29cf00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

