### PR TITLE
feat(mistral-ai): add new models [bot]

### DIFF
--- a/providers/mistral-ai/codestral-2508.yaml
+++ b/providers/mistral-ai/codestral-2508.yaml
@@ -4,11 +4,8 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - structured_output
-    - assistant_prefill
 limits:
-    context_window: 128000
+    context_window: 256000
     max_input_tokens: 128000
     max_output_tokens: 128000
     max_tokens: 128000
@@ -16,3 +13,6 @@ mode: chat
 model: codestral-2508
 sources:
     - https://docs.mistral.ai/models/codestral-25-08
+supportedModes:
+    - completion
+    - chat

--- a/providers/mistral-ai/codestral-latest.yaml
+++ b/providers/mistral-ai/codestral-latest.yaml
@@ -4,12 +4,12 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - structured_output
-    - assistant_prefill
 limits:
-    context_window: 128000
+    context_window: 256000
 mode: chat
 model: codestral-latest
 sources:
     - https://docs.mistral.ai/models/codestral-25-08
+supportedModes:
+    - completion
+    - chat

--- a/providers/mistral-ai/devstral-2512.yaml
+++ b/providers/mistral-ai/devstral-2512.yaml
@@ -4,11 +4,8 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - structured_output
-    - assistant_prefill
 limits:
-    context_window: 256000
+    context_window: 262144
     max_input_tokens: 256000
     max_output_tokens: 256000
     max_tokens: 256000
@@ -16,3 +13,5 @@ mode: chat
 model: devstral-2512
 sources:
     - https://docs.mistral.ai/models/devstral-2-25-12
+supportedModes:
+    - chat

--- a/providers/mistral-ai/devstral-latest.yaml
+++ b/providers/mistral-ai/devstral-latest.yaml
@@ -4,11 +4,8 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - structured_output
-    - assistant_prefill
 limits:
-    context_window: 256000
+    context_window: 262144
     max_input_tokens: 256000
     max_output_tokens: 256000
     max_tokens: 256000
@@ -16,3 +13,5 @@ mode: chat
 model: devstral-latest
 sources:
     - https://docs.mistral.ai/models/devstral-2-25-12
+supportedModes:
+    - chat

--- a/providers/mistral-ai/devstral-medium-latest.yaml
+++ b/providers/mistral-ai/devstral-medium-latest.yaml
@@ -4,12 +4,11 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - structured_output
-    - assistant_prefill
 limits:
-    context_window: 128000
+    context_window: 262144
 mode: chat
 model: devstral-medium-latest
 sources:
     - https://docs.mistral.ai/models/devstral-medium-1-0-25-07
+supportedModes:
+    - chat

--- a/providers/mistral-ai/labs-leanstral-2603.yaml
+++ b/providers/mistral-ai/labs-leanstral-2603.yaml
@@ -1,2 +1,11 @@
+features:
+    - function_calling
+limits:
+    context_window: 196608
+modalities:
+    input:
+        - image
 mode: unknown
 model: labs-leanstral-2603
+supportedModes:
+    - chat

--- a/providers/mistral-ai/labs-mistral-small-creative.yaml
+++ b/providers/mistral-ai/labs-mistral-small-creative.yaml
@@ -4,9 +4,8 @@ costs:
       region: "*"
 features:
     - function_calling
-    - structured_output
 limits:
-    context_window: 32000
+    context_window: 32768
     max_input_tokens: 32000
     max_output_tokens: 32000
     max_tokens: 32000
@@ -14,3 +13,5 @@ mode: chat
 model: labs-mistral-small-creative
 sources:
     - https://docs.mistral.ai/models/mistral-small-creative-25-12
+supportedModes:
+    - chat

--- a/providers/mistral-ai/magistral-medium-2509.yaml
+++ b/providers/mistral-ai/magistral-medium-2509.yaml
@@ -4,19 +4,16 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - structured_output
-    - assistant_prefill
 limits:
-    context_window: 128000
+    context_window: 131072
 modalities:
     input:
-        - doc
         - image
-        - pdf
 mode: chat
 model: magistral-medium-2509
 sources:
     - https://docs.mistral.ai/models/magistral-medium-1-2-25-09
     - https://docs.mistral.ai/capabilities/reasoning
+supportedModes:
+    - chat
 thinking: true

--- a/providers/mistral-ai/magistral-medium-latest.yaml
+++ b/providers/mistral-ai/magistral-medium-latest.yaml
@@ -4,15 +4,11 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - structured_output
-    - assistant_prefill
 limits:
-    context_window: 128000
+    context_window: 131072
 modalities:
     input:
-        - doc
-        - pdf
+        - image
 mode: chat
 model: magistral-medium-latest
 sources:
@@ -20,4 +16,6 @@ sources:
     - https://docs.mistral.ai/capabilities/reasoning/
     - https://docs.mistral.ai/capabilities/vision/
     - https://docs.mistral.ai/capabilities/function_calling
+supportedModes:
+    - chat
 thinking: true

--- a/providers/mistral-ai/magistral-small-2509.yaml
+++ b/providers/mistral-ai/magistral-small-2509.yaml
@@ -4,20 +4,19 @@ costs:
       region: "*"
 features:
     - function_calling
-    - structured_output
-    - assistant_prefill
 limits:
-    context_window: 128000
+    context_window: 131072
     max_input_tokens: 128000
     max_output_tokens: 128000
     max_tokens: 128000
 modalities:
     input:
-        - doc
         - image
 mode: chat
 model: magistral-small-2509
 sources:
     - https://docs.mistral.ai/models/magistral-small-1-2-25-09
     - https://huggingface.co/mistralai/Magistral-Small-2509
+supportedModes:
+    - chat
 thinking: true

--- a/providers/mistral-ai/magistral-small-latest.yaml
+++ b/providers/mistral-ai/magistral-small-latest.yaml
@@ -4,11 +4,8 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - structured_output
-    - assistant_prefill
 limits:
-    context_window: 128000
+    context_window: 131072
     max_input_tokens: 128000
     max_output_tokens: 128000
     max_tokens: 128000
@@ -24,4 +21,6 @@ sources:
     - https://docs.mistral.ai/models/magistral-small-1-2-25-09
     - https://docs.mistral.ai/capabilities/reasoning
     - https://mistral.ai/news/magistral
+supportedModes:
+    - chat
 thinking: true

--- a/providers/mistral-ai/ministral-14b-2512.yaml
+++ b/providers/mistral-ai/ministral-14b-2512.yaml
@@ -4,9 +4,8 @@ costs:
       region: "*"
 features:
     - function_calling
-    - structured_output
 limits:
-    context_window: 256000
+    context_window: 262144
     max_input_tokens: 256000
     max_output_tokens: 256000
     max_tokens: 256000
@@ -17,3 +16,5 @@ mode: chat
 model: ministral-14b-2512
 sources:
     - https://docs.mistral.ai/models/ministral-3-14b-25-12
+supportedModes:
+    - chat

--- a/providers/mistral-ai/ministral-14b-latest.yaml
+++ b/providers/mistral-ai/ministral-14b-latest.yaml
@@ -5,24 +5,19 @@ costs:
       region: "*"
 features:
     - function_calling
-    - parallel_function_calling
-    - structured_output
-    - system_messages
-    - tool_choice
-    - assistant_prefill
 limits:
-    context_window: 256000
+    context_window: 262144
     max_input_tokens: 256000
     max_output_tokens: 256000
     max_tokens: 256000
 modalities:
     input:
-        - doc
         - image
-        - pdf
 mode: chat
 model: ministral-14b-latest
 sources:
     - https://docs.mistral.ai/models/ministral-3-14b-25-12
     - https://docs.mistral.ai/capabilities/function_calling
     - https://docs.mistral.ai/capabilities/vision
+supportedModes:
+    - chat

--- a/providers/mistral-ai/ministral-3b-2512.yaml
+++ b/providers/mistral-ai/ministral-3b-2512.yaml
@@ -4,11 +4,8 @@ costs:
       region: "*"
 features:
     - function_calling
-    - structured_output
-    - assistant_prefill
-    - tool_choice
 limits:
-    context_window: 256000
+    context_window: 131072
 modalities:
     input:
         - image
@@ -17,3 +14,5 @@ model: ministral-3b-2512
 sources:
     - https://docs.mistral.ai/models/ministral-3-3b-25-12
     - https://docs.mistral.ai/capabilities/vision
+supportedModes:
+    - chat

--- a/providers/mistral-ai/ministral-3b-latest.yaml
+++ b/providers/mistral-ai/ministral-3b-latest.yaml
@@ -5,9 +5,8 @@ costs:
       region: "*"
 features:
     - function_calling
-    - structured_output
 limits:
-    context_window: 256000
+    context_window: 131072
 modalities:
     input:
         - image
@@ -15,3 +14,5 @@ mode: chat
 model: ministral-3b-latest
 sources:
     - https://docs.mistral.ai/models/ministral-3-3b-25-12
+supportedModes:
+    - chat

--- a/providers/mistral-ai/ministral-8b-2512.yaml
+++ b/providers/mistral-ai/ministral-8b-2512.yaml
@@ -4,21 +4,17 @@ costs:
       region: "*"
 features:
     - function_calling
-    - structured_output
-    - assistant_prefill
-    - tool_choice
-    - tools
 limits:
-    context_window: 256000
+    context_window: 262144
     max_input_tokens: 256000
     max_output_tokens: 256000
     max_tokens: 256000
 modalities:
     input:
-        - doc
         - image
-        - pdf
 mode: chat
 model: ministral-8b-2512
 sources:
     - https://docs.mistral.ai/models/ministral-3-8b-25-12
+supportedModes:
+    - chat

--- a/providers/mistral-ai/ministral-8b-latest.yaml
+++ b/providers/mistral-ai/ministral-8b-latest.yaml
@@ -4,11 +4,8 @@ costs:
       region: "*"
 features:
     - function_calling
-    - parallel_function_calling
-    - structured_output
-    - tool_choice
 limits:
-    context_window: 256000
+    context_window: 262144
 modalities:
     input:
         - image
@@ -19,3 +16,5 @@ sources:
     - https://docs.mistral.ai/capabilities/vision
     - https://docs.mistral.ai/capabilities/structured_output
     - https://docs.mistral.ai/capabilities/function_calling
+supportedModes:
+    - chat

--- a/providers/mistral-ai/mistral-embed-2312.yaml
+++ b/providers/mistral-ai/mistral-embed-2312.yaml
@@ -3,6 +3,7 @@ costs:
       region: "*"
 isDeprecated: true
 limits:
+    context_window: 8192
     max_input_tokens: 8192
     max_tokens: 4096
 mode: embedding

--- a/providers/mistral-ai/mistral-embed.yaml
+++ b/providers/mistral-ai/mistral-embed.yaml
@@ -3,6 +3,7 @@ costs:
       region: "*"
 isDeprecated: true
 limits:
+    context_window: 8192
     max_input_tokens: 8192
     max_tokens: 4096
 mode: embedding

--- a/providers/mistral-ai/mistral-large-2512.yaml
+++ b/providers/mistral-ai/mistral-large-2512.yaml
@@ -4,19 +4,14 @@ costs:
       region: "*"
 features:
     - function_calling
-    - parallel_function_calling
-    - tool_choice
-    - structured_output
 limits:
-    context_window: 256000
+    context_window: 262144
     max_input_tokens: 256000
     max_output_tokens: 256000
     max_tokens: 256000
 modalities:
     input:
-        - doc
         - image
-        - pdf
 mode: chat
 model: mistral-large-2512
 sources:
@@ -24,3 +19,5 @@ sources:
     - https://docs.mistral.ai/capabilities/vision
     - https://docs.mistral.ai/capabilities/function_calling
     - https://docs.mistral.ai/capabilities/audio
+supportedModes:
+    - chat

--- a/providers/mistral-ai/mistral-large-latest.yaml
+++ b/providers/mistral-ai/mistral-large-latest.yaml
@@ -4,24 +4,18 @@ costs:
       region: "*"
 features:
     - function_calling
-    - parallel_function_calling
-    - system_messages
-    - tool_choice
-    - structured_output
-    - assistant_prefill
-    - tools
 limits:
-    context_window: 256000
+    context_window: 262144
     max_input_tokens: 256000
     max_output_tokens: 256000
     max_tokens: 256000
 modalities:
     input:
-        - doc
         - image
-        - pdf
 mode: chat
 model: mistral-large-latest
 sources:
     - https://docs.mistral.ai/models/mistral-large-3-25-12
     - https://docs.mistral.ai/capabilities/function_calling/
+supportedModes:
+    - chat

--- a/providers/mistral-ai/mistral-medium-2505.yaml
+++ b/providers/mistral-ai/mistral-medium-2505.yaml
@@ -4,13 +4,16 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - structured_output
-    - assistant_prefill
 isDeprecated: true
 limits:
+    context_window: 131072
     max_input_tokens: 128000
     max_output_tokens: 128000
     max_tokens: 128000
+modalities:
+    input:
+        - image
 mode: chat
 model: mistral-medium-2505
+supportedModes:
+    - chat

--- a/providers/mistral-ai/mistral-medium-2508.yaml
+++ b/providers/mistral-ai/mistral-medium-2508.yaml
@@ -4,19 +4,14 @@ costs:
       region: "*"
 features:
     - function_calling
-    - system_messages
-    - tool_choice
-    - tools
-    - structured_output
-    - assistant_prefill
 limits:
-    context_window: 128000
+    context_window: 131072
 modalities:
     input:
-        - doc
         - image
-        - pdf
 mode: chat
 model: mistral-medium-2508
 sources:
     - https://docs.mistral.ai/models/mistral-medium-3-1-25-08
+supportedModes:
+    - chat

--- a/providers/mistral-ai/mistral-medium-latest.yaml
+++ b/providers/mistral-ai/mistral-medium-latest.yaml
@@ -4,21 +4,14 @@ costs:
       region: "*"
 features:
     - function_calling
-    - parallel_function_calling
-    - system_messages
-    - tool_choice
-    - structured_output
-    - assistant_prefill
-    - tools
 limits:
-    context_window: 128000
+    context_window: 131072
 modalities:
     input:
-        - audio
-        - doc
         - image
-        - pdf
 mode: chat
 model: mistral-medium-latest
 sources:
     - https://docs.mistral.ai/models/mistral-medium-3-1-25-08
+supportedModes:
+    - chat

--- a/providers/mistral-ai/mistral-medium.yaml
+++ b/providers/mistral-ai/mistral-medium.yaml
@@ -3,15 +3,19 @@ costs:
       output_cost_per_token: 0.0000081
       region: "*"
 features:
-    - tool_choice
-    - structured_output
-    - assistant_prefill
+    - function_calling
 isDeprecated: true
 limits:
+    context_window: 131072
     max_input_tokens: 32000
     max_output_tokens: 8191
+modalities:
+    input:
+        - image
 mode: chat
 model: mistral-medium
 params:
     - key: max_tokens
       maxValue: 32768
+supportedModes:
+    - chat

--- a/providers/mistral-ai/mistral-moderation-2411.yaml
+++ b/providers/mistral-ai/mistral-moderation-2411.yaml
@@ -2,9 +2,11 @@ costs:
     - input_cost_per_token: 1.e-7
       region: "*"
 limits:
-    context_window: 8000
+    context_window: 8192
 mode: chat
 model: mistral-moderation-2411
 sources:
     - https://docs.mistral.ai/models/mistral-moderation-24-11
     - https://docs.mistral.ai/capabilities/guardrailing
+supportedModes:
+    - moderation

--- a/providers/mistral-ai/mistral-moderation-latest.yaml
+++ b/providers/mistral-ai/mistral-moderation-latest.yaml
@@ -1,3 +1,5 @@
+limits:
+    context_window: 8192
 mode: moderation
 model: mistral-moderation-latest
 removeParams:
@@ -9,3 +11,5 @@ removeParams:
     - stream
 sources:
     - https://docs.mistral.ai/capabilities/guardrailing/
+supportedModes:
+    - moderation

--- a/providers/mistral-ai/mistral-ocr-2512.yaml
+++ b/providers/mistral-ai/mistral-ocr-2512.yaml
@@ -4,10 +4,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - structured_output
+limits:
+    context_window: 16384
 modalities:
     input:
-        - doc
         - image
         - pdf
 mode: chat

--- a/providers/mistral-ai/mistral-ocr-latest.yaml
+++ b/providers/mistral-ai/mistral-ocr-latest.yaml
@@ -4,14 +4,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - structured_output
-    - system_messages
-    - assistant_prefill
-    - tools
-    - tool_choice
+limits:
+    context_window: 16384
 modalities:
     input:
-        - doc
         - image
         - pdf
 mode: chat

--- a/providers/mistral-ai/mistral-small-2506.yaml
+++ b/providers/mistral-ai/mistral-small-2506.yaml
@@ -4,13 +4,8 @@ costs:
       region: "*"
 features:
     - function_calling
-    - parallel_function_calling
-    - tool_choice
-    - structured_output
-    - assistant_prefill
-    - system_messages
 limits:
-    context_window: 128000
+    context_window: 131072
     max_input_tokens: 128000
     max_output_tokens: 128000
     max_tokens: 128000
@@ -25,3 +20,5 @@ sources:
     - https://docs.mistral.ai/capabilities/function_calling
     - https://docs.mistral.ai/capabilities/structured_output
     - https://docs.mistral.ai/capabilities/reasoning
+supportedModes:
+    - chat

--- a/providers/mistral-ai/mistral-small-2603.yaml
+++ b/providers/mistral-ai/mistral-small-2603.yaml
@@ -1,2 +1,11 @@
+features:
+    - function_calling
+limits:
+    context_window: 262144
+modalities:
+    input:
+        - image
 mode: unknown
 model: mistral-small-2603
+supportedModes:
+    - chat

--- a/providers/mistral-ai/mistral-small-latest.yaml
+++ b/providers/mistral-ai/mistral-small-latest.yaml
@@ -4,23 +4,19 @@ costs:
       region: "*"
 features:
     - function_calling
-    - parallel_function_calling
-    - tool_choice
-    - structured_output
-    - assistant_prefill
 limits:
-    context_window: 128000
+    context_window: 262144
     max_input_tokens: 128000
     max_output_tokens: 128000
     max_tokens: 128000
 modalities:
     input:
-        - doc
         - image
-        - pdf
 mode: chat
 model: mistral-small-latest
 sources:
     - https://docs.mistral.ai/models/mistral-small-3-2-25-06
     - https://docs.mistral.ai/capabilities/vision/
     - https://docs.mistral.ai/capabilities/function_calling/
+supportedModes:
+    - chat

--- a/providers/mistral-ai/mistral-squarepoint-2602.yaml
+++ b/providers/mistral-ai/mistral-squarepoint-2602.yaml
@@ -1,2 +1,4 @@
+limits:
+    context_window: 32768
 mode: chat
 model: mistral-squarepoint-2602

--- a/providers/mistral-ai/mistral-tiny-2407.yaml
+++ b/providers/mistral-ai/mistral-tiny-2407.yaml
@@ -1,3 +1,9 @@
+features:
+    - function_calling
 isDeprecated: true
+limits:
+    context_window: 131072
 mode: unknown
 model: mistral-tiny-2407
+supportedModes:
+    - chat

--- a/providers/mistral-ai/mistral-tiny-latest.yaml
+++ b/providers/mistral-ai/mistral-tiny-latest.yaml
@@ -1,3 +1,9 @@
+features:
+    - function_calling
 isDeprecated: true
+limits:
+    context_window: 131072
 mode: unknown
 model: mistral-tiny-latest
+supportedModes:
+    - chat

--- a/providers/mistral-ai/mistral-vibe-cli-fast.yaml
+++ b/providers/mistral-ai/mistral-vibe-cli-fast.yaml
@@ -1,2 +1,11 @@
+features:
+    - function_calling
+limits:
+    context_window: 262144
+modalities:
+    input:
+        - image
 mode: unknown
 model: mistral-vibe-cli-fast
+supportedModes:
+    - chat

--- a/providers/mistral-ai/mistral-vibe-cli-latest.yaml
+++ b/providers/mistral-ai/mistral-vibe-cli-latest.yaml
@@ -1,4 +1,10 @@
+features:
+    - function_calling
+limits:
+    context_window: 262144
 mode: chat
 model: mistral-vibe-cli-latest
 sources:
     - https://docs.mistral.ai/mistral-vibe/introduction
+supportedModes:
+    - chat

--- a/providers/mistral-ai/mistral-vibe-cli-with-tools.yaml
+++ b/providers/mistral-ai/mistral-vibe-cli-with-tools.yaml
@@ -4,12 +4,11 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tools
-    - tool_choice
-    - system_messages
-    - structured_output
 limits:
-    context_window: 256000
+    context_window: 131072
+modalities:
+    input:
+        - image
 mode: chat
 model: mistral-vibe-cli-with-tools
 sources:
@@ -17,3 +16,5 @@ sources:
     - https://mistral.ai/news/devstral-2-vibe-cli
     - https://docs.mistral.ai/mistral-vibe/introduction
     - https://docs.mistral.ai/mistral-vibe/introduction/configuration
+supportedModes:
+    - chat

--- a/providers/mistral-ai/open-mistral-nemo-2407.yaml
+++ b/providers/mistral-ai/open-mistral-nemo-2407.yaml
@@ -4,12 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - structured_output
-    - assistant_prefill
 isDeprecated: true
 limits:
-    context_window: 128000
+    context_window: 131072
     max_input_tokens: 128000
     max_output_tokens: 128000
     max_tokens: 128000
@@ -18,3 +15,5 @@ model: open-mistral-nemo-2407
 sources:
     - https://docs.mistral.ai/models/mistral-nemo-12b-24-07
     - https://docs.mistral.ai/getting-started/models/models_overview/
+supportedModes:
+    - chat

--- a/providers/mistral-ai/open-mistral-nemo.yaml
+++ b/providers/mistral-ai/open-mistral-nemo.yaml
@@ -3,13 +3,14 @@ costs:
       output_cost_per_token: 1.5e-7
       region: "*"
 features:
-    - tool_choice
-    - structured_output
-    - assistant_prefill
+    - function_calling
 isDeprecated: true
 limits:
+    context_window: 131072
     max_input_tokens: 128000
     max_output_tokens: 128000
     max_tokens: 128000
 mode: chat
 model: open-mistral-nemo
+supportedModes:
+    - chat

--- a/providers/mistral-ai/voxtral-mini-2602.yaml
+++ b/providers/mistral-ai/voxtral-mini-2602.yaml
@@ -1,2 +1,6 @@
+limits:
+    context_window: 16384
 mode: unknown
 model: voxtral-mini-2602
+supportedModes:
+    - audio_transcription

--- a/providers/mistral-ai/voxtral-mini-latest.yaml
+++ b/providers/mistral-ai/voxtral-mini-latest.yaml
@@ -7,7 +7,7 @@ features:
     - function_calling
     - structured_output
 limits:
-    context_window: 32000
+    context_window: 16384
     max_tokens: 32768
 modalities:
     input:
@@ -17,3 +17,5 @@ mode: chat
 model: voxtral-mini-latest
 sources:
     - https://docs.mistral.ai/models/voxtral-mini-25-07
+supportedModes:
+    - audio_transcription

--- a/providers/mistral-ai/voxtral-mini-realtime-2602.yaml
+++ b/providers/mistral-ai/voxtral-mini-realtime-2602.yaml
@@ -8,6 +8,8 @@ features:
     - tools
     - tool_choice
     - system_messages
+limits:
+    context_window: 16384
 modalities:
     input:
         - audio
@@ -16,3 +18,6 @@ model: voxtral-mini-realtime-2602
 sources:
     - https://docs.mistral.ai/models/voxtral-mini-transcribe-realtime-26-02
     - https://docs.mistral.ai/capabilities/audio_transcription
+supportedModes:
+    - realtime
+    - chat

--- a/providers/mistral-ai/voxtral-mini-realtime-latest.yaml
+++ b/providers/mistral-ai/voxtral-mini-realtime-latest.yaml
@@ -4,6 +4,8 @@ costs:
 features:
     - function_calling
     - structured_output
+limits:
+    context_window: 16384
 modalities:
     input:
         - audio
@@ -16,3 +18,6 @@ removeParams:
     - top_p
 sources:
     - https://docs.mistral.ai/models/voxtral-mini-transcribe-realtime-26-02
+supportedModes:
+    - realtime
+    - chat

--- a/providers/mistral-ai/voxtral-mini-transcribe-realtime-2602.yaml
+++ b/providers/mistral-ai/voxtral-mini-transcribe-realtime-2602.yaml
@@ -1,6 +1,8 @@
 costs:
     - input_cost_per_second: 0.0001
       region: "*"
+limits:
+    context_window: 16384
 modalities:
     input:
         - audio
@@ -8,3 +10,6 @@ mode: audio_transcription
 model: voxtral-mini-transcribe-realtime-2602
 sources:
     - https://docs.mistral.ai/models/voxtral-mini-transcribe-realtime-26-02
+supportedModes:
+    - realtime
+    - chat

--- a/providers/mistral-ai/voxtral-small-2507.yaml
+++ b/providers/mistral-ai/voxtral-small-2507.yaml
@@ -5,16 +5,14 @@ costs:
       region: "*"
 features:
     - function_calling
-    - structured_output
-    - tools
 limits:
-    context_window: 32000
+    context_window: 32768
 modalities:
     input:
         - audio
-        - doc
-        - pdf
 mode: chat
 model: voxtral-small-2507
 sources:
     - https://docs.mistral.ai/models/voxtral-small-25-07
+supportedModes:
+    - chat

--- a/providers/mistral-ai/voxtral-small-latest.yaml
+++ b/providers/mistral-ai/voxtral-small-latest.yaml
@@ -5,20 +5,14 @@ costs:
       region: "*"
 features:
     - function_calling
-    - structured_output
-    - assistant_prefill
-    - tool_choice
-    - tools
-    - system_messages
 limits:
-    context_window: 32000
+    context_window: 32768
 modalities:
     input:
         - audio
-        - doc
-        - image
-        - pdf
 mode: chat
 model: voxtral-small-latest
 sources:
     - https://docs.mistral.ai/models/voxtral-small-25-07
+supportedModes:
+    - chat


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `mistral-ai`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily updates provider model metadata (context windows, modalities, and `supportedModes`), which can affect request validation/routing and token-limit enforcement. Risk is moderate due to potential mismatches with actual Mistral limits/capabilities causing runtime errors or truncated prompts.
> 
> **Overview**
> Updates the `mistral-ai` model catalog YAMLs to reflect new capabilities and limits.
> 
> Most models have revised `limits.context_window` values (often to power-of-two boundaries) and now declare `supportedModes` (e.g., adding `completion` for `codestral-*`, `moderation` for moderation models, and `realtime`/`audio_transcription` for Voxtral variants). Several entries also add or adjust `modalities` (notably `image`) and fill in missing `limits` for embed/moderation/OCR models, plus small capability flag fixes (e.g., ensuring `function_calling` is present on some deprecated models).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 886674b5fe778a62b4476d147931d37b5474116c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->