### PR TITLE
feat(openrouter): add new models [bot]

### DIFF
--- a/providers/openrouter/ai21/jamba-large-1.7.yaml
+++ b/providers/openrouter/ai21/jamba-large-1.7.yaml
@@ -9,7 +9,11 @@ features:
 limits:
     context_window: 256000
     max_output_tokens: 4096
-    max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: ai21/jamba-large-1.7
 sources:

--- a/providers/openrouter/aion-labs/aion-1.0-mini.yaml
+++ b/providers/openrouter/aion-labs/aion-1.0-mini.yaml
@@ -8,7 +8,11 @@ features:
 limits:
     context_window: 131072
     max_output_tokens: 32768
-    max_tokens: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: aion-labs/aion-1.0-mini
 sources:

--- a/providers/openrouter/aion-labs/aion-1.0.yaml
+++ b/providers/openrouter/aion-labs/aion-1.0.yaml
@@ -9,7 +9,11 @@ features:
 limits:
     context_window: 131072
     max_output_tokens: 32768
-    max_tokens: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: aion-labs/aion-1.0
 sources:

--- a/providers/openrouter/aion-labs/aion-2.0.yaml
+++ b/providers/openrouter/aion-labs/aion-2.0.yaml
@@ -9,7 +9,11 @@ features:
 limits:
     context_window: 131072
     max_output_tokens: 32768
-    max_tokens: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: aion-labs/aion-2.0
 sources:

--- a/providers/openrouter/aion-labs/aion-rp-llama-3.1-8b.yaml
+++ b/providers/openrouter/aion-labs/aion-rp-llama-3.1-8b.yaml
@@ -9,7 +9,11 @@ features:
 limits:
     context_window: 32768
     max_output_tokens: 32768
-    max_tokens: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: aion-labs/aion-rp-llama-3.1-8b
 sources:

--- a/providers/openrouter/alfredpros/codellama-7b-instruct-solidity.yaml
+++ b/providers/openrouter/alfredpros/codellama-7b-instruct-solidity.yaml
@@ -5,7 +5,11 @@ costs:
 limits:
     context_window: 4096
     max_output_tokens: 4096
-    max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: alfredpros/codellama-7b-instruct-solidity
 sources:

--- a/providers/openrouter/alibaba/tongyi-deepresearch-30b-a3b.yaml
+++ b/providers/openrouter/alibaba/tongyi-deepresearch-30b-a3b.yaml
@@ -1,5 +1,6 @@
 costs:
-    - input_cost_per_token: 9.e-8
+    - cache_read_input_token_cost: 9.e-8
+      input_cost_per_token: 9.e-8
       output_cost_per_token: 4.5e-7
       region: "*"
 features:
@@ -8,7 +9,12 @@ features:
     - system_messages
 limits:
     context_window: 131072
-    max_tokens: 131072
+    max_output_tokens: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: alibaba/tongyi-deepresearch-30b-a3b
 sources:

--- a/providers/openrouter/allenai/olmo-2-0325-32b-instruct.yaml
+++ b/providers/openrouter/allenai/olmo-2-0325-32b-instruct.yaml
@@ -4,6 +4,11 @@ costs:
       region: "*"
 limits:
     context_window: 128000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: allenai/olmo-2-0325-32b-instruct
 sources:

--- a/providers/openrouter/allenai/olmo-3-32b-think.yaml
+++ b/providers/openrouter/allenai/olmo-3-32b-think.yaml
@@ -9,7 +9,11 @@ features:
 limits:
     context_window: 65536
     max_output_tokens: 65536
-    max_tokens: 65536
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: allenai/olmo-3-32b-think
 sources:

--- a/providers/openrouter/allenai/olmo-3.1-32b-instruct.yaml
+++ b/providers/openrouter/allenai/olmo-3.1-32b-instruct.yaml
@@ -8,6 +8,11 @@ features:
     - structured_output
 limits:
     context_window: 65536
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: allenai/olmo-3.1-32b-instruct
 sources:

--- a/providers/openrouter/allenai/olmo-3.1-32b-think.yaml
+++ b/providers/openrouter/allenai/olmo-3.1-32b-think.yaml
@@ -7,7 +7,11 @@ features:
 limits:
     context_window: 65536
     max_output_tokens: 65536
-    max_tokens: 65536
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: allenai/olmo-3.1-32b-think
 sources:

--- a/providers/openrouter/alpindale/goliath-120b.yaml
+++ b/providers/openrouter/alpindale/goliath-120b.yaml
@@ -5,7 +5,11 @@ costs:
 limits:
     context_window: 6144
     max_output_tokens: 1024
-    max_tokens: 1024
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: alpindale/goliath-120b
 sources:

--- a/providers/openrouter/amazon/nova-2-lite-v1.yaml
+++ b/providers/openrouter/amazon/nova-2-lite-v1.yaml
@@ -9,10 +9,14 @@ features:
 limits:
     context_window: 1000000
     max_output_tokens: 65535
-    max_tokens: 65535
 modalities:
     input:
+        - text
         - image
+        - video
+        - pdf
+    output:
+        - text
 mode: chat
 model: amazon/nova-2-lite-v1
 params:

--- a/providers/openrouter/amazon/nova-lite-v1.yaml
+++ b/providers/openrouter/amazon/nova-lite-v1.yaml
@@ -8,12 +8,13 @@ features:
     - system_messages
 limits:
     context_window: 300000
-    max_input_tokens: 294880
     max_output_tokens: 5120
-    max_tokens: 5120
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: amazon/nova-lite-v1
 sources:

--- a/providers/openrouter/amazon/nova-micro-v1.yaml
+++ b/providers/openrouter/amazon/nova-micro-v1.yaml
@@ -8,7 +8,11 @@ features:
 limits:
     context_window: 128000
     max_output_tokens: 5120
-    max_tokens: 5120
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: amazon/nova-micro-v1
 sources:

--- a/providers/openrouter/amazon/nova-premier-v1.yaml
+++ b/providers/openrouter/amazon/nova-premier-v1.yaml
@@ -10,12 +10,13 @@ features:
     - tools
 limits:
     context_window: 1000000
-    max_input_tokens: 968000
     max_output_tokens: 32000
-    max_tokens: 32000
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: amazon/nova-premier-v1
 sources:

--- a/providers/openrouter/amazon/nova-pro-v1.yaml
+++ b/providers/openrouter/amazon/nova-pro-v1.yaml
@@ -8,10 +8,12 @@ features:
 limits:
     context_window: 300000
     max_output_tokens: 5120
-    max_tokens: 5120
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: amazon/nova-pro-v1
 sources:

--- a/providers/openrouter/anthracite-org/magnum-v4-72b.yaml
+++ b/providers/openrouter/anthracite-org/magnum-v4-72b.yaml
@@ -4,9 +4,12 @@ costs:
       region: "*"
 limits:
     context_window: 16384
-    max_input_tokens: 14336
     max_output_tokens: 2048
-    max_tokens: 2048
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: anthracite-org/magnum-v4-72b
 sources:

--- a/providers/openrouter/anthropic/claude-3-haiku.yaml
+++ b/providers/openrouter/anthropic/claude-3-haiku.yaml
@@ -11,10 +11,12 @@ features:
 limits:
     context_window: 200000
     max_output_tokens: 4096
-    max_tokens: 4096
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: anthropic/claude-3-haiku
 sources:

--- a/providers/openrouter/anthropic/claude-3.5-haiku.yaml
+++ b/providers/openrouter/anthropic/claude-3.5-haiku.yaml
@@ -10,12 +10,13 @@ features:
     - prompt_caching
 limits:
     context_window: 200000
-    max_input_tokens: 191808
     max_output_tokens: 8192
-    max_tokens: 8192
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: anthropic/claude-3.5-haiku
 sources:

--- a/providers/openrouter/anthropic/claude-3.5-sonnet.yaml
+++ b/providers/openrouter/anthropic/claude-3.5-sonnet.yaml
@@ -11,12 +11,14 @@ features:
     - prompt_caching
 limits:
     context_window: 200000
-    max_input_tokens: 200000
     max_output_tokens: 8192
-    max_tokens: 8192
 modalities:
     input:
+        - text
         - image
+        - pdf
+    output:
+        - text
 mode: chat
 model: anthropic/claude-3.5-sonnet
 sources:

--- a/providers/openrouter/anthropic/claude-haiku-4.5.yaml
+++ b/providers/openrouter/anthropic/claude-haiku-4.5.yaml
@@ -12,12 +12,13 @@ features:
     - structured_output
 limits:
     context_window: 200000
-    max_input_tokens: 200000
     max_output_tokens: 64000
-    max_tokens: 64000
 modalities:
     input:
         - image
+        - text
+    output:
+        - text
 mode: chat
 model: anthropic/claude-haiku-4.5
 sources:

--- a/providers/openrouter/anthropic/claude-opus-4.1.yaml
+++ b/providers/openrouter/anthropic/claude-opus-4.1.yaml
@@ -12,10 +12,13 @@ features:
 limits:
     context_window: 200000
     max_output_tokens: 32000
-    max_tokens: 32000
 modalities:
     input:
         - image
+        - text
+        - pdf
+    output:
+        - text
 mode: chat
 model: anthropic/claude-opus-4.1
 sources:

--- a/providers/openrouter/anthropic/claude-opus-4.5.yaml
+++ b/providers/openrouter/anthropic/claude-opus-4.5.yaml
@@ -12,12 +12,14 @@ features:
     - structured_output
 limits:
     context_window: 200000
-    max_input_tokens: 200000
     max_output_tokens: 64000
-    max_tokens: 64000
 modalities:
     input:
+        - pdf
         - image
+        - text
+    output:
+        - text
 mode: chat
 model: anthropic/claude-opus-4.5
 sources:

--- a/providers/openrouter/anthropic/claude-opus-4.6.yaml
+++ b/providers/openrouter/anthropic/claude-opus-4.6.yaml
@@ -4,19 +4,6 @@ costs:
       input_cost_per_token: 0.000005
       output_cost_per_token: 0.000025
       region: "*"
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 0.000001
-                from: 200000
-          cache_write:
-              - cost_per_token: 0.0000125
-                from: 200000
-          input:
-              - cost_per_token: 0.00001
-                from: 200000
-          output:
-              - cost_per_token: 0.0000375
-                from: 200000
 features:
     - function_calling
     - tool_choice
@@ -27,10 +14,12 @@ features:
 limits:
     context_window: 1000000
     max_output_tokens: 128000
-    max_tokens: 128000
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: anthropic/claude-opus-4.6
 params:

--- a/providers/openrouter/anthropic/claude-opus-4.yaml
+++ b/providers/openrouter/anthropic/claude-opus-4.yaml
@@ -1,7 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 0.00001875
       cache_read_input_token_cost: 0.0000015
-      input_cost_per_image: 0.0048
       input_cost_per_token: 0.000015
       output_cost_per_token: 0.000075
       region: "*"
@@ -12,12 +11,14 @@ features:
     - assistant_prefill
 limits:
     context_window: 200000
-    max_input_tokens: 200000
     max_output_tokens: 32000
-    max_tokens: 32000
 modalities:
     input:
         - image
+        - text
+        - pdf
+    output:
+        - text
 mode: chat
 model: anthropic/claude-opus-4
 sources:

--- a/providers/openrouter/anthropic/claude-sonnet-4.5.yaml
+++ b/providers/openrouter/anthropic/claude-sonnet-4.5.yaml
@@ -1,24 +1,9 @@
 costs:
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3.e-7
-      input_cost_per_image: 0.0048
-      input_cost_per_query: 0.01
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: "*"
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 6.e-7
-                from: 200000
-          cache_write:
-              - cost_per_token: 0.0000075
-                from: 200000
-          input:
-              - cost_per_token: 0.000006
-                from: 200000
-          output:
-              - cost_per_token: 0.0000225
-                from: 200000
 features:
     - function_calling
     - tool_choice
@@ -27,10 +12,13 @@ features:
 limits:
     context_window: 1000000
     max_output_tokens: 64000
-    max_tokens: 64000
 modalities:
     input:
+        - text
         - image
+        - pdf
+    output:
+        - text
 mode: chat
 model: anthropic/claude-sonnet-4.5
 sources:

--- a/providers/openrouter/anthropic/claude-sonnet-4.6.yaml
+++ b/providers/openrouter/anthropic/claude-sonnet-4.6.yaml
@@ -14,10 +14,12 @@ features:
 limits:
     context_window: 1000000
     max_output_tokens: 128000
-    max_tokens: 128000
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: anthropic/claude-sonnet-4.6
 params:

--- a/providers/openrouter/anthropic/claude-sonnet-4.yaml
+++ b/providers/openrouter/anthropic/claude-sonnet-4.yaml
@@ -4,19 +4,6 @@ costs:
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: "*"
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 6.e-7
-                from: 200000
-          cache_write:
-              - cost_per_token: 0.0000075
-                from: 200000
-          input:
-              - cost_per_token: 0.000006
-                from: 200000
-          output:
-              - cost_per_token: 0.0000225
-                from: 200000
 features:
     - function_calling
     - tool_choice
@@ -25,10 +12,13 @@ features:
 limits:
     context_window: 200000
     max_output_tokens: 64000
-    max_tokens: 64000
 modalities:
     input:
         - image
+        - text
+        - pdf
+    output:
+        - text
 mode: chat
 model: anthropic/claude-sonnet-4
 sources:

--- a/providers/openrouter/arcee-ai/coder-large.yaml
+++ b/providers/openrouter/arcee-ai/coder-large.yaml
@@ -7,6 +7,11 @@ features:
     - function_calling
 limits:
     context_window: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: arcee-ai/coder-large
 sources:

--- a/providers/openrouter/arcee-ai/maestro-reasoning.yaml
+++ b/providers/openrouter/arcee-ai/maestro-reasoning.yaml
@@ -5,7 +5,11 @@ costs:
 limits:
     context_window: 131072
     max_output_tokens: 32000
-    max_tokens: 32000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: arcee-ai/maestro-reasoning
 sources:

--- a/providers/openrouter/arcee-ai/spotlight.yaml
+++ b/providers/openrouter/arcee-ai/spotlight.yaml
@@ -5,10 +5,12 @@ costs:
 limits:
     context_window: 131072
     max_output_tokens: 65537
-    max_tokens: 65537
 modalities:
     input:
         - image
+        - text
+    output:
+        - text
 mode: chat
 model: arcee-ai/spotlight
 sources:

--- a/providers/openrouter/arcee-ai/trinity-large-preview:free.yaml
+++ b/providers/openrouter/arcee-ai/trinity-large-preview:free.yaml
@@ -1,5 +1,6 @@
 costs:
-    - input_cost_per_token: 0
+    - input_cost_per_image: 0
+      input_cost_per_token: 0
       output_cost_per_token: 0
       region: "*"
 features:
@@ -10,6 +11,11 @@ features:
     - tools
 limits:
     context_window: 131000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: arcee-ai/trinity-large-preview:free
 sources:

--- a/providers/openrouter/arcee-ai/trinity-mini.yaml
+++ b/providers/openrouter/arcee-ai/trinity-mini.yaml
@@ -10,7 +10,11 @@ features:
 limits:
     context_window: 131072
     max_output_tokens: 131072
-    max_tokens: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: arcee-ai/trinity-mini
 sources:

--- a/providers/openrouter/arcee-ai/trinity-mini:free.yaml
+++ b/providers/openrouter/arcee-ai/trinity-mini:free.yaml
@@ -9,8 +9,11 @@ features:
     - tools
 limits:
     context_window: 131072
-    max_output_tokens: 131072
-    max_tokens: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: arcee-ai/trinity-mini:free
 sources:

--- a/providers/openrouter/arcee-ai/virtuoso-large.yaml
+++ b/providers/openrouter/arcee-ai/virtuoso-large.yaml
@@ -8,9 +8,12 @@ features:
     - tools
 limits:
     context_window: 131072
-    max_input_tokens: 131072
     max_output_tokens: 64000
-    max_tokens: 64000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: arcee-ai/virtuoso-large
 sources:

--- a/providers/openrouter/baidu/ernie-4.5-21b-a3b-thinking.yaml
+++ b/providers/openrouter/baidu/ernie-4.5-21b-a3b-thinking.yaml
@@ -5,7 +5,11 @@ costs:
 limits:
     context_window: 131072
     max_output_tokens: 65536
-    max_tokens: 65536
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: baidu/ernie-4.5-21b-a3b-thinking
 sources:

--- a/providers/openrouter/baidu/ernie-4.5-21b-a3b.yaml
+++ b/providers/openrouter/baidu/ernie-4.5-21b-a3b.yaml
@@ -9,7 +9,11 @@ features:
 limits:
     context_window: 120000
     max_output_tokens: 8000
-    max_tokens: 8000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: baidu/ernie-4.5-21b-a3b
 sources:

--- a/providers/openrouter/baidu/ernie-4.5-300b-a47b.yaml
+++ b/providers/openrouter/baidu/ernie-4.5-300b-a47b.yaml
@@ -5,9 +5,13 @@ costs:
 features:
     - structured_output
 limits:
-    context_window: 131072
+    context_window: 123000
     max_output_tokens: 12000
-    max_tokens: 12000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: baidu/ernie-4.5-300b-a47b
 params:

--- a/providers/openrouter/baidu/ernie-4.5-vl-28b-a3b.yaml
+++ b/providers/openrouter/baidu/ernie-4.5-vl-28b-a3b.yaml
@@ -7,12 +7,14 @@ features:
     - tool_choice
     - tools
 limits:
-    context_window: 131072
+    context_window: 30000
     max_output_tokens: 8000
-    max_tokens: 8000
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: baidu/ernie-4.5-vl-28b-a3b
 sources:

--- a/providers/openrouter/baidu/ernie-4.5-vl-424b-a47b.yaml
+++ b/providers/openrouter/baidu/ernie-4.5-vl-424b-a47b.yaml
@@ -5,10 +5,12 @@ costs:
 limits:
     context_window: 123000
     max_output_tokens: 16000
-    max_tokens: 16000
 modalities:
     input:
         - image
+        - text
+    output:
+        - text
 mode: chat
 model: baidu/ernie-4.5-vl-424b-a47b
 sources:

--- a/providers/openrouter/bytedance-seed/seed-1.6-flash.yaml
+++ b/providers/openrouter/bytedance-seed/seed-1.6-flash.yaml
@@ -2,13 +2,6 @@ costs:
     - input_cost_per_token: 7.5e-8
       output_cost_per_token: 3.e-7
       region: "*"
-      tiered_pricing:
-          input:
-              - cost_per_token: 1.e-7
-                from: 128000
-          output:
-              - cost_per_token: 8.e-7
-                from: 128000
 features:
     - function_calling
     - tool_choice
@@ -17,10 +10,13 @@ features:
 limits:
     context_window: 262144
     max_output_tokens: 32768
-    max_tokens: 32768
 modalities:
     input:
         - image
+        - text
+        - video
+    output:
+        - text
 mode: chat
 model: bytedance-seed/seed-1.6-flash
 sources:

--- a/providers/openrouter/bytedance-seed/seed-1.6.yaml
+++ b/providers/openrouter/bytedance-seed/seed-1.6.yaml
@@ -2,13 +2,6 @@ costs:
     - input_cost_per_token: 2.5e-7
       output_cost_per_token: 0.000002
       region: "*"
-      tiered_pricing:
-          input:
-              - cost_per_token: 5.e-7
-                from: 128000
-          output:
-              - cost_per_token: 0.000004
-                from: 128000
 features:
     - function_calling
     - tool_choice
@@ -18,10 +11,13 @@ features:
 limits:
     context_window: 262144
     max_output_tokens: 32768
-    max_tokens: 32768
 modalities:
     input:
         - image
+        - text
+        - video
+    output:
+        - text
 mode: chat
 model: bytedance-seed/seed-1.6
 sources:

--- a/providers/openrouter/bytedance-seed/seed-2.0-lite.yaml
+++ b/providers/openrouter/bytedance-seed/seed-2.0-lite.yaml
@@ -2,13 +2,6 @@ costs:
     - input_cost_per_token: 2.5e-7
       output_cost_per_token: 0.000002
       region: "*"
-      tiered_pricing:
-          input:
-              - cost_per_token: 5.e-7
-                from: 128000
-          output:
-              - cost_per_token: 0.000004
-                from: 128000
 features:
     - function_calling
     - structured_output
@@ -17,10 +10,13 @@ features:
 limits:
     context_window: 262144
     max_output_tokens: 131072
-    max_tokens: 131072
 modalities:
     input:
+        - text
         - image
+        - video
+    output:
+        - text
 mode: chat
 model: bytedance-seed/seed-2.0-lite
 sources:

--- a/providers/openrouter/bytedance-seed/seed-2.0-mini.yaml
+++ b/providers/openrouter/bytedance-seed/seed-2.0-mini.yaml
@@ -2,13 +2,6 @@ costs:
     - input_cost_per_token: 1.e-7
       output_cost_per_token: 4.e-7
       region: "*"
-      tiered_pricing:
-          input:
-              - cost_per_token: 2.e-7
-                from: 128000
-          output:
-              - cost_per_token: 8.e-7
-                from: 128000
 features:
     - function_calling
     - tool_choice
@@ -18,10 +11,13 @@ features:
 limits:
     context_window: 262144
     max_output_tokens: 131072
-    max_tokens: 131072
 modalities:
     input:
+        - text
         - image
+        - video
+    output:
+        - text
 mode: chat
 model: bytedance-seed/seed-2.0-mini
 sources:

--- a/providers/openrouter/bytedance/ui-tars-1.5-7b.yaml
+++ b/providers/openrouter/bytedance/ui-tars-1.5-7b.yaml
@@ -4,12 +4,13 @@ costs:
       region: "*"
 limits:
     context_window: 128000
-    max_input_tokens: 128000
     max_output_tokens: 2048
-    max_tokens: 2048
 modalities:
     input:
         - image
+        - text
+    output:
+        - text
 mode: chat
 model: bytedance/ui-tars-1.5-7b
 sources:

--- a/providers/openrouter/cognitivecomputations/dolphin-mistral-24b-venice-edition:free.yaml
+++ b/providers/openrouter/cognitivecomputations/dolphin-mistral-24b-venice-edition:free.yaml
@@ -6,7 +6,11 @@ features:
     - structured_output
 limits:
     context_window: 32768
-    max_tokens: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: cognitivecomputations/dolphin-mistral-24b-venice-edition:free
 sources:

--- a/providers/openrouter/cohere/command-a.yaml
+++ b/providers/openrouter/cohere/command-a.yaml
@@ -10,7 +10,11 @@ features:
 limits:
     context_window: 256000
     max_output_tokens: 8192
-    max_tokens: 8192
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: cohere/command-a
 sources:

--- a/providers/openrouter/cohere/command-r-08-2024.yaml
+++ b/providers/openrouter/cohere/command-r-08-2024.yaml
@@ -11,7 +11,11 @@ features:
 limits:
     context_window: 128000
     max_output_tokens: 4000
-    max_tokens: 4000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: cohere/command-r-08-2024
 sources:

--- a/providers/openrouter/cohere/command-r-plus-08-2024.yaml
+++ b/providers/openrouter/cohere/command-r-plus-08-2024.yaml
@@ -11,7 +11,11 @@ features:
 limits:
     context_window: 128000
     max_output_tokens: 4000
-    max_tokens: 4000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: cohere/command-r-plus-08-2024
 sources:

--- a/providers/openrouter/cohere/command-r7b-12-2024.yaml
+++ b/providers/openrouter/cohere/command-r7b-12-2024.yaml
@@ -10,7 +10,11 @@ features:
 limits:
     context_window: 128000
     max_output_tokens: 4000
-    max_tokens: 4000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: cohere/command-r7b-12-2024
 sources:

--- a/providers/openrouter/deepcogito/cogito-v2.1-671b.yaml
+++ b/providers/openrouter/deepcogito/cogito-v2.1-671b.yaml
@@ -10,6 +10,11 @@ features:
     - system_messages
 limits:
     context_window: 128000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: deepcogito/cogito-v2.1-671b
 sources:

--- a/providers/openrouter/deepseek/deepseek-chat-v3-0324.yaml
+++ b/providers/openrouter/deepseek/deepseek-chat-v3-0324.yaml
@@ -9,6 +9,11 @@ features:
     - function_calling
 limits:
     context_window: 163840
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: deepseek/deepseek-chat-v3-0324
 sources:

--- a/providers/openrouter/deepseek/deepseek-chat-v3.1.yaml
+++ b/providers/openrouter/deepseek/deepseek-chat-v3.1.yaml
@@ -10,7 +10,11 @@ features:
 limits:
     context_window: 32768
     max_output_tokens: 7168
-    max_tokens: 7168
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: deepseek/deepseek-chat-v3.1
 sources:

--- a/providers/openrouter/deepseek/deepseek-chat.yaml
+++ b/providers/openrouter/deepseek/deepseek-chat.yaml
@@ -8,7 +8,11 @@ features:
 limits:
     context_window: 163840
     max_output_tokens: 163840
-    max_tokens: 163840
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: deepseek/deepseek-chat
 sources:

--- a/providers/openrouter/deepseek/deepseek-r1-0528.yaml
+++ b/providers/openrouter/deepseek/deepseek-r1-0528.yaml
@@ -12,7 +12,11 @@ features:
 limits:
     context_window: 163840
     max_output_tokens: 65536
-    max_tokens: 65536
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: deepseek/deepseek-r1-0528
 sources:

--- a/providers/openrouter/deepseek/deepseek-r1-distill-llama-70b.yaml
+++ b/providers/openrouter/deepseek/deepseek-r1-distill-llama-70b.yaml
@@ -5,7 +5,11 @@ costs:
 limits:
     context_window: 131072
     max_output_tokens: 16384
-    max_tokens: 16384
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: deepseek/deepseek-r1-distill-llama-70b
 sources:

--- a/providers/openrouter/deepseek/deepseek-r1-distill-qwen-32b.yaml
+++ b/providers/openrouter/deepseek/deepseek-r1-distill-qwen-32b.yaml
@@ -7,7 +7,11 @@ features:
 limits:
     context_window: 32768
     max_output_tokens: 32768
-    max_tokens: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: deepseek/deepseek-r1-distill-qwen-32b
 sources:

--- a/providers/openrouter/deepseek/deepseek-r1.yaml
+++ b/providers/openrouter/deepseek/deepseek-r1.yaml
@@ -10,7 +10,11 @@ features:
 limits:
     context_window: 64000
     max_output_tokens: 16000
-    max_tokens: 16000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: deepseek/deepseek-r1
 sources:

--- a/providers/openrouter/deepseek/deepseek-v3.1-terminus.yaml
+++ b/providers/openrouter/deepseek/deepseek-v3.1-terminus.yaml
@@ -1,5 +1,6 @@
 costs:
-    - input_cost_per_token: 2.1e-7
+    - cache_read_input_token_cost: 1.300000002e-7
+      input_cost_per_token: 2.1e-7
       output_cost_per_token: 7.9e-7
       region: "*"
 features:
@@ -8,6 +9,11 @@ features:
     - system_messages
 limits:
     context_window: 163840
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: deepseek/deepseek-v3.1-terminus
 sources:

--- a/providers/openrouter/deepseek/deepseek-v3.2-exp.yaml
+++ b/providers/openrouter/deepseek/deepseek-v3.2-exp.yaml
@@ -11,7 +11,11 @@ features:
 limits:
     context_window: 163840
     max_output_tokens: 65536
-    max_tokens: 65536
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: deepseek/deepseek-v3.2-exp
 sources:

--- a/providers/openrouter/deepseek/deepseek-v3.2-speciale.yaml
+++ b/providers/openrouter/deepseek/deepseek-v3.2-speciale.yaml
@@ -12,7 +12,11 @@ features:
 limits:
     context_window: 163840
     max_output_tokens: 163840
-    max_tokens: 163840
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: deepseek/deepseek-v3.2-speciale
 sources:

--- a/providers/openrouter/deepseek/deepseek-v3.2.yaml
+++ b/providers/openrouter/deepseek/deepseek-v3.2.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.6e-7
-      output_cost_per_token: 3.8e-7
+    - input_cost_per_token: 2.55e-7
+      output_cost_per_token: 4.e-7
       region: "*"
 features:
     - function_calling
@@ -9,9 +9,12 @@ features:
     - assistant_prefill
 limits:
     context_window: 163840
-    max_input_tokens: 163840
     max_output_tokens: 163840
-    max_tokens: 163840
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: deepseek/deepseek-v3.2
 sources:

--- a/providers/openrouter/eleutherai/llemma_7b.yaml
+++ b/providers/openrouter/eleutherai/llemma_7b.yaml
@@ -5,7 +5,11 @@ costs:
 limits:
     context_window: 4096
     max_output_tokens: 4096
-    max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: eleutherai/llemma_7b
 sources:

--- a/providers/openrouter/essentialai/rnj-1-instruct.yaml
+++ b/providers/openrouter/essentialai/rnj-1-instruct.yaml
@@ -8,6 +8,11 @@ features:
     - tools
 limits:
     context_window: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: essentialai/rnj-1-instruct
 sources:

--- a/providers/openrouter/google/gemini-2.5-flash-image.yaml
+++ b/providers/openrouter/google/gemini-2.5-flash-image.yaml
@@ -1,7 +1,8 @@
 costs:
-    - input_cost_per_audio_token: 0.000001
+    - cache_creation_input_token_cost: 8.333333333333334e-8
+      cache_read_input_token_cost: 3.e-8
+      input_cost_per_image: 3.e-7
       input_cost_per_token: 3.e-7
-      output_cost_per_image_token: 0.00003
       output_cost_per_token: 0.0000025
       region: "*"
 features:
@@ -10,10 +11,13 @@ features:
 limits:
     context_window: 32768
     max_output_tokens: 32768
-    max_tokens: 32768
 modalities:
     input:
         - image
+        - text
+    output:
+        - image
+        - text
 mode: chat
 model: google/gemini-2.5-flash-image
 sources:

--- a/providers/openrouter/google/gemini-2.5-flash-lite-preview-09-2025.yaml
+++ b/providers/openrouter/google/gemini-2.5-flash-lite-preview-09-2025.yaml
@@ -1,5 +1,7 @@
 costs:
-    - input_cost_per_audio_token: 3.e-7
+    - cache_creation_input_token_cost: 8.333333333333334e-8
+      cache_read_input_token_cost: 1.e-8
+      input_cost_per_image: 1.e-7
       input_cost_per_token: 1.e-7
       output_cost_per_token: 4.e-7
       region: "*"
@@ -11,11 +13,15 @@ features:
 limits:
     context_window: 1048576
     max_output_tokens: 65536
-    max_tokens: 65536
 modalities:
     input:
-        - audio
+        - text
         - image
+        - pdf
+        - audio
+        - video
+    output:
+        - text
 mode: chat
 model: google/gemini-2.5-flash-lite-preview-09-2025
 sources:

--- a/providers/openrouter/google/gemini-2.5-flash-lite.yaml
+++ b/providers/openrouter/google/gemini-2.5-flash-lite.yaml
@@ -1,8 +1,7 @@
 costs:
-    - cache_read_input_token_cost: 1.e-8
-      cache_storage_cost_per_token_per_hour: 8.33e-8
-      input_cost_per_audio_token: 3.e-7
-      input_cost_per_image_token: 1.e-7
+    - cache_creation_input_token_cost: 8.333333333333334e-8
+      cache_read_input_token_cost: 1.e-8
+      input_cost_per_image: 1.e-7
       input_cost_per_token: 1.e-7
       output_cost_per_token: 4.e-7
       region: "*"
@@ -15,11 +14,15 @@ features:
 limits:
     context_window: 1048576
     max_output_tokens: 65535
-    max_tokens: 65535
 modalities:
     input:
-        - audio
+        - text
         - image
+        - pdf
+        - audio
+        - video
+    output:
+        - text
 mode: chat
 model: google/gemini-2.5-flash-lite
 sources:

--- a/providers/openrouter/google/gemini-2.5-flash.yaml
+++ b/providers/openrouter/google/gemini-2.5-flash.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_creation_input_token_cost: 8.333333e-8
+    - cache_creation_input_token_cost: 8.333333333333334e-8
       cache_read_input_token_cost: 3.e-8
-      input_cost_per_audio_token: 0.000001
+      input_cost_per_image: 3.e-7
       input_cost_per_token: 3.e-7
       output_cost_per_token: 0.0000025
       region: "*"
@@ -13,11 +13,15 @@ features:
 limits:
     context_window: 1048576
     max_output_tokens: 65535
-    max_tokens: 65535
 modalities:
     input:
-        - audio
+        - pdf
         - image
+        - text
+        - audio
+        - video
+    output:
+        - text
 mode: chat
 model: google/gemini-2.5-flash
 sources:

--- a/providers/openrouter/google/gemini-2.5-pro-preview-05-06.yaml
+++ b/providers/openrouter/google/gemini-2.5-pro-preview-05-06.yaml
@@ -1,24 +1,10 @@
 costs:
     - cache_creation_input_token_cost: 3.75e-7
       cache_read_input_token_cost: 1.25e-7
-      input_cost_per_audio_token: 0.00000125
-      input_cost_per_image_token: 0.00000125
+      input_cost_per_image: 0.00000125
       input_cost_per_token: 0.00000125
       output_cost_per_token: 0.00001
       region: "*"
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 2.5e-7
-                from: 200000
-          cache_write:
-              - cost_per_token: 7.5e-7
-                from: 200000
-          input:
-              - cost_per_token: 0.0000025
-                from: 200000
-          output:
-              - cost_per_token: 0.000015
-                from: 200000
 features:
     - function_calling
     - system_messages
@@ -28,12 +14,16 @@ features:
     - tools
 limits:
     context_window: 1048576
-    max_output_tokens: 65536
-    max_tokens: 65536
+    max_output_tokens: 65535
 modalities:
     input:
-        - audio
+        - text
         - image
+        - pdf
+        - audio
+        - video
+    output:
+        - text
 mode: chat
 model: google/gemini-2.5-pro-preview-05-06
 sources:

--- a/providers/openrouter/google/gemini-2.5-pro-preview.yaml
+++ b/providers/openrouter/google/gemini-2.5-pro-preview.yaml
@@ -1,23 +1,10 @@
 costs:
     - cache_creation_input_token_cost: 3.75e-7
       cache_read_input_token_cost: 1.25e-7
-      input_cost_per_audio_token: 0.00000125
+      input_cost_per_image: 0.00000125
       input_cost_per_token: 0.00000125
       output_cost_per_token: 0.00001
       region: "*"
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 2.5e-7
-                from: 200000
-          cache_write:
-              - cost_per_token: 7.5e-7
-                from: 200000
-          input:
-              - cost_per_token: 0.0000025
-                from: 200000
-          output:
-              - cost_per_token: 0.000015
-                from: 200000
 features:
     - function_calling
     - tool_choice
@@ -27,11 +14,14 @@ features:
 limits:
     context_window: 1048576
     max_output_tokens: 65536
-    max_tokens: 65536
 modalities:
     input:
-        - audio
+        - pdf
         - image
+        - text
+        - audio
+    output:
+        - text
 mode: chat
 model: google/gemini-2.5-pro-preview
 sources:

--- a/providers/openrouter/google/gemini-2.5-pro.yaml
+++ b/providers/openrouter/google/gemini-2.5-pro.yaml
@@ -1,20 +1,10 @@
 costs:
-    - cache_read_input_token_cost: 1.25e-7
-      cache_storage_cost_per_token_per_hour: 0.0000045
-      input_cost_per_audio_token: 0.00000125
+    - cache_creation_input_token_cost: 3.75e-7
+      cache_read_input_token_cost: 1.25e-7
+      input_cost_per_image: 0.00000125
       input_cost_per_token: 0.00000125
       output_cost_per_token: 0.00001
       region: "*"
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 2.5e-7
-                from: 200000
-          input:
-              - cost_per_token: 0.0000025
-                from: 200000
-          output:
-              - cost_per_token: 0.000015
-                from: 200000
 features:
     - function_calling
     - system_messages
@@ -22,13 +12,16 @@ features:
     - structured_output
 limits:
     context_window: 1048576
-    max_input_tokens: 1048576
     max_output_tokens: 65536
-    max_tokens: 65536
 modalities:
     input:
-        - audio
+        - text
         - image
+        - pdf
+        - audio
+        - video
+    output:
+        - text
 mode: chat
 model: google/gemini-2.5-pro
 sources:

--- a/providers/openrouter/google/gemini-3-flash-preview.yaml
+++ b/providers/openrouter/google/gemini-3-flash-preview.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_token_cost: 5.e-8
-      cache_storage_cost_per_token_per_hour: 0.000001
-      input_cost_per_audio_token: 0.000001
+    - cache_creation_input_token_cost: 8.333333333333334e-8
+      cache_read_input_token_cost: 5.e-8
+      input_cost_per_image: 5.e-7
       input_cost_per_token: 5.e-7
       output_cost_per_token: 0.000003
       region: "*"
@@ -15,12 +15,15 @@ features:
 limits:
     context_window: 1048576
     max_output_tokens: 65536
-    max_tokens: 65536
 modalities:
     input:
-        - audio
+        - text
         - image
         - pdf
+        - audio
+        - video
+    output:
+        - text
 mode: chat
 model: google/gemini-3-flash-preview
 sources:

--- a/providers/openrouter/google/gemini-3-pro-image-preview.yaml
+++ b/providers/openrouter/google/gemini-3-pro-image-preview.yaml
@@ -1,10 +1,8 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
-      cache_storage_cost_per_token_per_hour: 0.0000045
-      input_cost_per_audio_token: 0.000002
-      input_cost_per_image_token: 0.000002
+    - cache_creation_input_token_cost: 3.75e-7
+      cache_read_input_token_cost: 2.e-7
+      input_cost_per_image: 0.000002
       input_cost_per_token: 0.000002
-      output_cost_per_image_token: 0.00012
       output_cost_per_token: 0.000012
       region: "*"
 features:
@@ -16,10 +14,13 @@ features:
 limits:
     context_window: 65536
     max_output_tokens: 32768
-    max_tokens: 32768
 modalities:
     input:
         - image
+        - text
+    output:
+        - image
+        - text
 mode: chat
 model: google/gemini-3-pro-image-preview
 sources:

--- a/providers/openrouter/google/gemini-3.1-flash-image-preview.yaml
+++ b/providers/openrouter/google/gemini-3.1-flash-image-preview.yaml
@@ -1,6 +1,5 @@
 costs:
     - input_cost_per_token: 5.e-7
-      output_cost_per_image_token: 0.00006
       output_cost_per_token: 0.000003
       region: "*"
 features:
@@ -12,10 +11,13 @@ features:
 limits:
     context_window: 65536
     max_output_tokens: 65536
-    max_tokens: 65536
 modalities:
     input:
         - image
+        - text
+    output:
+        - image
+        - text
 mode: chat
 model: google/gemini-3.1-flash-image-preview
 sources:

--- a/providers/openrouter/google/gemini-3.1-flash-lite-preview.yaml
+++ b/providers/openrouter/google/gemini-3.1-flash-lite-preview.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_token_cost: 2.5e-8
-      cache_storage_cost_per_token_per_hour: 0.000001
-      input_cost_per_audio_token: 5.e-7
+    - cache_creation_input_token_cost: 8.333333333333334e-8
+      cache_read_input_token_cost: 2.5e-8
+      input_cost_per_image: 2.5e-7
       input_cost_per_token: 2.5e-7
       output_cost_per_token: 0.0000015
       region: "*"
@@ -13,11 +13,15 @@ features:
 limits:
     context_window: 1048576
     max_output_tokens: 65536
-    max_tokens: 65536
 modalities:
     input:
-        - audio
+        - text
         - image
+        - video
+        - pdf
+        - audio
+    output:
+        - text
 mode: chat
 model: google/gemini-3.1-flash-lite-preview
 params:

--- a/providers/openrouter/google/gemini-3.1-pro-preview-customtools.yaml
+++ b/providers/openrouter/google/gemini-3.1-pro-preview-customtools.yaml
@@ -1,20 +1,10 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
-      cache_storage_cost_per_token_per_hour: 0.0000045
-      input_cost_per_audio_token: 0.000002
+    - cache_creation_input_token_cost: 3.75e-7
+      cache_read_input_token_cost: 2.e-7
+      input_cost_per_image: 0.000002
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000012
       region: "*"
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 4.e-7
-                from: 200000
-          input:
-              - cost_per_token: 0.000004
-                from: 200000
-          output:
-              - cost_per_token: 0.000018
-                from: 200000
 features:
     - function_calling
     - tool_choice
@@ -25,11 +15,15 @@ features:
 limits:
     context_window: 1048576
     max_output_tokens: 65536
-    max_tokens: 65536
 modalities:
     input:
+        - text
         - audio
         - image
+        - video
+        - pdf
+    output:
+        - text
 mode: chat
 model: google/gemini-3.1-pro-preview-customtools
 sources:

--- a/providers/openrouter/google/gemini-3.1-pro-preview.yaml
+++ b/providers/openrouter/google/gemini-3.1-pro-preview.yaml
@@ -1,5 +1,7 @@
 costs:
-    - input_cost_per_audio_token: 0.000002
+    - cache_creation_input_token_cost: 3.75e-7
+      cache_read_input_token_cost: 2.e-7
+      input_cost_per_image: 0.000002
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000012
       region: "*"
@@ -12,12 +14,15 @@ features:
 limits:
     context_window: 1048576
     max_output_tokens: 65536
-    max_tokens: 65536
 modalities:
     input:
         - audio
-        - image
         - pdf
+        - image
+        - text
+        - video
+    output:
+        - text
 mode: chat
 model: google/gemini-3.1-pro-preview
 sources:

--- a/providers/openrouter/google/gemma-2-27b-it.yaml
+++ b/providers/openrouter/google/gemma-2-27b-it.yaml
@@ -11,7 +11,11 @@ features:
 limits:
     context_window: 8192
     max_output_tokens: 2048
-    max_tokens: 2048
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: google/gemma-2-27b-it
 sources:

--- a/providers/openrouter/google/gemma-2-9b-it.yaml
+++ b/providers/openrouter/google/gemma-2-9b-it.yaml
@@ -8,6 +8,11 @@ features:
     - structured_output
 limits:
     context_window: 8192
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: google/gemma-2-9b-it
 sources:

--- a/providers/openrouter/google/gemma-3-12b-it.yaml
+++ b/providers/openrouter/google/gemma-3-12b-it.yaml
@@ -10,7 +10,10 @@ limits:
     context_window: 131072
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: google/gemma-3-12b-it
 sources:

--- a/providers/openrouter/google/gemma-3-12b-it:free.yaml
+++ b/providers/openrouter/google/gemma-3-12b-it:free.yaml
@@ -9,10 +9,12 @@ features:
 limits:
     context_window: 32768
     max_output_tokens: 8192
-    max_tokens: 8192
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: google/gemma-3-12b-it:free
 sources:

--- a/providers/openrouter/google/gemma-3-27b-it.yaml
+++ b/providers/openrouter/google/gemma-3-27b-it.yaml
@@ -10,12 +10,13 @@ features:
     - tools
 limits:
     context_window: 128000
-    max_input_tokens: 62464
     max_output_tokens: 65536
-    max_tokens: 65536
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: google/gemma-3-27b-it
 sources:

--- a/providers/openrouter/google/gemma-3-27b-it:free.yaml
+++ b/providers/openrouter/google/gemma-3-27b-it:free.yaml
@@ -10,10 +10,12 @@ features:
 limits:
     context_window: 131072
     max_output_tokens: 8192
-    max_tokens: 8192
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: google/gemma-3-27b-it:free
 sources:

--- a/providers/openrouter/google/gemma-3-4b-it.yaml
+++ b/providers/openrouter/google/gemma-3-4b-it.yaml
@@ -8,7 +8,10 @@ limits:
     context_window: 131072
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: google/gemma-3-4b-it
 sources:

--- a/providers/openrouter/google/gemma-3-4b-it:free.yaml
+++ b/providers/openrouter/google/gemma-3-4b-it:free.yaml
@@ -5,10 +5,12 @@ costs:
 limits:
     context_window: 32768
     max_output_tokens: 8192
-    max_tokens: 8192
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: google/gemma-3-4b-it:free
 sources:

--- a/providers/openrouter/google/gemma-3n-e2b-it:free.yaml
+++ b/providers/openrouter/google/gemma-3n-e2b-it:free.yaml
@@ -7,7 +7,11 @@ features:
 limits:
     context_window: 8192
     max_output_tokens: 2048
-    max_tokens: 2048
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: google/gemma-3n-e2b-it:free
 sources:

--- a/providers/openrouter/google/gemma-3n-e4b-it.yaml
+++ b/providers/openrouter/google/gemma-3n-e4b-it.yaml
@@ -4,11 +4,11 @@ costs:
       region: "*"
 limits:
     context_window: 32768
-    max_output_tokens: 4096
-    max_tokens: 4096
 modalities:
     input:
-        - image
+        - text
+    output:
+        - text
 mode: chat
 model: google/gemma-3n-e4b-it
 sources:

--- a/providers/openrouter/google/gemma-3n-e4b-it:free.yaml
+++ b/providers/openrouter/google/gemma-3n-e4b-it:free.yaml
@@ -7,7 +7,11 @@ features:
 limits:
     context_window: 8192
     max_output_tokens: 2048
-    max_tokens: 2048
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: google/gemma-3n-e4b-it:free
 params:

--- a/providers/openrouter/gryphe/mythomax-l2-13b.yaml
+++ b/providers/openrouter/gryphe/mythomax-l2-13b.yaml
@@ -5,7 +5,11 @@ costs:
 limits:
     context_window: 4096
     max_output_tokens: 4096
-    max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: gryphe/mythomax-l2-13b
 sources:

--- a/providers/openrouter/ibm-granite/granite-4.0-h-micro.yaml
+++ b/providers/openrouter/ibm-granite/granite-4.0-h-micro.yaml
@@ -9,6 +9,11 @@ features:
     - system_messages
 limits:
     context_window: 131000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: ibm-granite/granite-4.0-h-micro
 sources:

--- a/providers/openrouter/inception/mercury-2.yaml
+++ b/providers/openrouter/inception/mercury-2.yaml
@@ -11,7 +11,11 @@ features:
 limits:
     context_window: 128000
     max_output_tokens: 50000
-    max_tokens: 50000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: inception/mercury-2
 sources:

--- a/providers/openrouter/inception/mercury-coder.yaml
+++ b/providers/openrouter/inception/mercury-coder.yaml
@@ -11,7 +11,11 @@ features:
 limits:
     context_window: 128000
     max_output_tokens: 32000
-    max_tokens: 32000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: inception/mercury-coder
 sources:

--- a/providers/openrouter/inflection/inflection-3-pi.yaml
+++ b/providers/openrouter/inflection/inflection-3-pi.yaml
@@ -8,7 +8,11 @@ features:
 limits:
     context_window: 8000
     max_output_tokens: 1024
-    max_tokens: 1024
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: inflection/inflection-3-pi
 sources:

--- a/providers/openrouter/inflection/inflection-3-productivity.yaml
+++ b/providers/openrouter/inflection/inflection-3-productivity.yaml
@@ -8,7 +8,11 @@ features:
 limits:
     context_window: 8000
     max_output_tokens: 1024
-    max_tokens: 1024
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: inflection/inflection-3-productivity
 sources:

--- a/providers/openrouter/kwaipilot/kat-coder-pro.yaml
+++ b/providers/openrouter/kwaipilot/kat-coder-pro.yaml
@@ -11,7 +11,11 @@ features:
 limits:
     context_window: 256000
     max_output_tokens: 128000
-    max_tokens: 128000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: kwaipilot/kat-coder-pro
 sources:

--- a/providers/openrouter/liquid/lfm-2-24b-a2b.yaml
+++ b/providers/openrouter/liquid/lfm-2-24b-a2b.yaml
@@ -7,7 +7,11 @@ features:
     - tool_choice
 limits:
     context_window: 32768
-    max_tokens: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: liquid/lfm-2-24b-a2b
 sources:

--- a/providers/openrouter/liquid/lfm-2.2-6b.yaml
+++ b/providers/openrouter/liquid/lfm-2.2-6b.yaml
@@ -4,6 +4,11 @@ costs:
       region: "*"
 limits:
     context_window: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: liquid/lfm-2.2-6b
 sources:

--- a/providers/openrouter/liquid/lfm-2.5-1.2b-instruct:free.yaml
+++ b/providers/openrouter/liquid/lfm-2.5-1.2b-instruct:free.yaml
@@ -4,6 +4,11 @@ costs:
       region: "*"
 limits:
     context_window: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: liquid/lfm-2.5-1.2b-instruct:free
 sources:

--- a/providers/openrouter/liquid/lfm-2.5-1.2b-thinking:free.yaml
+++ b/providers/openrouter/liquid/lfm-2.5-1.2b-thinking:free.yaml
@@ -6,6 +6,11 @@ features:
     - system_messages
 limits:
     context_window: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: liquid/lfm-2.5-1.2b-thinking:free
 sources:

--- a/providers/openrouter/liquid/lfm2-8b-a1b.yaml
+++ b/providers/openrouter/liquid/lfm2-8b-a1b.yaml
@@ -4,7 +4,11 @@ costs:
       region: "*"
 limits:
     context_window: 32768
-    max_tokens: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: liquid/lfm2-8b-a1b
 sources:

--- a/providers/openrouter/mancer/weaver.yaml
+++ b/providers/openrouter/mancer/weaver.yaml
@@ -5,7 +5,11 @@ costs:
 limits:
     context_window: 8000
     max_output_tokens: 2000
-    max_tokens: 2000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: mancer/weaver
 sources:

--- a/providers/openrouter/meituan/longcat-flash-chat.yaml
+++ b/providers/openrouter/meituan/longcat-flash-chat.yaml
@@ -10,7 +10,11 @@ features:
 limits:
     context_window: 131072
     max_output_tokens: 131072
-    max_tokens: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: meituan/longcat-flash-chat
 sources:

--- a/providers/openrouter/meta-llama/llama-3-70b-instruct.yaml
+++ b/providers/openrouter/meta-llama/llama-3-70b-instruct.yaml
@@ -9,7 +9,11 @@ features:
 limits:
     context_window: 8192
     max_output_tokens: 8000
-    max_tokens: 8000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: meta-llama/llama-3-70b-instruct
 sources:

--- a/providers/openrouter/meta-llama/llama-3-8b-instruct.yaml
+++ b/providers/openrouter/meta-llama/llama-3-8b-instruct.yaml
@@ -10,7 +10,11 @@ features:
 limits:
     context_window: 8192
     max_output_tokens: 16384
-    max_tokens: 16384
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: meta-llama/llama-3-8b-instruct
 sources:

--- a/providers/openrouter/meta-llama/llama-3.1-405b.yaml
+++ b/providers/openrouter/meta-llama/llama-3.1-405b.yaml
@@ -5,7 +5,11 @@ costs:
 limits:
     context_window: 32768
     max_output_tokens: 32768
-    max_tokens: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: meta-llama/llama-3.1-405b
 sources:

--- a/providers/openrouter/meta-llama/llama-3.1-70b-instruct.yaml
+++ b/providers/openrouter/meta-llama/llama-3.1-70b-instruct.yaml
@@ -10,7 +10,11 @@ features:
     - structured_output
 limits:
     context_window: 131072
-    max_tokens: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: meta-llama/llama-3.1-70b-instruct
 sources:

--- a/providers/openrouter/meta-llama/llama-3.1-8b-instruct.yaml
+++ b/providers/openrouter/meta-llama/llama-3.1-8b-instruct.yaml
@@ -9,7 +9,11 @@ features:
 limits:
     context_window: 16384
     max_output_tokens: 16384
-    max_tokens: 16384
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: meta-llama/llama-3.1-8b-instruct
 sources:

--- a/providers/openrouter/meta-llama/llama-3.2-11b-vision-instruct.yaml
+++ b/providers/openrouter/meta-llama/llama-3.2-11b-vision-instruct.yaml
@@ -9,10 +9,12 @@ features:
 limits:
     context_window: 131072
     max_output_tokens: 16384
-    max_tokens: 16384
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: meta-llama/llama-3.2-11b-vision-instruct
 sources:

--- a/providers/openrouter/meta-llama/llama-3.2-1b-instruct.yaml
+++ b/providers/openrouter/meta-llama/llama-3.2-1b-instruct.yaml
@@ -6,8 +6,11 @@ features:
     - system_messages
 limits:
     context_window: 60000
-    max_output_tokens: 4096
-    max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: meta-llama/llama-3.2-1b-instruct
 sources:

--- a/providers/openrouter/meta-llama/llama-3.2-3b-instruct.yaml
+++ b/providers/openrouter/meta-llama/llama-3.2-3b-instruct.yaml
@@ -7,6 +7,11 @@ features:
     - system_messages
 limits:
     context_window: 80000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: meta-llama/llama-3.2-3b-instruct
 sources:

--- a/providers/openrouter/meta-llama/llama-3.2-3b-instruct:free.yaml
+++ b/providers/openrouter/meta-llama/llama-3.2-3b-instruct:free.yaml
@@ -7,6 +7,11 @@ features:
     - system_messages
 limits:
     context_window: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: meta-llama/llama-3.2-3b-instruct:free
 sources:

--- a/providers/openrouter/meta-llama/llama-3.3-70b-instruct.yaml
+++ b/providers/openrouter/meta-llama/llama-3.3-70b-instruct.yaml
@@ -7,9 +7,12 @@ features:
     - tool_choice
 limits:
     context_window: 131072
-    max_input_tokens: 131072
     max_output_tokens: 16384
-    max_tokens: 16384
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: meta-llama/llama-3.3-70b-instruct
 sources:

--- a/providers/openrouter/meta-llama/llama-3.3-70b-instruct:free.yaml
+++ b/providers/openrouter/meta-llama/llama-3.3-70b-instruct:free.yaml
@@ -9,7 +9,11 @@ features:
 limits:
     context_window: 128000
     max_output_tokens: 128000
-    max_tokens: 128000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: meta-llama/llama-3.3-70b-instruct:free
 sources:

--- a/providers/openrouter/meta-llama/llama-4-maverick.yaml
+++ b/providers/openrouter/meta-llama/llama-4-maverick.yaml
@@ -8,10 +8,12 @@ features:
 limits:
     context_window: 1048576
     max_output_tokens: 16384
-    max_tokens: 16384
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: meta-llama/llama-4-maverick
 sources:

--- a/providers/openrouter/meta-llama/llama-4-scout.yaml
+++ b/providers/openrouter/meta-llama/llama-4-scout.yaml
@@ -11,10 +11,12 @@ features:
 limits:
     context_window: 327680
     max_output_tokens: 16384
-    max_tokens: 16384
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: meta-llama/llama-4-scout
 sources:

--- a/providers/openrouter/meta-llama/llama-guard-3-8b.yaml
+++ b/providers/openrouter/meta-llama/llama-guard-3-8b.yaml
@@ -7,6 +7,11 @@ features:
     - tool_choice
 limits:
     context_window: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: meta-llama/llama-guard-3-8b
 sources:

--- a/providers/openrouter/meta-llama/llama-guard-4-12b.yaml
+++ b/providers/openrouter/meta-llama/llama-guard-4-12b.yaml
@@ -9,6 +9,9 @@ limits:
 modalities:
     input:
         - image
+        - text
+    output:
+        - text
 mode: chat
 model: meta-llama/llama-guard-4-12b
 sources:

--- a/providers/openrouter/microsoft/phi-4.yaml
+++ b/providers/openrouter/microsoft/phi-4.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 6.e-8
+    - input_cost_per_token: 6.5e-8
       output_cost_per_token: 1.4e-7
       region: "*"
 features:
@@ -7,7 +7,11 @@ features:
 limits:
     context_window: 16384
     max_output_tokens: 16384
-    max_tokens: 16384
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: microsoft/phi-4
 sources:

--- a/providers/openrouter/microsoft/wizardlm-2-8x22b.yaml
+++ b/providers/openrouter/microsoft/wizardlm-2-8x22b.yaml
@@ -9,7 +9,11 @@ features:
 limits:
     context_window: 65535
     max_output_tokens: 8000
-    max_tokens: 8000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: microsoft/wizardlm-2-8x22b
 sources:

--- a/providers/openrouter/minimax/minimax-01.yaml
+++ b/providers/openrouter/minimax/minimax-01.yaml
@@ -5,10 +5,12 @@ costs:
 limits:
     context_window: 1000192
     max_output_tokens: 1000192
-    max_tokens: 1000192
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: minimax/minimax-01
 sources:

--- a/providers/openrouter/minimax/minimax-m1.yaml
+++ b/providers/openrouter/minimax/minimax-m1.yaml
@@ -2,10 +2,6 @@ costs:
     - input_cost_per_token: 4.e-7
       output_cost_per_token: 0.0000022
       region: "*"
-      tiered_pricing:
-          input:
-              - cost_per_token: 0.0000013
-                from: 200000
 features:
     - function_calling
     - system_messages
@@ -13,7 +9,11 @@ features:
 limits:
     context_window: 1000000
     max_output_tokens: 40000
-    max_tokens: 40000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: minimax/minimax-m1
 sources:

--- a/providers/openrouter/minimax/minimax-m2-her.yaml
+++ b/providers/openrouter/minimax/minimax-m2-her.yaml
@@ -1,5 +1,6 @@
 costs:
-    - input_cost_per_token: 3.e-7
+    - cache_read_input_token_cost: 3.e-8
+      input_cost_per_token: 3.e-7
       output_cost_per_token: 0.0000012
       region: "*"
 features:
@@ -7,7 +8,11 @@ features:
 limits:
     context_window: 65536
     max_output_tokens: 2048
-    max_tokens: 2048
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: minimax/minimax-m2-her
 sources:

--- a/providers/openrouter/minimax/minimax-m2.1.yaml
+++ b/providers/openrouter/minimax/minimax-m2.1.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.9e-8
+    - cache_read_input_token_cost: 2.90000007e-8
       input_cost_per_token: 2.7e-7
       output_cost_per_token: 9.5e-7
       region: "*"
@@ -8,9 +8,11 @@ features:
     - tool_choice
 limits:
     context_window: 196608
-    max_input_tokens: 196608
-    max_output_tokens: 64000
-    max_tokens: 64000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: minimax/minimax-m2.1
 sources:

--- a/providers/openrouter/minimax/minimax-m2.5.yaml
+++ b/providers/openrouter/minimax/minimax-m2.5.yaml
@@ -1,7 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 3.e-8
-      input_cost_per_token: 2.7e-7
-      output_cost_per_token: 9.5e-7
+    - input_cost_per_token: 2.e-7
+      output_cost_per_token: 0.0000012
       region: "*"
 features:
     - function_calling
@@ -9,6 +8,12 @@ features:
     - structured_output
 limits:
     context_window: 196608
+    max_output_tokens: 196608
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: minimax/minimax-m2.5
 sources:

--- a/providers/openrouter/minimax/minimax-m2.5:free.yaml
+++ b/providers/openrouter/minimax/minimax-m2.5:free.yaml
@@ -11,7 +11,11 @@ features:
 limits:
     context_window: 196608
     max_output_tokens: 196608
-    max_tokens: 196608
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: minimax/minimax-m2.5:free
 sources:

--- a/providers/openrouter/minimax/minimax-m2.yaml
+++ b/providers/openrouter/minimax/minimax-m2.yaml
@@ -1,6 +1,7 @@
 costs:
-    - input_cost_per_token: 2.55e-7
-      output_cost_per_token: 0.00000102
+    - cache_read_input_token_cost: 3.e-8
+      input_cost_per_token: 2.55e-7
+      output_cost_per_token: 0.000001
       region: "*"
 features:
     - function_calling
@@ -8,9 +9,12 @@ features:
     - prompt_caching
 limits:
     context_window: 196608
-    max_input_tokens: 196608
     max_output_tokens: 196608
-    max_tokens: 196608
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: minimax/minimax-m2
 sources:

--- a/providers/openrouter/mistralai/codestral-2508.yaml
+++ b/providers/openrouter/mistralai/codestral-2508.yaml
@@ -1,5 +1,6 @@
 costs:
-    - input_cost_per_token: 3.e-7
+    - cache_read_input_token_cost: 3.e-8
+      input_cost_per_token: 3.e-7
       output_cost_per_token: 9.e-7
       region: "*"
 features:
@@ -9,6 +10,11 @@ features:
     - tools
 limits:
     context_window: 256000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: mistralai/codestral-2508
 sources:

--- a/providers/openrouter/mistralai/devstral-2512.yaml
+++ b/providers/openrouter/mistralai/devstral-2512.yaml
@@ -1,5 +1,6 @@
 costs:
-    - input_cost_per_token: 4.e-7
+    - cache_read_input_token_cost: 4.e-8
+      input_cost_per_token: 4.e-7
       output_cost_per_token: 0.000002
       region: "*"
 features:
@@ -8,9 +9,11 @@ features:
     - structured_output
 limits:
     context_window: 262144
-    max_input_tokens: 262144
-    max_output_tokens: 65536
-    max_tokens: 65536
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: mistralai/devstral-2512
 sources:

--- a/providers/openrouter/mistralai/devstral-medium.yaml
+++ b/providers/openrouter/mistralai/devstral-medium.yaml
@@ -1,5 +1,6 @@
 costs:
-    - input_cost_per_token: 4.e-7
+    - cache_read_input_token_cost: 4.e-8
+      input_cost_per_token: 4.e-7
       output_cost_per_token: 0.000002
       region: "*"
 features:
@@ -10,6 +11,11 @@ features:
     - tools
 limits:
     context_window: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: mistralai/devstral-medium
 sources:

--- a/providers/openrouter/mistralai/devstral-small.yaml
+++ b/providers/openrouter/mistralai/devstral-small.yaml
@@ -1,5 +1,6 @@
 costs:
-    - input_cost_per_token: 1.e-7
+    - cache_read_input_token_cost: 1.e-8
+      input_cost_per_token: 1.e-7
       output_cost_per_token: 3.e-7
       region: "*"
 features:
@@ -8,6 +9,11 @@ features:
     - tools
 limits:
     context_window: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: mistralai/devstral-small
 sources:

--- a/providers/openrouter/mistralai/ministral-14b-2512.yaml
+++ b/providers/openrouter/mistralai/ministral-14b-2512.yaml
@@ -1,5 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-7
+    - cache_read_input_token_cost: 2.e-8
+      input_cost_per_token: 2.e-7
       output_cost_per_token: 2.e-7
       region: "*"
 features:
@@ -8,12 +9,12 @@ features:
     - structured_output
 limits:
     context_window: 262144
-    max_input_tokens: 262144
-    max_output_tokens: 262144
-    max_tokens: 262144
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: mistralai/ministral-14b-2512
 sources:

--- a/providers/openrouter/mistralai/ministral-3b-2512.yaml
+++ b/providers/openrouter/mistralai/ministral-3b-2512.yaml
@@ -1,5 +1,6 @@
 costs:
-    - input_cost_per_token: 1.e-7
+    - cache_read_input_token_cost: 1.e-8
+      input_cost_per_token: 1.e-7
       output_cost_per_token: 1.e-7
       region: "*"
 features:
@@ -8,12 +9,12 @@ features:
     - structured_output
 limits:
     context_window: 131072
-    max_input_tokens: 131072
-    max_output_tokens: 131072
-    max_tokens: 131072
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: mistralai/ministral-3b-2512
 sources:

--- a/providers/openrouter/mistralai/ministral-8b-2512.yaml
+++ b/providers/openrouter/mistralai/ministral-8b-2512.yaml
@@ -1,5 +1,6 @@
 costs:
-    - input_cost_per_token: 1.5e-7
+    - cache_read_input_token_cost: 1.5e-8
+      input_cost_per_token: 1.5e-7
       output_cost_per_token: 1.5e-7
       region: "*"
 features:
@@ -7,12 +8,12 @@ features:
     - tool_choice
 limits:
     context_window: 262144
-    max_input_tokens: 262144
-    max_output_tokens: 262144
-    max_tokens: 262144
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: mistralai/ministral-8b-2512
 sources:

--- a/providers/openrouter/mistralai/mistral-7b-instruct-v0.1.yaml
+++ b/providers/openrouter/mistralai/mistral-7b-instruct-v0.1.yaml
@@ -4,6 +4,11 @@ costs:
       region: "*"
 limits:
     context_window: 2824
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: mistralai/mistral-7b-instruct-v0.1
 sources:

--- a/providers/openrouter/mistralai/mistral-large-2407.yaml
+++ b/providers/openrouter/mistralai/mistral-large-2407.yaml
@@ -1,5 +1,6 @@
 costs:
-    - input_cost_per_token: 0.000002
+    - cache_read_input_token_cost: 2.e-7
+      input_cost_per_token: 0.000002
       output_cost_per_token: 0.000006
       region: "*"
 features:
@@ -9,8 +10,11 @@ features:
     - tools
 limits:
     context_window: 131072
-    max_output_tokens: 4096
-    max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: mistralai/mistral-large-2407
 sources:

--- a/providers/openrouter/mistralai/mistral-large-2411.yaml
+++ b/providers/openrouter/mistralai/mistral-large-2411.yaml
@@ -1,5 +1,6 @@
 costs:
-    - input_cost_per_token: 0.000002
+    - cache_read_input_token_cost: 2.e-7
+      input_cost_per_token: 0.000002
       output_cost_per_token: 0.000006
       region: "*"
 features:
@@ -10,6 +11,11 @@ features:
     - system_messages
 limits:
     context_window: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: mistralai/mistral-large-2411
 sources:

--- a/providers/openrouter/mistralai/mistral-large-2512.yaml
+++ b/providers/openrouter/mistralai/mistral-large-2512.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_image: 0
+    - cache_read_input_token_cost: 5.e-8
       input_cost_per_token: 5.e-7
       output_cost_per_token: 0.0000015
       region: "*"
@@ -9,13 +9,12 @@ features:
     - structured_output
 limits:
     context_window: 262144
-    max_input_tokens: 262144
-    max_output_tokens: 262144
-    max_tokens: 262144
 modalities:
     input:
+        - text
         - image
-        - pdf
+    output:
+        - text
 mode: chat
 model: mistralai/mistral-large-2512
 sources:

--- a/providers/openrouter/mistralai/mistral-large.yaml
+++ b/providers/openrouter/mistralai/mistral-large.yaml
@@ -1,5 +1,6 @@
 costs:
-    - input_cost_per_token: 0.000002
+    - cache_read_input_token_cost: 2.e-7
+      input_cost_per_token: 0.000002
       output_cost_per_token: 0.000006
       region: "*"
 features:
@@ -7,8 +8,11 @@ features:
     - tool_choice
 limits:
     context_window: 128000
-    max_output_tokens: 32000
-    max_tokens: 32000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: mistralai/mistral-large
 sources:

--- a/providers/openrouter/mistralai/mistral-medium-3.1.yaml
+++ b/providers/openrouter/mistralai/mistral-medium-3.1.yaml
@@ -1,5 +1,6 @@
 costs:
-    - input_cost_per_token: 4.e-7
+    - cache_read_input_token_cost: 4.e-8
+      input_cost_per_token: 4.e-7
       output_cost_per_token: 0.000002
       region: "*"
 features:
@@ -10,10 +11,12 @@ features:
     - tools
 limits:
     context_window: 131072
-    max_output_tokens: 131072
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: mistralai/mistral-medium-3.1
 sources:

--- a/providers/openrouter/mistralai/mistral-medium-3.yaml
+++ b/providers/openrouter/mistralai/mistral-medium-3.yaml
@@ -1,5 +1,6 @@
 costs:
-    - input_cost_per_token: 4.e-7
+    - cache_read_input_token_cost: 4.e-8
+      input_cost_per_token: 4.e-7
       output_cost_per_token: 0.000002
       region: "*"
 features:
@@ -11,7 +12,10 @@ limits:
     context_window: 131072
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: mistralai/mistral-medium-3
 sources:

--- a/providers/openrouter/mistralai/mistral-nemo.yaml
+++ b/providers/openrouter/mistralai/mistral-nemo.yaml
@@ -11,7 +11,11 @@ features:
 limits:
     context_window: 131072
     max_output_tokens: 16384
-    max_tokens: 16384
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: mistralai/mistral-nemo
 sources:

--- a/providers/openrouter/mistralai/mistral-saba.yaml
+++ b/providers/openrouter/mistralai/mistral-saba.yaml
@@ -1,5 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-7
+    - cache_read_input_token_cost: 2.e-8
+      input_cost_per_token: 2.e-7
       output_cost_per_token: 6.e-7
       region: "*"
 features:
@@ -10,7 +11,11 @@ features:
     - tools
 limits:
     context_window: 32768
-    max_tokens: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: mistralai/mistral-saba
 sources:

--- a/providers/openrouter/mistralai/mistral-small-24b-instruct-2501.yaml
+++ b/providers/openrouter/mistralai/mistral-small-24b-instruct-2501.yaml
@@ -11,7 +11,11 @@ features:
 limits:
     context_window: 32768
     max_output_tokens: 16384
-    max_tokens: 16384
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: mistralai/mistral-small-24b-instruct-2501
 sources:

--- a/providers/openrouter/mistralai/mistral-small-2603.yaml
+++ b/providers/openrouter/mistralai/mistral-small-2603.yaml
@@ -1,2 +1,15 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 1.5e-8
+      input_cost_per_token: 1.5e-7
+      output_cost_per_token: 6.e-7
+      region: "*"
+limits:
+    context_window: 262144
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
+mode: chat
 model: mistralai/mistral-small-2603

--- a/providers/openrouter/mistralai/mistral-small-3.1-24b-instruct.yaml
+++ b/providers/openrouter/mistralai/mistral-small-3.1-24b-instruct.yaml
@@ -8,7 +8,10 @@ limits:
     context_window: 128000
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: mistralai/mistral-small-3.1-24b-instruct
 sources:

--- a/providers/openrouter/mistralai/mistral-small-3.1-24b-instruct:free.yaml
+++ b/providers/openrouter/mistralai/mistral-small-3.1-24b-instruct:free.yaml
@@ -12,7 +12,10 @@ limits:
     context_window: 128000
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: mistralai/mistral-small-3.1-24b-instruct:free
 sources:

--- a/providers/openrouter/mistralai/mistral-small-3.2-24b-instruct.yaml
+++ b/providers/openrouter/mistralai/mistral-small-3.2-24b-instruct.yaml
@@ -10,10 +10,12 @@ features:
 limits:
     context_window: 131072
     max_output_tokens: 131072
-    max_tokens: 131072
 modalities:
     input:
         - image
+        - text
+    output:
+        - text
 mode: chat
 model: mistralai/mistral-small-3.2-24b-instruct
 sources:

--- a/providers/openrouter/mistralai/mistral-small-creative.yaml
+++ b/providers/openrouter/mistralai/mistral-small-creative.yaml
@@ -1,5 +1,6 @@
 costs:
-    - input_cost_per_token: 1.e-7
+    - cache_read_input_token_cost: 1.e-8
+      input_cost_per_token: 1.e-7
       output_cost_per_token: 3.e-7
       region: "*"
 features:
@@ -8,8 +9,11 @@ features:
     - system_messages
 limits:
     context_window: 32768
-    max_output_tokens: 32768
-    max_tokens: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: mistralai/mistral-small-creative
 sources:

--- a/providers/openrouter/mistralai/mixtral-8x22b-instruct.yaml
+++ b/providers/openrouter/mistralai/mixtral-8x22b-instruct.yaml
@@ -1,5 +1,6 @@
 costs:
-    - input_cost_per_token: 0.000002
+    - cache_read_input_token_cost: 2.e-7
+      input_cost_per_token: 0.000002
       output_cost_per_token: 0.000006
       region: "*"
 features:
@@ -8,8 +9,11 @@ features:
     - structured_output
 limits:
     context_window: 65536
-    max_output_tokens: 65536
-    max_tokens: 65536
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: mistralai/mixtral-8x22b-instruct
 sources:

--- a/providers/openrouter/mistralai/mixtral-8x7b-instruct.yaml
+++ b/providers/openrouter/mistralai/mixtral-8x7b-instruct.yaml
@@ -11,7 +11,11 @@ features:
 limits:
     context_window: 32768
     max_output_tokens: 16384
-    max_tokens: 16384
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: mistralai/mixtral-8x7b-instruct
 sources:

--- a/providers/openrouter/mistralai/pixtral-large-2411.yaml
+++ b/providers/openrouter/mistralai/pixtral-large-2411.yaml
@@ -1,5 +1,6 @@
 costs:
-    - input_cost_per_token: 0.000002
+    - cache_read_input_token_cost: 2.e-7
+      input_cost_per_token: 0.000002
       output_cost_per_token: 0.000006
       region: "*"
 features:
@@ -10,11 +11,12 @@ features:
     - tools
 limits:
     context_window: 131072
-    max_output_tokens: 4096
-    max_tokens: 4096
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: mistralai/pixtral-large-2411
 sources:

--- a/providers/openrouter/mistralai/voxtral-small-24b-2507.yaml
+++ b/providers/openrouter/mistralai/voxtral-small-24b-2507.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_audio_token: 0.0001
+    - cache_read_input_token_cost: 1.e-8
       input_cost_per_token: 1.e-7
       output_cost_per_token: 3.e-7
       region: "*"
@@ -11,7 +11,10 @@ limits:
     context_window: 32000
 modalities:
     input:
+        - text
         - audio
+    output:
+        - text
 mode: chat
 model: mistralai/voxtral-small-24b-2507
 sources:

--- a/providers/openrouter/moonshotai/kimi-k2-0905.yaml
+++ b/providers/openrouter/moonshotai/kimi-k2-0905.yaml
@@ -11,6 +11,11 @@ features:
     - system_messages
 limits:
     context_window: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: moonshotai/kimi-k2-0905
 sources:

--- a/providers/openrouter/moonshotai/kimi-k2-thinking.yaml
+++ b/providers/openrouter/moonshotai/kimi-k2-thinking.yaml
@@ -11,6 +11,11 @@ features:
     - structured_output
 limits:
     context_window: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: moonshotai/kimi-k2-thinking
 params:

--- a/providers/openrouter/moonshotai/kimi-k2.5.yaml
+++ b/providers/openrouter/moonshotai/kimi-k2.5.yaml
@@ -10,10 +10,12 @@ features:
 limits:
     context_window: 262144
     max_output_tokens: 65535
-    max_tokens: 65535
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: moonshotai/kimi-k2.5
 sources:

--- a/providers/openrouter/moonshotai/kimi-k2.yaml
+++ b/providers/openrouter/moonshotai/kimi-k2.yaml
@@ -8,8 +8,11 @@ features:
     - tools
 limits:
     context_window: 131000
-    max_output_tokens: 131000
-    max_tokens: 131000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: moonshotai/kimi-k2
 sources:

--- a/providers/openrouter/morph/morph-v3-fast.yaml
+++ b/providers/openrouter/morph/morph-v3-fast.yaml
@@ -5,7 +5,11 @@ costs:
 limits:
     context_window: 81920
     max_output_tokens: 38000
-    max_tokens: 38000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: morph/morph-v3-fast
 sources:

--- a/providers/openrouter/morph/morph-v3-large.yaml
+++ b/providers/openrouter/morph/morph-v3-large.yaml
@@ -5,7 +5,11 @@ costs:
 limits:
     context_window: 262144
     max_output_tokens: 131072
-    max_tokens: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: morph/morph-v3-large
 sources:

--- a/providers/openrouter/nex-agi/deepseek-v3.1-nex-n1.yaml
+++ b/providers/openrouter/nex-agi/deepseek-v3.1-nex-n1.yaml
@@ -10,7 +10,11 @@ features:
 limits:
     context_window: 131072
     max_output_tokens: 163840
-    max_tokens: 163840
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: nex-agi/deepseek-v3.1-nex-n1
 sources:

--- a/providers/openrouter/nousresearch/hermes-2-pro-llama-3-8b.yaml
+++ b/providers/openrouter/nousresearch/hermes-2-pro-llama-3-8b.yaml
@@ -9,7 +9,11 @@ features:
 limits:
     context_window: 8192
     max_output_tokens: 8192
-    max_tokens: 8192
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: nousresearch/hermes-2-pro-llama-3-8b
 sources:

--- a/providers/openrouter/nousresearch/hermes-3-llama-3.1-405b.yaml
+++ b/providers/openrouter/nousresearch/hermes-3-llama-3.1-405b.yaml
@@ -9,7 +9,11 @@ features:
 limits:
     context_window: 131072
     max_output_tokens: 16384
-    max_tokens: 16384
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: nousresearch/hermes-3-llama-3.1-405b
 sources:

--- a/providers/openrouter/nousresearch/hermes-3-llama-3.1-405b:free.yaml
+++ b/providers/openrouter/nousresearch/hermes-3-llama-3.1-405b:free.yaml
@@ -8,6 +8,11 @@ features:
     - system_messages
 limits:
     context_window: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: nousresearch/hermes-3-llama-3.1-405b:free
 sources:

--- a/providers/openrouter/nousresearch/hermes-3-llama-3.1-70b.yaml
+++ b/providers/openrouter/nousresearch/hermes-3-llama-3.1-70b.yaml
@@ -10,6 +10,11 @@ features:
     - tool_choice
 limits:
     context_window: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: nousresearch/hermes-3-llama-3.1-70b
 sources:

--- a/providers/openrouter/nousresearch/hermes-4-405b.yaml
+++ b/providers/openrouter/nousresearch/hermes-4-405b.yaml
@@ -10,6 +10,11 @@ features:
     - system_messages
 limits:
     context_window: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: nousresearch/hermes-4-405b
 sources:

--- a/providers/openrouter/nousresearch/hermes-4-70b.yaml
+++ b/providers/openrouter/nousresearch/hermes-4-70b.yaml
@@ -9,6 +9,11 @@ features:
     - system_messages
 limits:
     context_window: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: nousresearch/hermes-4-70b
 sources:

--- a/providers/openrouter/nvidia/llama-3.1-nemotron-70b-instruct.yaml
+++ b/providers/openrouter/nvidia/llama-3.1-nemotron-70b-instruct.yaml
@@ -9,7 +9,11 @@ features:
 limits:
     context_window: 131072
     max_output_tokens: 16384
-    max_tokens: 16384
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: nvidia/llama-3.1-nemotron-70b-instruct
 sources:

--- a/providers/openrouter/nvidia/llama-3.3-nemotron-super-49b-v1.5.yaml
+++ b/providers/openrouter/nvidia/llama-3.3-nemotron-super-49b-v1.5.yaml
@@ -7,6 +7,11 @@ features:
     - tools
 limits:
     context_window: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: nvidia/llama-3.3-nemotron-super-49b-v1.5
 sources:

--- a/providers/openrouter/nvidia/nemotron-3-nano-30b-a3b.yaml
+++ b/providers/openrouter/nvidia/nemotron-3-nano-30b-a3b.yaml
@@ -10,6 +10,11 @@ features:
     - system_messages
 limits:
     context_window: 262144
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: nvidia/nemotron-3-nano-30b-a3b
 sources:

--- a/providers/openrouter/nvidia/nemotron-3-nano-30b-a3b:free.yaml
+++ b/providers/openrouter/nvidia/nemotron-3-nano-30b-a3b:free.yaml
@@ -9,6 +9,11 @@ features:
     - tools
 limits:
     context_window: 256000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: nvidia/nemotron-3-nano-30b-a3b:free
 sources:

--- a/providers/openrouter/nvidia/nemotron-3-super-120b-a12b:free.yaml
+++ b/providers/openrouter/nvidia/nemotron-3-super-120b-a12b:free.yaml
@@ -1,5 +1,6 @@
 costs:
-    - input_cost_per_token: 0
+    - input_cost_per_image: 0
+      input_cost_per_token: 0
       output_cost_per_token: 0
       region: "*"
 features:
@@ -11,7 +12,11 @@ features:
 limits:
     context_window: 262144
     max_output_tokens: 262144
-    max_tokens: 262144
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: nvidia/nemotron-3-super-120b-a12b:free
 sources:

--- a/providers/openrouter/nvidia/nemotron-nano-12b-v2-vl.yaml
+++ b/providers/openrouter/nvidia/nemotron-nano-12b-v2-vl.yaml
@@ -7,6 +7,10 @@ limits:
 modalities:
     input:
         - image
+        - text
+        - video
+    output:
+        - text
 mode: chat
 model: nvidia/nemotron-nano-12b-v2-vl
 sources:

--- a/providers/openrouter/nvidia/nemotron-nano-12b-v2-vl:free.yaml
+++ b/providers/openrouter/nvidia/nemotron-nano-12b-v2-vl:free.yaml
@@ -4,9 +4,14 @@ costs:
       region: "*"
 limits:
     context_window: 128000
+    max_output_tokens: 128000
 modalities:
     input:
         - image
+        - text
+        - video
+    output:
+        - text
 mode: chat
 model: nvidia/nemotron-nano-12b-v2-vl:free
 sources:

--- a/providers/openrouter/nvidia/nemotron-nano-9b-v2.yaml
+++ b/providers/openrouter/nvidia/nemotron-nano-9b-v2.yaml
@@ -7,6 +7,11 @@ features:
     - tools
 limits:
     context_window: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: nvidia/nemotron-nano-9b-v2
 sources:

--- a/providers/openrouter/nvidia/nemotron-nano-9b-v2:free.yaml
+++ b/providers/openrouter/nvidia/nemotron-nano-9b-v2:free.yaml
@@ -10,6 +10,11 @@ features:
     - tools
 limits:
     context_window: 128000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: nvidia/nemotron-nano-9b-v2:free
 sources:

--- a/providers/openrouter/openai/gpt-3.5-turbo-0613.yaml
+++ b/providers/openrouter/openai/gpt-3.5-turbo-0613.yaml
@@ -11,7 +11,11 @@ features:
 limits:
     context_window: 4095
     max_output_tokens: 4096
-    max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: openai/gpt-3.5-turbo-0613
 sources:

--- a/providers/openrouter/openai/gpt-3.5-turbo-16k.yaml
+++ b/providers/openrouter/openai/gpt-3.5-turbo-16k.yaml
@@ -8,7 +8,11 @@ features:
 limits:
     context_window: 16385
     max_output_tokens: 4096
-    max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: openai/gpt-3.5-turbo-16k
 sources:

--- a/providers/openrouter/openai/gpt-3.5-turbo-instruct.yaml
+++ b/providers/openrouter/openai/gpt-3.5-turbo-instruct.yaml
@@ -5,8 +5,12 @@ costs:
 limits:
     context_window: 4095
     max_output_tokens: 4096
-    max_tokens: 4096
-mode: completion
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: chat
 model: openai/gpt-3.5-turbo-instruct
 sources:
     - https://openrouter.ai/openai/gpt-3.5-turbo-instruct/api

--- a/providers/openrouter/openai/gpt-3.5-turbo.yaml
+++ b/providers/openrouter/openai/gpt-3.5-turbo.yaml
@@ -8,9 +8,12 @@ features:
     - structured_output
 limits:
     context_window: 16385
-    max_input_tokens: 16385
     max_output_tokens: 4096
-    max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: openai/gpt-3.5-turbo
 sources:

--- a/providers/openrouter/openai/gpt-4-0314.yaml
+++ b/providers/openrouter/openai/gpt-4-0314.yaml
@@ -1,3 +1,15 @@
+costs:
+    - input_cost_per_token: 0.00003
+      output_cost_per_token: 0.00006
+      region: "*"
 isDeprecated: true
-mode: unknown
+limits:
+    context_window: 8191
+    max_output_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: chat
 model: openai/gpt-4-0314

--- a/providers/openrouter/openai/gpt-4-1106-preview.yaml
+++ b/providers/openrouter/openai/gpt-4-1106-preview.yaml
@@ -10,7 +10,11 @@ features:
 limits:
     context_window: 128000
     max_output_tokens: 4096
-    max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: openai/gpt-4-1106-preview
 sources:

--- a/providers/openrouter/openai/gpt-4-turbo-preview.yaml
+++ b/providers/openrouter/openai/gpt-4-turbo-preview.yaml
@@ -12,7 +12,11 @@ features:
 limits:
     context_window: 128000
     max_output_tokens: 4096
-    max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: openai/gpt-4-turbo-preview
 sources:

--- a/providers/openrouter/openai/gpt-4-turbo.yaml
+++ b/providers/openrouter/openai/gpt-4-turbo.yaml
@@ -11,10 +11,12 @@ features:
 limits:
     context_window: 128000
     max_output_tokens: 4096
-    max_tokens: 4096
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: openai/gpt-4-turbo
 sources:

--- a/providers/openrouter/openai/gpt-4.1-mini.yaml
+++ b/providers/openrouter/openai/gpt-4.1-mini.yaml
@@ -11,12 +11,15 @@ features:
     - prompt_caching
     - structured_output
 limits:
-    max_input_tokens: 1047576
+    context_window: 1047576
     max_output_tokens: 32768
-    max_tokens: 32768
 modalities:
     input:
         - image
+        - text
+        - pdf
+    output:
+        - text
 mode: chat
 model: openai/gpt-4.1-mini
 sources:

--- a/providers/openrouter/openai/gpt-4.1-nano.yaml
+++ b/providers/openrouter/openai/gpt-4.1-nano.yaml
@@ -12,12 +12,14 @@ features:
     - structured_output
 limits:
     context_window: 1047576
-    max_input_tokens: 1047576
     max_output_tokens: 32768
-    max_tokens: 32768
 modalities:
     input:
         - image
+        - text
+        - pdf
+    output:
+        - text
 mode: chat
 model: openai/gpt-4.1-nano
 sources:

--- a/providers/openrouter/openai/gpt-4.1.yaml
+++ b/providers/openrouter/openai/gpt-4.1.yaml
@@ -12,12 +12,14 @@ features:
     - structured_output
 limits:
     context_window: 1047576
-    max_input_tokens: 1047576
     max_output_tokens: 32768
-    max_tokens: 32768
 modalities:
     input:
         - image
+        - text
+        - pdf
+    output:
+        - text
 mode: chat
 model: openai/gpt-4.1
 sources:

--- a/providers/openrouter/openai/gpt-4.yaml
+++ b/providers/openrouter/openai/gpt-4.yaml
@@ -9,7 +9,11 @@ features:
 limits:
     context_window: 8191
     max_output_tokens: 4096
-    max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: openai/gpt-4
 sources:

--- a/providers/openrouter/openai/gpt-4o-2024-05-13.yaml
+++ b/providers/openrouter/openai/gpt-4o-2024-05-13.yaml
@@ -9,12 +9,14 @@ features:
     - structured_output
 limits:
     context_window: 128000
-    max_input_tokens: 128000
     max_output_tokens: 4096
-    max_tokens: 4096
 modalities:
     input:
+        - text
         - image
+        - pdf
+    output:
+        - text
 mode: chat
 model: openai/gpt-4o-2024-05-13
 sources:

--- a/providers/openrouter/openai/gpt-4o-2024-08-06.yaml
+++ b/providers/openrouter/openai/gpt-4o-2024-08-06.yaml
@@ -13,10 +13,13 @@ features:
 limits:
     context_window: 128000
     max_output_tokens: 16384
-    max_tokens: 16384
 modalities:
     input:
+        - text
         - image
+        - pdf
+    output:
+        - text
 mode: chat
 model: openai/gpt-4o-2024-08-06
 sources:

--- a/providers/openrouter/openai/gpt-4o-2024-11-20.yaml
+++ b/providers/openrouter/openai/gpt-4o-2024-11-20.yaml
@@ -11,10 +11,13 @@ features:
 limits:
     context_window: 128000
     max_output_tokens: 16384
-    max_tokens: 16384
 modalities:
     input:
+        - text
         - image
+        - pdf
+    output:
+        - text
 mode: chat
 model: openai/gpt-4o-2024-11-20
 sources:

--- a/providers/openrouter/openai/gpt-4o-audio-preview.yaml
+++ b/providers/openrouter/openai/gpt-4o-audio-preview.yaml
@@ -1,7 +1,5 @@
 costs:
-    - input_cost_per_audio_token: 0.00004
-      input_cost_per_token: 0.0000025
-      output_cost_per_audio_token: 0.00008
+    - input_cost_per_token: 0.0000025
       output_cost_per_token: 0.00001
       region: "*"
 features:
@@ -13,11 +11,12 @@ features:
 limits:
     context_window: 128000
     max_output_tokens: 16384
-    max_tokens: 16384
 modalities:
     input:
         - audio
+        - text
     output:
+        - text
         - audio
 mode: chat
 model: openai/gpt-4o-audio-preview

--- a/providers/openrouter/openai/gpt-4o-mini-2024-07-18.yaml
+++ b/providers/openrouter/openai/gpt-4o-mini-2024-07-18.yaml
@@ -11,12 +11,14 @@ features:
     - tools
 limits:
     context_window: 128000
-    max_input_tokens: 128000
     max_output_tokens: 16384
-    max_tokens: 16384
 modalities:
     input:
+        - text
         - image
+        - pdf
+    output:
+        - text
 mode: chat
 model: openai/gpt-4o-mini-2024-07-18
 sources:

--- a/providers/openrouter/openai/gpt-4o-mini-search-preview.yaml
+++ b/providers/openrouter/openai/gpt-4o-mini-search-preview.yaml
@@ -1,6 +1,5 @@
 costs:
-    - input_cost_per_query: 0.0275
-      input_cost_per_token: 1.5e-7
+    - input_cost_per_token: 1.5e-7
       output_cost_per_token: 6.e-7
       region: "*"
 features:
@@ -9,7 +8,11 @@ features:
 limits:
     context_window: 128000
     max_output_tokens: 16384
-    max_tokens: 16384
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: openai/gpt-4o-mini-search-preview
 sources:

--- a/providers/openrouter/openai/gpt-4o-mini.yaml
+++ b/providers/openrouter/openai/gpt-4o-mini.yaml
@@ -12,10 +12,13 @@ features:
 limits:
     context_window: 128000
     max_output_tokens: 16384
-    max_tokens: 16384
 modalities:
     input:
+        - text
         - image
+        - pdf
+    output:
+        - text
 mode: chat
 model: openai/gpt-4o-mini
 sources:

--- a/providers/openrouter/openai/gpt-4o-search-preview.yaml
+++ b/providers/openrouter/openai/gpt-4o-search-preview.yaml
@@ -1,6 +1,5 @@
 costs:
-    - input_cost_per_query: 0.035
-      input_cost_per_token: 0.0000025
+    - input_cost_per_token: 0.0000025
       output_cost_per_token: 0.00001
       region: "*"
 features:
@@ -8,9 +7,12 @@ features:
     - structured_output
 limits:
     context_window: 128000
-    max_input_tokens: 128000
     max_output_tokens: 16384
-    max_tokens: 16384
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: openai/gpt-4o-search-preview
 sources:

--- a/providers/openrouter/openai/gpt-4o.yaml
+++ b/providers/openrouter/openai/gpt-4o.yaml
@@ -10,12 +10,14 @@ features:
     - structured_output
 limits:
     context_window: 128000
-    max_input_tokens: 128000
     max_output_tokens: 16384
-    max_tokens: 16384
 modalities:
     input:
+        - text
         - image
+        - pdf
+    output:
+        - text
 mode: chat
 model: openai/gpt-4o
 sources:

--- a/providers/openrouter/openai/gpt-4o:extended.yaml
+++ b/providers/openrouter/openai/gpt-4o:extended.yaml
@@ -10,10 +10,13 @@ features:
 limits:
     context_window: 128000
     max_output_tokens: 64000
-    max_tokens: 64000
 modalities:
     input:
+        - text
         - image
+        - pdf
+    output:
+        - text
 mode: chat
 model: openai/gpt-4o:extended
 params:

--- a/providers/openrouter/openai/gpt-5-chat.yaml
+++ b/providers/openrouter/openai/gpt-5-chat.yaml
@@ -11,10 +11,13 @@ features:
 limits:
     context_window: 128000
     max_output_tokens: 16384
-    max_tokens: 16384
 modalities:
     input:
+        - pdf
         - image
+        - text
+    output:
+        - text
 mode: chat
 model: openai/gpt-5-chat
 sources:

--- a/providers/openrouter/openai/gpt-5-codex.yaml
+++ b/providers/openrouter/openai/gpt-5-codex.yaml
@@ -10,12 +10,13 @@ features:
     - prompt_caching
 limits:
     context_window: 400000
-    max_input_tokens: 272000
     max_output_tokens: 128000
-    max_tokens: 128000
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: openai/gpt-5-codex
 sources:

--- a/providers/openrouter/openai/gpt-5-image-mini.yaml
+++ b/providers/openrouter/openai/gpt-5-image-mini.yaml
@@ -1,8 +1,6 @@
 costs:
     - cache_read_input_token_cost: 2.5e-7
-      input_cost_per_query: 0.01
       input_cost_per_token: 0.0000025
-      output_cost_per_image_token: 0.000008
       output_cost_per_token: 0.000002
       region: "*"
 features:
@@ -14,12 +12,15 @@ features:
     - prompt_caching
 limits:
     context_window: 400000
-    max_input_tokens: 272000
     max_output_tokens: 128000
-    max_tokens: 128000
 modalities:
     input:
+        - pdf
         - image
+        - text
+    output:
+        - image
+        - text
 mode: chat
 model: openai/gpt-5-image-mini
 sources:

--- a/providers/openrouter/openai/gpt-5-image.yaml
+++ b/providers/openrouter/openai/gpt-5-image.yaml
@@ -1,7 +1,6 @@
 costs:
     - cache_read_input_token_cost: 0.00000125
       input_cost_per_token: 0.00001
-      output_cost_per_image_token: 0.00004
       output_cost_per_token: 0.00001
       region: "*"
 features:
@@ -12,12 +11,15 @@ features:
     - structured_output
 limits:
     context_window: 400000
-    max_input_tokens: 272000
     max_output_tokens: 128000
-    max_tokens: 128000
 modalities:
     input:
         - image
+        - text
+        - pdf
+    output:
+        - image
+        - text
 mode: chat
 model: openai/gpt-5-image
 sources:

--- a/providers/openrouter/openai/gpt-5-mini.yaml
+++ b/providers/openrouter/openai/gpt-5-mini.yaml
@@ -9,12 +9,14 @@ features:
     - structured_output
 limits:
     context_window: 400000
-    max_input_tokens: 272000
     max_output_tokens: 128000
-    max_tokens: 128000
 modalities:
     input:
+        - text
         - image
+        - pdf
+    output:
+        - text
 mode: chat
 model: openai/gpt-5-mini
 sources:

--- a/providers/openrouter/openai/gpt-5-nano.yaml
+++ b/providers/openrouter/openai/gpt-5-nano.yaml
@@ -10,12 +10,14 @@ features:
     - prompt_caching
 limits:
     context_window: 400000
-    max_input_tokens: 272000
     max_output_tokens: 128000
-    max_tokens: 128000
 modalities:
     input:
+        - text
         - image
+        - pdf
+    output:
+        - text
 mode: chat
 model: openai/gpt-5-nano
 sources:

--- a/providers/openrouter/openai/gpt-5-pro.yaml
+++ b/providers/openrouter/openai/gpt-5-pro.yaml
@@ -1,6 +1,5 @@
 costs:
-    - input_cost_per_query: 0.01
-      input_cost_per_token: 0.000015
+    - input_cost_per_token: 0.000015
       output_cost_per_token: 0.00012
       region: "*"
 features:
@@ -11,12 +10,14 @@ features:
     - system_messages
 limits:
     context_window: 400000
-    max_input_tokens: 272000
     max_output_tokens: 128000
-    max_tokens: 128000
 modalities:
     input:
         - image
+        - text
+        - pdf
+    output:
+        - text
 mode: chat
 model: openai/gpt-5-pro
 sources:

--- a/providers/openrouter/openai/gpt-5.1-chat.yaml
+++ b/providers/openrouter/openai/gpt-5.1-chat.yaml
@@ -12,10 +12,13 @@ features:
 limits:
     context_window: 128000
     max_output_tokens: 16384
-    max_tokens: 16384
 modalities:
     input:
+        - pdf
         - image
+        - text
+    output:
+        - text
 mode: chat
 model: openai/gpt-5.1-chat
 sources:

--- a/providers/openrouter/openai/gpt-5.1-codex-max.yaml
+++ b/providers/openrouter/openai/gpt-5.1-codex-max.yaml
@@ -1,6 +1,5 @@
 costs:
     - cache_read_input_token_cost: 1.25e-7
-      input_cost_per_query: 0.01
       input_cost_per_token: 0.00000125
       output_cost_per_token: 0.00001
       region: "*"
@@ -12,12 +11,13 @@ features:
     - tools
 limits:
     context_window: 400000
-    max_input_tokens: 272000
     max_output_tokens: 128000
-    max_tokens: 128000
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: openai/gpt-5.1-codex-max
 params:

--- a/providers/openrouter/openai/gpt-5.1-codex-mini.yaml
+++ b/providers/openrouter/openai/gpt-5.1-codex-mini.yaml
@@ -11,12 +11,13 @@ features:
     - system_messages
 limits:
     context_window: 400000
-    max_input_tokens: 300000
     max_output_tokens: 100000
-    max_tokens: 100000
 modalities:
     input:
         - image
+        - text
+    output:
+        - text
 mode: chat
 model: openai/gpt-5.1-codex-mini
 sources:

--- a/providers/openrouter/openai/gpt-5.1-codex.yaml
+++ b/providers/openrouter/openai/gpt-5.1-codex.yaml
@@ -10,12 +10,13 @@ features:
     - tools
 limits:
     context_window: 400000
-    max_input_tokens: 272000
     max_output_tokens: 128000
-    max_tokens: 128000
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: openai/gpt-5.1-codex
 sources:

--- a/providers/openrouter/openai/gpt-5.1.yaml
+++ b/providers/openrouter/openai/gpt-5.1.yaml
@@ -12,13 +12,14 @@ features:
     - prompt_caching
 limits:
     context_window: 400000
-    max_input_tokens: 272000
     max_output_tokens: 128000
-    max_tokens: 128000
 modalities:
     input:
         - image
+        - text
         - pdf
+    output:
+        - text
 mode: chat
 model: openai/gpt-5.1
 sources:

--- a/providers/openrouter/openai/gpt-5.2-chat.yaml
+++ b/providers/openrouter/openai/gpt-5.2-chat.yaml
@@ -1,6 +1,5 @@
 costs:
     - cache_read_input_token_cost: 1.75e-7
-      input_cost_per_image: 0
       input_cost_per_token: 0.00000175
       output_cost_per_token: 0.000014
       region: "*"
@@ -10,12 +9,14 @@ features:
     - prompt_caching
 limits:
     context_window: 128000
-    max_input_tokens: 128000
     max_output_tokens: 16384
-    max_tokens: 16384
 modalities:
     input:
+        - pdf
         - image
+        - text
+    output:
+        - text
 mode: chat
 model: openai/gpt-5.2-chat
 sources:

--- a/providers/openrouter/openai/gpt-5.2-codex.yaml
+++ b/providers/openrouter/openai/gpt-5.2-codex.yaml
@@ -9,12 +9,13 @@ features:
     - structured_output
 limits:
     context_window: 400000
-    max_input_tokens: 272000
     max_output_tokens: 128000
-    max_tokens: 128000
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: openai/gpt-5.2-codex
 sources:

--- a/providers/openrouter/openai/gpt-5.2-pro.yaml
+++ b/providers/openrouter/openai/gpt-5.2-pro.yaml
@@ -1,6 +1,5 @@
 costs:
-    - input_cost_per_image: 0
-      input_cost_per_token: 0.000021
+    - input_cost_per_token: 0.000021
       output_cost_per_token: 0.000168
       region: "*"
 features:
@@ -9,12 +8,14 @@ features:
     - structured_output
 limits:
     context_window: 400000
-    max_input_tokens: 272000
     max_output_tokens: 128000
-    max_tokens: 128000
 modalities:
     input:
         - image
+        - text
+        - pdf
+    output:
+        - text
 mode: chat
 model: openai/gpt-5.2-pro
 sources:

--- a/providers/openrouter/openai/gpt-5.2.yaml
+++ b/providers/openrouter/openai/gpt-5.2.yaml
@@ -1,6 +1,5 @@
 costs:
     - cache_read_input_token_cost: 1.75e-7
-      input_cost_per_image: 0
       input_cost_per_token: 0.00000175
       output_cost_per_token: 0.000014
       region: "*"
@@ -11,13 +10,14 @@ features:
     - structured_output
 limits:
     context_window: 400000
-    max_input_tokens: 272000
     max_output_tokens: 128000
-    max_tokens: 128000
 modalities:
     input:
-        - image
         - pdf
+        - image
+        - text
+    output:
+        - text
 mode: chat
 model: openai/gpt-5.2
 sources:

--- a/providers/openrouter/openai/gpt-5.3-chat.yaml
+++ b/providers/openrouter/openai/gpt-5.3-chat.yaml
@@ -10,13 +10,14 @@ features:
     - system_messages
 limits:
     context_window: 128000
-    max_input_tokens: 111616
     max_output_tokens: 16384
-    max_tokens: 16384
 modalities:
     input:
+        - text
         - image
         - pdf
+    output:
+        - text
 mode: chat
 model: openai/gpt-5.3-chat
 sources:

--- a/providers/openrouter/openai/gpt-5.3-codex.yaml
+++ b/providers/openrouter/openai/gpt-5.3-codex.yaml
@@ -1,6 +1,5 @@
 costs:
     - cache_read_input_token_cost: 1.75e-7
-      input_cost_per_query: 0.01
       input_cost_per_token: 0.00000175
       output_cost_per_token: 0.000014
       region: "*"
@@ -12,12 +11,14 @@ features:
     - system_messages
 limits:
     context_window: 400000
-    max_input_tokens: 272000
     max_output_tokens: 128000
-    max_tokens: 128000
 modalities:
     input:
+        - text
         - image
+        - pdf
+    output:
+        - text
 mode: chat
 model: openai/gpt-5.3-codex
 params:

--- a/providers/openrouter/openai/gpt-5.4-mini.yaml
+++ b/providers/openrouter/openai/gpt-5.4-mini.yaml
@@ -1,2 +1,17 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 7.5e-8
+      input_cost_per_token: 7.5e-7
+      output_cost_per_token: 0.0000045
+      region: "*"
+limits:
+    context_window: 400000
+    max_output_tokens: 128000
+modalities:
+    input:
+        - pdf
+        - image
+        - text
+    output:
+        - text
+mode: chat
 model: openai/gpt-5.4-mini

--- a/providers/openrouter/openai/gpt-5.4-nano.yaml
+++ b/providers/openrouter/openai/gpt-5.4-nano.yaml
@@ -1,2 +1,17 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 2.e-8
+      input_cost_per_token: 2.e-7
+      output_cost_per_token: 0.00000125
+      region: "*"
+limits:
+    context_window: 400000
+    max_output_tokens: 128000
+modalities:
+    input:
+        - pdf
+        - image
+        - text
+    output:
+        - text
+mode: chat
 model: openai/gpt-5.4-nano

--- a/providers/openrouter/openai/gpt-5.4-pro.yaml
+++ b/providers/openrouter/openai/gpt-5.4-pro.yaml
@@ -1,15 +1,7 @@
 costs:
-    - input_cost_per_query: 0.01
-      input_cost_per_token: 0.00003
+    - input_cost_per_token: 0.00003
       output_cost_per_token: 0.00018
       region: "*"
-      tiered_pricing:
-          input:
-              - cost_per_token: 0.00006
-                from: 272000
-          output:
-              - cost_per_token: 0.00027
-                from: 272000
 features:
     - function_calling
     - tool_choice
@@ -18,12 +10,14 @@ features:
     - tools
 limits:
     context_window: 1050000
-    max_input_tokens: 922000
     max_output_tokens: 128000
-    max_tokens: 128000
 modalities:
     input:
+        - text
         - image
+        - pdf
+    output:
+        - text
 mode: chat
 model: openai/gpt-5.4-pro
 params:

--- a/providers/openrouter/openai/gpt-5.4.yaml
+++ b/providers/openrouter/openai/gpt-5.4.yaml
@@ -3,16 +3,6 @@ costs:
       input_cost_per_token: 0.0000025
       output_cost_per_token: 0.000015
       region: "*"
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 5.e-7
-                from: 272000
-          input:
-              - cost_per_token: 0.000005
-                from: 272000
-          output:
-              - cost_per_token: 0.0000225
-                from: 272000
 features:
     - function_calling
     - tool_choice
@@ -20,13 +10,14 @@ features:
     - system_messages
 limits:
     context_window: 1050000
-    max_input_tokens: 922000
     max_output_tokens: 128000
-    max_tokens: 128000
 modalities:
     input:
+        - text
         - image
         - pdf
+    output:
+        - text
 mode: chat
 model: openai/gpt-5.4
 sources:

--- a/providers/openrouter/openai/gpt-5.yaml
+++ b/providers/openrouter/openai/gpt-5.yaml
@@ -9,12 +9,14 @@ features:
     - structured_output
 limits:
     context_window: 400000
-    max_input_tokens: 272000
     max_output_tokens: 128000
-    max_tokens: 128000
 modalities:
     input:
+        - text
         - image
+        - pdf
+    output:
+        - text
 mode: chat
 model: openai/gpt-5
 sources:

--- a/providers/openrouter/openai/gpt-audio-mini.yaml
+++ b/providers/openrouter/openai/gpt-audio-mini.yaml
@@ -1,7 +1,5 @@
 costs:
-    - input_cost_per_audio_token: 6.e-7
-      input_cost_per_token: 6.e-7
-      output_cost_per_audio_token: 0.0000024
+    - input_cost_per_token: 6.e-7
       output_cost_per_token: 0.0000024
       region: "*"
 features:
@@ -12,11 +10,12 @@ features:
 limits:
     context_window: 128000
     max_output_tokens: 16384
-    max_tokens: 16384
 modalities:
     input:
+        - text
         - audio
     output:
+        - text
         - audio
 mode: chat
 model: openai/gpt-audio-mini

--- a/providers/openrouter/openai/gpt-audio.yaml
+++ b/providers/openrouter/openai/gpt-audio.yaml
@@ -1,7 +1,5 @@
 costs:
-    - input_cost_per_audio_token: 0.000032
-      input_cost_per_token: 0.0000025
-      output_cost_per_audio_token: 0.000064
+    - input_cost_per_token: 0.0000025
       output_cost_per_token: 0.00001
       region: "*"
 features:
@@ -10,11 +8,12 @@ features:
 limits:
     context_window: 128000
     max_output_tokens: 16384
-    max_tokens: 16384
 modalities:
     input:
+        - text
         - audio
     output:
+        - text
         - audio
 mode: chat
 model: openai/gpt-audio

--- a/providers/openrouter/openai/gpt-oss-120b.yaml
+++ b/providers/openrouter/openai/gpt-oss-120b.yaml
@@ -8,7 +8,11 @@ features:
     - structured_output
 limits:
     context_window: 131072
-    max_input_tokens: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: openai/gpt-oss-120b
 sources:

--- a/providers/openrouter/openai/gpt-oss-120b:free.yaml
+++ b/providers/openrouter/openai/gpt-oss-120b:free.yaml
@@ -11,7 +11,11 @@ features:
 limits:
     context_window: 131072
     max_output_tokens: 131072
-    max_tokens: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: openai/gpt-oss-120b:free
 sources:

--- a/providers/openrouter/openai/gpt-oss-20b.yaml
+++ b/providers/openrouter/openai/gpt-oss-20b.yaml
@@ -9,9 +9,11 @@ features:
     - structured_output
 limits:
     context_window: 131072
-    max_input_tokens: 131072
-    max_output_tokens: 32768
-    max_tokens: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: openai/gpt-oss-20b
 sources:

--- a/providers/openrouter/openai/gpt-oss-20b:free.yaml
+++ b/providers/openrouter/openai/gpt-oss-20b:free.yaml
@@ -11,7 +11,11 @@ features:
 limits:
     context_window: 131072
     max_output_tokens: 131072
-    max_tokens: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: openai/gpt-oss-20b:free
 sources:

--- a/providers/openrouter/openai/gpt-oss-safeguard-20b.yaml
+++ b/providers/openrouter/openai/gpt-oss-safeguard-20b.yaml
@@ -11,7 +11,11 @@ features:
 limits:
     context_window: 131072
     max_output_tokens: 65536
-    max_tokens: 65536
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: openai/gpt-oss-safeguard-20b
 params:

--- a/providers/openrouter/openai/o1-pro.yaml
+++ b/providers/openrouter/openai/o1-pro.yaml
@@ -7,10 +7,13 @@ features:
 limits:
     context_window: 200000
     max_output_tokens: 100000
-    max_tokens: 100000
 modalities:
     input:
+        - text
         - image
+        - pdf
+    output:
+        - text
 mode: chat
 model: openai/o1-pro
 sources:

--- a/providers/openrouter/openai/o1.yaml
+++ b/providers/openrouter/openai/o1.yaml
@@ -12,12 +12,14 @@ features:
     - structured_output
 limits:
     context_window: 200000
-    max_input_tokens: 200000
     max_output_tokens: 100000
-    max_tokens: 100000
 modalities:
     input:
+        - text
         - image
+        - pdf
+    output:
+        - text
 mode: chat
 model: openai/o1
 sources:

--- a/providers/openrouter/openai/o3-deep-research.yaml
+++ b/providers/openrouter/openai/o3-deep-research.yaml
@@ -12,10 +12,13 @@ features:
 limits:
     context_window: 200000
     max_output_tokens: 100000
-    max_tokens: 100000
 modalities:
     input:
         - image
+        - text
+        - pdf
+    output:
+        - text
 mode: chat
 model: openai/o3-deep-research
 sources:

--- a/providers/openrouter/openai/o3-mini-high.yaml
+++ b/providers/openrouter/openai/o3-mini-high.yaml
@@ -11,7 +11,12 @@ features:
 limits:
     context_window: 200000
     max_output_tokens: 100000
-    max_tokens: 100000
+modalities:
+    input:
+        - text
+        - pdf
+    output:
+        - text
 mode: chat
 model: openai/o3-mini-high
 sources:

--- a/providers/openrouter/openai/o3-mini.yaml
+++ b/providers/openrouter/openai/o3-mini.yaml
@@ -11,7 +11,12 @@ features:
 limits:
     context_window: 200000
     max_output_tokens: 100000
-    max_tokens: 100000
+modalities:
+    input:
+        - text
+        - pdf
+    output:
+        - text
 mode: chat
 model: openai/o3-mini
 params:

--- a/providers/openrouter/openai/o3-pro.yaml
+++ b/providers/openrouter/openai/o3-pro.yaml
@@ -10,10 +10,13 @@ features:
 limits:
     context_window: 200000
     max_output_tokens: 100000
-    max_tokens: 100000
 modalities:
     input:
+        - text
+        - pdf
         - image
+    output:
+        - text
 mode: chat
 model: openai/o3-pro
 sources:

--- a/providers/openrouter/openai/o3.yaml
+++ b/providers/openrouter/openai/o3.yaml
@@ -12,10 +12,13 @@ features:
 limits:
     context_window: 200000
     max_output_tokens: 100000
-    max_tokens: 100000
 modalities:
     input:
         - image
+        - text
+        - pdf
+    output:
+        - text
 mode: chat
 model: openai/o3
 sources:

--- a/providers/openrouter/openai/o4-mini-deep-research.yaml
+++ b/providers/openrouter/openai/o4-mini-deep-research.yaml
@@ -1,6 +1,5 @@
 costs:
     - cache_read_input_token_cost: 5.e-7
-      input_cost_per_query: 0.01
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000008
       region: "*"
@@ -13,10 +12,13 @@ features:
 limits:
     context_window: 200000
     max_output_tokens: 100000
-    max_tokens: 100000
 modalities:
     input:
+        - pdf
         - image
+        - text
+    output:
+        - text
 mode: chat
 model: openai/o4-mini-deep-research
 sources:

--- a/providers/openrouter/openai/o4-mini-high.yaml
+++ b/providers/openrouter/openai/o4-mini-high.yaml
@@ -12,10 +12,13 @@ features:
 limits:
     context_window: 200000
     max_output_tokens: 100000
-    max_tokens: 100000
 modalities:
     input:
         - image
+        - text
+        - pdf
+    output:
+        - text
 mode: chat
 model: openai/o4-mini-high
 sources:

--- a/providers/openrouter/openai/o4-mini.yaml
+++ b/providers/openrouter/openai/o4-mini.yaml
@@ -12,10 +12,13 @@ features:
 limits:
     context_window: 200000
     max_output_tokens: 100000
-    max_tokens: 100000
 modalities:
     input:
         - image
+        - text
+        - pdf
+    output:
+        - text
 mode: chat
 model: openai/o4-mini
 sources:

--- a/providers/openrouter/openrouter/auto.yaml
+++ b/providers/openrouter/openrouter/auto.yaml
@@ -1,8 +1,18 @@
+costs:
+    - input_cost_per_token: -1
+      output_cost_per_token: -1
+      region: "*"
 limits:
     context_window: 2000000
 modalities:
     input:
+        - text
+        - image
         - audio
+        - pdf
+        - video
+    output:
+        - text
         - image
 mode: chat
 model: openrouter/auto

--- a/providers/openrouter/openrouter/bodybuilder.yaml
+++ b/providers/openrouter/openrouter/bodybuilder.yaml
@@ -1,11 +1,16 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
+    - input_cost_per_token: -1
+      output_cost_per_token: -1
       region: "*"
 features:
     - system_messages
 limits:
     context_window: 128000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: openrouter/bodybuilder
 sources:

--- a/providers/openrouter/openrouter/free.yaml
+++ b/providers/openrouter/openrouter/free.yaml
@@ -9,7 +9,10 @@ limits:
     context_window: 200000
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: openrouter/free
 sources:

--- a/providers/openrouter/openrouter/healer-alpha.yaml
+++ b/providers/openrouter/openrouter/healer-alpha.yaml
@@ -1,5 +1,6 @@
 costs:
-    - input_cost_per_token: 0
+    - input_cost_per_image: 0
+      input_cost_per_token: 0
       output_cost_per_token: 0
       region: "*"
 features:
@@ -9,13 +10,15 @@ features:
     - system_messages
 limits:
     context_window: 262144
-    max_input_tokens: 230144
     max_output_tokens: 32000
-    max_tokens: 32000
 modalities:
     input:
-        - audio
+        - text
         - image
+        - audio
+        - video
+    output:
+        - text
 mode: chat
 model: openrouter/healer-alpha
 params:

--- a/providers/openrouter/openrouter/hunter-alpha.yaml
+++ b/providers/openrouter/openrouter/hunter-alpha.yaml
@@ -1,5 +1,6 @@
 costs:
-    - input_cost_per_token: 0
+    - input_cost_per_image: 0
+      input_cost_per_token: 0
       output_cost_per_token: 0
       region: "*"
 features:
@@ -10,7 +11,12 @@ features:
 limits:
     context_window: 1048576
     max_output_tokens: 32000
-    max_tokens: 32000
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
 mode: chat
 model: openrouter/hunter-alpha
 params:

--- a/providers/openrouter/perplexity/sonar-deep-research.yaml
+++ b/providers/openrouter/perplexity/sonar-deep-research.yaml
@@ -1,6 +1,5 @@
 costs:
-    - input_cost_per_query: 0.005
-      input_cost_per_token: 0.000002
+    - input_cost_per_token: 0.000002
       output_cost_per_token: 0.000008
       region: "*"
 features:
@@ -8,6 +7,11 @@ features:
     - tool_choice
 limits:
     context_window: 128000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: perplexity/sonar-deep-research
 sources:

--- a/providers/openrouter/perplexity/sonar-pro-search.yaml
+++ b/providers/openrouter/perplexity/sonar-pro-search.yaml
@@ -1,6 +1,5 @@
 costs:
-    - input_cost_per_request: 0.018
-      input_cost_per_token: 0.000003
+    - input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: "*"
 features:
@@ -10,10 +9,12 @@ features:
 limits:
     context_window: 200000
     max_output_tokens: 8000
-    max_tokens: 8000
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: perplexity/sonar-pro-search
 params:

--- a/providers/openrouter/perplexity/sonar-pro.yaml
+++ b/providers/openrouter/perplexity/sonar-pro.yaml
@@ -8,10 +8,12 @@ features:
 limits:
     context_window: 200000
     max_output_tokens: 8000
-    max_tokens: 8000
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: perplexity/sonar-pro
 sources:

--- a/providers/openrouter/perplexity/sonar-reasoning-pro.yaml
+++ b/providers/openrouter/perplexity/sonar-reasoning-pro.yaml
@@ -1,15 +1,15 @@
 costs:
-    - input_cost_per_query: 0.005
-      input_cost_per_token: 0.000002
+    - input_cost_per_token: 0.000002
       output_cost_per_token: 0.000008
       region: "*"
 limits:
     context_window: 128000
-    max_output_tokens: 128000
-    max_tokens: 128000
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: perplexity/sonar-reasoning-pro
 sources:

--- a/providers/openrouter/perplexity/sonar.yaml
+++ b/providers/openrouter/perplexity/sonar.yaml
@@ -1,6 +1,5 @@
 costs:
-    - input_cost_per_query: 0.005
-      input_cost_per_token: 0.000001
+    - input_cost_per_token: 0.000001
       output_cost_per_token: 0.000001
       region: "*"
 features:
@@ -11,7 +10,10 @@ limits:
     context_window: 127072
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: perplexity/sonar
 params:

--- a/providers/openrouter/prime-intellect/intellect-3.yaml
+++ b/providers/openrouter/prime-intellect/intellect-3.yaml
@@ -10,7 +10,11 @@ features:
 limits:
     context_window: 131072
     max_output_tokens: 131072
-    max_tokens: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: prime-intellect/intellect-3
 params:

--- a/providers/openrouter/qwen/qwen-2.5-72b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen-2.5-72b-instruct.yaml
@@ -11,7 +11,11 @@ features:
 limits:
     context_window: 32768
     max_output_tokens: 16384
-    max_tokens: 16384
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwen/qwen-2.5-72b-instruct
 sources:

--- a/providers/openrouter/qwen/qwen-2.5-7b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen-2.5-7b-instruct.yaml
@@ -8,8 +8,11 @@ features:
     - system_messages
 limits:
     context_window: 32768
-    max_output_tokens: 8000
-    max_tokens: 8000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwen/qwen-2.5-7b-instruct
 sources:

--- a/providers/openrouter/qwen/qwen-2.5-coder-32b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen-2.5-coder-32b-instruct.yaml
@@ -1,13 +1,16 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 2.e-7
+    - input_cost_per_token: 6.6e-7
+      output_cost_per_token: 0.000001
       region: "*"
 features:
     - tool_choice
 limits:
     context_window: 32768
-    max_output_tokens: 8192
-    max_tokens: 8192
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwen/qwen-2.5-coder-32b-instruct
 sources:

--- a/providers/openrouter/qwen/qwen-2.5-vl-7b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen-2.5-vl-7b-instruct.yaml
@@ -1,13 +1,15 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 2.e-7
+    - input_cost_per_token: 2.0000000000000002e-7
+      output_cost_per_token: 2.0000000000000002e-7
       region: "*"
 limits:
     context_window: 32768
-    max_output_tokens: 32768
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: qwen/qwen-2.5-vl-7b-instruct
 sources:

--- a/providers/openrouter/qwen/qwen-max.yaml
+++ b/providers/openrouter/qwen/qwen-max.yaml
@@ -10,7 +10,11 @@ features:
 limits:
     context_window: 32768
     max_output_tokens: 8192
-    max_tokens: 8192
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwen/qwen-max
 sources:

--- a/providers/openrouter/qwen/qwen-plus-2025-07-28.yaml
+++ b/providers/openrouter/qwen/qwen-plus-2025-07-28.yaml
@@ -2,22 +2,18 @@ costs:
     - input_cost_per_token: 2.6e-7
       output_cost_per_token: 7.8e-7
       region: "*"
-      tiered_pricing:
-          input:
-              - cost_per_token: 7.8e-7
-                from: 256000
-          output:
-              - cost_per_token: 0.00000234
-                from: 256000
 features:
     - function_calling
     - tool_choice
     - structured_output
 limits:
     context_window: 1000000
-    max_input_tokens: 995904
     max_output_tokens: 32768
-    max_tokens: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwen/qwen-plus-2025-07-28
 params:

--- a/providers/openrouter/qwen/qwen-plus-2025-07-28:thinking.yaml
+++ b/providers/openrouter/qwen/qwen-plus-2025-07-28:thinking.yaml
@@ -2,13 +2,6 @@ costs:
     - input_cost_per_token: 2.6e-7
       output_cost_per_token: 7.8e-7
       region: "*"
-      tiered_pricing:
-          input:
-              - cost_per_token: 0.0000012
-                from: 256000
-          output:
-              - cost_per_token: 0.0000036
-                from: 256000
 features:
     - function_calling
     - tool_choice
@@ -17,9 +10,12 @@ features:
     - tools
 limits:
     context_window: 1000000
-    max_input_tokens: 995904
     max_output_tokens: 32768
-    max_tokens: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwen/qwen-plus-2025-07-28:thinking
 sources:

--- a/providers/openrouter/qwen/qwen-plus.yaml
+++ b/providers/openrouter/qwen/qwen-plus.yaml
@@ -1,27 +1,20 @@
 costs:
-    - cache_read_input_token_cost: 8.e-8
-      input_cost_per_token: 4.e-7
-      output_cost_per_token: 0.0000012
+    - cache_read_input_token_cost: 5.2e-8
+      input_cost_per_token: 2.6e-7
+      output_cost_per_token: 7.8e-7
       region: "*"
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 2.4e-7
-                from: 256000
-          input:
-              - cost_per_token: 0.0000012
-                from: 256000
-          output:
-              - cost_per_token: 0.0000036
-                from: 256000
 features:
     - function_calling
     - tool_choice
     - structured_output
 limits:
     context_window: 1000000
-    max_input_tokens: 995904
     max_output_tokens: 32768
-    max_tokens: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwen/qwen-plus
 sources:

--- a/providers/openrouter/qwen/qwen-turbo.yaml
+++ b/providers/openrouter/qwen/qwen-turbo.yaml
@@ -1,5 +1,6 @@
 costs:
-    - input_cost_per_token: 3.25e-8
+    - cache_read_input_token_cost: 6.5e-9
+      input_cost_per_token: 3.25e-8
       output_cost_per_token: 1.3e-7
       region: "*"
 features:
@@ -8,9 +9,12 @@ features:
     - tools
 limits:
     context_window: 131072
-    max_input_tokens: 98304
     max_output_tokens: 8192
-    max_tokens: 8192
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwen/qwen-turbo
 sources:

--- a/providers/openrouter/qwen/qwen-vl-max.yaml
+++ b/providers/openrouter/qwen/qwen-vl-max.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 8.e-7
-      output_cost_per_token: 0.0000032
+    - input_cost_per_token: 5.2e-7
+      output_cost_per_token: 0.00000208
       region: "*"
 features:
     - function_calling
@@ -8,10 +8,12 @@ features:
 limits:
     context_window: 131072
     max_output_tokens: 32768
-    max_tokens: 32768
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: qwen/qwen-vl-max
 sources:

--- a/providers/openrouter/qwen/qwen-vl-plus.yaml
+++ b/providers/openrouter/qwen/qwen-vl-plus.yaml
@@ -7,12 +7,13 @@ features:
     - tool_choice
 limits:
     context_window: 131072
-    max_input_tokens: 129024
     max_output_tokens: 8192
-    max_tokens: 8192
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: qwen/qwen-vl-plus
 sources:

--- a/providers/openrouter/qwen/qwen2.5-coder-7b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen2.5-coder-7b-instruct.yaml
@@ -9,6 +9,11 @@ features:
     - tools
 limits:
     context_window: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwen/qwen2.5-coder-7b-instruct
 sources:

--- a/providers/openrouter/qwen/qwen2.5-vl-32b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen2.5-vl-32b-instruct.yaml
@@ -6,7 +6,10 @@ limits:
     context_window: 128000
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: qwen/qwen2.5-vl-32b-instruct
 sources:

--- a/providers/openrouter/qwen/qwen2.5-vl-72b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen2.5-vl-72b-instruct.yaml
@@ -5,10 +5,12 @@ costs:
 limits:
     context_window: 32768
     max_output_tokens: 32768
-    max_tokens: 32768
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: qwen/qwen2.5-vl-72b-instruct
 sources:

--- a/providers/openrouter/qwen/qwen3-14b.yaml
+++ b/providers/openrouter/qwen/qwen3-14b.yaml
@@ -11,7 +11,11 @@ features:
 limits:
     context_window: 40960
     max_output_tokens: 40960
-    max_tokens: 40960
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwen/qwen3-14b
 sources:

--- a/providers/openrouter/qwen/qwen3-235b-a22b-2507.yaml
+++ b/providers/openrouter/qwen/qwen3-235b-a22b-2507.yaml
@@ -7,9 +7,11 @@ features:
     - tool_choice
 limits:
     context_window: 262144
-    max_input_tokens: 262144
-    max_output_tokens: 262144
-    max_tokens: 262144
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwen/qwen3-235b-a22b-2507
 sources:

--- a/providers/openrouter/qwen/qwen3-235b-a22b-thinking-2507.yaml
+++ b/providers/openrouter/qwen/qwen3-235b-a22b-thinking-2507.yaml
@@ -9,9 +9,12 @@ features:
     - structured_output
 limits:
     context_window: 262144
-    max_input_tokens: 262144
     max_output_tokens: 262144
-    max_tokens: 262144
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwen/qwen3-235b-a22b-thinking-2507
 sources:

--- a/providers/openrouter/qwen/qwen3-235b-a22b.yaml
+++ b/providers/openrouter/qwen/qwen3-235b-a22b.yaml
@@ -8,12 +8,12 @@ features:
     - structured_output
 limits:
     context_window: 131072
-    max_input_tokens: 98304
     max_output_tokens: 8192
-    max_tokens: 8192
 modalities:
     input:
-        - image
+        - text
+    output:
+        - text
 mode: chat
 model: qwen/qwen3-235b-a22b
 params:

--- a/providers/openrouter/qwen/qwen3-30b-a3b-instruct-2507.yaml
+++ b/providers/openrouter/qwen/qwen3-30b-a3b-instruct-2507.yaml
@@ -9,7 +9,11 @@ features:
 limits:
     context_window: 262144
     max_output_tokens: 262144
-    max_tokens: 262144
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwen/qwen3-30b-a3b-instruct-2507
 sources:

--- a/providers/openrouter/qwen/qwen3-30b-a3b-thinking-2507.yaml
+++ b/providers/openrouter/qwen/qwen3-30b-a3b-thinking-2507.yaml
@@ -8,6 +8,11 @@ features:
     - tools
 limits:
     context_window: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwen/qwen3-30b-a3b-thinking-2507
 sources:

--- a/providers/openrouter/qwen/qwen3-30b-a3b.yaml
+++ b/providers/openrouter/qwen/qwen3-30b-a3b.yaml
@@ -10,7 +10,11 @@ features:
 limits:
     context_window: 40960
     max_output_tokens: 40960
-    max_tokens: 40960
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwen/qwen3-30b-a3b
 sources:

--- a/providers/openrouter/qwen/qwen3-32b.yaml
+++ b/providers/openrouter/qwen/qwen3-32b.yaml
@@ -10,7 +10,11 @@ features:
 limits:
     context_window: 40960
     max_output_tokens: 40960
-    max_tokens: 40960
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwen/qwen3-32b
 params:

--- a/providers/openrouter/qwen/qwen3-4b:free.yaml
+++ b/providers/openrouter/qwen/qwen3-4b:free.yaml
@@ -10,8 +10,11 @@ features:
     - system_messages
 limits:
     context_window: 40960
-    max_output_tokens: 40960
-    max_tokens: 40960
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwen/qwen3-4b:free
 sources:

--- a/providers/openrouter/qwen/qwen3-8b.yaml
+++ b/providers/openrouter/qwen/qwen3-8b.yaml
@@ -12,7 +12,11 @@ features:
 limits:
     context_window: 40960
     max_output_tokens: 8192
-    max_tokens: 8192
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwen/qwen3-8b
 sources:

--- a/providers/openrouter/qwen/qwen3-coder-30b-a3b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen3-coder-30b-a3b-instruct.yaml
@@ -11,7 +11,11 @@ features:
 limits:
     context_window: 160000
     max_output_tokens: 32768
-    max_tokens: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwen/qwen3-coder-30b-a3b-instruct
 sources:

--- a/providers/openrouter/qwen/qwen3-coder-flash.yaml
+++ b/providers/openrouter/qwen/qwen3-coder-flash.yaml
@@ -3,20 +3,6 @@ costs:
       input_cost_per_token: 1.95e-7
       output_cost_per_token: 9.75e-7
       region: "*"
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 1.e-7
-                from: 32000
-          input:
-              - cost_per_token: 3.25e-7
-                from: 32000
-              - cost_per_token: 5.e-7
-                from: 128000
-          output:
-              - cost_per_token: 0.000001625
-                from: 32000
-              - cost_per_token: 0.0000025
-                from: 128000
 features:
     - function_calling
     - tool_choice
@@ -24,9 +10,12 @@ features:
     - tools
 limits:
     context_window: 1000000
-    max_input_tokens: 997952
     max_output_tokens: 65536
-    max_tokens: 65536
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwen/qwen3-coder-flash
 sources:

--- a/providers/openrouter/qwen/qwen3-coder-next.yaml
+++ b/providers/openrouter/qwen/qwen3-coder-next.yaml
@@ -11,7 +11,11 @@ features:
 limits:
     context_window: 262144
     max_output_tokens: 65536
-    max_tokens: 65536
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwen/qwen3-coder-next
 sources:

--- a/providers/openrouter/qwen/qwen3-coder-plus.yaml
+++ b/providers/openrouter/qwen/qwen3-coder-plus.yaml
@@ -3,22 +3,6 @@ costs:
       input_cost_per_token: 6.5e-7
       output_cost_per_token: 0.00000325
       region: "*"
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 3.6e-7
-                from: 32000
-              - cost_per_token: 6.e-7
-                from: 128000
-          input:
-              - cost_per_token: 0.0000018
-                from: 32000
-              - cost_per_token: 0.000003
-                from: 128000
-          output:
-              - cost_per_token: 0.000009
-                from: 32000
-              - cost_per_token: 0.000015
-                from: 128000
 features:
     - function_calling
     - tool_choice
@@ -27,9 +11,12 @@ features:
     - tools
 limits:
     context_window: 1000000
-    max_input_tokens: 997952
     max_output_tokens: 65536
-    max_tokens: 65536
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwen/qwen3-coder-plus
 sources:

--- a/providers/openrouter/qwen/qwen3-coder.yaml
+++ b/providers/openrouter/qwen/qwen3-coder.yaml
@@ -8,9 +8,11 @@ features:
     - tool_choice
 limits:
     context_window: 262144
-    max_input_tokens: 262144
-    max_output_tokens: 262144
-    max_tokens: 262144
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwen/qwen3-coder
 sources:

--- a/providers/openrouter/qwen/qwen3-coder:free.yaml
+++ b/providers/openrouter/qwen/qwen3-coder:free.yaml
@@ -11,7 +11,11 @@ features:
 limits:
     context_window: 262000
     max_output_tokens: 262000
-    max_tokens: 262000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwen/qwen3-coder:free
 sources:

--- a/providers/openrouter/qwen/qwen3-max-thinking.yaml
+++ b/providers/openrouter/qwen/qwen3-max-thinking.yaml
@@ -2,26 +2,18 @@ costs:
     - input_cost_per_token: 7.8e-7
       output_cost_per_token: 0.0000039
       region: "*"
-      tiered_pricing:
-          input:
-              - cost_per_token: 0.0000024
-                from: 32000
-              - cost_per_token: 0.000003
-                from: 128000
-          output:
-              - cost_per_token: 0.000012
-                from: 32000
-              - cost_per_token: 0.000015
-                from: 128000
 features:
     - function_calling
     - tool_choice
     - structured_output
 limits:
     context_window: 262144
-    max_input_tokens: 258048
     max_output_tokens: 32768
-    max_tokens: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwen/qwen3-max-thinking
 params:

--- a/providers/openrouter/qwen/qwen3-max.yaml
+++ b/providers/openrouter/qwen/qwen3-max.yaml
@@ -1,24 +1,8 @@
 costs:
-    - cache_read_input_token_cost: 2.4e-7
-      input_cost_per_token: 0.0000012
-      output_cost_per_token: 0.000006
+    - cache_read_input_token_cost: 1.56e-7
+      input_cost_per_token: 7.8e-7
+      output_cost_per_token: 0.0000039
       region: "*"
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 4.8e-7
-                from: 32000
-              - cost_per_token: 6.e-7
-                from: 128000
-          input:
-              - cost_per_token: 0.0000024
-                from: 32000
-              - cost_per_token: 0.000003
-                from: 128000
-          output:
-              - cost_per_token: 0.000012
-                from: 32000
-              - cost_per_token: 0.000015
-                from: 128000
 features:
     - function_calling
     - tool_choice
@@ -28,9 +12,12 @@ features:
     - system_messages
 limits:
     context_window: 262144
-    max_input_tokens: 258048
     max_output_tokens: 32768
-    max_tokens: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwen/qwen3-max
 sources:

--- a/providers/openrouter/qwen/qwen3-next-80b-a3b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen3-next-80b-a3b-instruct.yaml
@@ -6,8 +6,11 @@ features:
     - system_messages
 limits:
     context_window: 131072
-    max_output_tokens: 131072
-    max_tokens: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwen/qwen3-next-80b-a3b-instruct
 sources:

--- a/providers/openrouter/qwen/qwen3-next-80b-a3b-instruct:free.yaml
+++ b/providers/openrouter/qwen/qwen3-next-80b-a3b-instruct:free.yaml
@@ -9,6 +9,11 @@ features:
     - tools
 limits:
     context_window: 262144
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwen/qwen3-next-80b-a3b-instruct:free
 sources:

--- a/providers/openrouter/qwen/qwen3-next-80b-a3b-thinking.yaml
+++ b/providers/openrouter/qwen/qwen3-next-80b-a3b-thinking.yaml
@@ -9,9 +9,12 @@ features:
     - tools
 limits:
     context_window: 131072
-    max_input_tokens: 126976
     max_output_tokens: 32768
-    max_tokens: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwen/qwen3-next-80b-a3b-thinking
 sources:

--- a/providers/openrouter/qwen/qwen3-vl-235b-a22b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen3-vl-235b-a22b-instruct.yaml
@@ -1,5 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-7
+    - cache_read_input_token_cost: 1.1e-7
+      input_cost_per_token: 2.e-7
       output_cost_per_token: 8.8e-7
       region: "*"
 features:
@@ -9,7 +10,10 @@ limits:
     context_window: 262144
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: qwen/qwen3-vl-235b-a22b-instruct
 sources:

--- a/providers/openrouter/qwen/qwen3-vl-235b-a22b-thinking.yaml
+++ b/providers/openrouter/qwen/qwen3-vl-235b-a22b-thinking.yaml
@@ -8,9 +8,13 @@ features:
     - tool_choice
 limits:
     context_window: 131072
+    max_output_tokens: 32768
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: qwen/qwen3-vl-235b-a22b-thinking
 sources:

--- a/providers/openrouter/qwen/qwen3-vl-30b-a3b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen3-vl-30b-a3b-instruct.yaml
@@ -7,12 +7,13 @@ features:
     - tool_choice
 limits:
     context_window: 131072
-    max_input_tokens: 129024
     max_output_tokens: 32768
-    max_tokens: 32768
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: qwen/qwen3-vl-30b-a3b-instruct
 sources:

--- a/providers/openrouter/qwen/qwen3-vl-30b-a3b-thinking.yaml
+++ b/providers/openrouter/qwen/qwen3-vl-30b-a3b-thinking.yaml
@@ -8,12 +8,13 @@ features:
     - tools
 limits:
     context_window: 131072
-    max_input_tokens: 126976
     max_output_tokens: 32768
-    max_tokens: 32768
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: qwen/qwen3-vl-30b-a3b-thinking
 sources:

--- a/providers/openrouter/qwen/qwen3-vl-32b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen3-vl-32b-instruct.yaml
@@ -8,12 +8,13 @@ features:
     - tools
 limits:
     context_window: 131072
-    max_input_tokens: 129024
     max_output_tokens: 32768
-    max_tokens: 32768
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: qwen/qwen3-vl-32b-instruct
 sources:

--- a/providers/openrouter/qwen/qwen3-vl-8b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen3-vl-8b-instruct.yaml
@@ -10,10 +10,12 @@ features:
 limits:
     context_window: 131072
     max_output_tokens: 32768
-    max_tokens: 32768
 modalities:
     input:
         - image
+        - text
+    output:
+        - text
 mode: chat
 model: qwen/qwen3-vl-8b-instruct
 sources:

--- a/providers/openrouter/qwen/qwen3-vl-8b-thinking.yaml
+++ b/providers/openrouter/qwen/qwen3-vl-8b-thinking.yaml
@@ -9,12 +9,13 @@ features:
     - tools
 limits:
     context_window: 131072
-    max_input_tokens: 126976
     max_output_tokens: 32768
-    max_tokens: 32768
 modalities:
     input:
         - image
+        - text
+    output:
+        - text
 mode: chat
 model: qwen/qwen3-vl-8b-thinking
 sources:

--- a/providers/openrouter/qwen/qwen3.5-122b-a10b.yaml
+++ b/providers/openrouter/qwen/qwen3.5-122b-a10b.yaml
@@ -9,12 +9,14 @@ features:
     - structured_output
 limits:
     context_window: 262144
-    max_input_tokens: 258048
     max_output_tokens: 65536
-    max_tokens: 65536
 modalities:
     input:
+        - text
         - image
+        - video
+    output:
+        - text
 mode: chat
 model: qwen/qwen3.5-122b-a10b
 sources:

--- a/providers/openrouter/qwen/qwen3.5-27b.yaml
+++ b/providers/openrouter/qwen/qwen3.5-27b.yaml
@@ -11,10 +11,13 @@ features:
 limits:
     context_window: 262144
     max_output_tokens: 65536
-    max_tokens: 65536
 modalities:
     input:
+        - text
         - image
+        - video
+    output:
+        - text
 mode: chat
 model: qwen/qwen3.5-27b
 sources:

--- a/providers/openrouter/qwen/qwen3.5-35b-a3b.yaml
+++ b/providers/openrouter/qwen/qwen3.5-35b-a3b.yaml
@@ -9,12 +9,14 @@ features:
     - tools
 limits:
     context_window: 262144
-    max_input_tokens: 258048
     max_output_tokens: 65536
-    max_tokens: 65536
 modalities:
     input:
+        - text
         - image
+        - video
+    output:
+        - text
 mode: chat
 model: qwen/qwen3.5-35b-a3b
 sources:

--- a/providers/openrouter/qwen/qwen3.5-397b-a17b.yaml
+++ b/providers/openrouter/qwen/qwen3.5-397b-a17b.yaml
@@ -8,12 +8,14 @@ features:
     - tools
 limits:
     context_window: 262144
-    max_input_tokens: 258048
     max_output_tokens: 65536
-    max_tokens: 65536
 modalities:
     input:
+        - text
         - image
+        - video
+    output:
+        - text
 mode: chat
 model: qwen/qwen3.5-397b-a17b
 sources:

--- a/providers/openrouter/qwen/qwen3.5-9b.yaml
+++ b/providers/openrouter/qwen/qwen3.5-9b.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 1.e-7
+    - input_cost_per_token: 5.e-8
       output_cost_per_token: 1.5e-7
       region: "*"
 features:
@@ -8,10 +8,14 @@ features:
     - structured_output
     - tools
 limits:
-    context_window: 262144
+    context_window: 256000
 modalities:
     input:
+        - text
         - image
+        - video
+    output:
+        - text
 mode: chat
 model: qwen/qwen3.5-9b
 sources:

--- a/providers/openrouter/qwen/qwen3.5-flash-02-23.yaml
+++ b/providers/openrouter/qwen/qwen3.5-flash-02-23.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 4.e-7
+    - input_cost_per_token: 6.5e-8
+      output_cost_per_token: 2.6e-7
       region: "*"
 features:
     - function_calling
@@ -9,12 +9,14 @@ features:
     - tools
 limits:
     context_window: 1000000
-    max_input_tokens: 983616
     max_output_tokens: 65536
-    max_tokens: 65536
 modalities:
     input:
+        - text
         - image
+        - video
+    output:
+        - text
 mode: chat
 model: qwen/qwen3.5-flash-02-23
 sources:

--- a/providers/openrouter/qwen/qwen3.5-plus-02-15.yaml
+++ b/providers/openrouter/qwen/qwen3.5-plus-02-15.yaml
@@ -2,13 +2,6 @@ costs:
     - input_cost_per_token: 2.6e-7
       output_cost_per_token: 0.00000156
       region: "*"
-      tiered_pricing:
-          input:
-              - cost_per_token: 3.25e-7
-                from: 256000
-          output:
-              - cost_per_token: 0.00000195
-                from: 256000
 features:
     - function_calling
     - tool_choice
@@ -17,10 +10,13 @@ features:
 limits:
     context_window: 1000000
     max_output_tokens: 65536
-    max_tokens: 65536
 modalities:
     input:
+        - text
         - image
+        - video
+    output:
+        - text
 mode: chat
 model: qwen/qwen3.5-plus-02-15
 params:

--- a/providers/openrouter/qwen/qwq-32b.yaml
+++ b/providers/openrouter/qwen/qwq-32b.yaml
@@ -7,7 +7,11 @@ features:
 limits:
     context_window: 32768
     max_output_tokens: 32768
-    max_tokens: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwen/qwq-32b
 sources:

--- a/providers/openrouter/relace/relace-apply-3.yaml
+++ b/providers/openrouter/relace/relace-apply-3.yaml
@@ -5,7 +5,11 @@ costs:
 limits:
     context_window: 256000
     max_output_tokens: 128000
-    max_tokens: 128000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: relace/relace-apply-3
 params:

--- a/providers/openrouter/relace/relace-search.yaml
+++ b/providers/openrouter/relace/relace-search.yaml
@@ -9,9 +9,12 @@ features:
     - system_messages
 limits:
     context_window: 256000
-    max_input_tokens: 128000
     max_output_tokens: 128000
-    max_tokens: 128000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: relace/relace-search
 sources:

--- a/providers/openrouter/sao10k/l3-euryale-70b.yaml
+++ b/providers/openrouter/sao10k/l3-euryale-70b.yaml
@@ -9,7 +9,11 @@ features:
 limits:
     context_window: 8192
     max_output_tokens: 8192
-    max_tokens: 8192
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: sao10k/l3-euryale-70b
 sources:

--- a/providers/openrouter/sao10k/l3-lunaris-8b.yaml
+++ b/providers/openrouter/sao10k/l3-lunaris-8b.yaml
@@ -4,6 +4,11 @@ costs:
       region: "*"
 limits:
     context_window: 8192
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: sao10k/l3-lunaris-8b
 sources:

--- a/providers/openrouter/sao10k/l3.1-70b-hanami-x1.yaml
+++ b/providers/openrouter/sao10k/l3.1-70b-hanami-x1.yaml
@@ -8,6 +8,11 @@ features:
     - system_messages
 limits:
     context_window: 16000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: sao10k/l3.1-70b-hanami-x1
 sources:

--- a/providers/openrouter/sao10k/l3.1-euryale-70b.yaml
+++ b/providers/openrouter/sao10k/l3.1-euryale-70b.yaml
@@ -7,7 +7,11 @@ features:
 limits:
     context_window: 131072
     max_output_tokens: 16384
-    max_tokens: 16384
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: sao10k/l3.1-euryale-70b
 sources:

--- a/providers/openrouter/sao10k/l3.3-euryale-70b.yaml
+++ b/providers/openrouter/sao10k/l3.3-euryale-70b.yaml
@@ -7,7 +7,11 @@ features:
 limits:
     context_window: 131072
     max_output_tokens: 16384
-    max_tokens: 16384
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: sao10k/l3.3-euryale-70b
 sources:

--- a/providers/openrouter/stepfun/step-3.5-flash.yaml
+++ b/providers/openrouter/stepfun/step-3.5-flash.yaml
@@ -10,7 +10,11 @@ features:
 limits:
     context_window: 256000
     max_output_tokens: 256000
-    max_tokens: 256000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: stepfun/step-3.5-flash
 sources:

--- a/providers/openrouter/stepfun/step-3.5-flash:free.yaml
+++ b/providers/openrouter/stepfun/step-3.5-flash:free.yaml
@@ -9,7 +9,11 @@ features:
 limits:
     context_window: 256000
     max_output_tokens: 256000
-    max_tokens: 256000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: stepfun/step-3.5-flash:free
 sources:

--- a/providers/openrouter/switchpoint/router.yaml
+++ b/providers/openrouter/switchpoint/router.yaml
@@ -6,9 +6,11 @@ features:
     - tool_choice
 limits:
     context_window: 131072
-    max_input_tokens: 131072
-    max_output_tokens: 131072
-    max_tokens: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: switchpoint/router
 sources:

--- a/providers/openrouter/tencent/hunyuan-a13b-instruct.yaml
+++ b/providers/openrouter/tencent/hunyuan-a13b-instruct.yaml
@@ -7,7 +7,11 @@ features:
 limits:
     context_window: 131072
     max_output_tokens: 131072
-    max_tokens: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: tencent/hunyuan-a13b-instruct
 sources:

--- a/providers/openrouter/thedrummer/cydonia-24b-v4.1.yaml
+++ b/providers/openrouter/thedrummer/cydonia-24b-v4.1.yaml
@@ -9,7 +9,11 @@ features:
 limits:
     context_window: 131072
     max_output_tokens: 131072
-    max_tokens: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: thedrummer/cydonia-24b-v4.1
 sources:

--- a/providers/openrouter/thedrummer/rocinante-12b.yaml
+++ b/providers/openrouter/thedrummer/rocinante-12b.yaml
@@ -9,7 +9,11 @@ features:
 limits:
     context_window: 32768
     max_output_tokens: 32768
-    max_tokens: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: thedrummer/rocinante-12b
 sources:

--- a/providers/openrouter/thedrummer/skyfall-36b-v2.yaml
+++ b/providers/openrouter/thedrummer/skyfall-36b-v2.yaml
@@ -9,7 +9,11 @@ features:
 limits:
     context_window: 32768
     max_output_tokens: 32768
-    max_tokens: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: thedrummer/skyfall-36b-v2
 sources:

--- a/providers/openrouter/thedrummer/unslopnemo-12b.yaml
+++ b/providers/openrouter/thedrummer/unslopnemo-12b.yaml
@@ -9,7 +9,11 @@ features:
 limits:
     context_window: 32768
     max_output_tokens: 32768
-    max_tokens: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: thedrummer/unslopnemo-12b
 sources:

--- a/providers/openrouter/tngtech/deepseek-r1t2-chimera.yaml
+++ b/providers/openrouter/tngtech/deepseek-r1t2-chimera.yaml
@@ -11,7 +11,11 @@ features:
 limits:
     context_window: 163840
     max_output_tokens: 163840
-    max_tokens: 163840
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: tngtech/deepseek-r1t2-chimera
 sources:

--- a/providers/openrouter/undi95/remm-slerp-l2-13b.yaml
+++ b/providers/openrouter/undi95/remm-slerp-l2-13b.yaml
@@ -5,7 +5,11 @@ costs:
 limits:
     context_window: 6144
     max_output_tokens: 4096
-    max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: undi95/remm-slerp-l2-13b
 sources:

--- a/providers/openrouter/upstage/solar-pro-3.yaml
+++ b/providers/openrouter/upstage/solar-pro-3.yaml
@@ -9,6 +9,11 @@ features:
     - structured_output
 limits:
     context_window: 128000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: upstage/solar-pro-3
 sources:

--- a/providers/openrouter/writer/palmyra-x5.yaml
+++ b/providers/openrouter/writer/palmyra-x5.yaml
@@ -8,7 +8,11 @@ features:
 limits:
     context_window: 1040000
     max_output_tokens: 8192
-    max_tokens: 8192
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: writer/palmyra-x5
 params:

--- a/providers/openrouter/x-ai/grok-3-beta.yaml
+++ b/providers/openrouter/x-ai/grok-3-beta.yaml
@@ -11,6 +11,11 @@ features:
     - tools
 limits:
     context_window: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: x-ai/grok-3-beta
 sources:

--- a/providers/openrouter/x-ai/grok-3-mini-beta.yaml
+++ b/providers/openrouter/x-ai/grok-3-mini-beta.yaml
@@ -9,6 +9,11 @@ features:
     - structured_output
 limits:
     context_window: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: x-ai/grok-3-mini-beta
 sources:

--- a/providers/openrouter/x-ai/grok-3-mini.yaml
+++ b/providers/openrouter/x-ai/grok-3-mini.yaml
@@ -10,7 +10,11 @@ features:
     - system_messages
 limits:
     context_window: 131072
-    max_tokens: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: x-ai/grok-3-mini
 sources:

--- a/providers/openrouter/x-ai/grok-3.yaml
+++ b/providers/openrouter/x-ai/grok-3.yaml
@@ -12,6 +12,11 @@ features:
     - prompt_caching
 limits:
     context_window: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: x-ai/grok-3
 sources:

--- a/providers/openrouter/x-ai/grok-4-fast.yaml
+++ b/providers/openrouter/x-ai/grok-4-fast.yaml
@@ -13,10 +13,12 @@ features:
 limits:
     context_window: 2000000
     max_output_tokens: 30000
-    max_tokens: 30000
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: x-ai/grok-4-fast
 sources:

--- a/providers/openrouter/x-ai/grok-4.1-fast.yaml
+++ b/providers/openrouter/x-ai/grok-4.1-fast.yaml
@@ -3,13 +3,6 @@ costs:
       input_cost_per_token: 2.e-7
       output_cost_per_token: 5.e-7
       region: "*"
-      tiered_pricing:
-          input:
-              - cost_per_token: 4.e-7
-                from: 128000
-          output:
-              - cost_per_token: 0.000001
-                from: 128000
 features:
     - function_calling
     - tool_choice
@@ -20,10 +13,12 @@ features:
 limits:
     context_window: 2000000
     max_output_tokens: 30000
-    max_tokens: 30000
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: x-ai/grok-4.1-fast
 params:

--- a/providers/openrouter/x-ai/grok-4.20-beta.yaml
+++ b/providers/openrouter/x-ai/grok-4.20-beta.yaml
@@ -1,17 +1,8 @@
 costs:
     - cache_read_input_token_cost: 2.e-7
       input_cost_per_token: 0.000002
-      input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000006
-      output_cost_per_token_batches: 0.000003
       region: "*"
-      tiered_pricing:
-          input:
-              - cost_per_token: 0.000004
-                from: 200000
-          output:
-              - cost_per_token: 0.000012
-                from: 200000
 features:
     - function_calling
     - tool_choice
@@ -21,7 +12,10 @@ limits:
     context_window: 2000000
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: x-ai/grok-4.20-beta
 sources:

--- a/providers/openrouter/x-ai/grok-4.20-multi-agent-beta.yaml
+++ b/providers/openrouter/x-ai/grok-4.20-multi-agent-beta.yaml
@@ -3,13 +3,6 @@ costs:
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000006
       region: "*"
-      tiered_pricing:
-          input:
-              - cost_per_token: 0.000004
-                from: 200000
-          output:
-              - cost_per_token: 0.000012
-                from: 200000
 features:
     - function_calling
     - tool_choice
@@ -19,7 +12,10 @@ limits:
     context_window: 2000000
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: x-ai/grok-4.20-multi-agent-beta
 sources:

--- a/providers/openrouter/x-ai/grok-4.yaml
+++ b/providers/openrouter/x-ai/grok-4.yaml
@@ -3,13 +3,6 @@ costs:
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: "*"
-      tiered_pricing:
-          input:
-              - cost_per_token: 0.000006
-                from: 128000
-          output:
-              - cost_per_token: 0.00003
-                from: 128000
 features:
     - function_calling
     - parallel_function_calling
@@ -20,6 +13,9 @@ limits:
 modalities:
     input:
         - image
+        - text
+    output:
+        - text
 mode: chat
 model: x-ai/grok-4
 sources:

--- a/providers/openrouter/x-ai/grok-code-fast-1.yaml
+++ b/providers/openrouter/x-ai/grok-code-fast-1.yaml
@@ -12,7 +12,11 @@ features:
 limits:
     context_window: 256000
     max_output_tokens: 10000
-    max_tokens: 10000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: x-ai/grok-code-fast-1
 sources:

--- a/providers/openrouter/xiaomi/mimo-v2-flash.yaml
+++ b/providers/openrouter/xiaomi/mimo-v2-flash.yaml
@@ -1,6 +1,5 @@
 costs:
-    - cache_creation_input_token_cost: 0
-      cache_read_input_token_cost: 4.5e-8
+    - cache_read_input_token_cost: 4.5e-8
       input_cost_per_token: 9.e-8
       output_cost_per_token: 2.9e-7
       region: "*"
@@ -9,9 +8,12 @@ features:
     - tool_choice
 limits:
     context_window: 262144
-    max_input_tokens: 262144
     max_output_tokens: 65536
-    max_tokens: 65536
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: xiaomi/mimo-v2-flash
 sources:

--- a/providers/openrouter/z-ai/glm-4-32b.yaml
+++ b/providers/openrouter/z-ai/glm-4-32b.yaml
@@ -8,6 +8,11 @@ features:
     - tools
 limits:
     context_window: 128000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: z-ai/glm-4-32b
 sources:

--- a/providers/openrouter/z-ai/glm-4.5-air.yaml
+++ b/providers/openrouter/z-ai/glm-4.5-air.yaml
@@ -10,7 +10,11 @@ features:
 limits:
     context_window: 131072
     max_output_tokens: 98304
-    max_tokens: 98304
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: z-ai/glm-4.5-air
 sources:

--- a/providers/openrouter/z-ai/glm-4.5-air:free.yaml
+++ b/providers/openrouter/z-ai/glm-4.5-air:free.yaml
@@ -10,7 +10,11 @@ features:
 limits:
     context_window: 131072
     max_output_tokens: 96000
-    max_tokens: 96000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: z-ai/glm-4.5-air:free
 sources:

--- a/providers/openrouter/z-ai/glm-4.5.yaml
+++ b/providers/openrouter/z-ai/glm-4.5.yaml
@@ -11,7 +11,11 @@ features:
 limits:
     context_window: 131072
     max_output_tokens: 98304
-    max_tokens: 98304
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: z-ai/glm-4.5
 sources:

--- a/providers/openrouter/z-ai/glm-4.5v.yaml
+++ b/providers/openrouter/z-ai/glm-4.5v.yaml
@@ -11,10 +11,12 @@ features:
 limits:
     context_window: 65536
     max_output_tokens: 16384
-    max_tokens: 16384
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: z-ai/glm-4.5v
 sources:

--- a/providers/openrouter/z-ai/glm-4.6.yaml
+++ b/providers/openrouter/z-ai/glm-4.6.yaml
@@ -9,7 +9,11 @@ features:
 limits:
     context_window: 204800
     max_output_tokens: 204800
-    max_tokens: 204800
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: z-ai/glm-4.6
 sources:

--- a/providers/openrouter/z-ai/glm-4.6v.yaml
+++ b/providers/openrouter/z-ai/glm-4.6v.yaml
@@ -10,10 +10,13 @@ features:
 limits:
     context_window: 131072
     max_output_tokens: 131072
-    max_tokens: 131072
 modalities:
     input:
         - image
+        - text
+        - video
+    output:
+        - text
 mode: chat
 model: z-ai/glm-4.6v
 params:

--- a/providers/openrouter/z-ai/glm-4.7-flash.yaml
+++ b/providers/openrouter/z-ai/glm-4.7-flash.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 0
+    - cache_read_input_token_cost: 1.00000002e-8
       input_cost_per_token: 6.e-8
       output_cost_per_token: 4.e-7
       region: "*"
@@ -9,6 +9,11 @@ features:
     - structured_output
 limits:
     context_window: 202752
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: z-ai/glm-4.7-flash
 sources:

--- a/providers/openrouter/z-ai/glm-4.7.yaml
+++ b/providers/openrouter/z-ai/glm-4.7.yaml
@@ -1,6 +1,5 @@
 costs:
-    - cache_creation_input_token_cost: 0
-      cache_read_input_token_cost: 1.9e-7
+    - cache_read_input_token_cost: 1.9e-7
       input_cost_per_token: 3.8e-7
       output_cost_per_token: 0.00000198
       region: "*"
@@ -10,9 +9,11 @@ features:
     - prompt_caching
 limits:
     context_window: 202752
-    max_input_tokens: 202752
-    max_output_tokens: 64000
-    max_tokens: 64000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: z-ai/glm-4.7
 sources:

--- a/providers/openrouter/z-ai/glm-5-turbo.yaml
+++ b/providers/openrouter/z-ai/glm-5-turbo.yaml
@@ -9,7 +9,11 @@ features:
 limits:
     context_window: 202752
     max_output_tokens: 131072
-    max_tokens: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: z-ai/glm-5-turbo
 sources:

--- a/providers/openrouter/z-ai/glm-5.yaml
+++ b/providers/openrouter/z-ai/glm-5.yaml
@@ -8,10 +8,13 @@ features:
     - system_messages
     - tool_choice
 limits:
-    context_window: 202752
-    max_input_tokens: 71680
+    context_window: 80000
     max_output_tokens: 131072
-    max_tokens: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: z-ai/glm-5
 sources:


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `openrouter`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Bulk edits to OpenRouter model YAMLs adjust pricing and token/context limits, which could impact billing calculations and request validation. Changes are configuration-only but touch many models, increasing the chance of an incorrect per-model setting slipping in.
> 
> **Overview**
> Updates a large set of OpenRouter model definition YAMLs to **standardize capability metadata** by adding explicit `modalities` (declaring supported input/output types) and aligning limit fields (e.g., favoring `max_output_tokens` over `max_tokens`).
> 
> Also refreshes per-model **pricing and limit details** in several entries (e.g., adding cache read/creation token costs, tweaking context windows/max outputs), and fills in previously incomplete `mode: unknown` specs (e.g., `openai/gpt-4-0314`, `mistralai/mistral-small-2603`, `openai/gpt-5.4-*`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ebb1ec6a7a81c8018dd2832381e7b347152922e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->