### PR TITLE
feat(google-gemini): add new models [bot]

### DIFF
--- a/providers/google-gemini/aqa.yaml
+++ b/providers/google-gemini/aqa.yaml
@@ -1,2 +1,5 @@
+limits:
+    max_input_tokens: 7168
+    max_output_tokens: 1024
 mode: unknown
 model: aqa

--- a/providers/google-gemini/deep-research-pro-preview-12-2025.yaml
+++ b/providers/google-gemini/deep-research-pro-preview-12-2025.yaml
@@ -18,9 +18,8 @@ features:
     - structured_output
     - system_messages
 limits:
-    context_window: 1048576
+    max_input_tokens: 131072
     max_output_tokens: 65536
-    max_tokens: 65536
 modalities:
     input:
         - image

--- a/providers/google-gemini/gemini-2.0-flash-001.yaml
+++ b/providers/google-gemini/gemini-2.0-flash-001.yaml
@@ -20,7 +20,6 @@ isDeprecated: true
 limits:
     max_input_tokens: 1048576
     max_output_tokens: 8192
-    max_tokens: 4096
 modalities:
     input:
         - doc

--- a/providers/google-gemini/gemini-2.0-flash-lite-001.yaml
+++ b/providers/google-gemini/gemini-2.0-flash-lite-001.yaml
@@ -15,7 +15,6 @@ isDeprecated: true
 limits:
     max_input_tokens: 1048576
     max_output_tokens: 8192
-    max_tokens: 4096
 modalities:
     input:
         - doc

--- a/providers/google-gemini/gemini-2.0-flash-lite.yaml
+++ b/providers/google-gemini/gemini-2.0-flash-lite.yaml
@@ -15,7 +15,6 @@ isDeprecated: true
 limits:
     max_input_tokens: 1048576
     max_output_tokens: 8192
-    max_tokens: 4096
 modalities:
     input:
         - doc

--- a/providers/google-gemini/gemini-2.5-computer-use-preview-10-2025.yaml
+++ b/providers/google-gemini/gemini-2.5-computer-use-preview-10-2025.yaml
@@ -14,9 +14,8 @@ features:
     - parallel_function_calling
     - tools
 limits:
-    max_input_tokens: 128000
-    max_output_tokens: 64000
-    max_tokens: 64000
+    max_input_tokens: 131072
+    max_output_tokens: 65536
 modalities:
     input:
         - image

--- a/providers/google-gemini/gemini-2.5-flash-image.yaml
+++ b/providers/google-gemini/gemini-2.5-flash-image.yaml
@@ -10,9 +10,8 @@ features:
     - prompt_caching
     - structured_output
 limits:
-    max_input_tokens: 65536
+    max_input_tokens: 32768
     max_output_tokens: 32768
-    max_tokens: 32768
 modalities:
     input:
         - image

--- a/providers/google-gemini/gemini-2.5-flash-lite-preview-09-2025.yaml
+++ b/providers/google-gemini/gemini-2.5-flash-lite-preview-09-2025.yaml
@@ -17,10 +17,8 @@ features:
     - tool_choice
 isDeprecated: true
 limits:
-    context_window: 1048576
     max_input_tokens: 1048576
     max_output_tokens: 65536
-    max_tokens: 65536
 modalities:
     input:
         - audio

--- a/providers/google-gemini/gemini-2.5-flash-lite.yaml
+++ b/providers/google-gemini/gemini-2.5-flash-lite.yaml
@@ -17,10 +17,8 @@ features:
     - prompt_caching
     - structured_output
 limits:
-    context_window: 1048576
     max_input_tokens: 1048576
     max_output_tokens: 65536
-    max_tokens: 65536
 modalities:
     input:
         - audio

--- a/providers/google-gemini/gemini-2.5-flash-native-audio-latest.yaml
+++ b/providers/google-gemini/gemini-2.5-flash-native-audio-latest.yaml
@@ -10,10 +10,8 @@ features:
     - system_messages
     - tool_choice
 limits:
-    context_window: 131072
     max_input_tokens: 131072
     max_output_tokens: 8192
-    max_tokens: 8192
 modalities:
     input:
         - audio

--- a/providers/google-gemini/gemini-2.5-flash-native-audio-preview-09-2025.yaml
+++ b/providers/google-gemini/gemini-2.5-flash-native-audio-preview-09-2025.yaml
@@ -12,7 +12,6 @@ features:
 limits:
     max_input_tokens: 131072
     max_output_tokens: 8192
-    max_tokens: 8192
 modalities:
     input:
         - audio

--- a/providers/google-gemini/gemini-2.5-flash-native-audio-preview-12-2025.yaml
+++ b/providers/google-gemini/gemini-2.5-flash-native-audio-preview-12-2025.yaml
@@ -12,7 +12,6 @@ features:
 limits:
     max_input_tokens: 131072
     max_output_tokens: 8192
-    max_tokens: 8192
 modalities:
     input:
         - audio

--- a/providers/google-gemini/gemini-2.5-flash-preview-tts.yaml
+++ b/providers/google-gemini/gemini-2.5-flash-preview-tts.yaml
@@ -5,7 +5,8 @@ costs:
       output_cost_per_token_batches: 0.000005
       region: "*"
 limits:
-    context_window: 32000
+    max_input_tokens: 8192
+    max_output_tokens: 16384
 modalities:
     output:
         - audio

--- a/providers/google-gemini/gemini-2.5-flash.yaml
+++ b/providers/google-gemini/gemini-2.5-flash.yaml
@@ -18,10 +18,8 @@ features:
     - structured_output
 isDeprecated: true
 limits:
-    context_window: 1048576
     max_input_tokens: 1048576
     max_output_tokens: 65536
-    max_tokens: 65536
 modalities:
     input:
         - audio

--- a/providers/google-gemini/gemini-2.5-pro-preview-tts.yaml
+++ b/providers/google-gemini/gemini-2.5-pro-preview-tts.yaml
@@ -5,10 +5,8 @@ costs:
       output_cost_per_token_batches: 0.00001
       region: "*"
 limits:
-    context_window: 32000
     max_input_tokens: 8192
     max_output_tokens: 16384
-    max_tokens: 16384
 modalities:
     output:
         - audio

--- a/providers/google-gemini/gemini-2.5-pro.yaml
+++ b/providers/google-gemini/gemini-2.5-pro.yaml
@@ -25,10 +25,8 @@ features:
     - structured_output
 isDeprecated: true
 limits:
-    context_window: 1048576
     max_input_tokens: 1048576
     max_output_tokens: 65536
-    max_tokens: 65536
 modalities:
     input:
         - audio

--- a/providers/google-gemini/gemini-3-flash-preview.yaml
+++ b/providers/google-gemini/gemini-3-flash-preview.yaml
@@ -17,10 +17,8 @@ features:
     - prompt_caching
     - structured_output
 limits:
-    context_window: 1048576
     max_input_tokens: 1048576
     max_output_tokens: 65536
-    max_tokens: 65536
 modalities:
     input:
         - audio

--- a/providers/google-gemini/gemini-3-pro-image-preview.yaml
+++ b/providers/google-gemini/gemini-3-pro-image-preview.yaml
@@ -12,9 +12,8 @@ features:
     - system_messages
     - structured_output
 limits:
-    max_input_tokens: 65536
+    max_input_tokens: 131072
     max_output_tokens: 32768
-    max_tokens: 32768
 modalities:
     input:
         - image

--- a/providers/google-gemini/gemini-3-pro-preview.yaml
+++ b/providers/google-gemini/gemini-3-pro-preview.yaml
@@ -26,7 +26,7 @@ features:
 isDeprecated: true
 limits:
     max_input_tokens: 1048576
-    max_output_tokens: 65535
+    max_output_tokens: 65536
 modalities:
     input:
         - audio
@@ -43,3 +43,4 @@ params:
       type: string
     - defaultValue: null
       key: thinking
+thinking: true

--- a/providers/google-gemini/gemini-3.1-flash-image-preview.yaml
+++ b/providers/google-gemini/gemini-3.1-flash-image-preview.yaml
@@ -9,10 +9,8 @@ features:
     - structured_output
     - system_messages
 limits:
-    context_window: 1048576
-    max_input_tokens: 1048576
+    max_input_tokens: 65536
     max_output_tokens: 65536
-    max_tokens: 65536
 modalities:
     input:
         - image

--- a/providers/google-gemini/gemini-3.1-flash-lite-preview.yaml
+++ b/providers/google-gemini/gemini-3.1-flash-lite-preview.yaml
@@ -16,10 +16,8 @@ features:
     - structured_output
     - tools
 limits:
-    context_window: 1048576
     max_input_tokens: 1048576
     max_output_tokens: 65536
-    max_tokens: 65536
 modalities:
     input:
         - audio

--- a/providers/google-gemini/gemini-3.1-pro-preview-customtools.yaml
+++ b/providers/google-gemini/gemini-3.1-pro-preview-customtools.yaml
@@ -24,10 +24,8 @@ features:
     - prompt_caching
     - structured_output
 limits:
-    context_window: 1048576
     max_input_tokens: 1048576
     max_output_tokens: 65536
-    max_tokens: 65536
 modalities:
     input:
         - audio

--- a/providers/google-gemini/gemini-3.1-pro-preview.yaml
+++ b/providers/google-gemini/gemini-3.1-pro-preview.yaml
@@ -24,10 +24,8 @@ features:
     - prompt_caching
     - structured_output
 limits:
-    context_window: 1048576
     max_input_tokens: 1048576
     max_output_tokens: 65536
-    max_tokens: 65536
 modalities:
     input:
         - audio

--- a/providers/google-gemini/gemini-embedding-001.yaml
+++ b/providers/google-gemini/gemini-embedding-001.yaml
@@ -6,7 +6,7 @@ costs:
 isDeprecated: true
 limits:
     max_input_tokens: 2048
-    output_vector_size: 3072
+    max_output_tokens: 1
 mode: embedding
 model: gemini-embedding-001
 removeParams:

--- a/providers/google-gemini/gemini-embedding-2-preview.yaml
+++ b/providers/google-gemini/gemini-embedding-2-preview.yaml
@@ -9,6 +9,7 @@ costs:
       region: "*"
 limits:
     max_input_tokens: 8192
+    max_output_tokens: 1
 modalities:
     input:
         - audio

--- a/providers/google-gemini/gemini-flash-latest.yaml
+++ b/providers/google-gemini/gemini-flash-latest.yaml
@@ -18,7 +18,6 @@ features:
 limits:
     max_input_tokens: 1048576
     max_output_tokens: 65536
-    max_tokens: 65536
 modalities:
     input:
         - audio

--- a/providers/google-gemini/gemini-flash-lite-latest.yaml
+++ b/providers/google-gemini/gemini-flash-lite-latest.yaml
@@ -16,10 +16,8 @@ features:
     - prompt_caching
     - structured_output
 limits:
-    context_window: 1048576
     max_input_tokens: 1048576
     max_output_tokens: 65536
-    max_tokens: 65536
 modalities:
     input:
         - audio

--- a/providers/google-gemini/gemini-pro-latest.yaml
+++ b/providers/google-gemini/gemini-pro-latest.yaml
@@ -26,7 +26,6 @@ isDeprecated: true
 limits:
     max_input_tokens: 1048576
     max_output_tokens: 65536
-    max_tokens: 65536
 modalities:
     input:
         - audio

--- a/providers/google-gemini/gemini-robotics-er-1.5-preview.yaml
+++ b/providers/google-gemini/gemini-robotics-er-1.5-preview.yaml
@@ -7,10 +7,8 @@ features:
     - function_calling
     - structured_output
 limits:
-    context_window: 1048576
     max_input_tokens: 1048576
     max_output_tokens: 65536
-    max_tokens: 65536
 modalities:
     input:
         - audio

--- a/providers/google-gemini/gemma-3-12b-it.yaml
+++ b/providers/google-gemini/gemma-3-12b-it.yaml
@@ -8,10 +8,8 @@ features:
     - system_messages
     - tool_choice
 limits:
-    context_window: 128000
-    max_input_tokens: 128000
+    max_input_tokens: 32768
     max_output_tokens: 8192
-    max_tokens: 8192
 modalities:
     input:
         - image

--- a/providers/google-gemini/gemma-3-1b-it.yaml
+++ b/providers/google-gemini/gemma-3-1b-it.yaml
@@ -11,7 +11,8 @@ features:
     - tools
     - structured_output
 limits:
-    context_window: 32000
+    max_input_tokens: 32768
+    max_output_tokens: 8192
 mode: chat
 model: gemma-3-1b-it
 sources:

--- a/providers/google-gemini/gemma-3-27b-it.yaml
+++ b/providers/google-gemini/gemma-3-27b-it.yaml
@@ -13,10 +13,8 @@ features:
     - structured_output
     - prompt_caching
 limits:
-    context_window: 128000
-    max_input_tokens: 128000
-    max_output_tokens: 128000
-    max_tokens: 128000
+    max_input_tokens: 131072
+    max_output_tokens: 8192
 modalities:
     input:
         - image

--- a/providers/google-gemini/gemma-3-4b-it.yaml
+++ b/providers/google-gemini/gemma-3-4b-it.yaml
@@ -8,9 +8,8 @@ features:
     - system_messages
     - tool_choice
 limits:
-    context_window: 128000
+    max_input_tokens: 32768
     max_output_tokens: 8192
-    max_tokens: 8192
 modalities:
     input:
         - image

--- a/providers/google-gemini/gemma-3n-e2b-it.yaml
+++ b/providers/google-gemini/gemma-3n-e2b-it.yaml
@@ -7,7 +7,8 @@ costs:
 features:
     - system_messages
 limits:
-    context_window: 32000
+    max_input_tokens: 8192
+    max_output_tokens: 2048
 modalities:
     input:
         - audio

--- a/providers/google-gemini/gemma-3n-e4b-it.yaml
+++ b/providers/google-gemini/gemma-3n-e4b-it.yaml
@@ -5,7 +5,8 @@ costs:
 features:
     - system_messages
 limits:
-    context_window: 32000
+    max_input_tokens: 8192
+    max_output_tokens: 2048
 modalities:
     input:
         - audio

--- a/providers/google-gemini/imagen-4.0-fast-generate-001.yaml
+++ b/providers/google-gemini/imagen-4.0-fast-generate-001.yaml
@@ -4,6 +4,7 @@ costs:
 isDeprecated: true
 limits:
     max_input_tokens: 480
+    max_output_tokens: 8192
 modalities:
     input:
         - image

--- a/providers/google-gemini/imagen-4.0-generate-001.yaml
+++ b/providers/google-gemini/imagen-4.0-generate-001.yaml
@@ -3,6 +3,7 @@ costs:
       region: "*"
 limits:
     max_input_tokens: 480
+    max_output_tokens: 8192
 modalities:
     input:
         - image

--- a/providers/google-gemini/imagen-4.0-ultra-generate-001.yaml
+++ b/providers/google-gemini/imagen-4.0-ultra-generate-001.yaml
@@ -4,6 +4,7 @@ costs:
 isDeprecated: true
 limits:
     max_input_tokens: 480
+    max_output_tokens: 8192
 modalities:
     input:
         - image

--- a/providers/google-gemini/nano-banana-pro-preview.yaml
+++ b/providers/google-gemini/nano-banana-pro-preview.yaml
@@ -19,9 +19,8 @@ features:
     - structured_output
     - system_messages
 limits:
-    max_input_tokens: 65536
+    max_input_tokens: 131072
     max_output_tokens: 32768
-    max_tokens: 32768
 modalities:
     input:
         - image

--- a/providers/google-gemini/veo-2.0-generate-001.yaml
+++ b/providers/google-gemini/veo-2.0-generate-001.yaml
@@ -1,6 +1,9 @@
 costs:
     - output_cost_per_second: 0.35
       region: "*"
+limits:
+    max_input_tokens: 480
+    max_output_tokens: 8192
 modalities:
     input:
         - image

--- a/providers/google-gemini/veo-3.0-fast-generate-001.yaml
+++ b/providers/google-gemini/veo-3.0-fast-generate-001.yaml
@@ -1,6 +1,9 @@
 costs:
     - output_cost_per_second: 0.15
       region: "*"
+limits:
+    max_input_tokens: 480
+    max_output_tokens: 8192
 modalities:
     input:
         - image

--- a/providers/google-gemini/veo-3.0-generate-001.yaml
+++ b/providers/google-gemini/veo-3.0-generate-001.yaml
@@ -1,6 +1,9 @@
 costs:
     - output_cost_per_second: 0.4
       region: "*"
+limits:
+    max_input_tokens: 480
+    max_output_tokens: 8192
 modalities:
     input:
         - image

--- a/providers/google-gemini/veo-3.1-fast-generate-preview.yaml
+++ b/providers/google-gemini/veo-3.1-fast-generate-preview.yaml
@@ -4,7 +4,8 @@ costs:
       output_cost_per_second_720p: 0.15
       region: "*"
 limits:
-    max_input_tokens: 1024
+    max_input_tokens: 480
+    max_output_tokens: 8192
 modalities:
     input:
         - image

--- a/providers/google-gemini/veo-3.1-generate-preview.yaml
+++ b/providers/google-gemini/veo-3.1-generate-preview.yaml
@@ -4,7 +4,8 @@ costs:
       output_cost_per_second_720p: 0.4
       region: "*"
 limits:
-    max_input_tokens: 1024
+    max_input_tokens: 480
+    max_output_tokens: 8192
 modalities:
     input:
         - image


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `google-gemini`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates model metadata (token limits and thinking flags) used for request validation/capability gating; incorrect values could cause preventable request failures or allow oversize prompts.
> 
> **Overview**
> Adds a new `aqa` model definition with explicit `max_input_tokens`/`max_output_tokens` limits.
> 
> Standardizes and corrects `limits` across many Google Gemini/Gemma/Imagen/Veo model YAMLs by removing legacy fields (e.g., `context_window`/`max_tokens`) and setting explicit `max_input_tokens` and `max_output_tokens` values, including a few notable limit adjustments (e.g., `gemini-2.5-flash-image`, `gemini-3-pro-image-preview`, Veo models). Also enables `thinking: true` on additional preview models (e.g., `gemini-3-pro-preview`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e8680efe037a2fc9d97edb53686dfea83b76d9a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->