### PR TITLE
feat(aws-bedrock): add new models [bot]

### DIFF
--- a/providers/aws-bedrock/ai21.jamba-1-5-large-v1:0.yaml
+++ b/providers/aws-bedrock/ai21.jamba-1-5-large-v1:0.yaml
@@ -9,7 +9,12 @@ limits:
     max_input_tokens: 256000
     max_output_tokens: 4096
     max_tokens: 4096
-mode: chat
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: unknown
 model: ai21.jamba-1-5-large-v1:0
 params:
     - defaultValue: 4096

--- a/providers/aws-bedrock/ai21.jamba-1-5-mini-v1:0.yaml
+++ b/providers/aws-bedrock/ai21.jamba-1-5-mini-v1:0.yaml
@@ -9,7 +9,12 @@ limits:
     max_input_tokens: 256000
     max_output_tokens: 4096
     max_tokens: 4096
-mode: chat
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: unknown
 model: ai21.jamba-1-5-mini-v1:0
 params:
     - defaultValue: 4096

--- a/providers/aws-bedrock/amazon.nova-2-multimodal-embeddings-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.nova-2-multimodal-embeddings-v1:0.yaml
@@ -7,9 +7,11 @@ limits:
     max_input_tokens: 8172
 modalities:
     input:
-        - audio
+        - text
         - image
-mode: embedding
+    output:
+        - text
+mode: unknown
 model: amazon.nova-2-multimodal-embeddings-v1:0
 removeParams:
     - temperature

--- a/providers/aws-bedrock/amazon.nova-2-sonic-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.nova-2-sonic-v1:0.yaml
@@ -28,11 +28,9 @@ limits:
     max_output_tokens: 65536
     max_tokens: 65536
 modalities:
-    input:
-        - audio
     output:
-        - audio
-mode: chat
+        - text
+mode: unknown
 model: amazon.nova-2-sonic-v1:0
 sources:
     - https://aws.amazon.com/nova/models/

--- a/providers/aws-bedrock/amazon.nova-canvas-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.nova-canvas-v1:0.yaml
@@ -7,8 +7,11 @@ costs:
       region: ap-northeast-1
 modalities:
     input:
+        - text
         - image
-mode: image
+    output:
+        - image
+mode: unknown
 model: amazon.nova-canvas-v1:0
 removeParams:
     - max_tokens

--- a/providers/aws-bedrock/amazon.nova-lite-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.nova-lite-v1:0.yaml
@@ -15,6 +15,7 @@ costs:
       input_cost_per_token: 6.e-8
       output_cost_per_token: 2.4e-7
       region: us-east-1
+    - region: me-central-1
     - input_cost_per_token: 8.8e-8
       output_cost_per_token: 3.52e-7
       region: eu-west-3
@@ -39,6 +40,7 @@ costs:
     - input_cost_per_token: 6.4e-8
       output_cost_per_token: 2.56e-7
       region: ca-central-1
+    - region: ap-southeast-3
     - input_cost_per_token: 6.3e-8
       output_cost_per_token: 2.52e-7
       region: ap-southeast-2
@@ -65,11 +67,11 @@ limits:
     max_tokens: 10000
 modalities:
     input:
-        - audio
-        - doc
+        - text
         - image
-        - pdf
-mode: chat
+    output:
+        - text
+mode: unknown
 model: amazon.nova-lite-v1:0
 params:
     - defaultValue: 4096

--- a/providers/aws-bedrock/amazon.nova-micro-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.nova-micro-v1:0.yaml
@@ -11,6 +11,7 @@ costs:
       output_cost_per_token: 1.4e-7
       output_cost_per_token_batches: 7.e-8
       region: us-east-1
+    - region: eu-west-2
     - input_cost_per_token: 3.7e-8
       output_cost_per_token: 1.48e-7
       region: ap-southeast-2
@@ -24,7 +25,12 @@ limits:
     context_window: 128000
     max_output_tokens: 5000
     max_tokens: 5000
-mode: chat
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: unknown
 model: amazon.nova-micro-v1:0
 params:
     - defaultValue: 5000

--- a/providers/aws-bedrock/amazon.nova-pro-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.nova-pro-v1:0.yaml
@@ -67,6 +67,7 @@ costs:
       output_cost_per_token: 0.00000348
       output_cost_per_token_batches: 0.00000174
       region: ap-southeast-4
+    - region: ap-southeast-3
     - input_cost_per_token: 8.4e-7
       input_cost_per_token_batches: 4.2e-7
       output_cost_per_token: 0.00000336
@@ -105,10 +106,11 @@ limits:
     max_tokens: 5000
 modalities:
     input:
-        - doc
+        - text
         - image
-        - pdf
-mode: chat
+    output:
+        - text
+mode: unknown
 model: amazon.nova-pro-v1:0
 params:
     - defaultValue: 5000

--- a/providers/aws-bedrock/amazon.nova-reel-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.nova-reel-v1:0.yaml
@@ -7,8 +7,9 @@ costs:
       region: ap-northeast-1
 modalities:
     input:
+        - text
         - image
-mode: video
+mode: unknown
 model: amazon.nova-reel-v1:0
 removeParams:
     - max_tokens

--- a/providers/aws-bedrock/amazon.nova-reel-v1:1.yaml
+++ b/providers/aws-bedrock/amazon.nova-reel-v1:1.yaml
@@ -5,8 +5,9 @@ costs:
       region: ap-northeast-1
 modalities:
     input:
+        - text
         - image
-mode: video
+mode: unknown
 model: amazon.nova-reel-v1:1
 removeParams:
     - max_tokens

--- a/providers/aws-bedrock/amazon.nova-sonic-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.nova-sonic-v1:0.yaml
@@ -21,11 +21,9 @@ features:
 limits:
     context_window: 300000
 modalities:
-    input:
-        - audio
     output:
-        - audio
-mode: chat
+        - text
+mode: unknown
 model: amazon.nova-sonic-v1:0
 removeParams:
     - "n"

--- a/providers/aws-bedrock/amazon.rerank-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.rerank-v1:0.yaml
@@ -11,7 +11,12 @@ limits:
     max_input_tokens: 32000
     max_output_tokens: 32000
     max_tokens: 4096
-mode: rerank
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: unknown
 model: amazon.rerank-v1:0
 removeParams:
     - stream

--- a/providers/aws-bedrock/amazon.titan-embed-g1-text-02.yaml
+++ b/providers/aws-bedrock/amazon.titan-embed-g1-text-02.yaml
@@ -3,7 +3,12 @@ costs:
       region: us-west-2
     - input_cost_per_token: 1.e-7
       region: us-east-1
-mode: embedding
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: unknown
 model: amazon.titan-embed-g1-text-02
 removeParams:
     - max_tokens

--- a/providers/aws-bedrock/amazon.titan-embed-image-v1.yaml
+++ b/providers/aws-bedrock/amazon.titan-embed-image-v1.yaml
@@ -34,8 +34,11 @@ limits:
     output_vector_size: 1024
 modalities:
     input:
+        - text
         - image
-mode: embedding
+    output:
+        - text
+mode: unknown
 model: amazon.titan-embed-image-v1
 removeParams:
     - temperature

--- a/providers/aws-bedrock/amazon.titan-embed-text-v1.yaml
+++ b/providers/aws-bedrock/amazon.titan-embed-text-v1.yaml
@@ -15,7 +15,12 @@ limits:
     max_input_tokens: 8192
     max_tokens: 8192
     output_vector_size: 1536
-mode: embedding
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: unknown
 model: amazon.titan-embed-text-v1
 removeParams:
     - temperature

--- a/providers/aws-bedrock/amazon.titan-embed-text-v2:0.yaml
+++ b/providers/aws-bedrock/amazon.titan-embed-text-v2:0.yaml
@@ -46,7 +46,12 @@ costs:
 limits:
     max_input_tokens: 8192
     output_vector_size: 1024
-mode: embedding
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: unknown
 model: amazon.titan-embed-text-v2:0
 removeParams:
     - max_tokens

--- a/providers/aws-bedrock/amazon.titan-image-generator-v2:0.yaml
+++ b/providers/aws-bedrock/amazon.titan-image-generator-v2:0.yaml
@@ -8,8 +8,11 @@ messages:
         - user
 modalities:
     input:
+        - text
         - image
-mode: image
+    output:
+        - image
+mode: unknown
 model: amazon.titan-image-generator-v2:0
 removeParams:
     - temperature

--- a/providers/aws-bedrock/amazon.titan-tg1-large.yaml
+++ b/providers/aws-bedrock/amazon.titan-tg1-large.yaml
@@ -12,7 +12,12 @@ limits:
     max_input_tokens: 8000
     max_output_tokens: 8000
     max_tokens: 8000
-mode: chat
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: unknown
 model: amazon.titan-tg1-large
 params:
     - defaultValue: 8000

--- a/providers/aws-bedrock/anthropic.claude-3-5-haiku-20241022-v1:0.yaml
+++ b/providers/aws-bedrock/anthropic.claude-3-5-haiku-20241022-v1:0.yaml
@@ -1,3 +1,10 @@
+costs:
+    - region: us-west-2
 isDeprecated: true
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: unknown
 model: anthropic.claude-3-5-haiku-20241022-v1:0

--- a/providers/aws-bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0.yaml
+++ b/providers/aws-bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0.yaml
@@ -1,3 +1,13 @@
+costs:
+    - region: ap-southeast-1
+    - region: ap-northeast-2
+    - region: ap-northeast-1
 isDeprecated: true
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
 mode: unknown
 model: anthropic.claude-3-5-sonnet-20240620-v1:0

--- a/providers/aws-bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0.yaml
+++ b/providers/aws-bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0.yaml
@@ -48,6 +48,7 @@ costs:
       output_cost_per_token: 0.00003
       output_cost_per_token_batches: 0.000015
       region: eu-central-1
+    - region: ap-southeast-2
 features:
     - function_calling
     - cache_control
@@ -62,10 +63,11 @@ limits:
     max_tokens: 8192
 modalities:
     input:
-        - doc
+        - text
         - image
-        - pdf
-mode: chat
+    output:
+        - text
+mode: unknown
 model: anthropic.claude-3-5-sonnet-20241022-v2:0
 params:
     - defaultValue: 8192

--- a/providers/aws-bedrock/anthropic.claude-3-7-sonnet-20250219-v1:0.yaml
+++ b/providers/aws-bedrock/anthropic.claude-3-7-sonnet-20250219-v1:0.yaml
@@ -1,3 +1,11 @@
+costs:
+    - region: eu-west-2
 isDeprecated: true
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
 mode: unknown
 model: anthropic.claude-3-7-sonnet-20250219-v1:0

--- a/providers/aws-bedrock/anthropic.claude-3-haiku-20240307-v1:0.yaml
+++ b/providers/aws-bedrock/anthropic.claude-3-haiku-20240307-v1:0.yaml
@@ -1,3 +1,19 @@
+costs:
+    - region: us-east-1
+    - region: sa-east-1
+    - region: eu-west-3
+    - region: eu-central-2
+    - region: ca-central-1
+    - region: ap-southeast-1
+    - region: ap-south-1
+    - region: ap-northeast-2
+    - region: ap-northeast-1
 isDeprecated: true
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
 mode: unknown
 model: anthropic.claude-3-haiku-20240307-v1:0

--- a/providers/aws-bedrock/anthropic.claude-3-sonnet-20240229-v1:0.yaml
+++ b/providers/aws-bedrock/anthropic.claude-3-sonnet-20240229-v1:0.yaml
@@ -1,3 +1,14 @@
+costs:
+    - region: sa-east-1
+    - region: eu-west-2
+    - region: ca-central-1
+    - region: ap-south-1
 isDeprecated: true
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
 mode: unknown
 model: anthropic.claude-3-sonnet-20240229-v1:0

--- a/providers/aws-bedrock/anthropic.claude-opus-4-6-v1.yaml
+++ b/providers/aws-bedrock/anthropic.claude-opus-4-6-v1.yaml
@@ -1,3 +1,5 @@
+costs:
+    - region: eu-west-2
 modalities:
     input:
         - text

--- a/providers/aws-bedrock/anthropic.claude-sonnet-4-6.yaml
+++ b/providers/aws-bedrock/anthropic.claude-sonnet-4-6.yaml
@@ -649,8 +649,11 @@ limits:
     tool_use_system_prompt_tokens: 346
 modalities:
     input:
+        - text
         - image
-mode: chat
+    output:
+        - text
+mode: unknown
 model: anthropic.claude-sonnet-4-6
 params:
     - defaultValue: 8192

--- a/providers/aws-bedrock/apac.amazon.nova-lite-v1:0.yaml
+++ b/providers/aws-bedrock/apac.amazon.nova-lite-v1:0.yaml
@@ -15,6 +15,7 @@ costs:
       input_cost_per_token: 6.5e-8
       output_cost_per_token: 2.6e-7
       region: ap-southeast-4
+    - region: ap-southeast-3
     - cache_read_input_token_cost: 1.57e-8
       input_cost_per_token: 6.3e-8
       output_cost_per_token: 2.52e-7
@@ -52,7 +53,7 @@ modalities:
         - doc
         - image
         - pdf
-mode: chat
+mode: unknown
 model: apac.amazon.nova-lite-v1:0
 params:
     - defaultValue: 0.7

--- a/providers/aws-bedrock/apac.amazon.nova-micro-v1:0.yaml
+++ b/providers/aws-bedrock/apac.amazon.nova-micro-v1:0.yaml
@@ -3,8 +3,10 @@ costs:
       input_cost_per_token: 3.5e-8
       output_cost_per_token: 1.4e-7
       region: me-central-1
+    - region: ap-southeast-7
     - input_cost_per_token: 4.2e-8
       region: ap-southeast-5
+    - region: ap-southeast-3
     - cache_read_input_token_cost: 9.3e-9
       input_cost_per_token: 3.7e-8
       output_cost_per_token: 1.48e-7
@@ -25,6 +27,7 @@ costs:
       input_cost_per_token: 4.2e-8
       output_cost_per_token: 1.68e-7
       region: ap-northeast-1
+    - region: ap-east-2
 features:
     - function_calling
     - prompt_caching
@@ -33,7 +36,7 @@ limits:
     max_input_tokens: 128000
     max_output_tokens: 10000
     max_tokens: 10000
-mode: chat
+mode: unknown
 model: apac.amazon.nova-micro-v1:0
 sources:
     - https://docs.aws.amazon.com/nova/latest/userguide/what-is-nova.html

--- a/providers/aws-bedrock/apac.amazon.nova-pro-v1:0.yaml
+++ b/providers/aws-bedrock/apac.amazon.nova-pro-v1:0.yaml
@@ -3,12 +3,14 @@ costs:
       input_cost_per_token: 8.e-7
       output_cost_per_token: 0.0000032
       region: me-central-1
+    - region: ap-southeast-7
     - input_cost_per_token: 9.6e-7
       region: ap-southeast-5
     - cache_read_input_token_cost: 2.175e-7
       input_cost_per_token: 8.7e-7
       output_cost_per_token: 0.00000348
       region: ap-southeast-4
+    - region: ap-southeast-3
     - cache_read_input_token_cost: 2.1e-7
       input_cost_per_token: 8.4e-7
       output_cost_per_token: 0.00000336
@@ -29,6 +31,7 @@ costs:
       input_cost_per_token: 9.6e-7
       output_cost_per_token: 0.00000384
       region: ap-northeast-1
+    - region: ap-east-2
 features:
     - function_calling
     - tool_choice
@@ -43,7 +46,7 @@ modalities:
         - doc
         - image
         - pdf
-mode: chat
+mode: unknown
 model: apac.amazon.nova-pro-v1:0
 params:
     - defaultValue: 512

--- a/providers/aws-bedrock/apac.anthropic.claude-3-5-sonnet-20240620-v1:0.yaml
+++ b/providers/aws-bedrock/apac.anthropic.claude-3-5-sonnet-20240620-v1:0.yaml
@@ -34,5 +34,5 @@ limits:
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: apac.anthropic.claude-3-5-sonnet-20240620-v1:0

--- a/providers/aws-bedrock/apac.anthropic.claude-3-5-sonnet-20241022-v2:0.yaml
+++ b/providers/aws-bedrock/apac.anthropic.claude-3-5-sonnet-20241022-v2:0.yaml
@@ -36,7 +36,7 @@ limits:
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: apac.anthropic.claude-3-5-sonnet-20241022-v2:0
 params:
     - defaultValue: 8192

--- a/providers/aws-bedrock/apac.anthropic.claude-3-7-sonnet-20250219-v1:0.yaml
+++ b/providers/aws-bedrock/apac.anthropic.claude-3-7-sonnet-20250219-v1:0.yaml
@@ -57,5 +57,5 @@ limits:
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: apac.anthropic.claude-3-7-sonnet-20250219-v1:0

--- a/providers/aws-bedrock/apac.anthropic.claude-3-haiku-20240307-v1:0.yaml
+++ b/providers/aws-bedrock/apac.anthropic.claude-3-haiku-20240307-v1:0.yaml
@@ -34,7 +34,7 @@ limits:
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: apac.anthropic.claude-3-haiku-20240307-v1:0
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference-support.html

--- a/providers/aws-bedrock/apac.anthropic.claude-3-sonnet-20240229-v1:0.yaml
+++ b/providers/aws-bedrock/apac.anthropic.claude-3-sonnet-20240229-v1:0.yaml
@@ -34,5 +34,5 @@ limits:
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: apac.anthropic.claude-3-sonnet-20240229-v1:0

--- a/providers/aws-bedrock/apac.anthropic.claude-sonnet-4-20250514-v1:0.yaml
+++ b/providers/aws-bedrock/apac.anthropic.claude-sonnet-4-20250514-v1:0.yaml
@@ -94,7 +94,7 @@ modalities:
     input:
         - image
         - pdf
-mode: chat
+mode: unknown
 model: apac.anthropic.claude-sonnet-4-20250514-v1:0
 params:
     - defaultValue: 64000

--- a/providers/aws-bedrock/au.anthropic.claude-haiku-4-5-20251001-v1:0.yaml
+++ b/providers/aws-bedrock/au.anthropic.claude-haiku-4-5-20251001-v1:0.yaml
@@ -1,4 +1,5 @@
 costs:
+    - region: ap-southeast-6
     - cache_creation_input_token_cost: 0.00000125
       cache_read_input_token_cost: 1.e-7
       input_cost_per_token: 0.000001
@@ -28,7 +29,7 @@ limits:
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: au.anthropic.claude-haiku-4-5-20251001-v1:0
 params:
     - defaultValue: 512

--- a/providers/aws-bedrock/au.anthropic.claude-opus-4-6-v1.yaml
+++ b/providers/aws-bedrock/au.anthropic.claude-opus-4-6-v1.yaml
@@ -1,4 +1,5 @@
 costs:
+    - region: ap-southeast-6
     - cache_creation_input_token_cost: 0.000006875
       cache_read_input_token_cost: 5.5e-7
       input_cost_per_token: 0.0000055
@@ -25,7 +26,7 @@ limits:
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: au.anthropic.claude-opus-4-6-v1
 sources:
     - https://platform.claude.com/docs/en/docs/about-claude/models

--- a/providers/aws-bedrock/au.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
+++ b/providers/aws-bedrock/au.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
@@ -1,4 +1,5 @@
 costs:
+    - region: ap-southeast-6
     - cache_creation_input_token_cost: 0.000004125
       cache_read_input_token_cost: 3.3e-7
       input_cost_per_token: 0.0000033
@@ -50,7 +51,7 @@ limits:
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: au.anthropic.claude-sonnet-4-5-20250929-v1:0
 params:
     - defaultValue: 64000

--- a/providers/aws-bedrock/au.anthropic.claude-sonnet-4-6.yaml
+++ b/providers/aws-bedrock/au.anthropic.claude-sonnet-4-6.yaml
@@ -1,4 +1,5 @@
 costs:
+    - region: ap-southeast-6
     - cache_creation_input_token_cost: 0.000004125
       cache_read_input_token_cost: 3.3e-7
       input_cost_per_token: 0.0000033
@@ -29,7 +30,7 @@ limits:
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: au.anthropic.claude-sonnet-4-6
 sources:
     - https://platform.claude.com/docs/en/docs/about-claude/models

--- a/providers/aws-bedrock/ca.amazon.nova-lite-v1:0.yaml
+++ b/providers/aws-bedrock/ca.amazon.nova-lite-v1:0.yaml
@@ -1,4 +1,5 @@
 costs:
+    - region: ca-west-1
     - cache_read_input_token_cost: 1.6e-8
       input_cost_per_token: 6.4e-8
       output_cost_per_token: 2.56e-7
@@ -18,7 +19,7 @@ modalities:
         - doc
         - image
         - pdf
-mode: chat
+mode: unknown
 model: ca.amazon.nova-lite-v1:0
 params:
     - defaultValue: 4096

--- a/providers/aws-bedrock/cohere.command-r-plus-v1:0.yaml
+++ b/providers/aws-bedrock/cohere.command-r-plus-v1:0.yaml
@@ -10,5 +10,10 @@ limits:
     max_input_tokens: 128000
     max_output_tokens: 4096
     max_tokens: 4096
-mode: chat
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: unknown
 model: cohere.command-r-plus-v1:0

--- a/providers/aws-bedrock/cohere.command-r-v1:0.yaml
+++ b/providers/aws-bedrock/cohere.command-r-v1:0.yaml
@@ -13,7 +13,12 @@ limits:
     max_input_tokens: 128000
     max_output_tokens: 4096
     max_tokens: 4096
-mode: chat
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: unknown
 model: cohere.command-r-v1:0
 params:
     - defaultValue: 512

--- a/providers/aws-bedrock/cohere.embed-english-v3.yaml
+++ b/providers/aws-bedrock/cohere.embed-english-v3.yaml
@@ -39,8 +39,10 @@ limits:
     max_input_tokens: 512
 modalities:
     input:
-        - image
-mode: embedding
+        - text
+    output:
+        - text
+mode: unknown
 model: cohere.embed-english-v3
 removeParams:
     - temperature

--- a/providers/aws-bedrock/cohere.embed-multilingual-v3.yaml
+++ b/providers/aws-bedrock/cohere.embed-multilingual-v3.yaml
@@ -39,8 +39,10 @@ limits:
     max_input_tokens: 512
 modalities:
     input:
-        - image
-mode: embedding
+        - text
+    output:
+        - text
+mode: unknown
 model: cohere.embed-multilingual-v3
 removeParams:
     - stream

--- a/providers/aws-bedrock/cohere.embed-v4:0.yaml
+++ b/providers/aws-bedrock/cohere.embed-v4:0.yaml
@@ -12,8 +12,11 @@ limits:
     max_input_tokens: 128000
 modalities:
     input:
+        - text
         - image
-mode: embedding
+    output:
+        - text
+mode: unknown
 model: cohere.embed-v4:0
 params:
     - defaultValue: 128000

--- a/providers/aws-bedrock/cohere.rerank-v3-5:0.yaml
+++ b/providers/aws-bedrock/cohere.rerank-v3-5:0.yaml
@@ -11,7 +11,12 @@ costs:
       region: ap-northeast-1
 limits:
     max_tokens: 4096
-mode: rerank
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: unknown
 model: cohere.rerank-v3-5:0
 removeParams:
     - stream

--- a/providers/aws-bedrock/deepseek.v3-v1:0.yaml
+++ b/providers/aws-bedrock/deepseek.v3-v1:0.yaml
@@ -30,7 +30,12 @@ limits:
     max_input_tokens: 163840
     max_output_tokens: 81920
     max_tokens: 4096
-mode: chat
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: unknown
 model: deepseek.v3-v1:0
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-deepseek.html

--- a/providers/aws-bedrock/deepseek.v3.2.yaml
+++ b/providers/aws-bedrock/deepseek.v3.2.yaml
@@ -11,6 +11,7 @@ costs:
     - input_cost_per_token: 7.4e-7
       output_cost_per_token: 0.00000222
       region: sa-east-1
+    - region: eu-west-2
     - input_cost_per_token: 7.4e-7
       output_cost_per_token: 0.00000222
       region: eu-north-1
@@ -32,7 +33,12 @@ limits:
     context_window: 128000
     max_output_tokens: 8000
     max_tokens: 8000
-mode: chat
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: unknown
 model: deepseek.v3.2
 params:
     - defaultValue: 8000

--- a/providers/aws-bedrock/eu.amazon.nova-2-lite-v1:0.yaml
+++ b/providers/aws-bedrock/eu.amazon.nova-2-lite-v1:0.yaml
@@ -36,7 +36,7 @@ modalities:
     input:
         - doc
         - image
-mode: chat
+mode: unknown
 model: eu.amazon.nova-2-lite-v1:0
 params:
     - defaultValue: 512

--- a/providers/aws-bedrock/eu.amazon.nova-lite-v1:0.yaml
+++ b/providers/aws-bedrock/eu.amazon.nova-lite-v1:0.yaml
@@ -40,7 +40,7 @@ modalities:
         - doc
         - image
         - pdf
-mode: chat
+mode: unknown
 model: eu.amazon.nova-lite-v1:0
 params:
     - defaultValue: 512

--- a/providers/aws-bedrock/eu.amazon.nova-micro-v1:0.yaml
+++ b/providers/aws-bedrock/eu.amazon.nova-micro-v1:0.yaml
@@ -36,7 +36,7 @@ limits:
     max_input_tokens: 128000
     max_output_tokens: 10000
     max_tokens: 10000
-mode: chat
+mode: unknown
 model: eu.amazon.nova-micro-v1:0
 params:
     - defaultValue: 4096

--- a/providers/aws-bedrock/eu.amazon.nova-pro-v1:0.yaml
+++ b/providers/aws-bedrock/eu.amazon.nova-pro-v1:0.yaml
@@ -41,7 +41,7 @@ modalities:
         - doc
         - image
         - pdf
-mode: chat
+mode: unknown
 model: eu.amazon.nova-pro-v1:0
 params:
     - defaultValue: 512

--- a/providers/aws-bedrock/eu.anthropic.claude-3-5-sonnet-20240620-v1:0.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-3-5-sonnet-20240620-v1:0.yaml
@@ -20,5 +20,5 @@ limits:
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: eu.anthropic.claude-3-5-sonnet-20240620-v1:0

--- a/providers/aws-bedrock/eu.anthropic.claude-3-7-sonnet-20250219-v1:0.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-3-7-sonnet-20250219-v1:0.yaml
@@ -36,5 +36,5 @@ limits:
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: eu.anthropic.claude-3-7-sonnet-20250219-v1:0

--- a/providers/aws-bedrock/eu.anthropic.claude-3-haiku-20240307-v1:0.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-3-haiku-20240307-v1:0.yaml
@@ -24,7 +24,7 @@ limits:
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: eu.anthropic.claude-3-haiku-20240307-v1:0
 params:
     - defaultValue: 512

--- a/providers/aws-bedrock/eu.anthropic.claude-3-sonnet-20240229-v1:0.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-3-sonnet-20240229-v1:0.yaml
@@ -24,7 +24,7 @@ limits:
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: eu.anthropic.claude-3-sonnet-20240229-v1:0
 params:
     - defaultValue: null

--- a/providers/aws-bedrock/eu.anthropic.claude-haiku-4-5-20251001-v1:0.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-haiku-4-5-20251001-v1:0.yaml
@@ -73,7 +73,7 @@ modalities:
     input:
         - image
         - pdf
-mode: chat
+mode: unknown
 model: eu.anthropic.claude-haiku-4-5-20251001-v1:0
 params:
     - key: max_tokens

--- a/providers/aws-bedrock/eu.anthropic.claude-opus-4-5-20251101-v1:0.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-opus-4-5-20251101-v1:0.yaml
@@ -70,7 +70,7 @@ limits:
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: eu.anthropic.claude-opus-4-5-20251101-v1:0
 params:
     - key: max_tokens

--- a/providers/aws-bedrock/eu.anthropic.claude-opus-4-6-v1.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-opus-4-6-v1.yaml
@@ -73,7 +73,7 @@ modalities:
     input:
         - image
         - pdf
-mode: chat
+mode: unknown
 model: eu.anthropic.claude-opus-4-6-v1
 params:
     - defaultValue: 128000

--- a/providers/aws-bedrock/eu.anthropic.claude-sonnet-4-20250514-v1:0.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-sonnet-4-20250514-v1:0.yaml
@@ -1,4 +1,5 @@
 costs:
+    - region: il-central-1
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3.e-7
       input_cost_per_token: 0.000003
@@ -124,7 +125,7 @@ modalities:
     input:
         - image
         - pdf
-mode: chat
+mode: unknown
 model: eu.anthropic.claude-sonnet-4-20250514-v1:0
 params:
     - key: max_tokens

--- a/providers/aws-bedrock/eu.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
@@ -175,7 +175,7 @@ modalities:
     input:
         - image
         - pdf
-mode: chat
+mode: unknown
 model: eu.anthropic.claude-sonnet-4-5-20250929-v1:0
 params:
     - key: max_tokens

--- a/providers/aws-bedrock/eu.anthropic.claude-sonnet-4-6.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-sonnet-4-6.yaml
@@ -70,7 +70,7 @@ limits:
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: eu.anthropic.claude-sonnet-4-6
 params:
     - defaultValue: 64000

--- a/providers/aws-bedrock/eu.cohere.embed-v4:0.yaml
+++ b/providers/aws-bedrock/eu.cohere.embed-v4:0.yaml
@@ -1,6 +1,7 @@
 costs:
     - input_cost_per_token: 1.2e-7
       region: eu-west-3
+    - region: eu-west-2
     - input_cost_per_token: 1.2e-7
       region: eu-west-1
     - input_cost_per_token: 1.2e-7
@@ -9,6 +10,7 @@ costs:
       region: eu-south-1
     - input_cost_per_token: 1.2e-7
       region: eu-north-1
+    - region: eu-central-2
     - input_cost_per_token: 1.2e-7
       region: eu-central-1
 limits:
@@ -17,7 +19,7 @@ limits:
 modalities:
     input:
         - image
-mode: embedding
+mode: unknown
 model: eu.cohere.embed-v4:0
 removeParams:
     - temperature

--- a/providers/aws-bedrock/eu.meta.llama3-2-1b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/eu.meta.llama3-2-1b-instruct-v1:0.yaml
@@ -15,5 +15,5 @@ limits:
     max_input_tokens: 128000
     max_output_tokens: 4096
     max_tokens: 4096
-mode: chat
+mode: unknown
 model: eu.meta.llama3-2-1b-instruct-v1:0

--- a/providers/aws-bedrock/eu.meta.llama3-2-3b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/eu.meta.llama3-2-3b-instruct-v1:0.yaml
@@ -19,7 +19,7 @@ limits:
 modalities:
     input:
         - doc
-mode: chat
+mode: unknown
 model: eu.meta.llama3-2-3b-instruct-v1:0
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-meta.html

--- a/providers/aws-bedrock/eu.mistral.pixtral-large-2502-v1:0.yaml
+++ b/providers/aws-bedrock/eu.mistral.pixtral-large-2502-v1:0.yaml
@@ -23,7 +23,7 @@ modalities:
     input:
         - doc
         - image
-mode: chat
+mode: unknown
 model: eu.mistral.pixtral-large-2502-v1:0
 params:
     - defaultValue: 512

--- a/providers/aws-bedrock/global.amazon.nova-2-lite-v1:0.yaml
+++ b/providers/aws-bedrock/global.amazon.nova-2-lite-v1:0.yaml
@@ -63,6 +63,7 @@ costs:
       input_cost_per_token: 4.1e-7
       output_cost_per_token: 0.00000339
       region: ap-southeast-7
+    - region: ap-southeast-6
     - cache_read_input_token_cost: 1.025e-7
       input_cost_per_token: 4.1e-7
       output_cost_per_token: 0.00000339
@@ -110,7 +111,7 @@ modalities:
     input:
         - doc
         - image
-mode: chat
+mode: unknown
 model: global.amazon.nova-2-lite-v1:0
 params:
     - defaultValue: 512

--- a/providers/aws-bedrock/global.anthropic.claude-haiku-4-5-20251001-v1:0.yaml
+++ b/providers/aws-bedrock/global.anthropic.claude-haiku-4-5-20251001-v1:0.yaml
@@ -139,6 +139,7 @@ costs:
       output_cost_per_token: 0.000005
       output_cost_per_token_batches: 0.0000025
       region: ap-southeast-7
+    - region: ap-southeast-6
     - cache_creation_input_token_cost: 0.00000125
       cache_read_input_token_cost: 1.e-7
       input_cost_per_token: 0.000001
@@ -238,7 +239,7 @@ modalities:
     input:
         - image
         - pdf
-mode: chat
+mode: unknown
 model: global.anthropic.claude-haiku-4-5-20251001-v1:0
 params:
     - key: max_tokens

--- a/providers/aws-bedrock/global.anthropic.claude-opus-4-5-20251101-v1:0.yaml
+++ b/providers/aws-bedrock/global.anthropic.claude-opus-4-5-20251101-v1:0.yaml
@@ -139,6 +139,7 @@ costs:
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: ap-southeast-7
+    - region: ap-southeast-6
     - cache_creation_input_token_cost: 0.00000625
       cache_read_input_token_cost: 5.e-7
       input_cost_per_token: 0.000005
@@ -238,7 +239,7 @@ limits:
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: global.anthropic.claude-opus-4-5-20251101-v1:0
 params:
     - key: max_tokens

--- a/providers/aws-bedrock/global.anthropic.claude-opus-4-6-v1.yaml
+++ b/providers/aws-bedrock/global.anthropic.claude-opus-4-6-v1.yaml
@@ -139,6 +139,7 @@ costs:
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: ap-southeast-7
+    - region: ap-southeast-6
     - cache_creation_input_token_cost: 0.00000625
       cache_read_input_token_cost: 5.e-7
       input_cost_per_token: 0.000005
@@ -234,7 +235,7 @@ limits:
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: global.anthropic.claude-opus-4-6-v1
 params:
     - defaultValue: 128000

--- a/providers/aws-bedrock/global.anthropic.claude-sonnet-4-20250514-v1:0.yaml
+++ b/providers/aws-bedrock/global.anthropic.claude-sonnet-4-20250514-v1:0.yaml
@@ -87,7 +87,7 @@ limits:
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: global.anthropic.claude-sonnet-4-20250514-v1:0
 params:
     - defaultValue: 512

--- a/providers/aws-bedrock/global.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
+++ b/providers/aws-bedrock/global.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
@@ -399,6 +399,7 @@ costs:
           output:
               - cost_per_token: 0.0000225
                 from: 200000
+    - region: ap-southeast-6
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3.e-7
       input_cost_per_token: 0.000003
@@ -656,7 +657,7 @@ modalities:
     input:
         - image
         - pdf
-mode: chat
+mode: unknown
 model: global.anthropic.claude-sonnet-4-5-20250929-v1:0
 params:
     - defaultValue: 64000

--- a/providers/aws-bedrock/global.anthropic.claude-sonnet-4-6.yaml
+++ b/providers/aws-bedrock/global.anthropic.claude-sonnet-4-6.yaml
@@ -139,6 +139,7 @@ costs:
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ap-southeast-7
+    - region: ap-southeast-6
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3.e-7
       input_cost_per_token: 0.000003
@@ -234,7 +235,7 @@ limits:
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: global.anthropic.claude-sonnet-4-6
 params:
     - defaultValue: 8192

--- a/providers/aws-bedrock/global.cohere.embed-v4:0.yaml
+++ b/providers/aws-bedrock/global.cohere.embed-v4:0.yaml
@@ -13,6 +13,7 @@ costs:
       region: eu-west-3
     - input_cost_per_token: 1.2e-7
       region: eu-west-2
+    - region: eu-west-1
     - input_cost_per_token: 1.2e-7
       region: eu-south-2
     - input_cost_per_token: 1.2e-7
@@ -48,7 +49,7 @@ limits:
 modalities:
     input:
         - image
-mode: embedding
+mode: unknown
 model: global.cohere.embed-v4:0
 removeParams:
     - max_tokens

--- a/providers/aws-bedrock/google.gemma-3-12b-it.yaml
+++ b/providers/aws-bedrock/google.gemma-3-12b-it.yaml
@@ -36,8 +36,11 @@ limits:
     max_tokens: 8192
 modalities:
     input:
+        - text
         - image
-mode: chat
+    output:
+        - text
+mode: unknown
 model: google.gemma-3-12b-it
 params:
     - defaultValue: 512

--- a/providers/aws-bedrock/google.gemma-3-27b-it.yaml
+++ b/providers/aws-bedrock/google.gemma-3-27b-it.yaml
@@ -38,8 +38,11 @@ limits:
     max_tokens: 8192
 modalities:
     input:
+        - text
         - image
-mode: chat
+    output:
+        - text
+mode: unknown
 model: google.gemma-3-27b-it
 params:
     - defaultValue: 8192

--- a/providers/aws-bedrock/google.gemma-3-4b-it.yaml
+++ b/providers/aws-bedrock/google.gemma-3-4b-it.yaml
@@ -36,8 +36,11 @@ limits:
     max_tokens: 8192
 modalities:
     input:
+        - text
         - image
-mode: chat
+    output:
+        - text
+mode: unknown
 model: google.gemma-3-4b-it
 params:
     - defaultValue: 8192

--- a/providers/aws-bedrock/jp.amazon.nova-2-lite-v1:0.yaml
+++ b/providers/aws-bedrock/jp.amazon.nova-2-lite-v1:0.yaml
@@ -14,7 +14,7 @@ limits:
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: jp.amazon.nova-2-lite-v1:0
 params:
     - defaultValue: 512

--- a/providers/aws-bedrock/jp.anthropic.claude-haiku-4-5-20251001-v1:0.yaml
+++ b/providers/aws-bedrock/jp.anthropic.claude-haiku-4-5-20251001-v1:0.yaml
@@ -29,7 +29,7 @@ limits:
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: jp.anthropic.claude-haiku-4-5-20251001-v1:0
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference-support.html

--- a/providers/aws-bedrock/jp.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
+++ b/providers/aws-bedrock/jp.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
@@ -56,7 +56,7 @@ modalities:
     input:
         - image
         - pdf
-mode: chat
+mode: unknown
 model: jp.anthropic.claude-sonnet-4-5-20250929-v1:0
 params:
     - defaultValue: 512

--- a/providers/aws-bedrock/jp.anthropic.claude-sonnet-4-6.yaml
+++ b/providers/aws-bedrock/jp.anthropic.claude-sonnet-4-6.yaml
@@ -49,7 +49,7 @@ limits:
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: jp.anthropic.claude-sonnet-4-6
 params:
     - defaultValue: 64000

--- a/providers/aws-bedrock/luma.ray-v2:0.yaml
+++ b/providers/aws-bedrock/luma.ray-v2:0.yaml
@@ -2,7 +2,10 @@ costs:
     - input_cost_per_token: 0.0000015
       output_cost_per_second: 1.5
       region: us-west-2
-mode: video
+modalities:
+    input:
+        - text
+mode: unknown
 model: luma.ray-v2:0
 removeParams:
     - max_tokens

--- a/providers/aws-bedrock/meta.llama3-1-405b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/meta.llama3-1-405b-instruct-v1:0.yaml
@@ -1,3 +1,10 @@
+costs:
+    - region: us-west-2
 isDeprecated: true
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: unknown
 model: meta.llama3-1-405b-instruct-v1:0

--- a/providers/aws-bedrock/meta.llama3-1-70b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/meta.llama3-1-70b-instruct-v1:0.yaml
@@ -16,7 +16,12 @@ limits:
     context_window: 128000
     max_output_tokens: 2048
     max_tokens: 2048
-mode: chat
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: unknown
 model: meta.llama3-1-70b-instruct-v1:0
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html

--- a/providers/aws-bedrock/meta.llama3-1-8b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/meta.llama3-1-8b-instruct-v1:0.yaml
@@ -24,8 +24,10 @@ limits:
     max_tokens: 2048
 modalities:
     input:
-        - doc
-mode: chat
+        - text
+    output:
+        - text
+mode: unknown
 model: meta.llama3-1-8b-instruct-v1:0
 removeParams:
     - "n"

--- a/providers/aws-bedrock/meta.llama3-3-70b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/meta.llama3-3-70b-instruct-v1:0.yaml
@@ -21,7 +21,12 @@ limits:
     context_window: 128000
     max_output_tokens: 2048
     max_tokens: 2048
-mode: chat
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: unknown
 model: meta.llama3-3-70b-instruct-v1:0
 removeParams:
     - "n"

--- a/providers/aws-bedrock/meta.llama3-70b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/meta.llama3-70b-instruct-v1:0.yaml
@@ -24,7 +24,12 @@ limits:
     max_input_tokens: 8192
     max_output_tokens: 2048
     max_tokens: 2048
-mode: chat
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: unknown
 model: meta.llama3-70b-instruct-v1:0
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-meta.html

--- a/providers/aws-bedrock/meta.llama3-8b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/meta.llama3-8b-instruct-v1:0.yaml
@@ -24,7 +24,12 @@ limits:
     max_input_tokens: 8192
     max_output_tokens: 2048
     max_tokens: 2048
-mode: chat
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: unknown
 model: meta.llama3-8b-instruct-v1:0
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-meta-llama-3-8b-instruct.html

--- a/providers/aws-bedrock/minimax.minimax-m2.1.yaml
+++ b/providers/aws-bedrock/minimax.minimax-m2.1.yaml
@@ -42,7 +42,12 @@ features:
     - function_calling
 limits:
     context_window: 204800
-mode: chat
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: unknown
 model: minimax.minimax-m2.1
 sources:
     - https://platform.minimaxi.com/docs/api-reference/text-anthropic-api

--- a/providers/aws-bedrock/minimax.minimax-m2.5.yaml
+++ b/providers/aws-bedrock/minimax.minimax-m2.5.yaml
@@ -1,3 +1,6 @@
+costs:
+    - region: us-west-2
+    - region: us-east-1
 modalities:
     input:
         - text

--- a/providers/aws-bedrock/minimax.minimax-m2.yaml
+++ b/providers/aws-bedrock/minimax.minimax-m2.yaml
@@ -38,7 +38,12 @@ limits:
     context_window: 200000
     max_output_tokens: 128000
     max_tokens: 128000
-mode: chat
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: unknown
 model: minimax.minimax-m2
 params:
     - defaultValue: 128000

--- a/providers/aws-bedrock/mistral.devstral-2-123b.yaml
+++ b/providers/aws-bedrock/mistral.devstral-2-123b.yaml
@@ -44,7 +44,12 @@ features:
     - tools
 limits:
     context_window: 256000
-mode: chat
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: unknown
 model: mistral.devstral-2-123b
 sources:
     - https://docs.mistral.ai/models/devstral-2-25-12

--- a/providers/aws-bedrock/mistral.magistral-small-2509.yaml
+++ b/providers/aws-bedrock/mistral.magistral-small-2509.yaml
@@ -20,6 +20,7 @@ costs:
     - input_cost_per_token: 5.9e-7
       output_cost_per_token: 0.00000176
       region: eu-south-1
+    - region: ap-southeast-2
     - input_cost_per_token: 5.9e-7
       output_cost_per_token: 0.00000176
       region: ap-south-1
@@ -36,8 +37,11 @@ limits:
     max_tokens: 8192
 modalities:
     input:
+        - text
         - image
-mode: chat
+    output:
+        - text
+mode: unknown
 model: mistral.magistral-small-2509
 sources:
     - https://docs.mistral.ai/models/magistral-small-1-2-25-09

--- a/providers/aws-bedrock/mistral.ministral-3-14b-instruct.yaml
+++ b/providers/aws-bedrock/mistral.ministral-3-14b-instruct.yaml
@@ -40,8 +40,11 @@ limits:
     max_tokens: 8192
 modalities:
     input:
+        - text
         - image
-mode: chat
+    output:
+        - text
+mode: unknown
 model: mistral.ministral-3-14b-instruct
 params:
     - defaultValue: 8192

--- a/providers/aws-bedrock/mistral.ministral-3-3b-instruct.yaml
+++ b/providers/aws-bedrock/mistral.ministral-3-3b-instruct.yaml
@@ -39,8 +39,11 @@ limits:
     max_tokens: 8192
 modalities:
     input:
+        - text
         - image
-mode: chat
+    output:
+        - text
+mode: unknown
 model: mistral.ministral-3-3b-instruct
 sources:
     - https://docs.mistral.ai/models/ministral-3-3b-25-12

--- a/providers/aws-bedrock/mistral.ministral-3-8b-instruct.yaml
+++ b/providers/aws-bedrock/mistral.ministral-3-8b-instruct.yaml
@@ -39,8 +39,11 @@ limits:
     max_tokens: 8192
 modalities:
     input:
+        - text
         - image
-mode: chat
+    output:
+        - text
+mode: unknown
 model: mistral.ministral-3-8b-instruct
 params:
     - defaultValue: 8192

--- a/providers/aws-bedrock/mistral.mistral-7b-instruct-v0:2.yaml
+++ b/providers/aws-bedrock/mistral.mistral-7b-instruct-v0:2.yaml
@@ -33,7 +33,12 @@ limits:
     max_input_tokens: 32000
     max_output_tokens: 8192
     max_tokens: 8192
-mode: chat
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: unknown
 model: mistral.mistral-7b-instruct-v0:2
 params:
     - defaultValue: 512

--- a/providers/aws-bedrock/mistral.mistral-large-2402-v1:0.yaml
+++ b/providers/aws-bedrock/mistral.mistral-large-2402-v1:0.yaml
@@ -33,7 +33,12 @@ limits:
     max_input_tokens: 32000
     max_output_tokens: 8192
     max_tokens: 8192
-mode: chat
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: unknown
 model: mistral.mistral-large-2402-v1:0
 params:
     - defaultValue: 8192

--- a/providers/aws-bedrock/mistral.mistral-large-2407-v1:0.yaml
+++ b/providers/aws-bedrock/mistral.mistral-large-2407-v1:0.yaml
@@ -11,8 +11,10 @@ limits:
     max_tokens: 8192
 modalities:
     input:
-        - doc
-mode: chat
+        - text
+    output:
+        - text
+mode: unknown
 model: mistral.mistral-large-2407-v1:0
 params:
     - defaultValue: 8192

--- a/providers/aws-bedrock/mistral.mistral-large-3-675b-instruct.yaml
+++ b/providers/aws-bedrock/mistral.mistral-large-3-675b-instruct.yaml
@@ -32,8 +32,11 @@ limits:
     max_tokens: 8192
 modalities:
     input:
+        - text
         - image
-mode: chat
+    output:
+        - text
+mode: unknown
 model: mistral.mistral-large-3-675b-instruct
 params:
     - defaultValue: 8192

--- a/providers/aws-bedrock/mistral.mistral-small-2402-v1:0.yaml
+++ b/providers/aws-bedrock/mistral.mistral-small-2402-v1:0.yaml
@@ -8,7 +8,12 @@ limits:
     max_input_tokens: 32000
     max_output_tokens: 8192
     max_tokens: 8192
-mode: chat
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: unknown
 model: mistral.mistral-small-2402-v1:0
 params:
     - defaultValue: 8192

--- a/providers/aws-bedrock/mistral.mixtral-8x7b-instruct-v0:1.yaml
+++ b/providers/aws-bedrock/mistral.mixtral-8x7b-instruct-v0:1.yaml
@@ -33,7 +33,12 @@ limits:
     max_input_tokens: 32000
     max_output_tokens: 4096
     max_tokens: 4096
-mode: chat
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: unknown
 model: mistral.mixtral-8x7b-instruct-v0:1
 params:
     - defaultValue: 512

--- a/providers/aws-bedrock/mistral.voxtral-mini-3b-2507.yaml
+++ b/providers/aws-bedrock/mistral.voxtral-mini-3b-2507.yaml
@@ -36,8 +36,10 @@ limits:
     context_window: 32000
 modalities:
     input:
-        - audio
-mode: chat
+        - text
+    output:
+        - text
+mode: unknown
 model: mistral.voxtral-mini-3b-2507
 sources:
     - https://docs.mistral.ai/models/voxtral-mini-25-07

--- a/providers/aws-bedrock/mistral.voxtral-small-24b-2507.yaml
+++ b/providers/aws-bedrock/mistral.voxtral-small-24b-2507.yaml
@@ -20,6 +20,7 @@ costs:
     - input_cost_per_token: 1.2e-7
       output_cost_per_token: 3.5e-7
       region: eu-south-1
+    - region: ap-southeast-2
     - input_cost_per_token: 1.2e-7
       output_cost_per_token: 3.5e-7
       region: ap-south-1
@@ -33,8 +34,10 @@ limits:
     context_window: 32000
 modalities:
     input:
-        - audio
-mode: chat
+        - text
+    output:
+        - text
+mode: unknown
 model: mistral.voxtral-small-24b-2507
 sources:
     - https://docs.mistral.ai/models/voxtral-small-25-07

--- a/providers/aws-bedrock/moonshot.kimi-k2-thinking.yaml
+++ b/providers/aws-bedrock/moonshot.kimi-k2-thinking.yaml
@@ -29,7 +29,12 @@ limits:
     context_window: 128000
     max_output_tokens: 16000
     max_tokens: 16000
-mode: chat
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: unknown
 model: moonshot.kimi-k2-thinking
 params:
     - defaultValue: 16000

--- a/providers/aws-bedrock/moonshotai.kimi-k2.5.yaml
+++ b/providers/aws-bedrock/moonshotai.kimi-k2.5.yaml
@@ -37,8 +37,11 @@ limits:
     max_tokens: 81920
 modalities:
     input:
+        - text
         - image
-mode: chat
+    output:
+        - text
+mode: unknown
 model: moonshotai.kimi-k2.5
 params:
     - defaultValue: 512

--- a/providers/aws-bedrock/nvidia.nemotron-nano-12b-v2.yaml
+++ b/providers/aws-bedrock/nvidia.nemotron-nano-12b-v2.yaml
@@ -36,8 +36,11 @@ limits:
     max_tokens: 8192
 modalities:
     input:
+        - text
         - image
-mode: chat
+    output:
+        - text
+mode: unknown
 model: nvidia.nemotron-nano-12b-v2
 sources:
     - https://build.nvidia.com/nvidia/nemotron-nano-12b-v2-vl/modelcard

--- a/providers/aws-bedrock/nvidia.nemotron-nano-3-30b.yaml
+++ b/providers/aws-bedrock/nvidia.nemotron-nano-3-30b.yaml
@@ -36,7 +36,12 @@ limits:
     max_input_tokens: 262144
     max_output_tokens: 8192
     max_tokens: 8192
-mode: chat
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: unknown
 model: nvidia.nemotron-nano-3-30b
 sources:
     - https://aws.amazon.com/about-aws/whats-new/2025/12/nvidia-nemotron-3-nano-amazon-bedrock/

--- a/providers/aws-bedrock/nvidia.nemotron-nano-9b-v2.yaml
+++ b/providers/aws-bedrock/nvidia.nemotron-nano-9b-v2.yaml
@@ -17,6 +17,7 @@ costs:
     - input_cost_per_token: 7.e-8
       output_cost_per_token: 2.7e-7
       region: eu-west-1
+    - region: eu-south-1
     - input_cost_per_token: 6.18e-8
       output_cost_per_token: 2.369e-7
       region: ap-southeast-2
@@ -33,7 +34,12 @@ limits:
     max_input_tokens: 128000
     max_output_tokens: 8192
     max_tokens: 8192
-mode: chat
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: unknown
 model: nvidia.nemotron-nano-9b-v2
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html

--- a/providers/aws-bedrock/nvidia.nemotron-super-3-120b.yaml
+++ b/providers/aws-bedrock/nvidia.nemotron-super-3-120b.yaml
@@ -1,3 +1,6 @@
+costs:
+    - region: us-west-2
+    - region: us-east-1
 modalities:
     input:
         - text

--- a/providers/aws-bedrock/openai.gpt-oss-120b-1:0.yaml
+++ b/providers/aws-bedrock/openai.gpt-oss-120b-1:0.yaml
@@ -29,6 +29,7 @@ costs:
     - input_cost_per_token: 1.6e-7
       output_cost_per_token: 6.2e-7
       region: ap-southeast-3
+    - region: ap-southeast-2
     - input_cost_per_token: 1.8e-7
       output_cost_per_token: 7.1e-7
       region: ap-south-1
@@ -43,7 +44,12 @@ messages:
         - user
         - assistant
         - developer
-mode: chat
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: unknown
 model: openai.gpt-oss-120b-1:0
 params:
     - key: max_tokens

--- a/providers/aws-bedrock/openai.gpt-oss-20b-1:0.yaml
+++ b/providers/aws-bedrock/openai.gpt-oss-20b-1:0.yaml
@@ -29,6 +29,7 @@ costs:
     - input_cost_per_token: 7.e-8
       output_cost_per_token: 3.1e-7
       region: ap-southeast-3
+    - region: ap-southeast-2
     - input_cost_per_token: 8.e-8
       output_cost_per_token: 3.5e-7
       region: ap-south-1
@@ -37,7 +38,12 @@ costs:
       region: ap-northeast-1
 limits:
     context_window: 128000
-mode: chat
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: unknown
 model: openai.gpt-oss-20b-1:0
 params:
     - key: max_tokens

--- a/providers/aws-bedrock/openai.gpt-oss-safeguard-120b.yaml
+++ b/providers/aws-bedrock/openai.gpt-oss-safeguard-120b.yaml
@@ -34,7 +34,12 @@ limits:
     max_input_tokens: 128000
     max_output_tokens: 8192
     max_tokens: 8192
-mode: chat
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: unknown
 model: openai.gpt-oss-safeguard-120b
 params:
     - defaultValue: 512

--- a/providers/aws-bedrock/openai.gpt-oss-safeguard-20b.yaml
+++ b/providers/aws-bedrock/openai.gpt-oss-safeguard-20b.yaml
@@ -36,7 +36,12 @@ limits:
     max_input_tokens: 128000
     max_output_tokens: 8192
     max_tokens: 8192
-mode: chat
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: unknown
 model: openai.gpt-oss-safeguard-20b
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-openai.html

--- a/providers/aws-bedrock/qwen.qwen3-235b-a22b-2507-v1:0.yaml
+++ b/providers/aws-bedrock/qwen.qwen3-235b-a22b-2507-v1:0.yaml
@@ -20,6 +20,7 @@ costs:
     - input_cost_per_token: 2.3e-7
       output_cost_per_token: 9.1e-7
       region: ap-southeast-3
+    - region: ap-southeast-2
     - input_cost_per_token: 2.6e-7
       output_cost_per_token: 0.00000104
       region: ap-south-1
@@ -32,7 +33,12 @@ limits:
     context_window: 128000
     max_output_tokens: 8000
     max_tokens: 8000
-mode: chat
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: unknown
 model: qwen.qwen3-235b-a22b-2507-v1:0
 params:
     - defaultValue: 512

--- a/providers/aws-bedrock/qwen.qwen3-32b-v1:0.yaml
+++ b/providers/aws-bedrock/qwen.qwen3-32b-v1:0.yaml
@@ -29,6 +29,7 @@ costs:
     - input_cost_per_token: 1.6e-7
       output_cost_per_token: 6.2e-7
       region: ap-southeast-3
+    - region: ap-southeast-2
     - input_cost_per_token: 1.8e-7
       output_cost_per_token: 7.1e-7
       region: ap-south-1
@@ -41,7 +42,12 @@ limits:
     context_window: 128000
     max_output_tokens: 8000
     max_tokens: 8000
-mode: chat
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: unknown
 model: qwen.qwen3-32b-v1:0
 params:
     - defaultValue: 512

--- a/providers/aws-bedrock/qwen.qwen3-coder-30b-a3b-v1:0.yaml
+++ b/providers/aws-bedrock/qwen.qwen3-coder-30b-a3b-v1:0.yaml
@@ -29,6 +29,7 @@ costs:
     - input_cost_per_token: 1.6e-7
       output_cost_per_token: 6.2e-7
       region: ap-southeast-3
+    - region: ap-southeast-2
     - input_cost_per_token: 1.8e-7
       output_cost_per_token: 7.1e-7
       region: ap-south-1
@@ -41,7 +42,12 @@ limits:
     context_window: 128000
     max_output_tokens: 16000
     max_tokens: 16000
-mode: chat
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: unknown
 model: qwen.qwen3-coder-30b-a3b-v1:0
 params:
     - defaultValue: 512

--- a/providers/aws-bedrock/qwen.qwen3-coder-480b-a35b-v1:0.yaml
+++ b/providers/aws-bedrock/qwen.qwen3-coder-480b-a35b-v1:0.yaml
@@ -14,6 +14,7 @@ costs:
     - input_cost_per_token: 4.7e-7
       output_cost_per_token: 0.00000187
       region: ap-southeast-3
+    - region: ap-southeast-2
     - input_cost_per_token: 5.3e-7
       output_cost_per_token: 0.00000212
       region: ap-south-1
@@ -27,7 +28,12 @@ limits:
     max_input_tokens: 262144
     max_output_tokens: 65536
     max_tokens: 65536
-mode: chat
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: unknown
 model: qwen.qwen3-coder-480b-a35b-v1:0
 params:
     - defaultValue: 512

--- a/providers/aws-bedrock/qwen.qwen3-coder-next.yaml
+++ b/providers/aws-bedrock/qwen.qwen3-coder-next.yaml
@@ -14,7 +14,12 @@ limits:
     context_window: 128000
     max_output_tokens: 16000
     max_tokens: 16000
-mode: chat
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: unknown
 model: qwen.qwen3-coder-next
 params:
     - defaultValue: 512

--- a/providers/aws-bedrock/qwen.qwen3-next-80b-a3b.yaml
+++ b/providers/aws-bedrock/qwen.qwen3-next-80b-a3b.yaml
@@ -36,7 +36,12 @@ limits:
     max_input_tokens: 128000
     max_output_tokens: 8192
     max_tokens: 8192
-mode: chat
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: unknown
 model: qwen.qwen3-next-80b-a3b
 sources:
     - https://huggingface.co/Qwen/Qwen3-Next-80B-A3B-Instruct

--- a/providers/aws-bedrock/qwen.qwen3-vl-235b-a22b.yaml
+++ b/providers/aws-bedrock/qwen.qwen3-vl-235b-a22b.yaml
@@ -38,8 +38,11 @@ limits:
     max_tokens: 8192
 modalities:
     input:
+        - text
         - image
-mode: chat
+    output:
+        - text
+mode: unknown
 model: qwen.qwen3-vl-235b-a22b
 params:
     - defaultValue: 8192

--- a/providers/aws-bedrock/stability.sd3-5-large-v1:0.yaml
+++ b/providers/aws-bedrock/stability.sd3-5-large-v1:0.yaml
@@ -3,8 +3,11 @@ costs:
       region: us-west-2
 modalities:
     input:
+        - text
         - image
-mode: image
+    output:
+        - image
+mode: unknown
 model: stability.sd3-5-large-v1:0
 removeParams:
     - max_tokens

--- a/providers/aws-bedrock/stability.stable-image-core-v1:1.yaml
+++ b/providers/aws-bedrock/stability.stable-image-core-v1:1.yaml
@@ -6,8 +6,10 @@ limits:
     max_tokens: 4096
 modalities:
     input:
+        - text
+    output:
         - image
-mode: image
+mode: unknown
 model: stability.stable-image-core-v1:1
 removeParams:
     - max_tokens

--- a/providers/aws-bedrock/stability.stable-image-ultra-v1:1.yaml
+++ b/providers/aws-bedrock/stability.stable-image-ultra-v1:1.yaml
@@ -6,8 +6,10 @@ limits:
     max_tokens: 4096
 modalities:
     input:
+        - text
+    output:
         - image
-mode: image
+mode: unknown
 model: stability.stable-image-ultra-v1:1
 removeParams:
     - max_tokens

--- a/providers/aws-bedrock/us.amazon.nova-2-lite-v1:0.yaml
+++ b/providers/aws-bedrock/us.amazon.nova-2-lite-v1:0.yaml
@@ -35,7 +35,7 @@ modalities:
         - doc
         - image
         - pdf
-mode: chat
+mode: unknown
 model: us.amazon.nova-2-lite-v1:0
 params:
     - defaultValue: 65536

--- a/providers/aws-bedrock/us.amazon.nova-lite-v1:0.yaml
+++ b/providers/aws-bedrock/us.amazon.nova-lite-v1:0.yaml
@@ -34,7 +34,7 @@ modalities:
         - doc
         - image
         - pdf
-mode: chat
+mode: unknown
 model: us.amazon.nova-lite-v1:0
 params:
     - defaultValue: 512

--- a/providers/aws-bedrock/us.amazon.nova-micro-v1:0.yaml
+++ b/providers/aws-bedrock/us.amazon.nova-micro-v1:0.yaml
@@ -24,7 +24,7 @@ limits:
     max_input_tokens: 128000
     max_output_tokens: 10000
     max_tokens: 10000
-mode: chat
+mode: unknown
 model: us.amazon.nova-micro-v1:0
 params:
     - defaultValue: 512

--- a/providers/aws-bedrock/us.amazon.nova-premier-v1:0.yaml
+++ b/providers/aws-bedrock/us.amazon.nova-premier-v1:0.yaml
@@ -25,7 +25,7 @@ modalities:
         - doc
         - image
         - pdf
-mode: chat
+mode: unknown
 model: us.amazon.nova-premier-v1:0
 params:
     - defaultValue: 5000

--- a/providers/aws-bedrock/us.amazon.nova-pro-v1:0.yaml
+++ b/providers/aws-bedrock/us.amazon.nova-pro-v1:0.yaml
@@ -28,7 +28,7 @@ modalities:
         - doc
         - image
         - pdf
-mode: chat
+mode: unknown
 model: us.amazon.nova-pro-v1:0
 params:
     - defaultValue: 512

--- a/providers/aws-bedrock/us.anthropic.claude-3-5-haiku-20241022-v1:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-3-5-haiku-20241022-v1:0.yaml
@@ -28,7 +28,7 @@ limits:
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: us.anthropic.claude-3-5-haiku-20241022-v1:0
 params:
     - key: tool_choice

--- a/providers/aws-bedrock/us.anthropic.claude-3-5-sonnet-20240620-v1:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-3-5-sonnet-20240620-v1:0.yaml
@@ -23,7 +23,7 @@ limits:
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: us.anthropic.claude-3-5-sonnet-20240620-v1:0
 params:
     - key: max_tokens

--- a/providers/aws-bedrock/us.anthropic.claude-3-5-sonnet-20241022-v2:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-3-5-sonnet-20241022-v2:0.yaml
@@ -34,7 +34,7 @@ limits:
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: us.anthropic.claude-3-5-sonnet-20241022-v2:0
 params:
     - key: max_tokens

--- a/providers/aws-bedrock/us.anthropic.claude-3-7-sonnet-20250219-v1:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-3-7-sonnet-20250219-v1:0.yaml
@@ -29,7 +29,7 @@ limits:
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: us.anthropic.claude-3-7-sonnet-20250219-v1:0
 params:
     - key: max_tokens

--- a/providers/aws-bedrock/us.anthropic.claude-3-haiku-20240307-v1:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-3-haiku-20240307-v1:0.yaml
@@ -27,7 +27,7 @@ limits:
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: us.anthropic.claude-3-haiku-20240307-v1:0
 params:
     - key: tool_choice

--- a/providers/aws-bedrock/us.anthropic.claude-3-opus-20240229-v1:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-3-opus-20240229-v1:0.yaml
@@ -15,7 +15,7 @@ limits:
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: us.anthropic.claude-3-opus-20240229-v1:0
 params:
     - defaultValue: null

--- a/providers/aws-bedrock/us.anthropic.claude-3-sonnet-20240229-v1:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-3-sonnet-20240229-v1:0.yaml
@@ -19,7 +19,7 @@ limits:
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: us.anthropic.claude-3-sonnet-20240229-v1:0
 params:
     - defaultValue: null

--- a/providers/aws-bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0.yaml
@@ -46,7 +46,7 @@ limits:
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: us.anthropic.claude-haiku-4-5-20251001-v1:0
 params:
     - key: max_tokens

--- a/providers/aws-bedrock/us.anthropic.claude-opus-4-1-20250805-v1:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-opus-4-1-20250805-v1:0.yaml
@@ -30,7 +30,7 @@ limits:
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: us.anthropic.claude-opus-4-1-20250805-v1:0
 params:
     - key: max_tokens

--- a/providers/aws-bedrock/us.anthropic.claude-opus-4-20250514-v1:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-opus-4-20250514-v1:0.yaml
@@ -29,7 +29,7 @@ modalities:
     input:
         - image
         - pdf
-mode: chat
+mode: unknown
 model: us.anthropic.claude-opus-4-20250514-v1:0
 params:
     - key: max_tokens

--- a/providers/aws-bedrock/us.anthropic.claude-opus-4-5-20251101-v1:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-opus-4-5-20251101-v1:0.yaml
@@ -50,7 +50,7 @@ modalities:
     input:
         - image
         - pdf
-mode: chat
+mode: unknown
 model: us.anthropic.claude-opus-4-5-20251101-v1:0
 params:
     - key: max_tokens

--- a/providers/aws-bedrock/us.anthropic.claude-opus-4-6-v1.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-opus-4-6-v1.yaml
@@ -54,7 +54,7 @@ limits:
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: us.anthropic.claude-opus-4-6-v1
 params:
     - defaultValue: 4096

--- a/providers/aws-bedrock/us.anthropic.claude-sonnet-4-20250514-v1:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-sonnet-4-20250514-v1:0.yaml
@@ -97,7 +97,7 @@ modalities:
     input:
         - image
         - pdf
-mode: chat
+mode: unknown
 model: us.anthropic.claude-sonnet-4-20250514-v1:0
 params:
     - key: max_tokens

--- a/providers/aws-bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
@@ -116,7 +116,7 @@ modalities:
     input:
         - image
         - pdf
-mode: chat
+mode: unknown
 model: us.anthropic.claude-sonnet-4-5-20250929-v1:0
 params:
     - key: max_tokens

--- a/providers/aws-bedrock/us.anthropic.claude-sonnet-4-6.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-sonnet-4-6.yaml
@@ -59,7 +59,7 @@ modalities:
     input:
         - image
         - pdf
-mode: chat
+mode: unknown
 model: us.anthropic.claude-sonnet-4-6
 params:
     - defaultValue: 64000

--- a/providers/aws-bedrock/us.cohere.embed-v4:0.yaml
+++ b/providers/aws-bedrock/us.cohere.embed-v4:0.yaml
@@ -13,7 +13,7 @@ limits:
 modalities:
     input:
         - image
-mode: embedding
+mode: unknown
 model: us.cohere.embed-v4:0
 params:
     - defaultValue: 128000

--- a/providers/aws-bedrock/us.deepseek.r1-v1:0.yaml
+++ b/providers/aws-bedrock/us.deepseek.r1-v1:0.yaml
@@ -15,7 +15,7 @@ limits:
     max_input_tokens: 128000
     max_output_tokens: 32768
     max_tokens: 32768
-mode: chat
+mode: unknown
 model: us.deepseek.r1-v1:0
 params:
     - defaultValue: 512

--- a/providers/aws-bedrock/us.meta.llama3-1-405b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/us.meta.llama3-1-405b-instruct-v1:0.yaml
@@ -11,5 +11,5 @@ limits:
     max_input_tokens: 128000
     max_output_tokens: 4096
     max_tokens: 4096
-mode: chat
+mode: unknown
 model: us.meta.llama3-1-405b-instruct-v1:0

--- a/providers/aws-bedrock/us.meta.llama3-1-70b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/us.meta.llama3-1-70b-instruct-v1:0.yaml
@@ -19,7 +19,7 @@ limits:
 modalities:
     input:
         - doc
-mode: chat
+mode: unknown
 model: us.meta.llama3-1-70b-instruct-v1:0
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference-support.html

--- a/providers/aws-bedrock/us.meta.llama3-1-8b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/us.meta.llama3-1-8b-instruct-v1:0.yaml
@@ -19,7 +19,7 @@ limits:
 modalities:
     input:
         - doc
-mode: chat
+mode: unknown
 model: us.meta.llama3-1-8b-instruct-v1:0
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-meta.html

--- a/providers/aws-bedrock/us.meta.llama3-2-11b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/us.meta.llama3-2-11b-instruct-v1:0.yaml
@@ -18,5 +18,5 @@ limits:
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: us.meta.llama3-2-11b-instruct-v1:0

--- a/providers/aws-bedrock/us.meta.llama3-2-1b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/us.meta.llama3-2-1b-instruct-v1:0.yaml
@@ -15,5 +15,5 @@ limits:
     max_input_tokens: 128000
     max_output_tokens: 4096
     max_tokens: 4096
-mode: chat
+mode: unknown
 model: us.meta.llama3-2-1b-instruct-v1:0

--- a/providers/aws-bedrock/us.meta.llama3-2-3b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/us.meta.llama3-2-3b-instruct-v1:0.yaml
@@ -15,5 +15,5 @@ limits:
     max_input_tokens: 128000
     max_output_tokens: 4096
     max_tokens: 4096
-mode: chat
+mode: unknown
 model: us.meta.llama3-2-3b-instruct-v1:0

--- a/providers/aws-bedrock/us.meta.llama3-2-90b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/us.meta.llama3-2-90b-instruct-v1:0.yaml
@@ -20,7 +20,7 @@ modalities:
     input:
         - doc
         - image
-mode: chat
+mode: unknown
 model: us.meta.llama3-2-90b-instruct-v1:0
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-meta.html

--- a/providers/aws-bedrock/us.meta.llama3-3-70b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/us.meta.llama3-3-70b-instruct-v1:0.yaml
@@ -15,7 +15,7 @@ limits:
     max_input_tokens: 128000
     max_output_tokens: 4096
     max_tokens: 4096
-mode: chat
+mode: unknown
 model: us.meta.llama3-3-70b-instruct-v1:0
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html

--- a/providers/aws-bedrock/us.meta.llama4-maverick-17b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/us.meta.llama4-maverick-17b-instruct-v1:0.yaml
@@ -22,7 +22,7 @@ modalities:
     input:
         - doc
         - image
-mode: chat
+mode: unknown
 model: us.meta.llama4-maverick-17b-instruct-v1:0
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-meta-llama-4-maverick-17b-instruct.html

--- a/providers/aws-bedrock/us.meta.llama4-scout-17b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/us.meta.llama4-scout-17b-instruct-v1:0.yaml
@@ -23,7 +23,7 @@ modalities:
     input:
         - doc
         - image
-mode: chat
+mode: unknown
 model: us.meta.llama4-scout-17b-instruct-v1:0
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference-supported-models-features.html

--- a/providers/aws-bedrock/us.mistral.pixtral-large-2502-v1:0.yaml
+++ b/providers/aws-bedrock/us.mistral.pixtral-large-2502-v1:0.yaml
@@ -19,7 +19,7 @@ limits:
 modalities:
     input:
         - image
-mode: chat
+mode: unknown
 model: us.mistral.pixtral-large-2502-v1:0
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-mistral-pixtral-large.html

--- a/providers/aws-bedrock/us.stability.stable-conservative-upscale-v1:0.yaml
+++ b/providers/aws-bedrock/us.stability.stable-conservative-upscale-v1:0.yaml
@@ -11,7 +11,7 @@ messages:
 modalities:
     input:
         - image
-mode: image
+mode: unknown
 model: us.stability.stable-conservative-upscale-v1:0
 params:
     - defaultValue: 0

--- a/providers/aws-bedrock/us.stability.stable-creative-upscale-v1:0.yaml
+++ b/providers/aws-bedrock/us.stability.stable-creative-upscale-v1:0.yaml
@@ -8,7 +8,7 @@ costs:
 modalities:
     input:
         - image
-mode: image
+mode: unknown
 model: us.stability.stable-creative-upscale-v1:0
 removeParams:
     - max_tokens

--- a/providers/aws-bedrock/us.stability.stable-fast-upscale-v1:0.yaml
+++ b/providers/aws-bedrock/us.stability.stable-fast-upscale-v1:0.yaml
@@ -1,9 +1,13 @@
+costs:
+    - region: us-west-2
+    - region: us-east-2
+    - region: us-east-1
 messages:
     options: []
 modalities:
     input:
         - image
-mode: image
+mode: unknown
 model: us.stability.stable-fast-upscale-v1:0
 removeParams:
     - max_tokens

--- a/providers/aws-bedrock/us.stability.stable-image-control-sketch-v1:0.yaml
+++ b/providers/aws-bedrock/us.stability.stable-image-control-sketch-v1:0.yaml
@@ -8,7 +8,7 @@ costs:
 modalities:
     input:
         - image
-mode: image
+mode: unknown
 model: us.stability.stable-image-control-sketch-v1:0
 removeParams:
     - max_tokens

--- a/providers/aws-bedrock/us.stability.stable-image-control-structure-v1:0.yaml
+++ b/providers/aws-bedrock/us.stability.stable-image-control-structure-v1:0.yaml
@@ -8,7 +8,7 @@ costs:
 modalities:
     input:
         - image
-mode: image
+mode: unknown
 model: us.stability.stable-image-control-structure-v1:0
 removeParams:
     - max_tokens

--- a/providers/aws-bedrock/us.stability.stable-image-erase-object-v1:0.yaml
+++ b/providers/aws-bedrock/us.stability.stable-image-erase-object-v1:0.yaml
@@ -8,7 +8,7 @@ costs:
 modalities:
     input:
         - image
-mode: image
+mode: unknown
 model: us.stability.stable-image-erase-object-v1:0
 params:
     - defaultValue: 0

--- a/providers/aws-bedrock/us.stability.stable-image-inpaint-v1:0.yaml
+++ b/providers/aws-bedrock/us.stability.stable-image-inpaint-v1:0.yaml
@@ -10,7 +10,7 @@ messages:
 modalities:
     input:
         - image
-mode: image
+mode: unknown
 model: us.stability.stable-image-inpaint-v1:0
 removeParams:
     - max_tokens

--- a/providers/aws-bedrock/us.stability.stable-image-remove-background-v1:0.yaml
+++ b/providers/aws-bedrock/us.stability.stable-image-remove-background-v1:0.yaml
@@ -11,7 +11,7 @@ messages:
 modalities:
     input:
         - image
-mode: image
+mode: unknown
 model: us.stability.stable-image-remove-background-v1:0
 removeParams:
     - max_tokens

--- a/providers/aws-bedrock/us.stability.stable-image-search-recolor-v1:0.yaml
+++ b/providers/aws-bedrock/us.stability.stable-image-search-recolor-v1:0.yaml
@@ -8,7 +8,7 @@ costs:
 modalities:
     input:
         - image
-mode: image
+mode: unknown
 model: us.stability.stable-image-search-recolor-v1:0
 removeParams:
     - max_tokens

--- a/providers/aws-bedrock/us.stability.stable-image-search-replace-v1:0.yaml
+++ b/providers/aws-bedrock/us.stability.stable-image-search-replace-v1:0.yaml
@@ -8,7 +8,7 @@ costs:
 modalities:
     input:
         - image
-mode: image
+mode: unknown
 model: us.stability.stable-image-search-replace-v1:0
 removeParams:
     - max_tokens

--- a/providers/aws-bedrock/us.stability.stable-image-style-guide-v1:0.yaml
+++ b/providers/aws-bedrock/us.stability.stable-image-style-guide-v1:0.yaml
@@ -8,7 +8,7 @@ costs:
 modalities:
     input:
         - image
-mode: image
+mode: unknown
 model: us.stability.stable-image-style-guide-v1:0
 removeParams:
     - max_tokens

--- a/providers/aws-bedrock/us.stability.stable-outpaint-v1:0.yaml
+++ b/providers/aws-bedrock/us.stability.stable-outpaint-v1:0.yaml
@@ -8,7 +8,7 @@ costs:
 modalities:
     input:
         - image
-mode: image
+mode: unknown
 model: us.stability.stable-outpaint-v1:0
 removeParams:
     - max_tokens

--- a/providers/aws-bedrock/us.stability.stable-style-transfer-v1:0.yaml
+++ b/providers/aws-bedrock/us.stability.stable-style-transfer-v1:0.yaml
@@ -8,7 +8,7 @@ costs:
 modalities:
     input:
         - image
-mode: image
+mode: unknown
 model: us.stability.stable-style-transfer-v1:0
 removeParams:
     - max_tokens

--- a/providers/aws-bedrock/us.writer.palmyra-x4-v1:0.yaml
+++ b/providers/aws-bedrock/us.writer.palmyra-x4-v1:0.yaml
@@ -22,7 +22,7 @@ limits:
 modalities:
     input:
         - doc
-mode: chat
+mode: unknown
 model: us.writer.palmyra-x4-v1:0
 params:
     - defaultValue: 16

--- a/providers/aws-bedrock/us.writer.palmyra-x5-v1:0.yaml
+++ b/providers/aws-bedrock/us.writer.palmyra-x5-v1:0.yaml
@@ -19,7 +19,7 @@ limits:
     max_input_tokens: 1040000
     max_output_tokens: 8192
     max_tokens: 8192
-mode: chat
+mode: unknown
 model: us.writer.palmyra-x5-v1:0
 params:
     - defaultValue: 16

--- a/providers/aws-bedrock/zai.glm-4.7-flash.yaml
+++ b/providers/aws-bedrock/zai.glm-4.7-flash.yaml
@@ -40,7 +40,12 @@ costs:
       region: ap-northeast-1
 features:
     - function_calling
-mode: chat
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: unknown
 model: zai.glm-4.7-flash
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference-supported-models-features.html

--- a/providers/aws-bedrock/zai.glm-4.7.yaml
+++ b/providers/aws-bedrock/zai.glm-4.7.yaml
@@ -35,7 +35,12 @@ limits:
     context_window: 128000
     max_output_tokens: 4000
     max_tokens: 4000
-mode: chat
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: unknown
 model: zai.glm-4.7
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-zai-glm-4-7.html

--- a/providers/aws-bedrock/zai.glm-5.yaml
+++ b/providers/aws-bedrock/zai.glm-5.yaml
@@ -1,3 +1,6 @@
+costs:
+    - region: us-west-2
+    - region: us-east-1
 modalities:
     input:
         - text


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `aws-bedrock`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large, auto-generated updates to many Bedrock model YAML specs (modalities, mode, and region pricing) could affect model capability detection and cost/routing logic, but no executable code paths are changed.
> 
> **Overview**
> Updates the AWS Bedrock model catalog YAMLs to **standardize `modalities` (input/output types) and set `mode: unknown`** across a wide set of chat/embedding/rerank/image/video models.
> 
> Also expands model metadata with **additional regional cost entries** for several Nova/Claude/Cohere/DeepSeek/OpenAI/Qwen/NVIDIA/Stability/etc. models, and adds/adjusts a few model-specific fields like `removeParams`/limits where needed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff05231107c2914c3c4d8558d876314af90f160c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->