### PR TITLE
feat(aws-bedrock): update model YAMLs [bot]

### DIFF
--- a/providers/aws-bedrock/jp.anthropic.claude-sonnet-4-6.yaml
+++ b/providers/aws-bedrock/jp.anthropic.claude-sonnet-4-6.yaml
@@ -6,19 +6,6 @@ costs:
       output_cost_per_token: 0.0000165
       output_cost_per_token_batches: 0.00000825
       region: ap-northeast-3
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 6.6e-7
-                from: 200000
-          cache_write:
-              - cost_per_token: 0.00000825
-                from: 200000
-          input:
-              - cost_per_token: 0.0000066
-                from: 200000
-          output:
-              - cost_per_token: 0.00002475
-                from: 200000
     - cache_creation_input_token_cost: 0.000004125
       cache_read_input_token_cost: 3.3e-7
       input_cost_per_token: 0.0000033
@@ -26,29 +13,25 @@ costs:
       output_cost_per_token: 0.0000165
       output_cost_per_token_batches: 0.00000825
       region: ap-northeast-1
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 6.6e-7
-                from: 200000
-          cache_write:
-              - cost_per_token: 0.00000825
-                from: 200000
-          input:
-              - cost_per_token: 0.0000066
-                from: 200000
-          output:
-              - cost_per_token: 0.00002475
-                from: 200000
 features:
     - function_calling
+    - system_messages
+    - tool_choice
+    - cache_control
+    - prompt_caching
+    - assistant_prefill
 limits:
-    context_window: 200000
-    max_input_tokens: 200000
+    context_window: 1000000
+    max_input_tokens: 1000000
     max_output_tokens: 64000
     max_tokens: 64000
+    tool_use_system_prompt_tokens: 346
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: jp.anthropic.claude-sonnet-4-6
 params:


### PR DESCRIPTION
Auto-generated by poc-agent for provider `aws-bedrock`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates model capability and limit metadata plus removes `tiered_pricing` overrides, which can affect token limit enforcement and cost calculations for this Bedrock model. Risk is moderate because it changes configuration used for routing/validation/billing, but is scoped to a single model YAML.
> 
> **Overview**
> Updates the `jp.anthropic.claude-sonnet-4-6` AWS Bedrock model config by **removing `tiered_pricing` blocks** from the regional cost entries and expanding declared capabilities (adds `system_messages`, `tool_choice`, caching-related features, and `assistant_prefill`).
> 
> Bumps limits from **200k to 1M** for `context_window`/`max_input_tokens`, adds `tool_use_system_prompt_tokens`, and refines modalities to explicitly include text I/O.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b49994e046417b12cba102762734c6a73de34dd7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->