### PR TITLE
feat(anthropic): update model YAMLs [bot]

### DIFF
--- a/providers/anthropic/claude-4-opus-20250514.yaml
+++ b/providers/anthropic/claude-4-opus-20250514.yaml
@@ -24,8 +24,11 @@ limits:
     tool_use_system_prompt_tokens: 346
 modalities:
     input:
+        - text
         - image
         - pdf
+    output:
+        - text
 mode: chat
 model: claude-4-opus-20250514
 params:

--- a/providers/anthropic/claude-4-sonnet-20250514.yaml
+++ b/providers/anthropic/claude-4-sonnet-20250514.yaml
@@ -23,16 +23,22 @@ features:
     - function_calling
     - tool_choice
     - prompt_caching
+    - cache_control
     - structured_output
     - assistant_prefill
 limits:
+    context_window: 1000000
     max_input_tokens: 1000000
     max_output_tokens: 64000
     max_tokens: 64000
+    tool_use_system_prompt_tokens: 346
 modalities:
     input:
+        - text
         - image
         - pdf
+    output:
+        - text
 mode: chat
 model: claude-4-sonnet-20250514
 params:

--- a/providers/anthropic/claude-haiku-4-5-20251001.yaml
+++ b/providers/anthropic/claude-haiku-4-5-20251001.yaml
@@ -18,10 +18,14 @@ limits:
     max_input_tokens: 200000
     max_output_tokens: 64000
     max_tokens: 64000
+    tool_use_system_prompt_tokens: 346
 modalities:
     input:
+        - text
         - image
         - pdf
+    output:
+        - text
 mode: chat
 model: claude-haiku-4-5-20251001
 params:

--- a/providers/anthropic/claude-haiku-4-5.yaml
+++ b/providers/anthropic/claude-haiku-4-5.yaml
@@ -10,6 +10,7 @@ features:
     - function_calling
     - tool_choice
     - prompt_caching
+    - cache_control
     - structured_output
     - assistant_prefill
 limits:
@@ -17,10 +18,14 @@ limits:
     max_input_tokens: 200000
     max_output_tokens: 64000
     max_tokens: 64000
+    tool_use_system_prompt_tokens: 346
 modalities:
     input:
+        - text
         - image
         - pdf
+    output:
+        - text
 mode: chat
 model: claude-haiku-4-5
 params:

--- a/providers/anthropic/claude-opus-4-1-20250805.yaml
+++ b/providers/anthropic/claude-opus-4-1-20250805.yaml
@@ -10,6 +10,7 @@ features:
     - function_calling
     - tools
     - tool_choice
+    - cache_control
     - prompt_caching
     - structured_output
     - assistant_prefill
@@ -18,10 +19,14 @@ limits:
     max_input_tokens: 200000
     max_output_tokens: 32000
     max_tokens: 32000
+    tool_use_system_prompt_tokens: 346
 modalities:
     input:
+        - text
         - image
         - pdf
+    output:
+        - text
 mode: chat
 model: claude-opus-4-1-20250805
 params:

--- a/providers/anthropic/claude-opus-4-1.yaml
+++ b/providers/anthropic/claude-opus-4-1.yaml
@@ -8,6 +8,7 @@ costs:
       region: "*"
 features:
     - function_calling
+    - cache_control
     - tools
     - tool_choice
     - prompt_caching
@@ -19,10 +20,14 @@ limits:
     max_input_tokens: 200000
     max_output_tokens: 32000
     max_tokens: 32000
+    tool_use_system_prompt_tokens: 346
 modalities:
     input:
+        - text
         - image
         - pdf
+    output:
+        - text
 mode: chat
 model: claude-opus-4-1
 params:

--- a/providers/anthropic/claude-opus-4-20250514.yaml
+++ b/providers/anthropic/claude-opus-4-20250514.yaml
@@ -11,6 +11,7 @@ features:
     - tools
     - tool_choice
     - prompt_caching
+    - cache_control
     - structured_output
     - assistant_prefill
 limits:
@@ -21,8 +22,11 @@ limits:
     tool_use_system_prompt_tokens: 346
 modalities:
     input:
+        - text
         - image
         - pdf
+    output:
+        - text
 mode: chat
 model: claude-opus-4-20250514
 params:

--- a/providers/anthropic/claude-opus-4-5.yaml
+++ b/providers/anthropic/claude-opus-4-5.yaml
@@ -19,10 +19,14 @@ limits:
     max_input_tokens: 200000
     max_output_tokens: 64000
     max_tokens: 64000
+    tool_use_system_prompt_tokens: 346
 modalities:
     input:
+        - text
         - image
         - pdf
+    output:
+        - text
 mode: chat
 model: claude-opus-4-5
 params:

--- a/providers/anthropic/claude-opus-4-6.yaml
+++ b/providers/anthropic/claude-opus-4-6.yaml
@@ -6,34 +6,29 @@ costs:
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: "*"
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 0.000001
-                from: 200000
-          cache_write:
-              - cost_per_token: 0.0000125
-                from: 200000
-          input:
-              - cost_per_token: 0.00001
-                from: 200000
-          output:
-              - cost_per_token: 0.0000375
-                from: 200000
 features:
     - function_calling
     - tool_choice
     - prompt_caching
     - structured_output
+    - cache_control
+    - assistant_prefill
 limits:
-    context_window: 200000
-    max_input_tokens: 200000
+    context_window: 1000000
+    max_input_tokens: 1000000
     max_output_tokens: 128000
     max_tokens: 128000
     tool_use_system_prompt_tokens: 346
 modalities:
     input:
+        - text
         - image
         - pdf
+    output:
+        - text
 mode: chat
 model: claude-opus-4-6
+params:
+    - key: max_tokens
+      maxValue: 128000
 thinking: true

--- a/providers/anthropic/claude-sonnet-4-20250514.yaml
+++ b/providers/anthropic/claude-sonnet-4-20250514.yaml
@@ -32,10 +32,14 @@ limits:
     max_input_tokens: 1000000
     max_output_tokens: 64000
     max_tokens: 64000
+    tool_use_system_prompt_tokens: 346
 modalities:
     input:
+        - text
         - image
         - pdf
+    output:
+        - text
 mode: chat
 model: claude-sonnet-4-20250514
 params:

--- a/providers/anthropic/claude-sonnet-4-5-20250929.yaml
+++ b/providers/anthropic/claude-sonnet-4-5-20250929.yaml
@@ -23,6 +23,7 @@ features:
     - function_calling
     - tools
     - tool_choice
+    - cache_control
     - prompt_caching
     - structured_output
     - assistant_prefill
@@ -34,8 +35,11 @@ limits:
     tool_use_system_prompt_tokens: 346
 modalities:
     input:
+        - text
         - image
         - pdf
+    output:
+        - text
 mode: chat
 model: claude-sonnet-4-5-20250929
 params:

--- a/providers/anthropic/claude-sonnet-4-5.yaml
+++ b/providers/anthropic/claude-sonnet-4-5.yaml
@@ -34,8 +34,11 @@ limits:
     tool_use_system_prompt_tokens: 346
 modalities:
     input:
+        - text
         - image
         - pdf
+    output:
+        - text
 mode: chat
 model: claude-sonnet-4-5
 params:

--- a/providers/anthropic/claude-sonnet-4-6.yaml
+++ b/providers/anthropic/claude-sonnet-4-6.yaml
@@ -6,19 +6,6 @@ costs:
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: "*"
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 6.e-7
-                from: 200000
-          cache_write:
-              - cost_per_token: 0.0000075
-                from: 200000
-          input:
-              - cost_per_token: 0.000006
-                from: 200000
-          output:
-              - cost_per_token: 0.0000225
-                from: 200000
 features:
     - function_calling
     - tool_choice
@@ -26,13 +13,17 @@ features:
     - structured_output
     - assistant_prefill
 limits:
-    context_window: 200000
+    context_window: 1000000
     max_output_tokens: 64000
     max_tokens: 64000
+    tool_use_system_prompt_tokens: 346
 modalities:
     input:
+        - text
         - image
         - pdf
+    output:
+        - text
 mode: chat
 model: claude-sonnet-4-6
 params:


### PR DESCRIPTION
Auto-generated by poc-agent for provider `anthropic`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates provider model metadata (limits, features, and modalities) which can change runtime token enforcement and caching behavior. Also removes some tiered pricing blocks, which may affect cost calculations if the system relies on them.
> 
> **Overview**
> Refreshes several Anthropic Claude model YAMLs to better reflect current capabilities and limits.
> 
> Adds explicit `modalities.input: [text,...]` and `modalities.output: [text]` across models, introduces/expands `cache_control` in `features`, and standardizes `limits.tool_use_system_prompt_tokens`.
> 
> Updates token limits for newer models (notably raising some `context_window`/`max_input_tokens` to 1,000,000 and adding `params` for `claude-opus-4-6`), and drops embedded `tiered_pricing` sections from the `*-4-6` YAMLs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7b2b70852263a84ecb4af78a1d93d77364f51a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->