### PR TITLE
feat(together-ai): add new models [bot]

### DIFF
--- a/providers/together-ai/ByteDance/Seedance-1.0-lite.yaml
+++ b/providers/together-ai/ByteDance/Seedance-1.0-lite.yaml
@@ -1,7 +1,7 @@
 costs:
     - input_cost_per_request: 0.14
       region: "*"
-mode: video
+mode: unknown
 model: ByteDance/Seedance-1.0-lite
 sources:
     - https://docs.together.ai/docs/serverless-models

--- a/providers/together-ai/ByteDance/Seedance-1.0-pro.yaml
+++ b/providers/together-ai/ByteDance/Seedance-1.0-pro.yaml
@@ -1,7 +1,7 @@
 costs:
     - input_cost_per_request: 0.57
       region: "*"
-mode: video
+mode: unknown
 model: ByteDance/Seedance-1.0-pro
 sources:
     - https://docs.together.ai/docs/serverless-models

--- a/providers/together-ai/MiniMaxAI/MiniMax-M1-40k.yaml
+++ b/providers/together-ai/MiniMaxAI/MiniMax-M1-40k.yaml
@@ -1,3 +1,3 @@
-mode: chat
+mode: unknown
 model: MiniMaxAI/MiniMax-M1-40k
 thinking: true

--- a/providers/together-ai/MiniMaxAI/MiniMax-M1-80k.yaml
+++ b/providers/together-ai/MiniMaxAI/MiniMax-M1-80k.yaml
@@ -3,7 +3,7 @@ features:
     - system_messages
 limits:
     context_window: 1000000
-mode: chat
+mode: unknown
 model: MiniMaxAI/MiniMax-M1-80k
 sources:
     - https://www.together.ai/pricing

--- a/providers/together-ai/MiniMaxAI/MiniMax-M2.1.yaml
+++ b/providers/together-ai/MiniMaxAI/MiniMax-M2.1.yaml
@@ -1,4 +1,4 @@
-mode: chat
+mode: unknown
 model: MiniMaxAI/MiniMax-M2.1
 sources:
     - https://together.ai/models

--- a/providers/together-ai/MiniMaxAI/MiniMax-M2.5.yaml
+++ b/providers/together-ai/MiniMaxAI/MiniMax-M2.5.yaml
@@ -8,7 +8,7 @@ features:
     - parallel_function_calling
     - structured_output
 limits:
-    context_window: 192000
+    context_window: 196608
 mode: chat
 model: MiniMaxAI/MiniMax-M2.5
 sources:

--- a/providers/together-ai/MiniMaxAI/MiniMax-M2.yaml
+++ b/providers/together-ai/MiniMaxAI/MiniMax-M2.yaml
@@ -1,4 +1,4 @@
-mode: chat
+mode: unknown
 model: MiniMaxAI/MiniMax-M2
 sources:
     - https://together.ai/models

--- a/providers/together-ai/NousResearch/Nous-Hermes-2-Mixtral-8x7B-DPO.yaml
+++ b/providers/together-ai/NousResearch/Nous-Hermes-2-Mixtral-8x7B-DPO.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: NousResearch/Nous-Hermes-2-Mixtral-8x7B-DPO

--- a/providers/together-ai/Qwen/QwQ-32B-Preview.yaml
+++ b/providers/together-ai/Qwen/QwQ-32B-Preview.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: Qwen/QwQ-32B-Preview

--- a/providers/together-ai/Qwen/QwQ-32B.yaml
+++ b/providers/together-ai/Qwen/QwQ-32B.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: Qwen/QwQ-32B

--- a/providers/together-ai/Qwen/Qwen2-1.5B-Instruct.yaml
+++ b/providers/together-ai/Qwen/Qwen2-1.5B-Instruct.yaml
@@ -1,4 +1,4 @@
-mode: chat
+mode: unknown
 model: Qwen/Qwen2-1.5B-Instruct
 sources:
     - https://docs.together.ai/llms.txt

--- a/providers/together-ai/Qwen/Qwen2-1.5B.yaml
+++ b/providers/together-ai/Qwen/Qwen2-1.5B.yaml
@@ -1,4 +1,4 @@
-mode: chat
+mode: unknown
 model: Qwen/Qwen2-1.5B
 sources:
     - https://together.ai/pricing

--- a/providers/together-ai/Qwen/Qwen2-72B-Instruct.yaml
+++ b/providers/together-ai/Qwen/Qwen2-72B-Instruct.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: Qwen/Qwen2-72B-Instruct

--- a/providers/together-ai/Qwen/Qwen2-7B.yaml
+++ b/providers/together-ai/Qwen/Qwen2-7B.yaml
@@ -1,2 +1,2 @@
-mode: completion
+mode: unknown
 model: Qwen/Qwen2-7B

--- a/providers/together-ai/Qwen/Qwen2-VL-72B-Instruct.yaml
+++ b/providers/together-ai/Qwen/Qwen2-VL-72B-Instruct.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: Qwen/Qwen2-VL-72B-Instruct

--- a/providers/together-ai/Qwen/Qwen2.5-1.5B-Instruct.yaml
+++ b/providers/together-ai/Qwen/Qwen2.5-1.5B-Instruct.yaml
@@ -1,6 +1,6 @@
 features:
     - function_calling
-mode: chat
+mode: unknown
 model: Qwen/Qwen2.5-1.5B-Instruct
 sources:
     - https://docs.together.ai/docs/changelog

--- a/providers/together-ai/Qwen/Qwen2.5-1.5B.yaml
+++ b/providers/together-ai/Qwen/Qwen2.5-1.5B.yaml
@@ -1,4 +1,4 @@
-mode: completion
+mode: unknown
 model: Qwen/Qwen2.5-1.5B
 sources:
     - https://docs.together.ai/docs/serverless-models

--- a/providers/together-ai/Qwen/Qwen2.5-14B-Instruct.yaml
+++ b/providers/together-ai/Qwen/Qwen2.5-14B-Instruct.yaml
@@ -1,3 +1,5 @@
 isDeprecated: true
+limits:
+    context_window: 32768
 mode: chat
 model: Qwen/Qwen2.5-14B-Instruct

--- a/providers/together-ai/Qwen/Qwen2.5-14B.yaml
+++ b/providers/together-ai/Qwen/Qwen2.5-14B.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: Qwen/Qwen2.5-14B

--- a/providers/together-ai/Qwen/Qwen2.5-32B-Instruct.yaml
+++ b/providers/together-ai/Qwen/Qwen2.5-32B-Instruct.yaml
@@ -1,7 +1,7 @@
 features:
     - function_calling
     - system_messages
-mode: chat
+mode: unknown
 model: Qwen/Qwen2.5-32B-Instruct
 sources:
     - https://www.together.ai/pricing

--- a/providers/together-ai/Qwen/Qwen2.5-32B.yaml
+++ b/providers/together-ai/Qwen/Qwen2.5-32B.yaml
@@ -1,2 +1,2 @@
-mode: completion
+mode: unknown
 model: Qwen/Qwen2.5-32B

--- a/providers/together-ai/Qwen/Qwen2.5-3B-Instruct.yaml
+++ b/providers/together-ai/Qwen/Qwen2.5-3B-Instruct.yaml
@@ -1,7 +1,7 @@
 features:
     - function_calling
     - system_messages
-mode: chat
+mode: unknown
 model: Qwen/Qwen2.5-3B-Instruct
 sources:
     - https://docs.together.ai/docs/serverless-models

--- a/providers/together-ai/Qwen/Qwen2.5-3B.yaml
+++ b/providers/together-ai/Qwen/Qwen2.5-3B.yaml
@@ -2,7 +2,7 @@ limits:
     context_window: 32768
     max_output_tokens: 8192
     max_tokens: 8192
-mode: completion
+mode: unknown
 model: Qwen/Qwen2.5-3B
 sources:
     - https://huggingface.co/Qwen/Qwen2.5-3B

--- a/providers/together-ai/Qwen/Qwen2.5-72B-Instruct-Turbo.yaml
+++ b/providers/together-ai/Qwen/Qwen2.5-72B-Instruct-Turbo.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: Qwen/Qwen2.5-72B-Instruct-Turbo

--- a/providers/together-ai/Qwen/Qwen2.5-72B-Instruct.yaml
+++ b/providers/together-ai/Qwen/Qwen2.5-72B-Instruct.yaml
@@ -1,3 +1,5 @@
 isDeprecated: true
+limits:
+    context_window: 32768
 mode: chat
 model: Qwen/Qwen2.5-72B-Instruct

--- a/providers/together-ai/Qwen/Qwen2.5-72B.yaml
+++ b/providers/together-ai/Qwen/Qwen2.5-72B.yaml
@@ -9,7 +9,7 @@ limits:
     max_input_tokens: 32768
     max_output_tokens: 32768
     max_tokens: 32768
-mode: chat
+mode: unknown
 model: Qwen/Qwen2.5-72B
 sources:
     - https://www.together.ai/pricing

--- a/providers/together-ai/Qwen/Qwen2.5-7B-Instruct.yaml
+++ b/providers/together-ai/Qwen/Qwen2.5-7B-Instruct.yaml
@@ -7,5 +7,5 @@ features:
     - structured_output
 limits:
     context_window: 32768
-mode: chat
+mode: unknown
 model: Qwen/Qwen2.5-7B-Instruct

--- a/providers/together-ai/Qwen/Qwen2.5-7B.yaml
+++ b/providers/together-ai/Qwen/Qwen2.5-7B.yaml
@@ -1,2 +1,2 @@
-mode: completion
+mode: unknown
 model: Qwen/Qwen2.5-7B

--- a/providers/together-ai/Qwen/Qwen2.5-Coder-32B-Instruct.yaml
+++ b/providers/together-ai/Qwen/Qwen2.5-Coder-32B-Instruct.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: Qwen/Qwen2.5-Coder-32B-Instruct

--- a/providers/together-ai/Qwen/Qwen2.5-VL-72B-Instruct.yaml
+++ b/providers/together-ai/Qwen/Qwen2.5-VL-72B-Instruct.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: Qwen/Qwen2.5-VL-72B-Instruct

--- a/providers/together-ai/Qwen/Qwen3-0.6B-Base.yaml
+++ b/providers/together-ai/Qwen/Qwen3-0.6B-Base.yaml
@@ -1,6 +1,6 @@
 limits:
     context_window: 32768
-mode: completion
+mode: unknown
 model: Qwen/Qwen3-0.6B-Base
 sources:
     - https://huggingface.co/Qwen/Qwen3-0.6B-Base

--- a/providers/together-ai/Qwen/Qwen3-0.6B.yaml
+++ b/providers/together-ai/Qwen/Qwen3-0.6B.yaml
@@ -5,7 +5,7 @@ limits:
     context_window: 32768
     max_output_tokens: 32768
     max_tokens: 32768
-mode: chat
+mode: unknown
 model: Qwen/Qwen3-0.6B
 sources:
     - https://huggingface.co/Qwen/Qwen3-0.6B

--- a/providers/together-ai/Qwen/Qwen3-1.7B-Base.yaml
+++ b/providers/together-ai/Qwen/Qwen3-1.7B-Base.yaml
@@ -1,4 +1,4 @@
-mode: completion
+mode: unknown
 model: Qwen/Qwen3-1.7B-Base
 sources:
     - https://www.together.ai/pricing

--- a/providers/together-ai/Qwen/Qwen3-1.7B.yaml
+++ b/providers/together-ai/Qwen/Qwen3-1.7B.yaml
@@ -1,4 +1,4 @@
-mode: chat
+mode: unknown
 model: Qwen/Qwen3-1.7B
 sources:
     - https://www.together.ai/pricing

--- a/providers/together-ai/Qwen/Qwen3-14B-Base.yaml
+++ b/providers/together-ai/Qwen/Qwen3-14B-Base.yaml
@@ -1,6 +1,6 @@
 limits:
     context_window: 32768
-mode: completion
+mode: unknown
 model: Qwen/Qwen3-14B-Base
 sources:
     - https://huggingface.co/Qwen/Qwen3-14B-Base

--- a/providers/together-ai/Qwen/Qwen3-14B.yaml
+++ b/providers/together-ai/Qwen/Qwen3-14B.yaml
@@ -1,4 +1,4 @@
-mode: completion
+mode: unknown
 model: Qwen/Qwen3-14B
 sources:
     - https://together.ai/models

--- a/providers/together-ai/Qwen/Qwen3-235B-A22B-Thinking-2507.yaml
+++ b/providers/together-ai/Qwen/Qwen3-235B-A22B-Thinking-2507.yaml
@@ -9,6 +9,7 @@ features:
     - structured_output
 isDeprecated: true
 limits:
+    context_window: 262144
     max_input_tokens: 256000
 mode: chat
 model: Qwen/Qwen3-235B-A22B-Thinking-2507

--- a/providers/together-ai/Qwen/Qwen3-235B-A22B-fp8.yaml
+++ b/providers/together-ai/Qwen/Qwen3-235B-A22B-fp8.yaml
@@ -2,7 +2,7 @@ features:
     - function_calling
     - structured_output
 isDeprecated: true
-mode: chat
+mode: unknown
 model: Qwen/Qwen3-235B-A22B-fp8
 sources:
     - https://together.ai/models

--- a/providers/together-ai/Qwen/Qwen3-30B-A3B-Base.yaml
+++ b/providers/together-ai/Qwen/Qwen3-30B-A3B-Base.yaml
@@ -1,2 +1,2 @@
-mode: completion
+mode: unknown
 model: Qwen/Qwen3-30B-A3B-Base

--- a/providers/together-ai/Qwen/Qwen3-30B-A3B-Instruct-2507.yaml
+++ b/providers/together-ai/Qwen/Qwen3-30B-A3B-Instruct-2507.yaml
@@ -5,7 +5,7 @@ limits:
     context_window: 262144
     max_output_tokens: 16384
     max_tokens: 16384
-mode: chat
+mode: unknown
 model: Qwen/Qwen3-30B-A3B-Instruct-2507
 sources:
     - https://huggingface.co/Qwen/Qwen3-30B-A3B-Instruct-2507

--- a/providers/together-ai/Qwen/Qwen3-30B-A3B.yaml
+++ b/providers/together-ai/Qwen/Qwen3-30B-A3B.yaml
@@ -4,7 +4,7 @@ costs:
       region: "*"
 features:
     - function_calling
-mode: chat
+mode: unknown
 model: Qwen/Qwen3-30B-A3B
 sources:
     - https://huggingface.co/Qwen/Qwen3-30B-A3B

--- a/providers/together-ai/Qwen/Qwen3-32B-FP8.yaml
+++ b/providers/together-ai/Qwen/Qwen3-32B-FP8.yaml
@@ -2,5 +2,5 @@ features:
     - function_calling
     - tool_choice
     - system_messages
-mode: chat
+mode: unknown
 model: Qwen/Qwen3-32B-FP8

--- a/providers/together-ai/Qwen/Qwen3-32B.yaml
+++ b/providers/together-ai/Qwen/Qwen3-32B.yaml
@@ -1,4 +1,4 @@
-mode: chat
+mode: unknown
 model: Qwen/Qwen3-32B
 sources:
     - https://together.ai/pricing

--- a/providers/together-ai/Qwen/Qwen3-4B-Base.yaml
+++ b/providers/together-ai/Qwen/Qwen3-4B-Base.yaml
@@ -1,6 +1,6 @@
 limits:
     context_window: 32768
-mode: completion
+mode: unknown
 model: Qwen/Qwen3-4B-Base
 sources:
     - https://huggingface.co/Qwen/Qwen3-4B-Base

--- a/providers/together-ai/Qwen/Qwen3-4B.yaml
+++ b/providers/together-ai/Qwen/Qwen3-4B.yaml
@@ -7,7 +7,7 @@ limits:
     context_window: 32768
     max_output_tokens: 32768
     max_tokens: 32768
-mode: chat
+mode: unknown
 model: Qwen/Qwen3-4B
 sources:
     - https://huggingface.co/Qwen/Qwen3-4B

--- a/providers/together-ai/Qwen/Qwen3-8B-Base.yaml
+++ b/providers/together-ai/Qwen/Qwen3-8B-Base.yaml
@@ -2,7 +2,7 @@ limits:
     context_window: 32768
     max_output_tokens: 32768
     max_tokens: 32768
-mode: completion
+mode: unknown
 model: Qwen/Qwen3-8B-Base
 sources:
     - https://huggingface.co/Qwen/Qwen3-8B-Base

--- a/providers/together-ai/Qwen/Qwen3-8B.yaml
+++ b/providers/together-ai/Qwen/Qwen3-8B.yaml
@@ -5,7 +5,7 @@ limits:
     context_window: 32768
     max_output_tokens: 32768
     max_tokens: 32768
-mode: chat
+mode: unknown
 model: Qwen/Qwen3-8B
 sources:
     - https://huggingface.co/Qwen/Qwen3-8B

--- a/providers/together-ai/Qwen/Qwen3-Coder-30B-A3B-Instruct.yaml
+++ b/providers/together-ai/Qwen/Qwen3-Coder-30B-A3B-Instruct.yaml
@@ -6,7 +6,7 @@ limits:
     context_window: 262144
     max_output_tokens: 65536
     max_tokens: 65536
-mode: chat
+mode: unknown
 model: Qwen/Qwen3-Coder-30B-A3B-Instruct
 sources:
     - https://huggingface.co/Qwen/Qwen3-Coder-30B-A3B-Instruct

--- a/providers/together-ai/Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8.yaml
+++ b/providers/together-ai/Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8.yaml
@@ -8,7 +8,7 @@ features:
     - tool_choice
     - structured_output
 limits:
-    context_window: 256000
+    context_window: 262144
     max_input_tokens: 256000
 mode: chat
 model: Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8

--- a/providers/together-ai/Qwen/Qwen3-Next-80B-A3B-Instruct-FP8.yaml
+++ b/providers/together-ai/Qwen/Qwen3-Next-80B-A3B-Instruct-FP8.yaml
@@ -7,7 +7,7 @@ features:
     - structured_output
 limits:
     context_window: 262144
-mode: chat
+mode: unknown
 model: Qwen/Qwen3-Next-80B-A3B-Instruct-FP8
 sources:
     - https://docs.together.ai/docs/serverless-models

--- a/providers/together-ai/Qwen/Qwen3-Next-80B-A3B-Thinking.yaml
+++ b/providers/together-ai/Qwen/Qwen3-Next-80B-A3B-Thinking.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: Qwen/Qwen3-Next-80B-A3B-Thinking

--- a/providers/together-ai/Qwen/Qwen3-VL-235B-A22B-Instruct-FP8.yaml
+++ b/providers/together-ai/Qwen/Qwen3-VL-235B-A22B-Instruct-FP8.yaml
@@ -1,7 +1,7 @@
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: Qwen/Qwen3-VL-235B-A22B-Instruct-FP8
 sources:
     - https://docs.together.ai/docs/serverless-models

--- a/providers/together-ai/Qwen/Qwen3-VL-235B-A22B-Instruct.yaml
+++ b/providers/together-ai/Qwen/Qwen3-VL-235B-A22B-Instruct.yaml
@@ -1,7 +1,7 @@
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: Qwen/Qwen3-VL-235B-A22B-Instruct
 sources:
     - https://together.ai/pricing

--- a/providers/together-ai/Qwen/Qwen3-VL-235B-A22B-Thinking-FP8.yaml
+++ b/providers/together-ai/Qwen/Qwen3-VL-235B-A22B-Thinking-FP8.yaml
@@ -4,7 +4,7 @@ features:
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: Qwen/Qwen3-VL-235B-A22B-Thinking-FP8
 sources:
     - https://huggingface.co/Qwen/Qwen3-VL-235B-A22B-Thinking-FP8

--- a/providers/together-ai/Qwen/Qwen3-VL-32B-Instruct.yaml
+++ b/providers/together-ai/Qwen/Qwen3-VL-32B-Instruct.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: Qwen/Qwen3-VL-32B-Instruct

--- a/providers/together-ai/Qwen/Qwen3.5-35B-A3B.yaml
+++ b/providers/together-ai/Qwen/Qwen3.5-35B-A3B.yaml
@@ -10,7 +10,7 @@ limits:
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: Qwen/Qwen3.5-35B-A3B
 sources:
     - https://together.ai/pricing

--- a/providers/together-ai/Qwen/Qwen3.5-397B-A17B-FP4.yaml
+++ b/providers/together-ai/Qwen/Qwen3.5-397B-A17B-FP4.yaml
@@ -10,7 +10,7 @@ limits:
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: Qwen/Qwen3.5-397B-A17B-FP4
 sources:
     - https://docs.together.ai/docs/changelog

--- a/providers/together-ai/Qwen/Qwen3.5-397B-A17B-FP8.yaml
+++ b/providers/together-ai/Qwen/Qwen3.5-397B-A17B-FP8.yaml
@@ -12,5 +12,5 @@ limits:
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: Qwen/Qwen3.5-397B-A17B-FP8

--- a/providers/together-ai/Qwen/Qwen3.5-9B-FP8.yaml
+++ b/providers/together-ai/Qwen/Qwen3.5-9B-FP8.yaml
@@ -10,7 +10,7 @@ limits:
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: Qwen/Qwen3.5-9B-FP8
 sources:
     - https://together.ai/models

--- a/providers/together-ai/Wan-AI/Wan2.2-I2V-A14B.yaml
+++ b/providers/together-ai/Wan-AI/Wan2.2-I2V-A14B.yaml
@@ -4,7 +4,7 @@ costs:
 modalities:
     input:
         - image
-mode: video
+mode: unknown
 model: Wan-AI/Wan2.2-I2V-A14B
 sources:
     - https://docs.together.ai/docs/videos-overview

--- a/providers/together-ai/Wan-AI/Wan2.2-T2V-A14B.yaml
+++ b/providers/together-ai/Wan-AI/Wan2.2-T2V-A14B.yaml
@@ -1,7 +1,7 @@
 costs:
     - input_cost_per_request: 0.66
       region: "*"
-mode: video
+mode: unknown
 model: Wan-AI/Wan2.2-T2V-A14B
 sources:
     - https://docs.together.ai/docs/videos-overview

--- a/providers/together-ai/agentica-org/DeepCoder-14B-Preview.yaml
+++ b/providers/together-ai/agentica-org/DeepCoder-14B-Preview.yaml
@@ -1,3 +1,3 @@
-mode: chat
+mode: unknown
 model: agentica-org/DeepCoder-14B-Preview
 thinking: true

--- a/providers/together-ai/allenai/Molmo-7B-D-0924.yaml
+++ b/providers/together-ai/allenai/Molmo-7B-D-0924.yaml
@@ -9,7 +9,7 @@ limits:
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: allenai/Molmo-7B-D-0924
 sources:
     - https://docs.together.ai/docs/vision-overview

--- a/providers/together-ai/arcee-ai/trinity-large-preview.yaml
+++ b/providers/together-ai/arcee-ai/trinity-large-preview.yaml
@@ -1,2 +1,2 @@
-mode: chat
+mode: unknown
 model: arcee-ai/trinity-large-preview

--- a/providers/together-ai/arcee-ai/trinity-mini.yaml
+++ b/providers/together-ai/arcee-ai/trinity-mini.yaml
@@ -7,7 +7,7 @@ features:
     - structured_output
 limits:
     context_window: 32768
-mode: chat
+mode: unknown
 model: arcee-ai/trinity-mini
 sources:
     - https://docs.together.ai/docs/serverless-models

--- a/providers/together-ai/arize-ai/qwen-2-1.5b-instruct.yaml
+++ b/providers/together-ai/arize-ai/qwen-2-1.5b-instruct.yaml
@@ -1,2 +1,4 @@
+limits:
+    context_window: 32768
 mode: chat
 model: arize-ai/qwen-2-1.5b-instruct

--- a/providers/together-ai/canopylabs/orpheus-3b-0.1-ft.yaml
+++ b/providers/together-ai/canopylabs/orpheus-3b-0.1-ft.yaml
@@ -5,5 +5,5 @@ costs:
 modalities:
     output:
         - audio
-mode: text_to_speech
+mode: unknown
 model: canopylabs/orpheus-3b-0.1-ft

--- a/providers/together-ai/cartesia/sonic-2.yaml
+++ b/providers/together-ai/cartesia/sonic-2.yaml
@@ -4,5 +4,5 @@ costs:
 modalities:
     output:
         - audio
-mode: text_to_speech
+mode: unknown
 model: cartesia/sonic-2

--- a/providers/together-ai/cartesia/sonic-3.yaml
+++ b/providers/together-ai/cartesia/sonic-3.yaml
@@ -4,7 +4,7 @@ costs:
 modalities:
     output:
         - audio
-mode: text_to_speech
+mode: unknown
 model: cartesia/sonic-3
 sources:
     - https://docs.together.ai/docs/text-to-speech

--- a/providers/together-ai/cartesia/sonic.yaml
+++ b/providers/together-ai/cartesia/sonic.yaml
@@ -4,5 +4,5 @@ costs:
 modalities:
     output:
         - audio
-mode: text_to_speech
+mode: unknown
 model: cartesia/sonic

--- a/providers/together-ai/deepcogito/cogito-v1-preview-llama-3B.yaml
+++ b/providers/together-ai/deepcogito/cogito-v1-preview-llama-3B.yaml
@@ -1,6 +1,6 @@
 features:
     - function_calling
-mode: chat
+mode: unknown
 model: deepcogito/cogito-v1-preview-llama-3B
 sources:
     - https://docs.together.ai/docs/serverless-models

--- a/providers/together-ai/deepcogito/cogito-v1-preview-llama-70B-Turbo.yaml
+++ b/providers/together-ai/deepcogito/cogito-v1-preview-llama-70B-Turbo.yaml
@@ -10,6 +10,6 @@ limits:
     max_input_tokens: 131072
     max_output_tokens: 4096
     max_tokens: 4096
-mode: chat
+mode: unknown
 model: deepcogito/cogito-v1-preview-llama-70B-Turbo
 thinking: true

--- a/providers/together-ai/deepcogito/cogito-v1-preview-llama-70B.yaml
+++ b/providers/together-ai/deepcogito/cogito-v1-preview-llama-70B.yaml
@@ -3,7 +3,7 @@ features:
     - tools
 limits:
     context_window: 128000
-mode: chat
+mode: unknown
 model: deepcogito/cogito-v1-preview-llama-70B
 sources:
     - https://www.together.ai/models/cogito-v1-preview-llama-70b

--- a/providers/together-ai/deepcogito/cogito-v1-preview-llama-8B.yaml
+++ b/providers/together-ai/deepcogito/cogito-v1-preview-llama-8B.yaml
@@ -1,4 +1,4 @@
-mode: chat
+mode: unknown
 model: deepcogito/cogito-v1-preview-llama-8B
 sources:
     - https://api.together.ai/models/deepcogito/cogito-v1-preview-llama-8B

--- a/providers/together-ai/deepcogito/cogito-v1-preview-qwen-14B.yaml
+++ b/providers/together-ai/deepcogito/cogito-v1-preview-qwen-14B.yaml
@@ -1,2 +1,2 @@
-mode: chat
+mode: unknown
 model: deepcogito/cogito-v1-preview-qwen-14B

--- a/providers/together-ai/deepcogito/cogito-v1-preview-qwen-32B.yaml
+++ b/providers/together-ai/deepcogito/cogito-v1-preview-qwen-32B.yaml
@@ -1,6 +1,6 @@
 features:
     - function_calling
-mode: chat
+mode: unknown
 model: deepcogito/cogito-v1-preview-qwen-32B
 sources:
     - https://together.ai/pricing

--- a/providers/together-ai/deepcogito/cogito-v2-1-671b.yaml
+++ b/providers/together-ai/deepcogito/cogito-v2-1-671b.yaml
@@ -5,6 +5,6 @@ costs:
 features:
     - structured_output
 limits:
-    context_window: 32768
+    context_window: 163840
 mode: chat
 model: deepcogito/cogito-v2-1-671b

--- a/providers/together-ai/deepgram/aura-2.yaml
+++ b/providers/together-ai/deepgram/aura-2.yaml
@@ -1,4 +1,4 @@
-mode: text_to_speech
+mode: unknown
 model: deepgram/aura-2
 sources:
     - https://docs.together.ai/docs/text-to-speech

--- a/providers/together-ai/deepgram/flux.yaml
+++ b/providers/together-ai/deepgram/flux.yaml
@@ -1,7 +1,7 @@
 modalities:
     input:
         - audio
-mode: audio_transcription
+mode: unknown
 model: deepgram/flux
 sources:
     - https://docs.together.ai/docs/speech-to-text

--- a/providers/together-ai/deepgram/nova-3-en.yaml
+++ b/providers/together-ai/deepgram/nova-3-en.yaml
@@ -1,7 +1,7 @@
 modalities:
     input:
         - audio
-mode: audio_transcription
+mode: unknown
 model: deepgram/nova-3-en
 sources:
     - https://docs.together.ai/docs/speech-to-text

--- a/providers/together-ai/deepgram/nova-3-multi.yaml
+++ b/providers/together-ai/deepgram/nova-3-multi.yaml
@@ -1,7 +1,7 @@
 modalities:
     input:
         - audio
-mode: audio_transcription
+mode: unknown
 model: deepgram/nova-3-multi
 sources:
     - https://docs.together.ai/docs/speech-to-text

--- a/providers/together-ai/deepseek-ai/DeepSeek-R1-0528.yaml
+++ b/providers/together-ai/deepseek-ai/DeepSeek-R1-0528.yaml
@@ -6,7 +6,7 @@ features:
     - function_calling
     - structured_output
 limits:
-    context_window: 163839
+    context_window: 163840
 mode: chat
 model: deepseek-ai/DeepSeek-R1-0528
 sources:

--- a/providers/together-ai/deepseek-ai/DeepSeek-R1-Distill-Llama-70B.yaml
+++ b/providers/together-ai/deepseek-ai/DeepSeek-R1-Distill-Llama-70B.yaml
@@ -1,0 +1,4 @@
+limits:
+    context_window: 131072
+mode: chat
+model: deepseek-ai/DeepSeek-R1-Distill-Llama-70B

--- a/providers/together-ai/deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B.yaml
+++ b/providers/together-ai/deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B

--- a/providers/together-ai/deepseek-ai/DeepSeek-R1-Distill-Qwen-14B.yaml
+++ b/providers/together-ai/deepseek-ai/DeepSeek-R1-Distill-Qwen-14B.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: deepseek-ai/DeepSeek-R1-Distill-Qwen-14B

--- a/providers/together-ai/deepseek-ai/DeepSeek-R1-Distill-Qwen-7B.yaml
+++ b/providers/together-ai/deepseek-ai/DeepSeek-R1-Distill-Qwen-7B.yaml
@@ -1,3 +1,3 @@
-mode: chat
+mode: unknown
 model: deepseek-ai/DeepSeek-R1-Distill-Qwen-7B
 thinking: true

--- a/providers/together-ai/deepseek-ai/DeepSeek-R1.yaml
+++ b/providers/together-ai/deepseek-ai/DeepSeek-R1.yaml
@@ -9,7 +9,7 @@ features:
     - structured_output
     - system_messages
 limits:
-    context_window: 163839
+    context_window: 163840
     max_output_tokens: 64000
     max_tokens: 64000
 mode: chat

--- a/providers/together-ai/deepseek-ai/DeepSeek-V3-0324.yaml
+++ b/providers/together-ai/deepseek-ai/DeepSeek-V3-0324.yaml
@@ -8,8 +8,8 @@ features:
     - structured_output
 limits:
     context_window: 131000
-mode: chat
-model: deepseek-ai/DeepSeek-V3
+mode: unknown
+model: deepseek-ai/DeepSeek-V3-0324
 sources:
     - https://www.together.ai/models/deepseek-v3
     - https://www.together.ai/models/deepseek-v3-1

--- a/providers/together-ai/deepseek-ai/DeepSeek-V3-Base.yaml
+++ b/providers/together-ai/deepseek-ai/DeepSeek-V3-Base.yaml
@@ -1,2 +1,2 @@
-mode: completion
+mode: unknown
 model: deepseek-ai/DeepSeek-V3-Base

--- a/providers/together-ai/deepseek-ai/DeepSeek-V3-DE.yaml
+++ b/providers/together-ai/deepseek-ai/DeepSeek-V3-DE.yaml
@@ -1,2 +1,2 @@
-mode: chat
+mode: unknown
 model: deepseek-ai/DeepSeek-V3-DE

--- a/providers/together-ai/deepseek-ai/DeepSeek-V3.1-Base.yaml
+++ b/providers/together-ai/deepseek-ai/DeepSeek-V3.1-Base.yaml
@@ -4,7 +4,7 @@ costs:
       region: "*"
 limits:
     context_window: 128000
-mode: completion
+mode: unknown
 model: deepseek-ai/DeepSeek-V3.1-Base
 sources:
     - https://together.ai/pricing

--- a/providers/together-ai/deepseek-ai/DeepSeek-V3.1-Terminus.yaml
+++ b/providers/together-ai/deepseek-ai/DeepSeek-V3.1-Terminus.yaml
@@ -1,6 +1,6 @@
 features:
     - function_calling
-mode: chat
+mode: unknown
 model: deepseek-ai/DeepSeek-V3.1-Terminus
 sources:
     - https://huggingface.co/deepseek-ai/DeepSeek-V3.1-Terminus

--- a/providers/together-ai/deepseek-ai/DeepSeek-V3.1.yaml
+++ b/providers/together-ai/deepseek-ai/DeepSeek-V3.1.yaml
@@ -8,7 +8,7 @@ features:
     - tool_choice
     - structured_output
 limits:
-    context_window: 128000
+    context_window: 131072
 mode: chat
 model: deepseek-ai/DeepSeek-V3.1
 sources:

--- a/providers/together-ai/deepseek-ai/DeepSeek-V3.2-Exp.yaml
+++ b/providers/together-ai/deepseek-ai/DeepSeek-V3.2-Exp.yaml
@@ -1,4 +1,4 @@
-mode: chat
+mode: unknown
 model: deepseek-ai/DeepSeek-V3.2-Exp
 sources:
     - https://together.ai/pricing

--- a/providers/together-ai/deepseek-ai/DeepSeek-V3.2.yaml
+++ b/providers/together-ai/deepseek-ai/DeepSeek-V3.2.yaml
@@ -5,7 +5,7 @@ limits:
     context_window: 128000
     max_output_tokens: 8192
     max_tokens: 8192
-mode: chat
+mode: unknown
 model: deepseek-ai/DeepSeek-V3.2
 sources:
     - https://together.ai/pricing

--- a/providers/together-ai/deepseek-ai/deepseek-coder-33b-instruct.yaml
+++ b/providers/together-ai/deepseek-ai/deepseek-coder-33b-instruct.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: deepseek-ai/deepseek-coder-33b-instruct

--- a/providers/together-ai/google/gemma-2-27b-it.yaml
+++ b/providers/together-ai/google/gemma-2-27b-it.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/gemma-2-27b-it

--- a/providers/together-ai/google/gemma-3-12b-it.yaml
+++ b/providers/together-ai/google/gemma-3-12b-it.yaml
@@ -1,7 +1,7 @@
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: google/gemma-3-12b-it
 sources:
     - https://www.together.ai/pricing

--- a/providers/together-ai/google/gemma-3-1b-it.yaml
+++ b/providers/together-ai/google/gemma-3-1b-it.yaml
@@ -1,2 +1,2 @@
-mode: chat
+mode: unknown
 model: google/gemma-3-1b-it

--- a/providers/together-ai/google/gemma-3-1b-pt.yaml
+++ b/providers/together-ai/google/gemma-3-1b-pt.yaml
@@ -1,2 +1,2 @@
-mode: completion
+mode: unknown
 model: google/gemma-3-1b-pt

--- a/providers/together-ai/google/gemma-3-270m-it.yaml
+++ b/providers/together-ai/google/gemma-3-270m-it.yaml
@@ -1,2 +1,2 @@
-mode: chat
+mode: unknown
 model: google/gemma-3-270m-it

--- a/providers/together-ai/google/gemma-3-27b-it.yaml
+++ b/providers/together-ai/google/gemma-3-27b-it.yaml
@@ -1,7 +1,7 @@
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: google/gemma-3-27b-it
 sources:
     - https://together.ai/pricing

--- a/providers/together-ai/google/gemma-3-27b-pt.yaml
+++ b/providers/together-ai/google/gemma-3-27b-pt.yaml
@@ -1,2 +1,2 @@
-mode: completion
+mode: unknown
 model: google/gemma-3-27b-pt

--- a/providers/together-ai/google/gemma-3-4b-it.yaml
+++ b/providers/together-ai/google/gemma-3-4b-it.yaml
@@ -1,4 +1,4 @@
 features:
     - function_calling
-mode: chat
+mode: unknown
 model: google/gemma-3-4b-it

--- a/providers/together-ai/google/gemma-3-4b-pt.yaml
+++ b/providers/together-ai/google/gemma-3-4b-pt.yaml
@@ -1,6 +1,6 @@
 limits:
     context_window: 131072
-mode: completion
+mode: unknown
 model: google/gemma-3-4b-pt
 sources:
     - https://www.together.ai/pricing

--- a/providers/together-ai/google/medgemma-27b-text-it.yaml
+++ b/providers/together-ai/google/medgemma-27b-text-it.yaml
@@ -5,7 +5,7 @@ limits:
     max_input_tokens: 131072
     max_output_tokens: 8192
     max_tokens: 8192
-mode: chat
+mode: unknown
 model: google/medgemma-27b-text-it
 sources:
     - https://huggingface.co/google/medgemma-27b-text-it

--- a/providers/together-ai/google/veo-2.0.yaml
+++ b/providers/together-ai/google/veo-2.0.yaml
@@ -1,7 +1,7 @@
 costs:
     - input_cost_per_image: 2.5
       region: "*"
-mode: video
+mode: unknown
 model: google/veo-2.0
 sources:
     - https://docs.together.ai/docs/serverless-models

--- a/providers/together-ai/google/veo-3.0-audio.yaml
+++ b/providers/together-ai/google/veo-3.0-audio.yaml
@@ -4,5 +4,5 @@ costs:
 modalities:
     output:
         - audio
-mode: video
+mode: unknown
 model: google/veo-3.0-audio

--- a/providers/together-ai/google/veo-3.0-fast-audio.yaml
+++ b/providers/together-ai/google/veo-3.0-fast-audio.yaml
@@ -4,7 +4,7 @@ costs:
 modalities:
     output:
         - audio
-mode: video
+mode: unknown
 model: google/veo-3.0-fast-audio
 sources:
     - https://docs.together.ai/reference/create-video

--- a/providers/together-ai/google/veo-3.0-fast.yaml
+++ b/providers/together-ai/google/veo-3.0-fast.yaml
@@ -1,7 +1,7 @@
 costs:
     - input_cost_per_request: 0.8
       region: "*"
-mode: video
+mode: unknown
 model: google/veo-3.0-fast
 sources:
     - https://docs.together.ai/docs/serverless-models

--- a/providers/together-ai/google/veo-3.0.yaml
+++ b/providers/together-ai/google/veo-3.0.yaml
@@ -1,7 +1,7 @@
 costs:
     - input_cost_per_request: 1.6
       region: "*"
-mode: video
+mode: unknown
 model: google/veo-3.0
 sources:
     - https://docs.together.ai/docs/serverless-models

--- a/providers/together-ai/hexgrad/Kokoro-82M.yaml
+++ b/providers/together-ai/hexgrad/Kokoro-82M.yaml
@@ -5,5 +5,5 @@ costs:
 modalities:
     output:
         - audio
-mode: text_to_speech
+mode: unknown
 model: hexgrad/Kokoro-82M

--- a/providers/together-ai/kwaivgI/kling-1.6-pro.yaml
+++ b/providers/together-ai/kwaivgI/kling-1.6-pro.yaml
@@ -1,7 +1,7 @@
 costs:
     - input_cost_per_request: 0.32
       region: "*"
-mode: video
+mode: unknown
 model: kwaivgI/kling-1.6-pro
 sources:
     - https://docs.together.ai/docs/serverless-models

--- a/providers/together-ai/kwaivgI/kling-1.6-standard.yaml
+++ b/providers/together-ai/kwaivgI/kling-1.6-standard.yaml
@@ -1,7 +1,7 @@
 costs:
     - input_cost_per_request: 0.19
       region: "*"
-mode: video
+mode: unknown
 model: kwaivgI/kling-1.6-standard
 sources:
     - https://docs.together.ai/docs/serverless-models

--- a/providers/together-ai/kwaivgI/kling-2.0-master.yaml
+++ b/providers/together-ai/kwaivgI/kling-2.0-master.yaml
@@ -1,5 +1,5 @@
 costs:
     - input_cost_per_request: 0.92
       region: "*"
-mode: video
+mode: unknown
 model: kwaivgI/kling-2.0-master

--- a/providers/together-ai/kwaivgI/kling-2.1-master.yaml
+++ b/providers/together-ai/kwaivgI/kling-2.1-master.yaml
@@ -1,7 +1,7 @@
 costs:
     - input_cost_per_request: 0.92
       region: "*"
-mode: video
+mode: unknown
 model: kwaivgI/kling-2.1-master
 sources:
     - https://docs.together.ai/docs/serverless-models

--- a/providers/together-ai/kwaivgI/kling-2.1-pro.yaml
+++ b/providers/together-ai/kwaivgI/kling-2.1-pro.yaml
@@ -1,7 +1,7 @@
 costs:
     - input_cost_per_request: 0.32
       region: "*"
-mode: video
+mode: unknown
 model: kwaivgI/kling-2.1-pro
 sources:
     - https://docs.together.ai/docs/serverless-models

--- a/providers/together-ai/kwaivgI/kling-2.1-standard.yaml
+++ b/providers/together-ai/kwaivgI/kling-2.1-standard.yaml
@@ -1,7 +1,7 @@
 costs:
     - input_cost_per_request: 0.18
       region: "*"
-mode: video
+mode: unknown
 model: kwaivgI/kling-2.1-standard
 sources:
     - https://docs.together.ai/docs/serverless-models

--- a/providers/together-ai/meta-llama/Llama-2-13b-chat-hf.yaml
+++ b/providers/together-ai/meta-llama/Llama-2-13b-chat-hf.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: meta-llama/Llama-2-13b-chat-hf

--- a/providers/together-ai/meta-llama/Llama-2-7b-chat-hf.yaml
+++ b/providers/together-ai/meta-llama/Llama-2-7b-chat-hf.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: meta-llama/Llama-2-7b-chat-hf

--- a/providers/together-ai/meta-llama/Llama-3-8b-chat-hf.yaml
+++ b/providers/together-ai/meta-llama/Llama-3-8b-chat-hf.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: meta-llama/Llama-3-8b-chat-hf

--- a/providers/together-ai/meta-llama/Llama-3.1-405B-Instruct.yaml
+++ b/providers/together-ai/meta-llama/Llama-3.1-405B-Instruct.yaml
@@ -1,3 +1,5 @@
 isDeprecated: true
+limits:
+    context_window: 4096
 mode: chat
 model: meta-llama/Llama-3.1-405B-Instruct

--- a/providers/together-ai/meta-llama/Llama-3.1-405B.yaml
+++ b/providers/together-ai/meta-llama/Llama-3.1-405B.yaml
@@ -6,7 +6,7 @@ costs:
       region: "*"
 features:
     - function_calling
-mode: chat
+mode: unknown
 model: meta-llama/Llama-3.1-405B
 sources:
     - https://together.ai/pricing

--- a/providers/together-ai/meta-llama/Llama-3.1-8B-Instruct.yaml
+++ b/providers/together-ai/meta-llama/Llama-3.1-8B-Instruct.yaml
@@ -1,4 +1,4 @@
-mode: chat
+mode: unknown
 model: meta-llama/Llama-3.1-8B-Instruct
 sources:
     - https://docs.together.ai/docs/serverless-models

--- a/providers/together-ai/meta-llama/Llama-3.2-1B.yaml
+++ b/providers/together-ai/meta-llama/Llama-3.2-1B.yaml
@@ -1,2 +1,2 @@
-mode: completion
+mode: unknown
 model: meta-llama/Llama-3.2-1B

--- a/providers/together-ai/meta-llama/Llama-3.2-3B-Instruct.yaml
+++ b/providers/together-ai/meta-llama/Llama-3.2-3B-Instruct.yaml
@@ -2,7 +2,7 @@ features:
     - function_calling
 limits:
     context_window: 131072
-mode: chat
+mode: unknown
 model: meta-llama/Llama-3.2-3B-Instruct
 sources:
     - https://together.ai/pricing

--- a/providers/together-ai/meta-llama/Llama-3.2-3B.yaml
+++ b/providers/together-ai/meta-llama/Llama-3.2-3B.yaml
@@ -1,2 +1,2 @@
-mode: completion
+mode: unknown
 model: meta-llama/Llama-3.2-3B

--- a/providers/together-ai/meta-llama/Llama-3.3-70B-Instruct.yaml
+++ b/providers/together-ai/meta-llama/Llama-3.3-70B-Instruct.yaml
@@ -7,7 +7,7 @@ features:
     - structured_output
 limits:
     context_window: 131072
-mode: chat
+mode: unknown
 model: meta-llama/Llama-3.3-70B-Instruct
 sources:
     - https://www.together.ai/pricing

--- a/providers/together-ai/meta-llama/Llama-4-Maverick-17B-128E.yaml
+++ b/providers/together-ai/meta-llama/Llama-4-Maverick-17B-128E.yaml
@@ -10,7 +10,7 @@ limits:
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: meta-llama/Llama-4-Maverick-17B-128E
 sources:
     - https://docs.together.ai/docs/serverless-models

--- a/providers/together-ai/meta-llama/Llama-4-Scout-17B-16E-Instruct-64k.yaml
+++ b/providers/together-ai/meta-llama/Llama-4-Scout-17B-16E-Instruct-64k.yaml
@@ -8,7 +8,7 @@ limits:
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: meta-llama/Llama-4-Scout-17B-16E-Instruct-64k
 sources:
     - https://www.together.ai/pricing

--- a/providers/together-ai/meta-llama/Llama-4-Scout-17B-16E-Instruct.yaml
+++ b/providers/together-ai/meta-llama/Llama-4-Scout-17B-16E-Instruct.yaml
@@ -1,0 +1,4 @@
+limits:
+    context_window: 1048576
+mode: chat
+model: meta-llama/Llama-4-Scout-17B-16E-Instruct

--- a/providers/together-ai/meta-llama/Llama-Guard-4-12B.yaml
+++ b/providers/together-ai/meta-llama/Llama-Guard-4-12B.yaml
@@ -7,7 +7,7 @@ limits:
 modalities:
     input:
         - image
-mode: chat
+mode: moderation
 model: meta-llama/Llama-Guard-4-12B
 sources:
     - https://www.together.ai/models/llama-guard-4-12b

--- a/providers/together-ai/meta-llama/Meta-Llama-3-70B-Instruct-Turbo.yaml
+++ b/providers/together-ai/meta-llama/Meta-Llama-3-70B-Instruct-Turbo.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: meta-llama/Meta-Llama-3-70B-Instruct-Turbo

--- a/providers/together-ai/meta-llama/Meta-Llama-3-8B-Instruct.yaml
+++ b/providers/together-ai/meta-llama/Meta-Llama-3-8B-Instruct.yaml
@@ -1,0 +1,4 @@
+limits:
+    context_window: 8192
+mode: chat
+model: meta-llama/Meta-Llama-3-8B-Instruct

--- a/providers/together-ai/meta-llama/Meta-Llama-3-8B.yaml
+++ b/providers/together-ai/meta-llama/Meta-Llama-3-8B.yaml
@@ -3,7 +3,7 @@ limits:
     max_input_tokens: 8192
     max_output_tokens: 8192
     max_tokens: 8192
-mode: completion
+mode: unknown
 model: meta-llama/Meta-Llama-3-8B
 sources:
     - https://docs.together.ai/docs/serverless-models#language-models

--- a/providers/together-ai/meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo.yaml
+++ b/providers/together-ai/meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo.yaml
@@ -1,0 +1,4 @@
+limits:
+    context_window: 131072
+mode: chat
+model: meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo

--- a/providers/together-ai/meta-llama/Meta-Llama-3.1-70B-Instruct.yaml
+++ b/providers/together-ai/meta-llama/Meta-Llama-3.1-70B-Instruct.yaml
@@ -10,7 +10,7 @@ limits:
     context_window: 131072
     max_output_tokens: 131072
     max_tokens: 131072
-mode: chat
+mode: unknown
 model: meta-llama/Meta-Llama-3.1-70B-Instruct
 sources:
     - https://www.together.ai/pricing

--- a/providers/together-ai/meta-llama/Meta-Llama-3.1-70B.yaml
+++ b/providers/together-ai/meta-llama/Meta-Llama-3.1-70B.yaml
@@ -1,4 +1,4 @@
-mode: completion
+mode: unknown
 model: meta-llama/Meta-Llama-3.1-70B
 sources:
     - https://www.together.ai/pricing

--- a/providers/together-ai/meta-llama/Meta-Llama-3.1-8B-Instruct-Reference.yaml
+++ b/providers/together-ai/meta-llama/Meta-Llama-3.1-8B-Instruct-Reference.yaml
@@ -2,7 +2,7 @@ features:
     - function_calling
     - system_messages
 limits:
-    context_window: 131072
+    context_window: 16384
 mode: chat
 model: meta-llama/Meta-Llama-3.1-8B-Instruct-Reference
 sources:

--- a/providers/together-ai/meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo.yaml
+++ b/providers/together-ai/meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo.yaml
@@ -8,5 +8,7 @@ features:
     - tool_choice
     - structured_output
 isDeprecated: true
+limits:
+    context_window: 131072
 mode: chat
 model: meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo

--- a/providers/together-ai/meta-llama/Meta-Llama-3.1-8B-Instruct.yaml
+++ b/providers/together-ai/meta-llama/Meta-Llama-3.1-8B-Instruct.yaml
@@ -4,7 +4,7 @@ costs:
       region: "*"
 limits:
     context_window: 131072
-mode: chat
+mode: unknown
 model: meta-llama/Meta-Llama-3.1-8B-Instruct
 sources:
     - https://docs.together.ai/docs/function-calling

--- a/providers/together-ai/meta-llama/Meta-Llama-3.1-8B.yaml
+++ b/providers/together-ai/meta-llama/Meta-Llama-3.1-8B.yaml
@@ -3,7 +3,7 @@ limits:
     max_input_tokens: 131072
     max_output_tokens: 131072
     max_tokens: 131072
-mode: completion
+mode: unknown
 model: meta-llama/Meta-Llama-3.1-8B
 sources:
     - https://docs.together.ai/docs/serverless-models

--- a/providers/together-ai/minimax/hailuo-02.yaml
+++ b/providers/together-ai/minimax/hailuo-02.yaml
@@ -1,7 +1,7 @@
 costs:
     - input_cost_per_request: 0.49
       region: "*"
-mode: video
+mode: unknown
 model: minimax/hailuo-02
 sources:
     - https://docs.together.ai/docs/serverless-models

--- a/providers/together-ai/minimax/speech-2.6-turbo.yaml
+++ b/providers/together-ai/minimax/speech-2.6-turbo.yaml
@@ -1,7 +1,7 @@
 modalities:
     output:
         - audio
-mode: text_to_speech
+mode: unknown
 model: minimax/speech-2.6-turbo
 sources:
     - https://docs.together.ai/docs/text-to-speech

--- a/providers/together-ai/minimax/video-01-director.yaml
+++ b/providers/together-ai/minimax/video-01-director.yaml
@@ -1,7 +1,7 @@
 costs:
     - input_cost_per_request: 0.28
       region: "*"
-mode: video
+mode: unknown
 model: minimax/video-01-director
 sources:
     - https://docs.together.ai/docs/videos-overview

--- a/providers/together-ai/mistralai/Devstral-Small-2505.yaml
+++ b/providers/together-ai/mistralai/Devstral-Small-2505.yaml
@@ -4,7 +4,7 @@ features:
 limits:
     context_window: 128000
     max_input_tokens: 128000
-mode: chat
+mode: unknown
 model: mistralai/Devstral-Small-2505
 sources:
     - https://docs.mistral.ai/models/

--- a/providers/together-ai/mistralai/Magistral-Small-2506.yaml
+++ b/providers/together-ai/mistralai/Magistral-Small-2506.yaml
@@ -3,7 +3,7 @@ features:
     - system_messages
 limits:
     context_window: 40000
-mode: chat
+mode: unknown
 model: mistralai/Magistral-Small-2506
 sources:
     - https://docs.mistral.ai/getting-started/models/

--- a/providers/together-ai/mistralai/Mistral-7B-Instruct-v0.1.yaml
+++ b/providers/together-ai/mistralai/Mistral-7B-Instruct-v0.1.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: mistralai/Mistral-7B-Instruct-v0.1

--- a/providers/together-ai/mistralai/Mistral-7B-Instruct-v0.2.yaml
+++ b/providers/together-ai/mistralai/Mistral-7B-Instruct-v0.2.yaml
@@ -8,8 +8,8 @@ features:
     - structured_output
 limits:
     context_window: 32768
-mode: chat
-model: mistralai/Mistral-Small-24B-Instruct-2501
+mode: unknown
+model: mistralai/Mistral-7B-Instruct-v0.2
 sources:
     - https://docs.together.ai/docs/serverless-models
     - https://www.together.ai/pricing

--- a/providers/together-ai/mistralai/Mistral-7B-Instruct-v0.3.yaml
+++ b/providers/together-ai/mistralai/Mistral-7B-Instruct-v0.3.yaml
@@ -1,3 +1,5 @@
 isDeprecated: true
+limits:
+    context_window: 32768
 mode: chat
 model: mistralai/Mistral-7B-Instruct-v0.3

--- a/providers/together-ai/mistralai/Mistral-7B-v0.1.yaml
+++ b/providers/together-ai/mistralai/Mistral-7B-v0.1.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: mistralai/Mistral-7B-v0.1

--- a/providers/together-ai/moonshotai/Kimi-K2-Thinking.yaml
+++ b/providers/together-ai/moonshotai/Kimi-K2-Thinking.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: moonshotai/Kimi-K2-Thinking

--- a/providers/together-ai/moonshotai/Kimi-K2.5-fp4.yaml
+++ b/providers/together-ai/moonshotai/Kimi-K2.5-fp4.yaml
@@ -7,5 +7,5 @@ features:
     - structured_output
 limits:
     context_window: 262144
-mode: chat
+mode: unknown
 model: moonshotai/Kimi-K2.5-fp4

--- a/providers/together-ai/nim/meta/llama-3.1-70b-instruct.yaml
+++ b/providers/together-ai/nim/meta/llama-3.1-70b-instruct.yaml
@@ -1,5 +1,5 @@
 features:
     - function_calling
     - system_messages
-mode: chat
+mode: unknown
 model: nim/meta/llama-3.1-70b-instruct

--- a/providers/together-ai/nim/meta/llama-3.1-8b-instruct.yaml
+++ b/providers/together-ai/nim/meta/llama-3.1-8b-instruct.yaml
@@ -1,5 +1,5 @@
 features:
     - function_calling
     - system_messages
-mode: chat
+mode: unknown
 model: nim/meta/llama-3.1-8b-instruct

--- a/providers/together-ai/nim/meta/llama-3.2-11b-vision-instruct.yaml
+++ b/providers/together-ai/nim/meta/llama-3.2-11b-vision-instruct.yaml
@@ -1,5 +1,5 @@
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: nim/meta/llama-3.2-11b-vision-instruct

--- a/providers/together-ai/nim/meta/llama-3.2-90b-vision-instruct.yaml
+++ b/providers/together-ai/nim/meta/llama-3.2-90b-vision-instruct.yaml
@@ -7,5 +7,5 @@ limits:
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: nim/meta/llama-3.2-90b-vision-instruct

--- a/providers/together-ai/nim/meta/llama-3.3-70b-instruct.yaml
+++ b/providers/together-ai/nim/meta/llama-3.3-70b-instruct.yaml
@@ -5,7 +5,7 @@ limits:
     context_window: 131072
     max_output_tokens: 131072
     max_tokens: 131072
-mode: chat
+mode: unknown
 model: nim/meta/llama-3.3-70b-instruct
 sources:
     - https://together.ai/models

--- a/providers/together-ai/nim/mistralai/mixtral-8x7b-instruct-v01.yaml
+++ b/providers/together-ai/nim/mistralai/mixtral-8x7b-instruct-v01.yaml
@@ -2,7 +2,7 @@ features:
     - function_calling
 limits:
     context_window: 32768
-mode: chat
+mode: unknown
 model: nim/mistralai/mixtral-8x7b-instruct-v01
 sources:
     - https://docs.together.ai/docs/dedicated-models

--- a/providers/together-ai/nim/nv-mistralai/mistral-nemo-12b-instruct.yaml
+++ b/providers/together-ai/nim/nv-mistralai/mistral-nemo-12b-instruct.yaml
@@ -1,5 +1,5 @@
 features:
     - function_calling
     - system_messages
-mode: chat
+mode: unknown
 model: nim/nv-mistralai/mistral-nemo-12b-instruct

--- a/providers/together-ai/nim/nvidia/llama-3.3-nemotron-super-49b-v1.yaml
+++ b/providers/together-ai/nim/nvidia/llama-3.3-nemotron-super-49b-v1.yaml
@@ -7,7 +7,7 @@ limits:
     max_input_tokens: 131072
     max_output_tokens: 16384
     max_tokens: 16384
-mode: chat
+mode: unknown
 model: nim/nvidia/llama-3.3-nemotron-super-49b-v1
 sources:
     - https://www.together.ai/models/nim-llama-3-3-nemotron-super-49b-v1

--- a/providers/together-ai/nvidia/Llama-3.1-Nemotron-70B-Instruct-HF.yaml
+++ b/providers/together-ai/nvidia/Llama-3.1-Nemotron-70B-Instruct-HF.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: nvidia/Llama-3.1-Nemotron-70B-Instruct-HF

--- a/providers/together-ai/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16.yaml
+++ b/providers/together-ai/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16.yaml
@@ -2,7 +2,7 @@ features:
     - function_calling
 limits:
     context_window: 1000000
-mode: chat
+mode: unknown
 model: nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16
 sources:
     - https://together.ai/models/nvidia-nemotron-3-nano

--- a/providers/together-ai/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8.yaml
+++ b/providers/together-ai/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8.yaml
@@ -6,7 +6,7 @@ features:
     - tools
 limits:
     context_window: 1000000
-mode: chat
+mode: unknown
 model: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8
 sources:
     - https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8

--- a/providers/together-ai/nvidia/NVIDIA-Nemotron-Nano-9B-v2.yaml
+++ b/providers/together-ai/nvidia/NVIDIA-Nemotron-Nano-9B-v2.yaml
@@ -1,3 +1,3 @@
 isDeprecated: true
-mode: chat
+mode: unknown
 model: nvidia/NVIDIA-Nemotron-Nano-9B-v2

--- a/providers/together-ai/nvidia/parakeet-tdt-0.6b-v3.yaml
+++ b/providers/together-ai/nvidia/parakeet-tdt-0.6b-v3.yaml
@@ -1,2 +1,4 @@
-mode: audio_transcription
+limits:
+    context_window: 448
+mode: unknown
 model: nvidia/parakeet-tdt-0.6b-v3

--- a/providers/together-ai/openai/gpt-oss-120b.yaml
+++ b/providers/together-ai/openai/gpt-oss-120b.yaml
@@ -8,7 +8,7 @@ features:
     - tool_choice
     - structured_output
 limits:
-    context_window: 128000
+    context_window: 131072
     max_input_tokens: 128000
 mode: chat
 model: openai/gpt-oss-120b

--- a/providers/together-ai/openai/gpt-oss-20b.yaml
+++ b/providers/together-ai/openai/gpt-oss-20b.yaml
@@ -9,7 +9,7 @@ features:
     - tool_choice
     - structured_output
 limits:
-    context_window: 128000
+    context_window: 131072
 mode: chat
 model: openai/gpt-oss-20b
 sources:

--- a/providers/together-ai/openai/sora-2-pro.yaml
+++ b/providers/together-ai/openai/sora-2-pro.yaml
@@ -1,7 +1,7 @@
 costs:
     - input_cost_per_request: 2.4
       region: "*"
-mode: video
+mode: unknown
 model: openai/sora-2-pro
 sources:
     - https://docs.together.ai/docs/videos-overview

--- a/providers/together-ai/openai/sora-2.yaml
+++ b/providers/together-ai/openai/sora-2.yaml
@@ -1,5 +1,5 @@
 costs:
     - input_cost_per_request: 0.8
       region: "*"
-mode: video
+mode: unknown
 model: openai/sora-2

--- a/providers/together-ai/openai/whisper-large-v3.yaml
+++ b/providers/together-ai/openai/whisper-large-v3.yaml
@@ -1,5 +1,5 @@
 costs:
     - input_cost_per_second: 0.0045
       region: "*"
-mode: audio_transcription
+mode: unknown
 model: openai/whisper-large-v3

--- a/providers/together-ai/pixverse/pixverse-v5.6.yaml
+++ b/providers/together-ai/pixverse/pixverse-v5.6.yaml
@@ -1,7 +1,7 @@
 costs:
     - input_cost_per_request: 0.3
       region: "*"
-mode: video
+mode: unknown
 model: pixverse/pixverse-v5.6
 sources:
     - https://docs.together.ai/docs/serverless-models

--- a/providers/together-ai/pixverse/pixverse-v5.yaml
+++ b/providers/together-ai/pixverse/pixverse-v5.yaml
@@ -1,7 +1,7 @@
 costs:
     - input_cost_per_image: 0.3
       region: "*"
-mode: video
+mode: unknown
 model: pixverse/pixverse-v5
 sources:
     - https://docs.together.ai/docs/serverless-models

--- a/providers/together-ai/rica40325/10_14dpo.yaml
+++ b/providers/together-ai/rica40325/10_14dpo.yaml
@@ -1,2 +1,2 @@
-mode: chat
+mode: unknown
 model: rica40325/10_14dpo

--- a/providers/together-ai/rime-labs/rime-arcana-v2.yaml
+++ b/providers/together-ai/rime-labs/rime-arcana-v2.yaml
@@ -1,7 +1,7 @@
 modalities:
     output:
         - audio
-mode: text_to_speech
+mode: unknown
 model: rime-labs/rime-arcana-v2
 sources:
     - https://together.ai/models

--- a/providers/together-ai/rime-labs/rime-arcana-v3-turbo.yaml
+++ b/providers/together-ai/rime-labs/rime-arcana-v3-turbo.yaml
@@ -1,7 +1,7 @@
 modalities:
     output:
         - audio
-mode: text_to_speech
+mode: unknown
 model: rime-labs/rime-arcana-v3-turbo
 sources:
     - https://docs.together.ai/docs/text-to-speech

--- a/providers/together-ai/rime-labs/rime-arcana-v3.yaml
+++ b/providers/together-ai/rime-labs/rime-arcana-v3.yaml
@@ -1,7 +1,7 @@
 modalities:
     output:
         - audio
-mode: text_to_speech
+mode: unknown
 model: rime-labs/rime-arcana-v3
 sources:
     - https://docs.together.ai/docs/text-to-speech

--- a/providers/together-ai/rime-labs/rime-mist-v2.yaml
+++ b/providers/together-ai/rime-labs/rime-mist-v2.yaml
@@ -1,7 +1,7 @@
 modalities:
     output:
         - audio
-mode: text_to_speech
+mode: unknown
 model: rime-labs/rime-mist-v2
 sources:
     - https://docs.together.ai/docs/text-to-speech

--- a/providers/together-ai/salesforce/Llama-Rank-V1.yaml
+++ b/providers/together-ai/salesforce/Llama-Rank-V1.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: Salesforce/Llama-Rank-V1

--- a/providers/together-ai/salesforce/sarvam-m.yaml
+++ b/providers/together-ai/salesforce/sarvam-m.yaml
@@ -6,7 +6,7 @@ limits:
     context_window: 32768
     max_output_tokens: 8192
     max_tokens: 8192
-mode: chat
+mode: unknown
 model: salesforce/sarvam-m
 sources:
     - https://openrouter.ai/sarvamai/sarvam-m/api

--- a/providers/together-ai/sarvamai/sarvam-m.yaml
+++ b/providers/together-ai/sarvamai/sarvam-m.yaml
@@ -6,7 +6,7 @@ limits:
     context_window: 32768
     max_output_tokens: 16384
     max_tokens: 16384
-mode: chat
+mode: unknown
 model: sarvamai/sarvam-m
 sources:
     - https://www.together.ai/pricing

--- a/providers/together-ai/sarvamai/sarvam-translate.yaml
+++ b/providers/together-ai/sarvamai/sarvam-translate.yaml
@@ -1,2 +1,2 @@
-mode: chat
+mode: unknown
 model: sarvamai/sarvam-translate

--- a/providers/together-ai/smarterdx/atlas-v3-spotlight.yaml
+++ b/providers/together-ai/smarterdx/atlas-v3-spotlight.yaml
@@ -1,4 +1,4 @@
-mode: chat
+mode: unknown
 model: smarterdx/atlas-v3-spotlight
 sources:
     - https://docs.together.ai/llms.txt

--- a/providers/together-ai/stabilityai/stable-diffusion-xl-base-1.0.yaml
+++ b/providers/together-ai/stabilityai/stable-diffusion-xl-base-1.0.yaml
@@ -1,0 +1,2 @@
+mode: image
+model: stabilityai/stable-diffusion-xl-base-1.0

--- a/providers/together-ai/togethercomputer/DeepCoder-14B-Preview.yaml
+++ b/providers/together-ai/togethercomputer/DeepCoder-14B-Preview.yaml
@@ -1,4 +1,4 @@
-mode: chat
+mode: unknown
 model: togethercomputer/DeepCoder-14B-Preview
 sources:
     - https://www.together.ai/pricing

--- a/providers/together-ai/togethercomputer/EssentialAI-RNJ-1-Instruct.yaml
+++ b/providers/together-ai/togethercomputer/EssentialAI-RNJ-1-Instruct.yaml
@@ -9,7 +9,7 @@ limits:
     context_window: 32768
     max_output_tokens: 32768
     max_tokens: 32768
-mode: chat
+mode: unknown
 model: togethercomputer/EssentialAI-RNJ-1-Instruct
 sources:
     - https://docs.together.ai/docs/serverless-models

--- a/providers/together-ai/togethercomputer/Larp-Qwen14b-250805.yaml
+++ b/providers/together-ai/togethercomputer/Larp-Qwen14b-250805.yaml
@@ -1,2 +1,2 @@
-mode: chat
+mode: unknown
 model: togethercomputer/Larp-Qwen14b-250805

--- a/providers/together-ai/togethercomputer/deepcogito-cogito-v2-preview-llama-109B-MoE.yaml
+++ b/providers/together-ai/togethercomputer/deepcogito-cogito-v2-preview-llama-109B-MoE.yaml
@@ -5,7 +5,7 @@ features:
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: togethercomputer/deepcogito-cogito-v2-preview-llama-109B-MoE
 sources:
     - https://huggingface.co/deepcogito/cogito-v2-preview-llama-109B-MoE

--- a/providers/together-ai/togethercomputer/meta-llama-3.1-8B-Instruct-AWQ-INT4.yaml
+++ b/providers/together-ai/togethercomputer/meta-llama-3.1-8B-Instruct-AWQ-INT4.yaml
@@ -8,7 +8,7 @@ limits:
     context_window: 131072
     max_output_tokens: 131072
     max_tokens: 131072
-mode: chat
+mode: unknown
 model: togethercomputer/meta-llama-3.1-8B-Instruct-AWQ-INT4
 sources:
     - https://www.together.ai/pricing

--- a/providers/together-ai/vidu/vidu-2.0.yaml
+++ b/providers/together-ai/vidu/vidu-2.0.yaml
@@ -1,5 +1,5 @@
 costs:
     - input_cost_per_request: 0.28
       region: "*"
-mode: video
+mode: unknown
 model: vidu/vidu-2.0

--- a/providers/together-ai/vidu/vidu-q1.yaml
+++ b/providers/together-ai/vidu/vidu-q1.yaml
@@ -1,5 +1,5 @@
 costs:
     - input_cost_per_image: 0.22
       region: "*"
-mode: video
+mode: unknown
 model: vidu/vidu-q1

--- a/providers/together-ai/zai-org/GLM-4.5V.yaml
+++ b/providers/together-ai/zai-org/GLM-4.5V.yaml
@@ -1,7 +1,7 @@
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: zai-org/GLM-4.5V
 sources:
     - https://docs.together.ai/docs/serverless-models

--- a/providers/together-ai/zai-org/GLM-4.6.yaml
+++ b/providers/together-ai/zai-org/GLM-4.6.yaml
@@ -7,7 +7,7 @@ features:
     - structured_output
     - tool_choice
 limits:
-    context_window: 200000
+    context_window: 202752
     max_output_tokens: 128000
     max_tokens: 128000
 mode: chat

--- a/providers/together-ai/zai-org/GLM-5-FP4.yaml
+++ b/providers/together-ai/zai-org/GLM-5-FP4.yaml
@@ -7,7 +7,7 @@ features:
     - structured_output
 limits:
     context_window: 202752
-mode: chat
+mode: unknown
 model: zai-org/GLM-5-FP4
 sources:
     - https://docs.together.ai/docs/serverless-models


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `together-ai`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly data-only YAML updates, but widespread changes setting `mode: unknown` (and one `mode: moderation`) could affect how downstream tooling classifies/routes Together AI models if `mode` is relied on for API selection.
> 
> **Overview**
> Updates the Together AI model registry with **many new model entries** across vendors (e.g., Qwen/DeepSeek/Mistral/Meta-Llama, plus new image/video/audio models).
> 
> Normalizes a large set of existing Together AI configs by changing their `mode` to `unknown` (with `meta-llama/Llama-Guard-4-12B` explicitly set to `moderation`) and tweaks several `limits.context_window` values (notably rounding/aligning to powers-of-two like `131072`/`163840`/`262144`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d02939a1ec2037f652c6b8a0d8739e7a4c9e57c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->