### PR TITLE
feat(sambanova): add new models [bot]

### DIFF
--- a/providers/sambanova/DeepSeek-R1-0528.yaml
+++ b/providers/sambanova/DeepSeek-R1-0528.yaml
@@ -3,7 +3,8 @@ features:
     - tool_choice
     - structured_output
 limits:
-    context_window: 128000
+    context_window: 131072
+    max_output_tokens: 7168
 mode: chat
 model: DeepSeek-R1-0528
 sources:

--- a/providers/sambanova/DeepSeek-R1-Distill-Llama-70B.yaml
+++ b/providers/sambanova/DeepSeek-R1-Distill-Llama-70B.yaml
@@ -3,7 +3,7 @@ costs:
       output_cost_per_token: 0.0000014
       region: "*"
 limits:
-    context_window: 128000
+    context_window: 131072
     max_output_tokens: 4096
     max_tokens: 4096
 mode: chat

--- a/providers/sambanova/DeepSeek-V3.1-Terminus.yaml
+++ b/providers/sambanova/DeepSeek-V3.1-Terminus.yaml
@@ -3,7 +3,8 @@ features:
     - tool_choice
     - system_messages
 limits:
-    context_window: 128000
+    context_window: 131072
+    max_output_tokens: 7168
 mode: chat
 model: DeepSeek-V3.1-Terminus
 sources:

--- a/providers/sambanova/DeepSeek-V3.1-cb.yaml
+++ b/providers/sambanova/DeepSeek-V3.1-cb.yaml
@@ -8,7 +8,8 @@ features:
     - structured_output
     - system_messages
 limits:
-    context_window: 128000
+    context_window: 32768
+    max_output_tokens: 32768
 mode: chat
 model: DeepSeek-V3.1-cb
 sources:

--- a/providers/sambanova/DeepSeek-V3.1.yaml
+++ b/providers/sambanova/DeepSeek-V3.1.yaml
@@ -8,7 +8,8 @@ features:
     - structured_output
     - system_messages
 limits:
-    context_window: 128000
+    context_window: 131072
+    max_output_tokens: 7168
 mode: chat
 model: DeepSeek-V3.1
 sources:

--- a/providers/sambanova/DeepSeek-V3.2.yaml
+++ b/providers/sambanova/DeepSeek-V3.2.yaml
@@ -3,7 +3,8 @@ features:
     - system_messages
     - tool_choice
 limits:
-    context_window: 8000
+    context_window: 8192
+    max_output_tokens: 7168
 mode: chat
 model: DeepSeek-V3.2
 sources:

--- a/providers/sambanova/E5-Mistral-7B-Instruct.yaml
+++ b/providers/sambanova/E5-Mistral-7B-Instruct.yaml
@@ -4,5 +4,6 @@ costs:
       region: "*"
 limits:
     context_window: 4096
+    max_output_tokens: 4096
 mode: embedding
 model: E5-Mistral-7B-Instruct

--- a/providers/sambanova/Llama-3.3-Swallow-70B-Instruct-v0.4.yaml
+++ b/providers/sambanova/Llama-3.3-Swallow-70B-Instruct-v0.4.yaml
@@ -5,6 +5,7 @@ costs:
 features:
     - function_calling
 limits:
-    context_window: 16384
+    context_window: 131072
+    max_output_tokens: 3072
 mode: chat
 model: Llama-3.3-Swallow-70B-Instruct-v0.4

--- a/providers/sambanova/Llama-4-Maverick-17B-128E-Instruct.yaml
+++ b/providers/sambanova/Llama-4-Maverick-17B-128E-Instruct.yaml
@@ -7,7 +7,8 @@ features:
     - tool_choice
     - structured_output
 limits:
-    context_window: 128000
+    context_window: 131072
+    max_output_tokens: 4096
 modalities:
     input:
         - image

--- a/providers/sambanova/Meta-Llama-3.1-8B-Instruct.yaml
+++ b/providers/sambanova/Meta-Llama-3.1-8B-Instruct.yaml
@@ -9,7 +9,7 @@ features:
 limits:
     context_window: 16384
     max_input_tokens: 16384
-    max_output_tokens: 16384
+    max_output_tokens: 4096
     max_tokens: 16384
 mode: chat
 model: Meta-Llama-3.1-8B-Instruct

--- a/providers/sambanova/Meta-Llama-3.3-70B-Instruct.yaml
+++ b/providers/sambanova/Meta-Llama-3.3-70B-Instruct.yaml
@@ -7,7 +7,8 @@ features:
     - tool_choice
     - structured_output
 limits:
-    context_window: 128000
+    context_window: 131072
+    max_output_tokens: 3072
 mode: chat
 model: Meta-Llama-3.3-70B-Instruct
 sources:

--- a/providers/sambanova/Qwen3-235B.yaml
+++ b/providers/sambanova/Qwen3-235B.yaml
@@ -5,9 +5,10 @@ costs:
 features:
     - function_calling
 limits:
-    context_window: 64000
+    context_window: 65536
+    max_output_tokens: 4096
 mode: chat
-model: Qwen3-235B-A22B-Instruct-2507
+model: Qwen3-235B
 sources:
     - https://docs.sambanova.ai/docs/en/features/function-calling
     - https://docs.sambanova.ai/docs/en/build/reasoning

--- a/providers/sambanova/Qwen3-32B.yaml
+++ b/providers/sambanova/Qwen3-32B.yaml
@@ -6,7 +6,8 @@ features:
     - function_calling
     - tool_choice
 limits:
-    context_window: 32000
+    context_window: 32768
+    max_output_tokens: 4096
 mode: chat
 model: Qwen3-32B
 sources:

--- a/providers/sambanova/gpt-oss-120b.yaml
+++ b/providers/sambanova/gpt-oss-120b.yaml
@@ -6,7 +6,8 @@ features:
     - function_calling
     - tool_choice
 limits:
-    context_window: 128000
+    context_window: 131072
+    max_output_tokens: 131072
 mode: chat
 model: gpt-oss-120b
 sources:


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `sambanova`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only updates, but changes to `context_window`/`max_output_tokens` may affect request validation and truncate outputs for some SambaNova models.
> 
> **Overview**
> Updates SambaNova model definition YAMLs to align published limits by adjusting `context_window` values (mostly to `131072`, plus `8192/32768/65536` where applicable) and adding explicit `max_output_tokens` caps across multiple models.
> 
> Also corrects the `Qwen3-235B` model identifier and updates a few models’ output limits (notably reducing `Meta-Llama-3.1-8B-Instruct` `max_output_tokens` to `4096` and setting `gpt-oss-120b` output cap to `131072`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6a064e2942d23d0bf6dec52c776ce7bb2f86d68c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->