### PR TITLE
feat(elevenlabs): add new models [bot]

### DIFF
--- a/providers/elevenlabs/eleven_english_sts_v2.yaml
+++ b/providers/elevenlabs/eleven_english_sts_v2.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: eleven_english_sts_v2

--- a/providers/elevenlabs/eleven_multilingual_sts_v2.yaml
+++ b/providers/elevenlabs/eleven_multilingual_sts_v2.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: eleven_multilingual_sts_v2


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `elevenlabs`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk data-only change adding two new ElevenLabs model definition YAMLs. Main risk is if `mode: unknown` is rejected by validation or causes these models to be unusable until a supported mode is set.
> 
> **Overview**
> Adds two new ElevenLabs provider model definition files, `eleven_english_sts_v2.yaml` and `eleven_multilingual_sts_v2.yaml`, registering the corresponding `model` IDs.
> 
> Both configs currently set `mode: unknown`, differing from existing ElevenLabs entries that specify a concrete mode.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit acedb5cd9b8b83627cb4a2b0ab01bc5b1c2d345d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->