### PR TITLE
feat(aws-bedrock): add new models [bot]

### DIFF
--- a/providers/aws-bedrock/anthropic.claude-opus-4-6-v1.yaml
+++ b/providers/aws-bedrock/anthropic.claude-opus-4-6-v1.yaml
@@ -1,0 +1,8 @@
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
+mode: unknown
+model: anthropic.claude-opus-4-6-v1

--- a/providers/aws-bedrock/minimax.minimax-m2.5.yaml
+++ b/providers/aws-bedrock/minimax.minimax-m2.5.yaml
@@ -1,0 +1,7 @@
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: unknown
+model: minimax.minimax-m2.5

--- a/providers/aws-bedrock/nvidia.nemotron-super-3-120b.yaml
+++ b/providers/aws-bedrock/nvidia.nemotron-super-3-120b.yaml
@@ -1,0 +1,7 @@
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: unknown
+model: nvidia.nemotron-super-3-120b

--- a/providers/aws-bedrock/zai.glm-5.yaml
+++ b/providers/aws-bedrock/zai.glm-5.yaml
@@ -1,0 +1,7 @@
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: unknown
+model: zai.glm-5


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `aws-bedrock`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new `aws-bedrock` model YAML entries only, with no code-path or behavioral changes beyond exposing additional model IDs/capabilities.
> 
> **Overview**
> Adds four new `aws-bedrock` model definition files to register additional Bedrock model IDs: `anthropic.claude-opus-4-6-v1` (text+image input), `minimax.minimax-m2.5`, `nvidia.nemotron-super-3-120b`, and `zai.glm-5` (text-only).
> 
> Each new YAML specifies supported input/output modalities and marks `mode: unknown`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f4463aaacdaa4b714b2701d34973636b71f2b75. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->