### PR TITLE
feat(aws-bedrock): update model YAMLs [bot]

### DIFF
--- a/providers/aws-bedrock/amazon.nova-2-sonic-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.nova-2-sonic-v1:0.yaml
@@ -28,13 +28,23 @@ limits:
     max_output_tokens: 65536
     max_tokens: 65536
 modalities:
+    input:
+        - text
+        - audio
     output:
         - text
+        - audio
 mode: chat
 model: amazon.nova-2-sonic-v1:0
+params:
+    - defaultValue: 65536
+      key: max_tokens
+      maxValue: 65536
+      minValue: 1
 sources:
     - https://aws.amazon.com/nova/models/
     - https://docs.aws.amazon.com/nova/latest/nova2-userguide/what-is-nova-2.html
     - https://docs.aws.amazon.com/nova/latest/nova2-userguide/using-conversational-speech.html
     - https://docs.aws.amazon.com/ai/responsible-ai/nova-2-sonic/overview.html
     - https://aws.amazon.com/nova/pricing/
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-amazon-nova-2-sonic.html

--- a/providers/aws-bedrock/amazon.nova-micro-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.nova-micro-v1:0.yaml
@@ -41,6 +41,9 @@ params:
       key: temperature
       maxValue: 1
       minValue: 0.00001
+    - key: top_k
+      maxValue: 128
+      minValue: 0
 removeParams:
     - "n"
 sources:

--- a/providers/aws-bedrock/amazon.nova-pro-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.nova-pro-v1:0.yaml
@@ -101,13 +101,15 @@ features:
     - tools
 limits:
     context_window: 300000
-    max_input_tokens: 295000
     max_output_tokens: 5000
     max_tokens: 5000
 modalities:
     input:
         - text
         - image
+        - video
+        - pdf
+        - doc
     output:
         - text
 mode: chat
@@ -121,8 +123,7 @@ params:
       key: temperature
       maxValue: 1
       minValue: 0.00001
-    - defaultValue: 250
-      key: top_k
+    - key: top_k
       maxValue: 128
       minValue: 0
 removeParams:

--- a/providers/aws-bedrock/amazon.nova-sonic-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.nova-sonic-v1:0.yaml
@@ -18,6 +18,7 @@ features:
     - function_calling
     - tools
     - system_messages
+isDeprecated: true
 limits:
     context_window: 300000
 modalities:

--- a/providers/aws-bedrock/amazon.titan-embed-g1-text-02.yaml
+++ b/providers/aws-bedrock/amazon.titan-embed-g1-text-02.yaml
@@ -3,6 +3,7 @@ costs:
       region: us-west-2
     - input_cost_per_token: 1.e-7
       region: us-east-1
+isDeprecated: true
 modalities:
     input:
         - text

--- a/providers/aws-bedrock/anthropic.claude-opus-4-6-v1.yaml
+++ b/providers/aws-bedrock/anthropic.claude-opus-4-6-v1.yaml
@@ -1,10 +1,195 @@
 costs:
-    - region: eu-west-2
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: us-west-2
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: us-west-1
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: us-east-2
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: us-east-1
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: sa-east-1
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: mx-central-1
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: me-south-1
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: me-central-1
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: il-central-1
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: eu-west-3
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: eu-west-2
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: eu-west-1
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: eu-south-2
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: eu-south-1
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: eu-north-1
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: eu-central-2
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: eu-central-1
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: ca-west-1
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: ca-central-1
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: ap-southeast-7
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: ap-southeast-5
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: ap-southeast-4
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: ap-southeast-3
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: ap-southeast-2
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: ap-southeast-1
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: ap-south-2
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: ap-south-1
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: ap-northeast-3
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: ap-northeast-2
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: ap-northeast-1
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: ap-east-2
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: af-south-1
+features:
+    - function_calling
+    - system_messages
+    - tool_choice
+    - prompt_caching
+    - cache_control
+    - assistant_prefill
+    - tools
+    - structured_output
+limits:
+    context_window: 1000000
+    max_output_tokens: 128000
+    max_tokens: 128000
+    tool_use_system_prompt_tokens: 346
 modalities:
     input:
         - text
         - image
+        - pdf
     output:
         - text
-mode: unknown
+mode: chat
 model: anthropic.claude-opus-4-6-v1
+params:
+    - defaultValue: 512
+      key: max_tokens
+      maxValue: 128000
+      minValue: 1
+removeParams:
+    - "n"
+sources:
+    - https://platform.claude.com/docs/en/docs/about-claude/models
+    - https://platform.claude.com/docs/en/docs/about-claude/pricing
+thinking: true

--- a/providers/aws-bedrock/anthropic.claude-sonnet-4-6.yaml
+++ b/providers/aws-bedrock/anthropic.claude-sonnet-4-6.yaml
@@ -6,19 +6,6 @@ costs:
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: us-west-2
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 6.e-7
-                from: 200000
-          cache_write:
-              - cost_per_token: 0.0000075
-                from: 200000
-          input:
-              - cost_per_token: 0.000006
-                from: 200000
-          output:
-              - cost_per_token: 0.0000225
-                from: 200000
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3.e-7
       input_cost_per_token: 0.000003
@@ -26,19 +13,6 @@ costs:
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: us-west-1
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 6.e-7
-                from: 200000
-          cache_write:
-              - cost_per_token: 0.0000075
-                from: 200000
-          input:
-              - cost_per_token: 0.000006
-                from: 200000
-          output:
-              - cost_per_token: 0.0000225
-                from: 200000
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3.e-7
       input_cost_per_token: 0.000003
@@ -46,19 +20,6 @@ costs:
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: us-east-2
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 6.e-7
-                from: 200000
-          cache_write:
-              - cost_per_token: 0.0000075
-                from: 200000
-          input:
-              - cost_per_token: 0.000006
-                from: 200000
-          output:
-              - cost_per_token: 0.0000225
-                from: 200000
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3.e-7
       input_cost_per_token: 0.000003
@@ -66,19 +27,6 @@ costs:
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: us-east-1
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 6.e-7
-                from: 200000
-          cache_write:
-              - cost_per_token: 0.0000075
-                from: 200000
-          input:
-              - cost_per_token: 0.000006
-                from: 200000
-          output:
-              - cost_per_token: 0.0000225
-                from: 200000
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3.e-7
       input_cost_per_token: 0.000003
@@ -86,19 +34,6 @@ costs:
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: sa-east-1
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 6.e-7
-                from: 200000
-          cache_write:
-              - cost_per_token: 0.0000075
-                from: 200000
-          input:
-              - cost_per_token: 0.000006
-                from: 200000
-          output:
-              - cost_per_token: 0.0000225
-                from: 200000
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3.e-7
       input_cost_per_token: 0.000003
@@ -106,19 +41,6 @@ costs:
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: mx-central-1
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 6.e-7
-                from: 200000
-          cache_write:
-              - cost_per_token: 0.0000075
-                from: 200000
-          input:
-              - cost_per_token: 0.000006
-                from: 200000
-          output:
-              - cost_per_token: 0.0000225
-                from: 200000
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3.e-7
       input_cost_per_token: 0.000003
@@ -126,19 +48,6 @@ costs:
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: me-south-1
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 6.e-7
-                from: 200000
-          cache_write:
-              - cost_per_token: 0.0000075
-                from: 200000
-          input:
-              - cost_per_token: 0.000006
-                from: 200000
-          output:
-              - cost_per_token: 0.0000225
-                from: 200000
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3.e-7
       input_cost_per_token: 0.000003
@@ -146,19 +55,6 @@ costs:
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: me-central-1
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 6.e-7
-                from: 200000
-          cache_write:
-              - cost_per_token: 0.0000075
-                from: 200000
-          input:
-              - cost_per_token: 0.000006
-                from: 200000
-          output:
-              - cost_per_token: 0.0000225
-                from: 200000
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3.e-7
       input_cost_per_token: 0.000003
@@ -166,19 +62,6 @@ costs:
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: il-central-1
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 6.e-7
-                from: 200000
-          cache_write:
-              - cost_per_token: 0.0000075
-                from: 200000
-          input:
-              - cost_per_token: 0.000006
-                from: 200000
-          output:
-              - cost_per_token: 0.0000225
-                from: 200000
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3.e-7
       input_cost_per_token: 0.000003
@@ -186,19 +69,6 @@ costs:
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: eu-west-3
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 6.e-7
-                from: 200000
-          cache_write:
-              - cost_per_token: 0.0000075
-                from: 200000
-          input:
-              - cost_per_token: 0.000006
-                from: 200000
-          output:
-              - cost_per_token: 0.0000225
-                from: 200000
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3.e-7
       input_cost_per_token: 0.000003
@@ -206,19 +76,6 @@ costs:
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: eu-west-2
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 6.e-7
-                from: 200000
-          cache_write:
-              - cost_per_token: 0.0000075
-                from: 200000
-          input:
-              - cost_per_token: 0.000006
-                from: 200000
-          output:
-              - cost_per_token: 0.0000225
-                from: 200000
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3.e-7
       input_cost_per_token: 0.000003
@@ -226,19 +83,6 @@ costs:
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: eu-west-1
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 6.e-7
-                from: 200000
-          cache_write:
-              - cost_per_token: 0.0000075
-                from: 200000
-          input:
-              - cost_per_token: 0.000006
-                from: 200000
-          output:
-              - cost_per_token: 0.0000225
-                from: 200000
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3.e-7
       input_cost_per_token: 0.000003
@@ -246,19 +90,6 @@ costs:
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: eu-south-2
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 6.e-7
-                from: 200000
-          cache_write:
-              - cost_per_token: 0.0000075
-                from: 200000
-          input:
-              - cost_per_token: 0.000006
-                from: 200000
-          output:
-              - cost_per_token: 0.0000225
-                from: 200000
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3.e-7
       input_cost_per_token: 0.000003
@@ -266,19 +97,6 @@ costs:
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: eu-south-1
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 6.e-7
-                from: 200000
-          cache_write:
-              - cost_per_token: 0.0000075
-                from: 200000
-          input:
-              - cost_per_token: 0.000006
-                from: 200000
-          output:
-              - cost_per_token: 0.0000225
-                from: 200000
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3.e-7
       input_cost_per_token: 0.000003
@@ -286,19 +104,6 @@ costs:
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: eu-north-1
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 6.e-7
-                from: 200000
-          cache_write:
-              - cost_per_token: 0.0000075
-                from: 200000
-          input:
-              - cost_per_token: 0.000006
-                from: 200000
-          output:
-              - cost_per_token: 0.0000225
-                from: 200000
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3.e-7
       input_cost_per_token: 0.000003
@@ -306,19 +111,6 @@ costs:
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: eu-central-2
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 6.e-7
-                from: 200000
-          cache_write:
-              - cost_per_token: 0.0000075
-                from: 200000
-          input:
-              - cost_per_token: 0.000006
-                from: 200000
-          output:
-              - cost_per_token: 0.0000225
-                from: 200000
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3.e-7
       input_cost_per_token: 0.000003
@@ -326,19 +118,6 @@ costs:
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: eu-central-1
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 6.e-7
-                from: 200000
-          cache_write:
-              - cost_per_token: 0.0000075
-                from: 200000
-          input:
-              - cost_per_token: 0.000006
-                from: 200000
-          output:
-              - cost_per_token: 0.0000225
-                from: 200000
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3.e-7
       input_cost_per_token: 0.000003
@@ -346,19 +125,6 @@ costs:
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ca-west-1
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 6.e-7
-                from: 200000
-          cache_write:
-              - cost_per_token: 0.0000075
-                from: 200000
-          input:
-              - cost_per_token: 0.000006
-                from: 200000
-          output:
-              - cost_per_token: 0.0000225
-                from: 200000
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3.e-7
       input_cost_per_token: 0.000003
@@ -366,19 +132,6 @@ costs:
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ca-central-1
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 6.e-7
-                from: 200000
-          cache_write:
-              - cost_per_token: 0.0000075
-                from: 200000
-          input:
-              - cost_per_token: 0.000006
-                from: 200000
-          output:
-              - cost_per_token: 0.0000225
-                from: 200000
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3.e-7
       input_cost_per_token: 0.000003
@@ -386,19 +139,6 @@ costs:
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ap-southeast-7
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 6.e-7
-                from: 200000
-          cache_write:
-              - cost_per_token: 0.0000075
-                from: 200000
-          input:
-              - cost_per_token: 0.000006
-                from: 200000
-          output:
-              - cost_per_token: 0.0000225
-                from: 200000
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3.e-7
       input_cost_per_token: 0.000003
@@ -406,19 +146,6 @@ costs:
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ap-southeast-5
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 6.e-7
-                from: 200000
-          cache_write:
-              - cost_per_token: 0.0000075
-                from: 200000
-          input:
-              - cost_per_token: 0.000006
-                from: 200000
-          output:
-              - cost_per_token: 0.0000225
-                from: 200000
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3.e-7
       input_cost_per_token: 0.000003
@@ -426,19 +153,6 @@ costs:
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ap-southeast-4
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 6.e-7
-                from: 200000
-          cache_write:
-              - cost_per_token: 0.0000075
-                from: 200000
-          input:
-              - cost_per_token: 0.000006
-                from: 200000
-          output:
-              - cost_per_token: 0.0000225
-                from: 200000
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3.e-7
       input_cost_per_token: 0.000003
@@ -446,19 +160,6 @@ costs:
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ap-southeast-3
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 6.e-7
-                from: 200000
-          cache_write:
-              - cost_per_token: 0.0000075
-                from: 200000
-          input:
-              - cost_per_token: 0.000006
-                from: 200000
-          output:
-              - cost_per_token: 0.0000225
-                from: 200000
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3.e-7
       input_cost_per_token: 0.000003
@@ -466,19 +167,6 @@ costs:
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ap-southeast-2
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 6.e-7
-                from: 200000
-          cache_write:
-              - cost_per_token: 0.0000075
-                from: 200000
-          input:
-              - cost_per_token: 0.000006
-                from: 200000
-          output:
-              - cost_per_token: 0.0000225
-                from: 200000
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3.e-7
       input_cost_per_token: 0.000003
@@ -486,19 +174,6 @@ costs:
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ap-southeast-1
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 6.e-7
-                from: 200000
-          cache_write:
-              - cost_per_token: 0.0000075
-                from: 200000
-          input:
-              - cost_per_token: 0.000006
-                from: 200000
-          output:
-              - cost_per_token: 0.0000225
-                from: 200000
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3.e-7
       input_cost_per_token: 0.000003
@@ -506,19 +181,6 @@ costs:
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ap-south-2
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 6.e-7
-                from: 200000
-          cache_write:
-              - cost_per_token: 0.0000075
-                from: 200000
-          input:
-              - cost_per_token: 0.000006
-                from: 200000
-          output:
-              - cost_per_token: 0.0000225
-                from: 200000
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3.e-7
       input_cost_per_token: 0.000003
@@ -526,19 +188,6 @@ costs:
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ap-south-1
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 6.e-7
-                from: 200000
-          cache_write:
-              - cost_per_token: 0.0000075
-                from: 200000
-          input:
-              - cost_per_token: 0.000006
-                from: 200000
-          output:
-              - cost_per_token: 0.0000225
-                from: 200000
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3.e-7
       input_cost_per_token: 0.000003
@@ -546,19 +195,6 @@ costs:
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ap-northeast-3
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 6.e-7
-                from: 200000
-          cache_write:
-              - cost_per_token: 0.0000075
-                from: 200000
-          input:
-              - cost_per_token: 0.000006
-                from: 200000
-          output:
-              - cost_per_token: 0.0000225
-                from: 200000
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3.e-7
       input_cost_per_token: 0.000003
@@ -566,19 +202,6 @@ costs:
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ap-northeast-2
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 6.e-7
-                from: 200000
-          cache_write:
-              - cost_per_token: 0.0000075
-                from: 200000
-          input:
-              - cost_per_token: 0.000006
-                from: 200000
-          output:
-              - cost_per_token: 0.0000225
-                from: 200000
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3.e-7
       input_cost_per_token: 0.000003
@@ -586,19 +209,6 @@ costs:
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ap-northeast-1
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 6.e-7
-                from: 200000
-          cache_write:
-              - cost_per_token: 0.0000075
-                from: 200000
-          input:
-              - cost_per_token: 0.000006
-                from: 200000
-          output:
-              - cost_per_token: 0.0000225
-                from: 200000
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3.e-7
       input_cost_per_token: 0.000003
@@ -606,19 +216,6 @@ costs:
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ap-east-2
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 6.e-7
-                from: 200000
-          cache_write:
-              - cost_per_token: 0.0000075
-                from: 200000
-          input:
-              - cost_per_token: 0.000006
-                from: 200000
-          output:
-              - cost_per_token: 0.0000225
-                from: 200000
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3.e-7
       input_cost_per_token: 0.000003
@@ -626,24 +223,12 @@ costs:
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: af-south-1
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 6.e-7
-                from: 200000
-          cache_write:
-              - cost_per_token: 0.0000075
-                from: 200000
-          input:
-              - cost_per_token: 0.000006
-                from: 200000
-          output:
-              - cost_per_token: 0.0000225
-                from: 200000
 features:
     - function_calling
+    - prompt_caching
 limits:
-    context_window: 200000
-    max_input_tokens: 200000
+    context_window: 1000000
+    max_input_tokens: 1000000
     max_output_tokens: 64000
     max_tokens: 64000
     tool_use_system_prompt_tokens: 346

--- a/providers/aws-bedrock/meta.llama3-3-70b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/meta.llama3-3-70b-instruct-v1:0.yaml
@@ -32,4 +32,5 @@ removeParams:
     - "n"
 sources:
     - https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct
-    - https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonBedrock/current/index.json
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-meta.html
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/model-lifecycle.html

--- a/providers/aws-bedrock/minimax.minimax-m2.5.yaml
+++ b/providers/aws-bedrock/minimax.minimax-m2.5.yaml
@@ -1,10 +1,33 @@
 costs:
-    - region: us-west-2
-    - region: us-east-1
+    - cache_creation_input_token_cost: 3.75e-7
+      cache_read_input_token_cost: 3.e-8
+      input_cost_per_token: 3.e-7
+      output_cost_per_token: 0.0000012
+      region: us-west-2
+    - cache_creation_input_token_cost: 3.75e-7
+      cache_read_input_token_cost: 3.e-8
+      input_cost_per_token: 3.e-7
+      output_cost_per_token: 0.0000012
+      region: us-east-1
+features:
+    - function_calling
+    - system_messages
+    - tool_choice
+limits:
+    context_window: 204800
 modalities:
     input:
         - text
     output:
         - text
-mode: unknown
+mode: chat
 model: minimax.minimax-m2.5
+removeParams:
+    - "n"
+sources:
+    - https://aws.amazon.com/about-aws/whats-new/2026/03/amazon-bedrock-minimax-glm/
+    - https://platform.minimax.io/docs/api-reference/api-overview
+    - https://platform.minimax.io/docs/guides/pricing-paygo
+    - https://platform.minimax.io/docs/api-reference/text-anthropic-api
+    - https://www.minimax.io/news/minimax-m25
+thinking: true

--- a/providers/aws-bedrock/mistral.devstral-2-123b.yaml
+++ b/providers/aws-bedrock/mistral.devstral-2-123b.yaml
@@ -53,4 +53,3 @@ mode: chat
 model: mistral.devstral-2-123b
 sources:
     - https://docs.mistral.ai/models/devstral-2-25-12
-thinking: false

--- a/providers/aws-bedrock/nvidia.nemotron-super-3-120b.yaml
+++ b/providers/aws-bedrock/nvidia.nemotron-super-3-120b.yaml
@@ -1,10 +1,32 @@
 costs:
-    - region: us-west-2
-    - region: us-east-1
+    - input_cost_per_token: 1.5e-7
+      output_cost_per_token: 6.5e-7
+      region: us-west-2
+    - input_cost_per_token: 1.5e-7
+      output_cost_per_token: 6.5e-7
+      region: us-east-1
+features:
+    - function_calling
+    - tool_choice
+    - system_messages
+    - structured_output
+limits:
+    max_output_tokens: 32768
+    max_tokens: 32768
 modalities:
     input:
         - text
     output:
         - text
-mode: unknown
+mode: chat
 model: nvidia.nemotron-super-3-120b
+params:
+    - key: max_tokens
+      maxValue: 32768
+removeParams:
+    - "n"
+sources:
+    - https://build.nvidia.com/nvidia/nemotron-3-super-120b-a12b/modelcard
+    - https://aws.amazon.com/marketplace/pp/prodview-pb4o36dbo6dzi
+    - https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16
+thinking: true

--- a/providers/aws-bedrock/us.stability.stable-conservative-upscale-v1:0.yaml
+++ b/providers/aws-bedrock/us.stability.stable-conservative-upscale-v1:0.yaml
@@ -10,6 +10,9 @@ messages:
         - user
 modalities:
     input:
+        - text
+        - image
+    output:
         - image
 mode: image
 model: us.stability.stable-conservative-upscale-v1:0

--- a/providers/aws-bedrock/us.stability.stable-creative-upscale-v1:0.yaml
+++ b/providers/aws-bedrock/us.stability.stable-creative-upscale-v1:0.yaml
@@ -7,6 +7,9 @@ costs:
       region: us-east-1
 modalities:
     input:
+        - text
+        - image
+    output:
         - image
 mode: image
 model: us.stability.stable-creative-upscale-v1:0

--- a/providers/aws-bedrock/us.stability.stable-fast-upscale-v1:0.yaml
+++ b/providers/aws-bedrock/us.stability.stable-fast-upscale-v1:0.yaml
@@ -1,11 +1,16 @@
 costs:
-    - region: us-west-2
-    - region: us-east-2
-    - region: us-east-1
+    - input_cost_per_image: 0.03
+      region: us-west-2
+    - input_cost_per_image: 0.03
+      region: us-east-2
+    - input_cost_per_image: 0.03
+      region: us-east-1
 messages:
     options: []
 modalities:
     input:
+        - image
+    output:
         - image
 mode: image
 model: us.stability.stable-fast-upscale-v1:0

--- a/providers/aws-bedrock/us.stability.stable-image-control-sketch-v1:0.yaml
+++ b/providers/aws-bedrock/us.stability.stable-image-control-sketch-v1:0.yaml
@@ -7,6 +7,9 @@ costs:
       region: us-east-1
 modalities:
     input:
+        - text
+        - image
+    output:
         - image
 mode: image
 model: us.stability.stable-image-control-sketch-v1:0
@@ -19,3 +22,4 @@ removeParams:
     - stream
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/stable-image-services.html
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-stability-ai-stable-image-control-sketch.html

--- a/providers/aws-bedrock/us.stability.stable-image-control-structure-v1:0.yaml
+++ b/providers/aws-bedrock/us.stability.stable-image-control-structure-v1:0.yaml
@@ -7,6 +7,9 @@ costs:
       region: us-east-1
 modalities:
     input:
+        - text
+        - image
+    output:
         - image
 mode: image
 model: us.stability.stable-image-control-structure-v1:0

--- a/providers/aws-bedrock/us.stability.stable-image-erase-object-v1:0.yaml
+++ b/providers/aws-bedrock/us.stability.stable-image-erase-object-v1:0.yaml
@@ -7,6 +7,9 @@ costs:
       region: us-east-1
 modalities:
     input:
+        - text
+        - image
+    output:
         - image
 mode: image
 model: us.stability.stable-image-erase-object-v1:0
@@ -25,3 +28,4 @@ removeParams:
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/stable-image-services.html
     - https://aws.amazon.com/about-aws/whats-new/2025/10/stability-ai-image-updates-amazon-bedrock/
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html

--- a/providers/aws-bedrock/us.stability.stable-image-inpaint-v1:0.yaml
+++ b/providers/aws-bedrock/us.stability.stable-image-inpaint-v1:0.yaml
@@ -9,6 +9,9 @@ messages:
     options: []
 modalities:
     input:
+        - text
+        - image
+    output:
         - image
 mode: image
 model: us.stability.stable-image-inpaint-v1:0

--- a/providers/aws-bedrock/us.stability.stable-image-remove-background-v1:0.yaml
+++ b/providers/aws-bedrock/us.stability.stable-image-remove-background-v1:0.yaml
@@ -11,6 +11,8 @@ messages:
 modalities:
     input:
         - image
+    output:
+        - image
 mode: image
 model: us.stability.stable-image-remove-background-v1:0
 removeParams:

--- a/providers/aws-bedrock/us.stability.stable-image-search-recolor-v1:0.yaml
+++ b/providers/aws-bedrock/us.stability.stable-image-search-recolor-v1:0.yaml
@@ -8,6 +8,8 @@ costs:
 modalities:
     input:
         - image
+    output:
+        - image
 mode: image
 model: us.stability.stable-image-search-recolor-v1:0
 removeParams:

--- a/providers/aws-bedrock/us.stability.stable-image-search-replace-v1:0.yaml
+++ b/providers/aws-bedrock/us.stability.stable-image-search-replace-v1:0.yaml
@@ -8,6 +8,8 @@ costs:
 modalities:
     input:
         - image
+    output:
+        - image
 mode: image
 model: us.stability.stable-image-search-replace-v1:0
 removeParams:
@@ -19,3 +21,4 @@ removeParams:
     - stream
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/stable-image-services.html
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html

--- a/providers/aws-bedrock/us.stability.stable-image-style-guide-v1:0.yaml
+++ b/providers/aws-bedrock/us.stability.stable-image-style-guide-v1:0.yaml
@@ -7,6 +7,9 @@ costs:
       region: us-east-1
 modalities:
     input:
+        - text
+        - image
+    output:
         - image
 mode: image
 model: us.stability.stable-image-style-guide-v1:0

--- a/providers/aws-bedrock/us.stability.stable-outpaint-v1:0.yaml
+++ b/providers/aws-bedrock/us.stability.stable-outpaint-v1:0.yaml
@@ -1,12 +1,15 @@
 costs:
-    - input_cost_per_image: 0
+    - input_cost_per_image: 0.06
       region: us-west-2
-    - input_cost_per_image: 0
+    - input_cost_per_image: 0.06
       region: us-east-2
-    - input_cost_per_image: 0
+    - input_cost_per_image: 0.06
       region: us-east-1
 modalities:
     input:
+        - image
+        - text
+    output:
         - image
 mode: image
 model: us.stability.stable-outpaint-v1:0
@@ -19,3 +22,4 @@ removeParams:
     - stream
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/stable-image-services.html
+    - https://docs.aws.amazon.com/en_us/bedrock/latest/userguide/model-card-stability-ai-stable-image-outpaint.html

--- a/providers/aws-bedrock/us.stability.stable-style-transfer-v1:0.yaml
+++ b/providers/aws-bedrock/us.stability.stable-style-transfer-v1:0.yaml
@@ -7,6 +7,9 @@ costs:
       region: us-east-1
 modalities:
     input:
+        - text
+        - image
+    output:
         - image
 mode: image
 model: us.stability.stable-style-transfer-v1:0
@@ -19,3 +22,4 @@ removeParams:
     - stream
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/stable-image-services.html
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html

--- a/providers/aws-bedrock/zai.glm-5.yaml
+++ b/providers/aws-bedrock/zai.glm-5.yaml
@@ -1,10 +1,31 @@
 costs:
-    - region: us-west-2
-    - region: us-east-1
+    - input_cost_per_token: 0.000001
+      output_cost_per_token: 0.0000032
+      region: us-west-2
+    - input_cost_per_token: 0.000001
+      output_cost_per_token: 0.0000032
+      region: us-east-1
+features:
+    - function_calling
+    - structured_output
+    - prompt_caching
+limits:
+    context_window: 200000
+    max_output_tokens: 128000
+    max_tokens: 128000
 modalities:
     input:
         - text
     output:
         - text
-mode: unknown
+mode: chat
 model: zai.glm-5
+params:
+    - defaultValue: 512
+      key: max_tokens
+      maxValue: 128000
+      minValue: 1
+sources:
+    - https://aws.amazon.com/about-aws/whats-new/2026/03/amazon-bedrock-minimax-glm/
+    - https://docs.z.ai/guides/llm/glm-5
+thinking: true


### PR DESCRIPTION
Auto-generated by poc-agent for provider `aws-bedrock`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily updates provider YAML metadata (limits, modalities, params, pricing) which can change routing/validation behavior and displayed costs. Risk is moderate because incorrect values could cause request failures or mis-priced usage for affected models.
> 
> **Overview**
> Updates AWS Bedrock model YAMLs to reflect current capabilities, limits, and pricing across several models.
> 
> Notable changes include: adding audio I/O and `max_tokens` param metadata for `amazon.nova-2-sonic-v1:0`; expanding `amazon.nova-pro-v1:0` input modalities (adds video/pdf/doc) and correcting `top_k` bounds; marking `amazon.nova-sonic-v1:0` and `amazon.titan-embed-g1-text-02` as **deprecated**.
> 
> Adds/refreshes full definitions (costs, features, limits, params, sources) for newer chat models like `anthropic.claude-opus-4-6-v1`, `minimax.minimax-m2.5`, `nvidia.nemotron-super-3-120b`, and `zai.glm-5`, and normalizes Stability image model modalities/cost entries (including adding explicit output modalities and updated sources).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 160afcec35b2a52242bd86c61490608553e2421b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->