### PR TITLE
feat(groq): add new models [bot]

### DIFF
--- a/providers/groq/moonshotai/kimi-k2-instruct.yaml
+++ b/providers/groq/moonshotai/kimi-k2-instruct.yaml
@@ -1,3 +1,6 @@
 isDeprecated: true
+limits:
+    context_window: 131072
+    max_output_tokens: 16384
 mode: unknown
 model: moonshotai/kimi-k2-instruct

--- a/providers/groq/whisper-large-v3-turbo.yaml
+++ b/providers/groq/whisper-large-v3-turbo.yaml
@@ -4,6 +4,7 @@ costs:
       region: "*"
 limits:
     context_window: 448
+    max_output_tokens: 448
 modalities:
     input:
         - audio

--- a/providers/groq/whisper-large-v3.yaml
+++ b/providers/groq/whisper-large-v3.yaml
@@ -4,6 +4,7 @@ costs:
       region: "*"
 limits:
     context_window: 448
+    max_output_tokens: 448
 modalities:
     input:
         - audio


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `groq`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk metadata-only change: updates Groq model YAMLs to explicitly declare output-token limits, affecting validation/routing but not runtime logic.
> 
> **Overview**
> Adds explicit `limits.max_output_tokens` metadata to Groq model configs: `moonshotai/kimi-k2-instruct` now declares a `131072` context window and `16384` max output, and `whisper-large-v3` / `whisper-large-v3-turbo` now cap output at `448` to match their `context_window`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6a23f9a543f8594c6fd654b26573f841e8e54a99. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->