### PR TITLE
feat(sambanova): add new models [bot]

### DIFF
--- a/providers/sambanova/ALLaM-7B-Instruct-preview.yaml
+++ b/providers/sambanova/ALLaM-7B-Instruct-preview.yaml
@@ -1,13 +1,14 @@
 costs:
-    - input_cost_per_token: 2.2e-7
-      output_cost_per_token: 5.9e-7
+    - input_cost_per_token: "0.00000022"
+      output_cost_per_token: "0.00000059"
       region: "*"
 features:
     - function_calling
 isDeprecated: true
 limits:
+    context_window: 4096
     max_input_tokens: 131072
-    max_output_tokens: 131072
+    max_output_tokens: 4096
     max_tokens: 131072
 mode: chat
 model: ALLaM-7B-Instruct-preview

--- a/providers/sambanova/DeepSeek-R1-0528.yaml
+++ b/providers/sambanova/DeepSeek-R1-0528.yaml
@@ -1,9 +1,14 @@
+costs:
+    - input_cost_per_token: "0.00000500"
+      output_cost_per_token: "0.00000700"
+      region: "*"
 features:
     - function_calling
     - tool_choice
     - structured_output
 limits:
-    context_window: 128000
+    context_window: 131072
+    max_output_tokens: 7168
 mode: chat
 model: DeepSeek-R1-0528
 sources:

--- a/providers/sambanova/DeepSeek-R1-Distill-Llama-70B.yaml
+++ b/providers/sambanova/DeepSeek-R1-Distill-Llama-70B.yaml
@@ -1,9 +1,9 @@
 costs:
-    - input_cost_per_token: 7.e-7
-      output_cost_per_token: 0.0000014
+    - input_cost_per_token: "0.00000070"
+      output_cost_per_token: "0.00000140"
       region: "*"
 limits:
-    context_window: 128000
+    context_window: 131072
     max_output_tokens: 4096
     max_tokens: 4096
 mode: chat

--- a/providers/sambanova/DeepSeek-V3-0324.yaml
+++ b/providers/sambanova/DeepSeek-V3-0324.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 0.000003
-      output_cost_per_token: 0.0000045
+    - input_cost_per_token: "0.00000300"
+      output_cost_per_token: "0.00000450"
       region: "*"
 features:
     - function_calling

--- a/providers/sambanova/DeepSeek-V3.1-Terminus.yaml
+++ b/providers/sambanova/DeepSeek-V3.1-Terminus.yaml
@@ -1,9 +1,14 @@
+costs:
+    - input_cost_per_token: "0.00000300"
+      output_cost_per_token: "0.00000450"
+      region: "*"
 features:
     - function_calling
     - tool_choice
     - system_messages
 limits:
-    context_window: 128000
+    context_window: 131072
+    max_output_tokens: 7168
 mode: chat
 model: DeepSeek-V3.1-Terminus
 sources:

--- a/providers/sambanova/DeepSeek-V3.1.yaml
+++ b/providers/sambanova/DeepSeek-V3.1.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 0.000003
-      output_cost_per_token: 0.0000045
+    - input_cost_per_token: "0.00000300"
+      output_cost_per_token: "0.00000450"
       region: "*"
 features:
     - function_calling
@@ -8,7 +8,8 @@ features:
     - structured_output
     - system_messages
 limits:
-    context_window: 128000
+    context_window: 131072
+    max_output_tokens: 7168
 mode: chat
 model: DeepSeek-V3.1
 sources:

--- a/providers/sambanova/DeepSeek-V3.2.yaml
+++ b/providers/sambanova/DeepSeek-V3.2.yaml
@@ -1,9 +1,14 @@
+costs:
+    - input_cost_per_token: "0.00000300"
+      output_cost_per_token: "0.00000450"
+      region: "*"
 features:
     - function_calling
     - system_messages
     - tool_choice
 limits:
-    context_window: 8000
+    context_window: 8192
+    max_output_tokens: 7168
 mode: chat
 model: DeepSeek-V3.2
 sources:

--- a/providers/sambanova/Llama-3.3-Swallow-70B-Instruct-v0.4.yaml
+++ b/providers/sambanova/Llama-3.3-Swallow-70B-Instruct-v0.4.yaml
@@ -1,10 +1,11 @@
 costs:
-    - input_cost_per_token: 6.e-7
-      output_cost_per_token: 0.0000012
+    - input_cost_per_token: "0.00000060"
+      output_cost_per_token: "0.00000120"
       region: "*"
 features:
     - function_calling
 limits:
-    context_window: 16384
+    context_window: 131072
+    max_output_tokens: 3072
 mode: chat
 model: Llama-3.3-Swallow-70B-Instruct-v0.4

--- a/providers/sambanova/Llama-4-Maverick-17B-128E-Instruct.yaml
+++ b/providers/sambanova/Llama-4-Maverick-17B-128E-Instruct.yaml
@@ -1,13 +1,14 @@
 costs:
-    - input_cost_per_token: 6.3e-7
-      output_cost_per_token: 0.0000018
+    - input_cost_per_token: "0.00000063"
+      output_cost_per_token: "0.00000180"
       region: "*"
 features:
     - function_calling
     - tool_choice
     - structured_output
 limits:
-    context_window: 128000
+    context_window: 131072
+    max_output_tokens: 4096
 modalities:
     input:
         - image

--- a/providers/sambanova/Meta-Llama-3.1-8B-Instruct.yaml
+++ b/providers/sambanova/Meta-Llama-3.1-8B-Instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 2.e-7
+    - input_cost_per_token: "0.00000010"
+      output_cost_per_token: "0.00000020"
       region: "*"
 features:
     - function_calling
@@ -9,7 +9,7 @@ features:
 limits:
     context_window: 16384
     max_input_tokens: 16384
-    max_output_tokens: 16384
+    max_output_tokens: 4096
     max_tokens: 16384
 mode: chat
 model: Meta-Llama-3.1-8B-Instruct

--- a/providers/sambanova/Meta-Llama-3.3-70B-Instruct.yaml
+++ b/providers/sambanova/Meta-Llama-3.3-70B-Instruct.yaml
@@ -1,13 +1,14 @@
 costs:
-    - input_cost_per_token: 6.e-7
-      output_cost_per_token: 0.0000012
+    - input_cost_per_token: "0.00000060"
+      output_cost_per_token: "0.00000120"
       region: "*"
 features:
     - function_calling
     - tool_choice
     - structured_output
 limits:
-    context_window: 128000
+    context_window: 131072
+    max_output_tokens: 3072
 mode: chat
 model: Meta-Llama-3.3-70B-Instruct
 sources:

--- a/providers/sambanova/Qwen3-235B.yaml
+++ b/providers/sambanova/Qwen3-235B.yaml
@@ -1,13 +1,14 @@
 costs:
-    - input_cost_per_token: 4.e-7
-      output_cost_per_token: 8.e-7
+    - input_cost_per_token: "0.00000040"
+      output_cost_per_token: "0.00000080"
       region: "*"
 features:
     - function_calling
 limits:
-    context_window: 64000
+    context_window: 65536
+    max_output_tokens: 4096
 mode: chat
-model: Qwen3-235B-A22B-Instruct-2507
+model: Qwen3-235B
 sources:
     - https://docs.sambanova.ai/docs/en/features/function-calling
     - https://docs.sambanova.ai/docs/en/build/reasoning

--- a/providers/sambanova/Qwen3-32B.yaml
+++ b/providers/sambanova/Qwen3-32B.yaml
@@ -1,12 +1,13 @@
 costs:
-    - input_cost_per_token: 4.e-7
-      output_cost_per_token: 8.e-7
+    - input_cost_per_token: "0.00000040"
+      output_cost_per_token: "0.00000080"
       region: "*"
 features:
     - function_calling
     - tool_choice
 limits:
-    context_window: 32000
+    context_window: 32768
+    max_output_tokens: 4096
 mode: chat
 model: Qwen3-32B
 sources:

--- a/providers/sambanova/Whisper-Large-v3.yaml
+++ b/providers/sambanova/Whisper-Large-v3.yaml
@@ -1,6 +1,11 @@
 costs:
     - input_cost_per_second: 0.00002778
+      input_cost_per_token: "0.00000000"
+      output_cost_per_token: "0.00000000"
       region: "*"
+limits:
+    context_window: 4096
+    max_output_tokens: 4096
 modalities:
     input:
         - audio

--- a/providers/sambanova/gpt-oss-120b.yaml
+++ b/providers/sambanova/gpt-oss-120b.yaml
@@ -1,12 +1,13 @@
 costs:
-    - input_cost_per_token: 2.2e-7
-      output_cost_per_token: 5.9e-7
+    - input_cost_per_token: "0.00000022"
+      output_cost_per_token: "0.00000059"
       region: "*"
 features:
     - function_calling
     - tool_choice
 limits:
-    context_window: 128000
+    context_window: 131072
+    max_output_tokens: 131072
 mode: chat
 model: gpt-oss-120b
 sources:

--- a/providers/sambanova/llama3-8b.yaml
+++ b/providers/sambanova/llama3-8b.yaml
@@ -1,9 +1,8 @@
 costs:
-    - input_cost_per_token: "0.00000013"
+    - input_cost_per_token: "0.00000000"
       output_cost_per_token: "0.00000000"
       region: "*"
 limits:
     context_window: 4096
     max_output_tokens: 4096
-mode: embedding
-model: E5-Mistral-7B-Instruct
+model: llama3-8b


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `sambanova`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches only provider model metadata YAMLs, but changes token/cost fields (including switching numeric values to strings) and advertised token limits, which can affect downstream validation, UI display, or cost calculations if parsers are strict.
> 
> **Overview**
> Updates SambaNova provider model metadata by normalizing/adding `costs` entries, bumping several `context_window` values to 131072 (or 8192/65536/32768 where applicable), and setting/adjusting `max_output_tokens` limits across multiple models.
> 
> Adds new model definition `llama3-8b`, corrects `Qwen3-235B`’s `model` identifier, and expands metadata for `Whisper-Large-v3` (adds token cost placeholders plus `limits`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 792d5af82a6a06445f13126868d651abd8403992. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->