### PR TITLE
feat(openai): update model YAMLs [bot]

### DIFF
--- a/providers/openai/gpt-5.4-mini-2026-03-17.yaml
+++ b/providers/openai/gpt-5.4-mini-2026-03-17.yaml
@@ -1,2 +1,39 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 7.5e-8
+      input_cost_per_token: 7.5e-7
+      input_cost_per_token_batches: 3.75e-7
+      output_cost_per_token: 0.0000045
+      output_cost_per_token_batches: 0.00000225
+      region: "*"
+features:
+    - function_calling
+    - parallel_function_calling
+    - tool_choice
+    - prompt_caching
+    - structured_output
+    - system_messages
+limits:
+    context_window: 400000
+    max_output_tokens: 128000
+    max_tokens: 128000
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
+mode: chat
 model: gpt-5.4-mini-2026-03-17
+params:
+    - defaultValue: 128
+      key: max_tokens
+      maxValue: 128000
+      minValue: 1
+    - defaultValue: medium
+      key: reasoning_effort
+sources:
+    - https://developers.openai.com/api/docs/pricing
+    - https://developers.openai.com/api/docs/deprecations
+    - https://developers.openai.com/api/docs/guides/reasoning
+    - https://developers.openai.com/api/docs/guides/structured-outputs
+thinking: true

--- a/providers/openai/gpt-5.4-mini.yaml
+++ b/providers/openai/gpt-5.4-mini.yaml
@@ -1,2 +1,38 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 7.5e-8
+      input_cost_per_token: 7.5e-7
+      input_cost_per_token_batches: 3.75e-7
+      output_cost_per_token: 0.0000045
+      output_cost_per_token_batches: 0.00000225
+      region: "*"
+features:
+    - function_calling
+    - structured_output
+    - prompt_caching
+    - tools
+    - tool_choice
+    - system_messages
+limits:
+    context_window: 400000
+    max_output_tokens: 128000
+    max_tokens: 128000
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
+mode: chat
 model: gpt-5.4-mini
+params:
+    - defaultValue: 128000
+      key: max_tokens
+      maxValue: 128000
+      minValue: 1
+    - defaultValue: medium
+      key: reasoning_effort
+sources:
+    - https://developers.openai.com/api/docs/models/gpt-5.4-mini
+    - https://developers.openai.com/api/docs/pricing
+    - https://developers.openai.com/api/docs/guides/latest-model
+thinking: true

--- a/providers/openai/gpt-5.4-nano-2026-03-17.yaml
+++ b/providers/openai/gpt-5.4-nano-2026-03-17.yaml
@@ -1,2 +1,35 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 2.e-8
+      input_cost_per_token: 2.e-7
+      output_cost_per_token: 0.00000125
+      region: "*"
+features:
+    - function_calling
+    - parallel_function_calling
+    - tool_choice
+    - system_messages
+    - structured_output
+    - prompt_caching
+limits:
+    context_window: 400000
+    max_output_tokens: 128000
+    max_tokens: 128000
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
+mode: chat
 model: gpt-5.4-nano-2026-03-17
+params:
+    - defaultValue: 128
+      key: max_tokens
+      maxValue: 128000
+      minValue: 1
+    - defaultValue: medium
+      key: reasoning_effort
+      type: string
+sources:
+    - https://developers.openai.com/api/docs/models/gpt-5.4-nano
+thinking: true

--- a/providers/openai/gpt-5.4-nano.yaml
+++ b/providers/openai/gpt-5.4-nano.yaml
@@ -1,2 +1,30 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 2.e-8
+      input_cost_per_token: 2.e-7
+      output_cost_per_token: 0.00000125
+      region: "*"
+features:
+    - function_calling
+    - structured_output
+    - tool_choice
+    - system_messages
+limits:
+    context_window: 400000
+    max_output_tokens: 128000
+    max_tokens: 128000
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
+mode: chat
 model: gpt-5.4-nano
+params:
+    - defaultValue: 128
+      key: max_tokens
+      maxValue: 128000
+      minValue: 1
+sources:
+    - https://developers.openai.com/api/docs/models/gpt-5.4-nano
+thinking: true


### PR DESCRIPTION
Auto-generated by poc-agent for provider `openai`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only changes adding/refreshing model metadata (costs, limits, features) for OpenAI models; low risk unless downstream code assumes different defaults (e.g., `max_tokens`).
> 
> **Overview**
> Adds new/expanded model definition YAMLs for OpenAI `gpt-5.4-mini` and `gpt-5.4-nano`, including `-2026-03-17` variants.
> 
> The YAMLs now specify **token pricing**, **context/output limits** (up to `400000` context / `128000` output), declared **capabilities** (e.g., prompt caching, structured outputs, function/tool calling), and **tunable params** like `max_tokens` and `reasoning_effort`, along with updated documentation `sources` and `thinking: true`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b9367a69fbce22804c17acfefc0ea252d676589. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->