### PR TITLE
feat(azure-open-ai): add new models [bot]

### DIFF
--- a/providers/azure-open-ai/codex-mini-2025-05-16.yaml
+++ b/providers/azure-open-ai/codex-mini-2025-05-16.yaml
@@ -1,2 +1,21 @@
+costs:
+    - input_cost_per_token: 0.00000165
+      region: westus3
+    - input_cost_per_token: 0.00000165
+      region: westus
+    - input_cost_per_token: 0.000001815
+      region: swedencentral
+    - input_cost_per_token: 0.00000165
+      region: southcentralus
+    - input_cost_per_token: 0.00000165
+      region: northcentralus
+    - input_cost_per_token: 0.0000015
+      region: global
+    - input_cost_per_token: 0.00000165
+      region: eastus2
+    - input_cost_per_token: 0.00000165
+      region: eastus
+    - input_cost_per_token: 0.00000165
+      region: centralus
 mode: unknown
 model: codex-mini-2025-05-16

--- a/providers/azure-open-ai/gpt-35-turbo-instruct.yaml
+++ b/providers/azure-open-ai/gpt-35-turbo-instruct.yaml
@@ -1,3 +1,6 @@
+costs:
+    - input_cost_per_token: 0.0000015
+      region: global
 mode: completion
 model: gpt-35-turbo-instruct
 supportedModes:

--- a/providers/azure-open-ai/gpt-5-chat-2025-08-07.yaml
+++ b/providers/azure-open-ai/gpt-5-chat-2025-08-07.yaml
@@ -1,3 +1,8 @@
+costs:
+    - cache_read_input_token_cost: 1.25e-7
+      input_cost_per_token: 0.00000125
+      output_cost_per_token: 0.00001
+      region: global
 mode: chat
 model: gpt-5-chat-2025-08-07
 supportedModes:

--- a/providers/azure-open-ai/gpt-5-chat-2025-08-15.yaml
+++ b/providers/azure-open-ai/gpt-5-chat-2025-08-15.yaml
@@ -1,3 +1,8 @@
+costs:
+    - cache_read_input_token_cost: 1.25e-7
+      input_cost_per_token: 0.00000125
+      output_cost_per_token: 0.00001
+      region: global
 mode: chat
 model: gpt-5-chat-2025-08-15
 supportedModes:

--- a/providers/azure-open-ai/gpt-5-chat-2025-10-03.yaml
+++ b/providers/azure-open-ai/gpt-5-chat-2025-10-03.yaml
@@ -1,3 +1,8 @@
+costs:
+    - cache_read_input_token_cost: 1.25e-7
+      input_cost_per_token: 0.00000125
+      output_cost_per_token: 0.00001
+      region: global
 mode: chat
 model: gpt-5-chat-2025-10-03
 supportedModes:

--- a/providers/azure-open-ai/gpt-5-codex-2025-09-15.yaml
+++ b/providers/azure-open-ai/gpt-5-codex-2025-09-15.yaml
@@ -1,2 +1,12 @@
+costs:
+    - input_cost_per_token: 0.00000125
+      output_cost_per_token: 0.00001
+      region: global
+    - input_cost_per_token: 0.000001375
+      output_cost_per_token: 0.000011
+      region: datazone_us
+    - input_cost_per_token: 0.000001375
+      output_cost_per_token: 0.000011
+      region: datazone_eu
 mode: unknown
 model: gpt-5-codex-2025-09-15

--- a/providers/azure-open-ai/gpt-5-pro-2025-10-06.yaml
+++ b/providers/azure-open-ai/gpt-5-pro-2025-10-06.yaml
@@ -1,2 +1,7 @@
+costs:
+    - input_cost_per_token: 0.000014999999999999999
+      input_cost_per_token_batches: 0.000007499999999999999
+      output_cost_per_token_batches: 0.000059999999999999995
+      region: global
 mode: unknown
 model: gpt-5-pro-2025-10-06

--- a/providers/azure-open-ai/gpt-5.1-codex-2025-11-13.yaml
+++ b/providers/azure-open-ai/gpt-5.1-codex-2025-11-13.yaml
@@ -1,2 +1,12 @@
+costs:
+    - input_cost_per_token: 0.00000125
+      output_cost_per_token: 0.00001
+      region: global
+    - input_cost_per_token: 0.000001375
+      output_cost_per_token: 0.000011
+      region: datazone_us
+    - input_cost_per_token: 0.000001375
+      output_cost_per_token: 0.000011
+      region: datazone_eu
 mode: unknown
 model: gpt-5.1-codex-2025-11-13

--- a/providers/azure-open-ai/gpt-5.1-codex-max-2025-12-04.yaml
+++ b/providers/azure-open-ai/gpt-5.1-codex-max-2025-12-04.yaml
@@ -1,2 +1,12 @@
+costs:
+    - input_cost_per_token: 0.00000125
+      output_cost_per_token: 0.00001
+      region: global
+    - input_cost_per_token: 0.000001375
+      output_cost_per_token: 0.000011
+      region: datazone_us
+    - input_cost_per_token: 0.000001375
+      output_cost_per_token: 0.000011
+      region: datazone_eu
 mode: unknown
 model: gpt-5.1-codex-max-2025-12-04

--- a/providers/azure-open-ai/gpt-5.1-codex-mini-2025-11-13.yaml
+++ b/providers/azure-open-ai/gpt-5.1-codex-mini-2025-11-13.yaml
@@ -1,2 +1,12 @@
+costs:
+    - input_cost_per_token: 2.5e-7
+      output_cost_per_token: 0.000002
+      region: global
+    - input_cost_per_token: 2.75e-7
+      output_cost_per_token: 0.0000022
+      region: datazone_us
+    - input_cost_per_token: 2.75e-7
+      output_cost_per_token: 0.0000022
+      region: datazone_eu
 mode: unknown
 model: gpt-5.1-codex-mini-2025-11-13

--- a/providers/azure-open-ai/gpt-5.2-chat-2026-02-10.yaml
+++ b/providers/azure-open-ai/gpt-5.2-chat-2026-02-10.yaml
@@ -1,3 +1,13 @@
+costs:
+    - input_cost_per_token: 0.00000175
+      output_cost_per_token: 0.000014
+      region: global
+    - input_cost_per_token: 0.000001925
+      output_cost_per_token: 0.0000154
+      region: datazone_us
+    - input_cost_per_token: 0.000001925
+      output_cost_per_token: 0.0000154
+      region: datazone_eu
 mode: chat
 model: gpt-5.2-chat-2026-02-10
 supportedModes:

--- a/providers/azure-open-ai/gpt-5.2-codex-2026-01-14.yaml
+++ b/providers/azure-open-ai/gpt-5.2-codex-2026-01-14.yaml
@@ -1,2 +1,12 @@
+costs:
+    - input_cost_per_token: 0.00000175
+      output_cost_per_token: 0.000014
+      region: global
+    - input_cost_per_token: 0.000001925
+      output_cost_per_token: 0.0000154
+      region: datazone_us
+    - input_cost_per_token: 0.000001925
+      output_cost_per_token: 0.0000154
+      region: datazone_eu
 mode: unknown
 model: gpt-5.2-codex-2026-01-14

--- a/providers/azure-open-ai/gpt-5.3-chat-2026-03-03.yaml
+++ b/providers/azure-open-ai/gpt-5.3-chat-2026-03-03.yaml
@@ -1,3 +1,13 @@
+costs:
+    - input_cost_per_token: 0.00000175
+      output_cost_per_token: 0.000014
+      region: global
+    - input_cost_per_token: 0.000001925
+      output_cost_per_token: 0.0000154
+      region: datazone_us
+    - input_cost_per_token: 0.000001925
+      output_cost_per_token: 0.0000154
+      region: datazone_eu
 mode: chat
 model: gpt-5.3-chat-2026-03-03
 supportedModes:

--- a/providers/azure-open-ai/gpt-5.3-codex-2026-02-20.yaml
+++ b/providers/azure-open-ai/gpt-5.3-codex-2026-02-20.yaml
@@ -1,2 +1,12 @@
+costs:
+    - input_cost_per_token: 0.00000175
+      output_cost_per_token: 0.000014
+      region: global
+    - input_cost_per_token: 0.000001925
+      output_cost_per_token: 0.0000154
+      region: datazone_us
+    - input_cost_per_token: 0.000001925
+      output_cost_per_token: 0.0000154
+      region: datazone_eu
 mode: unknown
 model: gpt-5.3-codex-2026-02-20

--- a/providers/azure-open-ai/gpt-5.3-codex-2026-02-24.yaml
+++ b/providers/azure-open-ai/gpt-5.3-codex-2026-02-24.yaml
@@ -1,2 +1,12 @@
+costs:
+    - input_cost_per_token: 0.00000175
+      output_cost_per_token: 0.000014
+      region: global
+    - input_cost_per_token: 0.000001925
+      output_cost_per_token: 0.0000154
+      region: datazone_us
+    - input_cost_per_token: 0.000001925
+      output_cost_per_token: 0.0000154
+      region: datazone_eu
 mode: unknown
 model: gpt-5.3-codex-2026-02-24

--- a/providers/azure-open-ai/gpt-5.4-2026-03-05.yaml
+++ b/providers/azure-open-ai/gpt-5.4-2026-03-05.yaml
@@ -1,3 +1,19 @@
+costs:
+    - input_cost_per_token: 0.0000025
+      input_cost_per_token_batches: 0.00000125
+      output_cost_per_token: 0.000015
+      output_cost_per_token_batches: 0.0000075
+      region: global
+    - input_cost_per_token: 0.00000275
+      input_cost_per_token_batches: 0.000001375
+      output_cost_per_token: 0.0000165
+      output_cost_per_token_batches: 0.00000825
+      region: datazone_us
+    - input_cost_per_token: 0.00000275
+      input_cost_per_token_batches: 0.000001375
+      output_cost_per_token: 0.0000165
+      output_cost_per_token_batches: 0.00000825
+      region: datazone_eu
 mode: chat
 model: gpt-5.4-2026-03-05
 supportedModes:

--- a/providers/azure-open-ai/gpt-5.4-pro-2026-03-05.yaml
+++ b/providers/azure-open-ai/gpt-5.4-pro-2026-03-05.yaml
@@ -1,2 +1,18 @@
+costs:
+    - input_cost_per_token: 0.00003
+      input_cost_per_token_batches: 0.000015
+      output_cost_per_token: 0.00018
+      output_cost_per_token_batches: 0.00009
+      region: global
+    - input_cost_per_token: 0.000033
+      input_cost_per_token_batches: 0.0000165
+      output_cost_per_token: 0.000198
+      output_cost_per_token_batches: 0.000099
+      region: datazone_us
+    - input_cost_per_token: 0.000033
+      input_cost_per_token_batches: 0.0000165
+      output_cost_per_token: 0.000198
+      output_cost_per_token_batches: 0.000099
+      region: datazone_eu
 mode: unknown
 model: gpt-5.4-pro-2026-03-05

--- a/providers/azure-open-ai/o1-pro-2025-03-19.yaml
+++ b/providers/azure-open-ai/o1-pro-2025-03-19.yaml
@@ -1,2 +1,40 @@
+costs:
+    - input_cost_per_token: 0.000165
+      output_cost_per_token: 0.00066
+      region: westus3
+    - input_cost_per_token: 0.000165
+      output_cost_per_token: 0.00066
+      region: westus
+    - input_cost_per_token: 0.0001815
+      output_cost_per_token: 0.000726
+      region: swedencentral
+    - input_cost_per_token: 0.000165
+      output_cost_per_token: 0.00066
+      region: southcentralus
+    - input_cost_per_token: 0.000165
+      output_cost_per_token: 0.00066
+      region: northcentralus
+    - cache_read_input_token_cost: 0.000075
+      input_cost_per_token: 0.00015
+      input_cost_per_token_batches: 0.000075
+      output_cost_per_token: 0.0006
+      output_cost_per_token_batches: 0.0003
+      region: global
+    - input_cost_per_token: 0.000165
+      output_cost_per_token: 0.00066
+      region: eastus2
+    - input_cost_per_token: 0.000165
+      output_cost_per_token: 0.00066
+      region: eastus
+    - input_cost_per_token: 0.000165
+      input_cost_per_token_batches: 0.0000825
+      output_cost_per_token: 0.00066
+      output_cost_per_token_batches: 0.00033
+      region: datazone_us
+    - input_cost_per_token: 0.000165
+      input_cost_per_token_batches: 0.0000825
+      output_cost_per_token: 0.00066
+      output_cost_per_token_batches: 0.00033
+      region: datazone_eu
 mode: unknown
 model: o1-pro-2025-03-19

--- a/providers/azure-open-ai/o1-pro.yaml
+++ b/providers/azure-open-ai/o1-pro.yaml
@@ -1,2 +1,40 @@
+costs:
+    - input_cost_per_token: 0.000165
+      output_cost_per_token: 0.00066
+      region: westus3
+    - input_cost_per_token: 0.000165
+      output_cost_per_token: 0.00066
+      region: westus
+    - input_cost_per_token: 0.0001815
+      output_cost_per_token: 0.000726
+      region: swedencentral
+    - input_cost_per_token: 0.000165
+      output_cost_per_token: 0.00066
+      region: southcentralus
+    - input_cost_per_token: 0.000165
+      output_cost_per_token: 0.00066
+      region: northcentralus
+    - cache_read_input_token_cost: 0.000075
+      input_cost_per_token: 0.00015
+      input_cost_per_token_batches: 0.000075
+      output_cost_per_token: 0.0006
+      output_cost_per_token_batches: 0.0003
+      region: global
+    - input_cost_per_token: 0.000165
+      output_cost_per_token: 0.00066
+      region: eastus2
+    - input_cost_per_token: 0.000165
+      output_cost_per_token: 0.00066
+      region: eastus
+    - input_cost_per_token: 0.000165
+      input_cost_per_token_batches: 0.0000825
+      output_cost_per_token: 0.00066
+      output_cost_per_token_batches: 0.00033
+      region: datazone_us
+    - input_cost_per_token: 0.000165
+      input_cost_per_token_batches: 0.0000825
+      output_cost_per_token: 0.00066
+      output_cost_per_token_batches: 0.00033
+      region: datazone_eu
 mode: unknown
 model: o1-pro

--- a/providers/azure-open-ai/o3-deep-research-2025-06-26.yaml
+++ b/providers/azure-open-ai/o3-deep-research-2025-06-26.yaml
@@ -1,3 +1,16 @@
+costs:
+    - cache_read_input_token_cost: 0.0000025
+      input_cost_per_token: 0.00001
+      output_cost_per_token: 0.00004
+      region: global
+    - cache_read_input_token_cost: 0.00000275
+      input_cost_per_token: 0.000011
+      output_cost_per_token: 0.000044
+      region: datazone_us
+    - cache_read_input_token_cost: 0.00000275
+      input_cost_per_token: 0.000011
+      output_cost_per_token: 0.000044
+      region: datazone_eu
 mode: chat
 model: o3-deep-research-2025-06-26
 supportedModes:

--- a/providers/azure-open-ai/o3-pro-2025-06-10.yaml
+++ b/providers/azure-open-ai/o3-pro-2025-06-10.yaml
@@ -1,2 +1,8 @@
+costs:
+    - input_cost_per_token: 0.00002
+      input_cost_per_token_batches: 0.00001
+      output_cost_per_token: 0.00008
+      output_cost_per_token_batches: 0.00004
+      region: global
 mode: unknown
 model: o3-pro-2025-06-10

--- a/providers/azure-open-ai/o3-pro.yaml
+++ b/providers/azure-open-ai/o3-pro.yaml
@@ -1,2 +1,8 @@
+costs:
+    - input_cost_per_token: 0.00002
+      input_cost_per_token_batches: 0.00001
+      output_cost_per_token: 0.00008
+      output_cost_per_token_batches: 0.00004
+      region: global
 mode: unknown
 model: o3-pro


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `azure-open-ai`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only add/update YAML metadata (per-token pricing by region) for Azure OpenAI model definitions, with no runtime logic changes.
> 
> **Overview**
> Adds `costs` sections to a set of Azure OpenAI model definition YAMLs, introducing per-token input/output (and in some cases cache-read and batch) pricing by region.
> 
> Also updates `gpt-35-turbo-instruct` and several `gpt-5*`, `o1-pro*`, and `o3*` entries to include global and datazone/region-specific pricing metadata alongside their existing `mode`/`supportedModes` declarations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1fc3d6364b79710ec14b8c5569b90e033824fa22. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->