### PR TITLE
feat(cerebras): update model YAMLs [bot]

### DIFF
--- a/providers/cerebras/gpt-oss-120b.yaml
+++ b/providers/cerebras/gpt-oss-120b.yaml
@@ -15,6 +15,11 @@ limits:
     max_input_tokens: 131000
     max_output_tokens: 40000
     max_tokens: 40000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: gpt-oss-120b
 params:

--- a/providers/cerebras/llama3.1-8b.yaml
+++ b/providers/cerebras/llama3.1-8b.yaml
@@ -13,6 +13,11 @@ limits:
     context_window: 32000
     max_output_tokens: 8000
     max_tokens: 8000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: llama3.1-8b
 params:
@@ -24,3 +29,5 @@ sources:
     - https://inference-docs.cerebras.ai/capabilities/structured-outputs
     - https://inference-docs.cerebras.ai/capabilities/prompt-caching
     - https://inference-docs.cerebras.ai/api-reference/chat-completions
+supportedModes:
+    - completion

--- a/providers/cerebras/qwen-3-235b-a22b-instruct-2507.yaml
+++ b/providers/cerebras/qwen-3-235b-a22b-instruct-2507.yaml
@@ -15,11 +15,24 @@ limits:
     max_input_tokens: 131072
     max_output_tokens: 40960
     max_tokens: 40960
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwen-3-235b-a22b-instruct-2507
+params:
+    - key: max_tokens
+      maxValue: 40960
+    - key: temperature
+      maxValue: 1.5
+    - key: seed
+      type: number
 sources:
     - https://inference-docs.cerebras.ai/models/qwen-3-235b-2507
     - https://inference-docs.cerebras.ai/capabilities/prompt-caching
     - https://inference-docs.cerebras.ai/capabilities/tool-use
     - https://inference-docs.cerebras.ai/capabilities/structured-outputs
     - https://www.cerebras.ai/pricing
+    - https://inference-docs.cerebras.ai/api-reference/chat-completions

--- a/providers/cerebras/zai-glm-4.7.yaml
+++ b/providers/cerebras/zai-glm-4.7.yaml
@@ -11,6 +11,11 @@ limits:
     context_window: 131072
     max_output_tokens: 40000
     max_tokens: 40000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: zai-glm-4.7
 params:


### PR DESCRIPTION
Auto-generated by poc-agent for provider `cerebras`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are limited to Cerebras model configuration YAMLs (capabilities/limits/params metadata) with no runtime logic modifications. Risk is mainly misconfiguration affecting model selection/validation for the updated entries.
> 
> **Overview**
> Updates Cerebras provider model YAMLs to explicitly declare `modalities` (text in/out) for `gpt-oss-120b`, `llama3.1-8b`, `qwen-3-235b-a22b-instruct-2507`, and `zai-glm-4.7`.
> 
> Extends model metadata by adding `supportedModes: [completion]` to `llama3.1-8b`, and introducing/expanding `params` for `qwen-3-235b-a22b-instruct-2507` (e.g., `max_tokens`, `temperature`, `seed`) plus an additional chat completions API source link.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14c1bc3c8aa3c0993dd8c96ec071b5531be712a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->