### PR TITLE
feat(sambanova): add new models [bot]

### DIFF
--- a/providers/sambanova/ALLaM-7B-Instruct-preview.yaml
+++ b/providers/sambanova/ALLaM-7B-Instruct-preview.yaml
@@ -6,8 +6,9 @@ features:
     - function_calling
 isDeprecated: true
 limits:
+    context_window: 4096
     max_input_tokens: 131072
-    max_output_tokens: 131072
+    max_output_tokens: 4096
     max_tokens: 131072
 mode: chat
 model: ALLaM-7B-Instruct-preview

--- a/providers/sambanova/DeepSeek-R1-0528.yaml
+++ b/providers/sambanova/DeepSeek-R1-0528.yaml
@@ -3,7 +3,8 @@ features:
     - tool_choice
     - structured_output
 limits:
-    context_window: 128000
+    context_window: 131072
+    max_output_tokens: 7168
 mode: chat
 model: DeepSeek-R1-0528
 sources:

--- a/providers/sambanova/DeepSeek-R1-Distill-Llama-70B.yaml
+++ b/providers/sambanova/DeepSeek-R1-Distill-Llama-70B.yaml
@@ -3,7 +3,7 @@ costs:
       output_cost_per_token: 0.0000014
       region: "*"
 limits:
-    context_window: 128000
+    context_window: 131072
     max_output_tokens: 4096
     max_tokens: 4096
 mode: chat

--- a/providers/sambanova/DeepSeek-V3.1-Terminus.yaml
+++ b/providers/sambanova/DeepSeek-V3.1-Terminus.yaml
@@ -3,7 +3,8 @@ features:
     - tool_choice
     - system_messages
 limits:
-    context_window: 128000
+    context_window: 131072
+    max_output_tokens: 7168
 mode: chat
 model: DeepSeek-V3.1-Terminus
 sources:

--- a/providers/sambanova/DeepSeek-V3.1.yaml
+++ b/providers/sambanova/DeepSeek-V3.1.yaml
@@ -8,7 +8,8 @@ features:
     - structured_output
     - system_messages
 limits:
-    context_window: 128000
+    context_window: 131072
+    max_output_tokens: 7168
 mode: chat
 model: DeepSeek-V3.1
 sources:

--- a/providers/sambanova/DeepSeek-V3.2.yaml
+++ b/providers/sambanova/DeepSeek-V3.2.yaml
@@ -3,7 +3,8 @@ features:
     - system_messages
     - tool_choice
 limits:
-    context_window: 8000
+    context_window: 8192
+    max_output_tokens: 7168
 mode: chat
 model: DeepSeek-V3.2
 sources:

--- a/providers/sambanova/E5-Mistral-7B-Instruct.yaml
+++ b/providers/sambanova/E5-Mistral-7B-Instruct.yaml
@@ -4,5 +4,6 @@ costs:
       region: "*"
 limits:
     context_window: 4096
+    max_output_tokens: 4096
 mode: embedding
 model: E5-Mistral-7B-Instruct

--- a/providers/sambanova/Llama-3.3-Swallow-70B-Instruct-v0.4.yaml
+++ b/providers/sambanova/Llama-3.3-Swallow-70B-Instruct-v0.4.yaml
@@ -5,6 +5,7 @@ costs:
 features:
     - function_calling
 limits:
-    context_window: 16384
+    context_window: 131072
+    max_output_tokens: 3072
 mode: chat
 model: Llama-3.3-Swallow-70B-Instruct-v0.4

--- a/providers/sambanova/Llama-4-Maverick-17B-128E-Instruct.yaml
+++ b/providers/sambanova/Llama-4-Maverick-17B-128E-Instruct.yaml
@@ -7,7 +7,8 @@ features:
     - tool_choice
     - structured_output
 limits:
-    context_window: 128000
+    context_window: 131072
+    max_output_tokens: 4096
 modalities:
     input:
         - image

--- a/providers/sambanova/Meta-Llama-3.1-8B-Instruct.yaml
+++ b/providers/sambanova/Meta-Llama-3.1-8B-Instruct.yaml
@@ -9,7 +9,7 @@ features:
 limits:
     context_window: 16384
     max_input_tokens: 16384
-    max_output_tokens: 16384
+    max_output_tokens: 4096
     max_tokens: 16384
 mode: chat
 model: Meta-Llama-3.1-8B-Instruct

--- a/providers/sambanova/Meta-Llama-3.3-70B-Instruct.yaml
+++ b/providers/sambanova/Meta-Llama-3.3-70B-Instruct.yaml
@@ -7,7 +7,8 @@ features:
     - tool_choice
     - structured_output
 limits:
-    context_window: 128000
+    context_window: 131072
+    max_output_tokens: 3072
 mode: chat
 model: Meta-Llama-3.3-70B-Instruct
 sources:

--- a/providers/sambanova/Qwen3-235B.yaml
+++ b/providers/sambanova/Qwen3-235B.yaml
@@ -5,9 +5,10 @@ costs:
 features:
     - function_calling
 limits:
-    context_window: 64000
+    context_window: 65536
+    max_output_tokens: 4096
 mode: chat
-model: Qwen3-235B-A22B-Instruct-2507
+model: Qwen3-235B
 sources:
     - https://docs.sambanova.ai/docs/en/features/function-calling
     - https://docs.sambanova.ai/docs/en/build/reasoning

--- a/providers/sambanova/Qwen3-32B.yaml
+++ b/providers/sambanova/Qwen3-32B.yaml
@@ -6,7 +6,8 @@ features:
     - function_calling
     - tool_choice
 limits:
-    context_window: 32000
+    context_window: 32768
+    max_output_tokens: 4096
 mode: chat
 model: Qwen3-32B
 sources:

--- a/providers/sambanova/Whisper-Large-v3.yaml
+++ b/providers/sambanova/Whisper-Large-v3.yaml
@@ -1,6 +1,9 @@
 costs:
     - input_cost_per_second: 0.00002778
       region: "*"
+limits:
+    context_window: 4096
+    max_output_tokens: 4096
 modalities:
     input:
         - audio

--- a/providers/sambanova/gpt-oss-120b.yaml
+++ b/providers/sambanova/gpt-oss-120b.yaml
@@ -6,7 +6,8 @@ features:
     - function_calling
     - tool_choice
 limits:
-    context_window: 128000
+    context_window: 131072
+    max_output_tokens: 131072
 mode: chat
 model: gpt-oss-120b
 sources:

--- a/providers/sambanova/llama3-8b.yaml
+++ b/providers/sambanova/llama3-8b.yaml
@@ -1,0 +1,4 @@
+limits:
+    context_window: 4096
+    max_output_tokens: 4096
+model: llama3-8b


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `sambanova`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly updates YAML metadata for SambaNova model limits (context window/output token caps) and adds one new model entry; low risk aside from potential runtime validation issues if limit values are consumed strictly.
> 
> **Overview**
> Updates SambaNova provider model catalogs to reflect new/normalized `limits` across multiple models, mainly bumping `context_window` values and adding/adjusting `max_output_tokens` caps (including reducing some previously very large output limits).
> 
> Adds missing `limits` for `Whisper-Large-v3` and introduces a new `llama3-8b` model config; also corrects the `Qwen3-235B` model identifier.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6fa88fa32768b3b3ef38cec54428a8cb347f093a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->