### PR TITLE
feat(openrouter): add new models [bot]

### DIFF
--- a/providers/openrouter/minimax/minimax-m2.7.yaml
+++ b/providers/openrouter/minimax/minimax-m2.7.yaml
@@ -1,0 +1,20 @@
+costs:
+    - cache_read_input_token_cost: 6.e-8
+      input_cost_per_token: 3.e-7
+      output_cost_per_token: 0.0000012
+      region: "*"
+limits:
+    context_window: 204800
+    max_output_tokens: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: chat
+model: minimax/minimax-m2.7
+params:
+    - defaultValue: 1
+      key: temperature
+    - defaultValue: 0.95
+      key: top_p

--- a/providers/openrouter/nvidia/nemotron-3-super-120b-a12b.yaml
+++ b/providers/openrouter/nvidia/nemotron-3-super-120b-a12b.yaml
@@ -1,0 +1,19 @@
+costs:
+    - cache_read_input_token_cost: 4.e-8
+      input_cost_per_token: 1.e-7
+      output_cost_per_token: 5.e-7
+      region: "*"
+limits:
+    context_window: 262144
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: chat
+model: nvidia/nemotron-3-super-120b-a12b
+params:
+    - defaultValue: 1
+      key: temperature
+    - defaultValue: 0.95
+      key: top_p

--- a/providers/openrouter/xiaomi/mimo-v2-omni.yaml
+++ b/providers/openrouter/xiaomi/mimo-v2-omni.yaml
@@ -1,0 +1,23 @@
+costs:
+    - cache_read_input_token_cost: 8.e-8
+      input_cost_per_token: 4.e-7
+      output_cost_per_token: 0.000002
+      region: "*"
+limits:
+    context_window: 262144
+    max_output_tokens: 65536
+modalities:
+    input:
+        - text
+        - audio
+        - image
+        - video
+    output:
+        - text
+mode: chat
+model: xiaomi/mimo-v2-omni
+params:
+    - defaultValue: 1
+      key: temperature
+    - defaultValue: 0.95
+      key: top_p

--- a/providers/openrouter/xiaomi/mimo-v2-pro.yaml
+++ b/providers/openrouter/xiaomi/mimo-v2-pro.yaml
@@ -1,0 +1,20 @@
+costs:
+    - cache_read_input_token_cost: 2.e-7
+      input_cost_per_token: 0.000001
+      output_cost_per_token: 0.000003
+      region: "*"
+limits:
+    context_window: 1048576
+    max_output_tokens: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: chat
+model: xiaomi/mimo-v2-pro
+params:
+    - defaultValue: 1
+      key: temperature
+    - defaultValue: 0.95
+      key: top_p


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `openrouter`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only adds new OpenRouter model metadata (costs/limits/modalities/params) and does not change runtime code paths. Main risk is incorrect pricing/limits values affecting downstream cost estimation or validation.
> 
> **Overview**
> Adds four new OpenRouter model definition YAMLs: `minimax/minimax-m2.7`, `nvidia/nemotron-3-super-120b-a12b`, and Xiaomi’s `mimo-v2-omni` (multimodal inputs) and `mimo-v2-pro`.
> 
> Each file specifies per-token costs, context/output limits, supported modalities, and default sampling params (`temperature`, `top_p`) for chat mode.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 87560d36465d20500058a30bb00a5f41b619ec24. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->