### PR TITLE
feat(deepinfra): update model YAMLs [bot]

### DIFF
--- a/providers/deepinfra/Gryphe/MythoMax-L2-13b.yaml
+++ b/providers/deepinfra/Gryphe/MythoMax-L2-13b.yaml
@@ -3,12 +3,14 @@ costs:
       output_cost_per_token: 4.e-7
       region: "*"
 features:
-    - tool_choice
     - structured_output
 limits:
     context_window: 4096
-    max_input_tokens: 4096
-    max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: Gryphe/MythoMax-L2-13b
 sources:

--- a/providers/deepinfra/NousResearch/Hermes-3-Llama-3.1-405B.yaml
+++ b/providers/deepinfra/NousResearch/Hermes-3-Llama-3.1-405B.yaml
@@ -9,8 +9,11 @@ features:
 limits:
     context_window: 131072
     max_input_tokens: 131072
-    max_output_tokens: 131072
-    max_tokens: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: NousResearch/Hermes-3-Llama-3.1-405B
 sources:

--- a/providers/deepinfra/Qwen/Qwen2.5-72B-Instruct.yaml
+++ b/providers/deepinfra/Qwen/Qwen2.5-72B-Instruct.yaml
@@ -5,11 +5,18 @@ costs:
 features:
     - function_calling
     - tool_choice
+    - structured_output
+    - prompt_caching
 limits:
     context_window: 32768
     max_input_tokens: 32768
-    max_output_tokens: 32768
-    max_tokens: 32768
+    max_output_tokens: 16384
+    max_tokens: 16384
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: Qwen/Qwen2.5-72B-Instruct
 sources:

--- a/providers/deepinfra/Qwen/Qwen2.5-7B-Instruct.yaml
+++ b/providers/deepinfra/Qwen/Qwen2.5-7B-Instruct.yaml
@@ -2,11 +2,13 @@ costs:
     - input_cost_per_token: 4.e-8
       output_cost_per_token: 1.e-7
       region: "*"
+deprecationDate: 2025-11-06T00:00:00.000Z
 features:
     - function_calling
     - system_messages
     - tool_choice
     - structured_output
+isDeprecated: true
 limits:
     context_window: 32768
     max_input_tokens: 32768

--- a/providers/deepinfra/Qwen/Qwen2.5-VL-32B-Instruct.yaml
+++ b/providers/deepinfra/Qwen/Qwen2.5-VL-32B-Instruct.yaml
@@ -9,10 +9,12 @@ features:
 limits:
     context_window: 128000
     max_input_tokens: 128000
-    max_tokens: 128000
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: Qwen/Qwen2.5-VL-32B-Instruct
 sources:

--- a/providers/deepinfra/Qwen/Qwen3-14B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-14B.yaml
@@ -9,7 +9,6 @@ features:
     - structured_output
 limits:
     context_window: 40960
-    max_tokens: 40960
 mode: chat
 model: Qwen/Qwen3-14B
 sources:

--- a/providers/deepinfra/Qwen/Qwen3-235B-A22B-Instruct-2507.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-235B-A22B-Instruct-2507.yaml
@@ -12,10 +12,14 @@ limits:
     max_input_tokens: 262144
     max_output_tokens: 262144
     max_tokens: 262144
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: Qwen/Qwen3-235B-A22B-Instruct-2507
 sources:
     - https://deepinfra.com/Qwen/Qwen3-235B-A22B-Instruct-2507/api
     - https://api.deepinfra.com/models/Qwen/Qwen3-235B-A22B-Instruct-2507
     - https://huggingface.co/Qwen/Qwen3-235B-A22B-Instruct-2507
-thinking: true

--- a/providers/deepinfra/Qwen/Qwen3-235B-A22B-Thinking-2507.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-235B-A22B-Thinking-2507.yaml
@@ -1,15 +1,22 @@
 costs:
-    - cache_read_input_token_cost: 2.000000006e-7
+    - cache_read_input_token_cost: 2.e-7
       input_cost_per_token: 2.3e-7
       output_cost_per_token: 0.0000023
       region: "*"
 features:
     - prompt_caching
+    - function_calling
+    - structured_output
 limits:
     context_window: 262144
     max_input_tokens: 262144
-    max_output_tokens: 262144
-    max_tokens: 262144
+    max_output_tokens: 32768
+    max_tokens: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: Qwen/Qwen3-235B-A22B-Thinking-2507
 sources:

--- a/providers/deepinfra/Qwen/Qwen3-235B-A22B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-235B-A22B.yaml
@@ -9,6 +9,11 @@ limits:
     context_window: 131072
     max_output_tokens: 32768
     max_tokens: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: Qwen/Qwen3-235B-A22B
 sources:

--- a/providers/deepinfra/Qwen/Qwen3-30B-A3B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-30B-A3B.yaml
@@ -6,9 +6,15 @@ features:
     - function_calling
     - tool_choice
     - structured_output
+    - prompt_caching
 limits:
     context_window: 40960
     max_tokens: 40960
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: Qwen/Qwen3-30B-A3B
 sources:

--- a/providers/deepinfra/Qwen/Qwen3-32B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-32B.yaml
@@ -10,6 +10,11 @@ limits:
     max_input_tokens: 40960
     max_output_tokens: 40960
     max_tokens: 40960
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: Qwen/Qwen3-32B
 sources:

--- a/providers/deepinfra/Qwen/Qwen3-Coder-480B-A35B-Instruct-Turbo.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Coder-480B-A35B-Instruct-Turbo.yaml
@@ -4,11 +4,17 @@ costs:
       output_cost_per_token: 0.000001
       region: "*"
 features:
+    - function_calling
     - prompt_caching
 limits:
     context_window: 262144
     max_output_tokens: 16384
-    max_tokens: 262144
+    max_tokens: 16384
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: Qwen/Qwen3-Coder-480B-A35B-Instruct-Turbo
 sources:

--- a/providers/deepinfra/Qwen/Qwen3-Coder-480B-A35B-Instruct.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Coder-480B-A35B-Instruct.yaml
@@ -10,8 +10,14 @@ limits:
     context_window: 262144
     max_input_tokens: 262144
     max_output_tokens: 65536
-    max_tokens: 262144
+    max_tokens: 65536
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: Qwen/Qwen3-Coder-480B-A35B-Instruct
 sources:
     - https://huggingface.co/Qwen/Qwen3-Coder-480B-A35B-Instruct
+    - https://deepinfra.com/Qwen/Qwen3-Coder-480B-A35B-Instruct/api

--- a/providers/deepinfra/Qwen/Qwen3-Max-Thinking.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Max-Thinking.yaml
@@ -24,7 +24,7 @@ features:
 limits:
     context_window: 256000
     max_output_tokens: 16384
-    max_tokens: 256000
+    max_tokens: 16384
 mode: chat
 model: Qwen/Qwen3-Max-Thinking
 sources:

--- a/providers/deepinfra/Qwen/Qwen3-Max.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Max.yaml
@@ -18,15 +18,23 @@ costs:
               - cost_per_token: 0.000015
                 from: 128000
 features:
+    - function_calling
     - prompt_caching
+    - tool_choice
 limits:
-    context_window: 256000
+    context_window: 262144
     max_input_tokens: 258048
     max_output_tokens: 32768
-    max_tokens: 256000
+    max_tokens: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: Qwen/Qwen3-Max
 sources:
     - https://www.alibabacloud.com/help/en/model-studio/models
+    - https://www.alibabacloud.com/help/en/model-studio/billing-for-model-studio
     - https://openrouter.ai/qwen/qwen3-max/api
 thinking: true

--- a/providers/deepinfra/Qwen/Qwen3-Next-80B-A3B-Instruct.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Next-80B-A3B-Instruct.yaml
@@ -6,13 +6,17 @@ features:
     - function_calling
     - tool_choice
 limits:
-    context_window: 131072
+    context_window: 262144
     max_input_tokens: 262144
     max_output_tokens: 262144
-    max_tokens: 131072
+    max_tokens: 262144
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: Qwen/Qwen3-Next-80B-A3B-Instruct
 sources:
     - https://deepinfra.com/Qwen/Qwen3-Next-80B-A3B-Instruct
     - https://huggingface.co/Qwen/Qwen3-Next-80B-A3B-Instruct
-thinking: true

--- a/providers/deepinfra/Qwen/Qwen3-VL-235B-A22B-Instruct.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-VL-235B-A22B-Instruct.yaml
@@ -12,7 +12,9 @@ limits:
     max_tokens: 262144
 modalities:
     input:
+        - text
         - image
+        - video
 mode: chat
 model: Qwen/Qwen3-VL-235B-A22B-Instruct
 sources:

--- a/providers/deepinfra/Qwen/Qwen3-VL-30B-A3B-Instruct.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-VL-30B-A3B-Instruct.yaml
@@ -10,10 +10,14 @@ features:
 limits:
     context_window: 262144
     max_output_tokens: 16384
-    max_tokens: 262144
+    max_tokens: 16384
 modalities:
     input:
+        - text
         - image
+        - video
+    output:
+        - text
 mode: chat
 model: Qwen/Qwen3-VL-30B-A3B-Instruct
 sources:

--- a/providers/deepinfra/Sao10K/L3.1-70B-Euryale-v2.2.yaml
+++ b/providers/deepinfra/Sao10K/L3.1-70B-Euryale-v2.2.yaml
@@ -7,7 +7,6 @@ features:
     - prompt_caching
 limits:
     context_window: 131072
-    max_tokens: 131072
 mode: chat
 model: Sao10K/L3.1-70B-Euryale-v2.2
 sources:

--- a/providers/deepinfra/allenai/Olmo-3.1-32B-Instruct.yaml
+++ b/providers/deepinfra/allenai/Olmo-3.1-32B-Instruct.yaml
@@ -7,6 +7,11 @@ limits:
     max_input_tokens: 65536
     max_output_tokens: 65536
     max_tokens: 65536
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: allenai/Olmo-3.1-32B-Instruct
 sources:

--- a/providers/deepinfra/allenai/olmOCR-2-7B-1025.yaml
+++ b/providers/deepinfra/allenai/olmOCR-2-7B-1025.yaml
@@ -4,10 +4,14 @@ costs:
       region: "*"
 limits:
     context_window: 16384
+    max_output_tokens: 16384
     max_tokens: 16384
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: allenai/olmOCR-2-7B-1025
 sources:

--- a/providers/deepinfra/anthropic/claude-3-7-sonnet-latest.yaml
+++ b/providers/deepinfra/anthropic/claude-3-7-sonnet-latest.yaml
@@ -4,13 +4,17 @@ costs:
       output_cost_per_token: 0.0000165
       region: "*"
 features:
+    - function_calling
     - prompt_caching
+    - structured_output
 limits:
     context_window: 200000
-    max_tokens: 200000
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: anthropic/claude-3-7-sonnet-latest
 sources:

--- a/providers/deepinfra/anthropic/claude-4-opus.yaml
+++ b/providers/deepinfra/anthropic/claude-4-opus.yaml
@@ -11,15 +11,18 @@ limits:
     context_window: 200000
     max_input_tokens: 200000
     max_output_tokens: 32000
-    max_tokens: 200000
+    max_tokens: 32000
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: anthropic/claude-4-opus
 sources:
     - https://deepinfra.com/anthropic/claude-4-opus/api
     - https://deepinfra.com/claude
-    - https://platform.claude.com/docs/en/about-claude/models
-    - https://platform.claude.com/docs/en/about-claude/pricing
+    - https://platform.claude.com/docs/en/docs/about-claude/models
+    - https://platform.claude.com/docs/en/docs/about-claude/pricing
 thinking: true

--- a/providers/deepinfra/anthropic/claude-4-sonnet.yaml
+++ b/providers/deepinfra/anthropic/claude-4-sonnet.yaml
@@ -7,18 +7,24 @@ features:
     - tool_choice
     - system_messages
     - prompt_caching
+    - structured_output
+    - assistant_prefill
 limits:
     context_window: 200000
     max_input_tokens: 200000
     max_output_tokens: 64000
-    max_tokens: 200000
+    max_tokens: 64000
 modalities:
     input:
+        - text
         - image
+        - pdf
+    output:
+        - text
 mode: chat
 model: anthropic/claude-4-sonnet
 sources:
     - https://deepinfra.com/anthropic/claude-4-sonnet
-    - https://platform.claude.com/docs/en/about-claude/models/overview
-    - https://platform.claude.com/docs/en/about-claude/pricing
+    - https://platform.claude.com/docs/en/docs/about-claude/models
+    - https://platform.claude.com/docs/en/docs/about-claude/pricing
 thinking: true

--- a/providers/deepinfra/deepseek-ai/DeepSeek-OCR.yaml
+++ b/providers/deepinfra/deepseek-ai/DeepSeek-OCR.yaml
@@ -9,7 +9,10 @@ limits:
     max_tokens: 8192
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: deepseek-ai/DeepSeek-OCR
 sources:

--- a/providers/deepinfra/deepseek-ai/DeepSeek-R1-0528-Turbo.yaml
+++ b/providers/deepinfra/deepseek-ai/DeepSeek-R1-0528-Turbo.yaml
@@ -10,6 +10,11 @@ limits:
     context_window: 32768
     max_output_tokens: 32768
     max_tokens: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: deepseek-ai/DeepSeek-R1-0528-Turbo
 sources:

--- a/providers/deepinfra/deepseek-ai/DeepSeek-R1-0528.yaml
+++ b/providers/deepinfra/deepseek-ai/DeepSeek-R1-0528.yaml
@@ -5,11 +5,18 @@ costs:
       region: "*"
 features:
     - prompt_caching
+    - function_calling
+    - structured_output
 limits:
     context_window: 163840
     max_input_tokens: 163840
     max_output_tokens: 32768
-    max_tokens: 163840
+    max_tokens: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: deepseek-ai/DeepSeek-R1-0528
 sources:

--- a/providers/deepinfra/deepseek-ai/DeepSeek-R1-Distill-Llama-70B.yaml
+++ b/providers/deepinfra/deepseek-ai/DeepSeek-R1-Distill-Llama-70B.yaml
@@ -7,6 +7,11 @@ limits:
     max_input_tokens: 131072
     max_output_tokens: 131072
     max_tokens: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: deepseek-ai/DeepSeek-R1-Distill-Llama-70B
 sources:

--- a/providers/deepinfra/deepseek-ai/DeepSeek-V3-0324.yaml
+++ b/providers/deepinfra/deepseek-ai/DeepSeek-V3-0324.yaml
@@ -5,10 +5,17 @@ costs:
       region: "*"
 features:
     - prompt_caching
+    - function_calling
 limits:
     context_window: 163840
     max_input_tokens: 163840
+    max_output_tokens: 163840
     max_tokens: 163840
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: deepseek-ai/DeepSeek-V3-0324
 sources:

--- a/providers/deepinfra/deepseek-ai/DeepSeek-V3.1-Terminus.yaml
+++ b/providers/deepinfra/deepseek-ai/DeepSeek-V3.1-Terminus.yaml
@@ -1,10 +1,10 @@
 costs:
-    - cache_read_input_token_cost: 1.300000002e-7
-      input_cost_per_token: 2.1e-7
+    - input_cost_per_token: 2.1e-7
       output_cost_per_token: 7.9e-7
       region: "*"
 features:
-    - prompt_caching
+    - function_calling
+    - structured_output
 limits:
     context_window: 163840
     max_input_tokens: 163840

--- a/providers/deepinfra/deepseek-ai/DeepSeek-V3.1.yaml
+++ b/providers/deepinfra/deepseek-ai/DeepSeek-V3.1.yaml
@@ -9,7 +9,7 @@ limits:
     context_window: 163840
     max_input_tokens: 163840
     max_output_tokens: 32768
-    max_tokens: 163840
+    max_tokens: 32768
 mode: chat
 model: deepseek-ai/DeepSeek-V3.1
 sources:

--- a/providers/deepinfra/deepseek-ai/DeepSeek-V3.2.yaml
+++ b/providers/deepinfra/deepseek-ai/DeepSeek-V3.2.yaml
@@ -5,11 +5,18 @@ costs:
       region: "*"
 features:
     - prompt_caching
+    - function_calling
+    - structured_output
 limits:
     context_window: 163840
     max_input_tokens: 163840
     max_output_tokens: 16384
-    max_tokens: 163840
+    max_tokens: 16384
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: deepseek-ai/DeepSeek-V3.2
 sources:

--- a/providers/deepinfra/deepseek-ai/DeepSeek-V3.yaml
+++ b/providers/deepinfra/deepseek-ai/DeepSeek-V3.yaml
@@ -11,7 +11,12 @@ limits:
     context_window: 163840
     max_input_tokens: 163840
     max_output_tokens: 16384
-    max_tokens: 163840
+    max_tokens: 16384
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: deepseek-ai/DeepSeek-V3
 sources:

--- a/providers/deepinfra/google/gemini-2.5-flash.yaml
+++ b/providers/deepinfra/google/gemini-2.5-flash.yaml
@@ -9,11 +9,12 @@ features:
 limits:
     context_window: 1000000
     max_input_tokens: 1000000
-    max_output_tokens: 1000000
-    max_tokens: 1000000
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: google/gemini-2.5-flash
 sources:

--- a/providers/deepinfra/google/gemini-2.5-pro.yaml
+++ b/providers/deepinfra/google/gemini-2.5-pro.yaml
@@ -6,18 +6,34 @@ costs:
       output_cost_per_token: 0.00001
       output_cost_per_token_batches: 0.000005
       region: "*"
+      tiered_pricing:
+          cache_read:
+              - cost_per_token: 2.5e-7
+                from: 200000
+          input:
+              - cost_per_token: 0.0000025
+                from: 200000
+          output:
+              - cost_per_token: 0.000015
+                from: 200000
 features:
     - function_calling
     - tool_choice
     - structured_output
 limits:
-    context_window: 1000000
+    context_window: 1048576
     max_input_tokens: 1048576
     max_output_tokens: 65536
-    max_tokens: 1000000
+    max_tokens: 65536
 modalities:
     input:
+        - text
         - image
+        - audio
+        - video
+        - pdf
+    output:
+        - text
 mode: chat
 model: google/gemini-2.5-pro
 sources:

--- a/providers/deepinfra/google/gemma-3-12b-it.yaml
+++ b/providers/deepinfra/google/gemma-3-12b-it.yaml
@@ -11,10 +11,13 @@ limits:
     context_window: 131072
     max_input_tokens: 131072
     max_output_tokens: 16384
-    max_tokens: 131072
+    max_tokens: 16384
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: google/gemma-3-12b-it
 sources:

--- a/providers/deepinfra/google/gemma-3-27b-it.yaml
+++ b/providers/deepinfra/google/gemma-3-27b-it.yaml
@@ -12,7 +12,10 @@ limits:
     max_tokens: 131072
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: google/gemma-3-27b-it
 sources:

--- a/providers/deepinfra/google/gemma-3-4b-it.yaml
+++ b/providers/deepinfra/google/gemma-3-4b-it.yaml
@@ -10,10 +10,13 @@ limits:
     context_window: 131072
     max_input_tokens: 131072
     max_output_tokens: 16384
-    max_tokens: 131072
+    max_tokens: 16384
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: google/gemma-3-4b-it
 sources:

--- a/providers/deepinfra/meta-llama/Llama-3.2-11B-Vision-Instruct.yaml
+++ b/providers/deepinfra/meta-llama/Llama-3.2-11B-Vision-Instruct.yaml
@@ -2,6 +2,9 @@ costs:
     - input_cost_per_token: 4.9e-8
       output_cost_per_token: 4.9e-8
       region: "*"
+features:
+    - function_calling
+    - system_messages
 limits:
     context_window: 131072
     max_input_tokens: 131072
@@ -9,7 +12,10 @@ limits:
     max_tokens: 131072
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: meta-llama/Llama-3.2-11B-Vision-Instruct
 sources:

--- a/providers/deepinfra/meta-llama/Llama-3.2-3B-Instruct.yaml
+++ b/providers/deepinfra/meta-llama/Llama-3.2-3B-Instruct.yaml
@@ -10,6 +10,11 @@ limits:
     max_input_tokens: 131072
     max_output_tokens: 131072
     max_tokens: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: meta-llama/Llama-3.2-3B-Instruct
 sources:

--- a/providers/deepinfra/meta-llama/Llama-3.3-70B-Instruct-Turbo.yaml
+++ b/providers/deepinfra/meta-llama/Llama-3.3-70B-Instruct-Turbo.yaml
@@ -9,7 +9,12 @@ limits:
     context_window: 131072
     max_input_tokens: 131072
     max_output_tokens: 16384
-    max_tokens: 131072
+    max_tokens: 16384
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: meta-llama/Llama-3.3-70B-Instruct-Turbo
 sources:

--- a/providers/deepinfra/meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8.yaml
+++ b/providers/deepinfra/meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8.yaml
@@ -8,10 +8,13 @@ features:
 limits:
     context_window: 1048576
     max_output_tokens: 16384
-    max_tokens: 1048576
+    max_tokens: 16384
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8
 sources:

--- a/providers/deepinfra/meta-llama/Llama-4-Scout-17B-16E-Instruct.yaml
+++ b/providers/deepinfra/meta-llama/Llama-4-Scout-17B-16E-Instruct.yaml
@@ -13,7 +13,10 @@ limits:
     max_tokens: 327680
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: meta-llama/Llama-4-Scout-17B-16E-Instruct
 sources:

--- a/providers/deepinfra/meta-llama/Llama-Guard-4-12B.yaml
+++ b/providers/deepinfra/meta-llama/Llama-Guard-4-12B.yaml
@@ -9,7 +9,10 @@ limits:
     max_tokens: 163840
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: meta-llama/Llama-Guard-4-12B
 sources:

--- a/providers/deepinfra/meta-llama/Meta-Llama-3-8B-Instruct.yaml
+++ b/providers/deepinfra/meta-llama/Meta-Llama-3-8B-Instruct.yaml
@@ -10,6 +10,11 @@ limits:
     max_input_tokens: 8192
     max_output_tokens: 8192
     max_tokens: 8192
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: meta-llama/Meta-Llama-3-8B-Instruct
 sources:

--- a/providers/deepinfra/meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo.yaml
+++ b/providers/deepinfra/meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo.yaml
@@ -10,7 +10,12 @@ limits:
     context_window: 131072
     max_input_tokens: 131072
     max_output_tokens: 16384
-    max_tokens: 131072
+    max_tokens: 16384
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo
 sources:

--- a/providers/deepinfra/meta-llama/Meta-Llama-3.1-70B-Instruct.yaml
+++ b/providers/deepinfra/meta-llama/Meta-Llama-3.1-70B-Instruct.yaml
@@ -9,7 +9,12 @@ limits:
     context_window: 131072
     max_input_tokens: 131072
     max_output_tokens: 16384
-    max_tokens: 131072
+    max_tokens: 16384
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: meta-llama/Meta-Llama-3.1-70B-Instruct
 sources:

--- a/providers/deepinfra/meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo.yaml
+++ b/providers/deepinfra/meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo.yaml
@@ -5,11 +5,17 @@ costs:
 features:
     - function_calling
     - tool_choice
+    - system_messages
 limits:
     context_window: 131072
     max_input_tokens: 131072
     max_output_tokens: 16384
-    max_tokens: 131072
+    max_tokens: 16384
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo
 sources:

--- a/providers/deepinfra/microsoft/WizardLM-2-8x22B.yaml
+++ b/providers/deepinfra/microsoft/WizardLM-2-8x22B.yaml
@@ -7,6 +7,11 @@ limits:
     max_input_tokens: 65536
     max_output_tokens: 65536
     max_tokens: 65536
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: microsoft/WizardLM-2-8x22B
 sources:

--- a/providers/deepinfra/microsoft/phi-4.yaml
+++ b/providers/deepinfra/microsoft/phi-4.yaml
@@ -9,6 +9,11 @@ limits:
     max_input_tokens: 16384
     max_output_tokens: 16384
     max_tokens: 16384
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: microsoft/phi-4
 sources:

--- a/providers/deepinfra/mistralai/Mistral-Nemo-Instruct-2407.yaml
+++ b/providers/deepinfra/mistralai/Mistral-Nemo-Instruct-2407.yaml
@@ -11,6 +11,11 @@ limits:
     max_input_tokens: 131072
     max_output_tokens: 131072
     max_tokens: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: mistralai/Mistral-Nemo-Instruct-2407
 sources:

--- a/providers/deepinfra/mistralai/Mistral-Small-24B-Instruct-2501.yaml
+++ b/providers/deepinfra/mistralai/Mistral-Small-24B-Instruct-2501.yaml
@@ -11,8 +11,14 @@ limits:
     max_input_tokens: 32768
     max_output_tokens: 32768
     max_tokens: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: mistralai/Mistral-Small-24B-Instruct-2501
 sources:
     - https://deepinfra.com/mistralai/Mistral-Small-24B-Instruct-2501
     - https://deepinfra.com/mistralai/Mistral-Small-24B-Instruct-2501/api
+    - https://huggingface.co/mistralai/Mistral-Small-24B-Instruct-2501

--- a/providers/deepinfra/mistralai/Mistral-Small-3.2-24B-Instruct-2506.yaml
+++ b/providers/deepinfra/mistralai/Mistral-Small-3.2-24B-Instruct-2506.yaml
@@ -13,7 +13,10 @@ limits:
     max_tokens: 128000
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: mistralai/Mistral-Small-3.2-24B-Instruct-2506
 sources:

--- a/providers/deepinfra/mistralai/Mixtral-8x7B-Instruct-v0.1.yaml
+++ b/providers/deepinfra/mistralai/Mixtral-8x7B-Instruct-v0.1.yaml
@@ -5,11 +5,18 @@ costs:
 features:
     - function_calling
     - tool_choice
+    - structured_output
+    - prompt_caching
 limits:
     context_window: 32768
     max_input_tokens: 32768
     max_output_tokens: 32768
     max_tokens: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: mistralai/Mixtral-8x7B-Instruct-v0.1
 sources:

--- a/providers/deepinfra/moonshotai/Kimi-K2-Instruct-0905.yaml
+++ b/providers/deepinfra/moonshotai/Kimi-K2-Instruct-0905.yaml
@@ -5,11 +5,19 @@ costs:
       region: "*"
 features:
     - prompt_caching
+    - function_calling
+    - tool_choice
+    - system_messages
 limits:
     context_window: 131072
     max_input_tokens: 262144
     max_output_tokens: 131072
     max_tokens: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: moonshotai/Kimi-K2-Instruct-0905
 sources:

--- a/providers/deepinfra/moonshotai/Kimi-K2-Thinking.yaml
+++ b/providers/deepinfra/moonshotai/Kimi-K2-Thinking.yaml
@@ -4,12 +4,19 @@ costs:
       output_cost_per_token: 0.000002
       region: "*"
 features:
+    - function_calling
     - prompt_caching
+    - system_messages
 limits:
     context_window: 131072
     max_input_tokens: 262144
     max_output_tokens: 131072
     max_tokens: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: moonshotai/Kimi-K2-Thinking
 sources:

--- a/providers/deepinfra/moonshotai/Kimi-K2.5.yaml
+++ b/providers/deepinfra/moonshotai/Kimi-K2.5.yaml
@@ -1,17 +1,23 @@
 costs:
-    - cache_read_input_token_cost: 7.0000002e-8
+    - cache_read_input_token_cost: 7.e-8
       input_cost_per_token: 4.5e-7
       output_cost_per_token: 0.00000225
       region: "*"
 features:
     - prompt_caching
+    - function_calling
+    - tool_choice
+    - structured_output
 limits:
     context_window: 262144
     max_output_tokens: 64000
-    max_tokens: 262144
+    max_tokens: 64000
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: moonshotai/Kimi-K2.5
 sources:

--- a/providers/deepinfra/nvidia/Llama-3.1-Nemotron-70B-Instruct.yaml
+++ b/providers/deepinfra/nvidia/Llama-3.1-Nemotron-70B-Instruct.yaml
@@ -4,11 +4,18 @@ costs:
       region: "*"
 features:
     - tool_choice
+    - function_calling
+    - system_messages
 limits:
     context_window: 131072
     max_input_tokens: 131072
     max_output_tokens: 4096
-    max_tokens: 131072
+    max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: nvidia/Llama-3.1-Nemotron-70B-Instruct
 sources:

--- a/providers/deepinfra/nvidia/Llama-3.3-Nemotron-Super-49B-v1.5.yaml
+++ b/providers/deepinfra/nvidia/Llama-3.3-Nemotron-Super-49B-v1.5.yaml
@@ -11,6 +11,11 @@ limits:
     max_input_tokens: 131072
     max_output_tokens: 131072
     max_tokens: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: nvidia/Llama-3.3-Nemotron-Super-49B-v1.5
 sources:

--- a/providers/deepinfra/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B.yaml
+++ b/providers/deepinfra/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B.yaml
@@ -5,9 +5,15 @@ costs:
       region: "*"
 features:
     - prompt_caching
+    - function_calling
+    - structured_output
 limits:
     context_window: 262144
-    max_tokens: 262144
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B
 sources:

--- a/providers/deepinfra/nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL.yaml
+++ b/providers/deepinfra/nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL.yaml
@@ -6,13 +6,16 @@ features:
     - function_calling
     - system_messages
 limits:
-    context_window: 131072
-    max_input_tokens: 128000
+    context_window: 128000
     max_output_tokens: 8192
-    max_tokens: 131072
+    max_tokens: 8192
 modalities:
     input:
+        - text
         - image
+        - video
+    output:
+        - text
 mode: chat
 model: nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL
 sources:

--- a/providers/deepinfra/nvidia/NVIDIA-Nemotron-Nano-9B-v2.yaml
+++ b/providers/deepinfra/nvidia/NVIDIA-Nemotron-Nano-9B-v2.yaml
@@ -10,6 +10,11 @@ limits:
     max_input_tokens: 131072
     max_output_tokens: 131072
     max_tokens: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: nvidia/NVIDIA-Nemotron-Nano-9B-v2
 sources:

--- a/providers/deepinfra/nvidia/Nemotron-3-Nano-30B-A3B.yaml
+++ b/providers/deepinfra/nvidia/Nemotron-3-Nano-30B-A3B.yaml
@@ -10,6 +10,11 @@ limits:
     max_input_tokens: 262144
     max_output_tokens: 262144
     max_tokens: 262144
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: nvidia/Nemotron-3-Nano-30B-A3B
 sources:

--- a/providers/deepinfra/openai/gpt-oss-120b.yaml
+++ b/providers/deepinfra/openai/gpt-oss-120b.yaml
@@ -11,9 +11,15 @@ limits:
     max_input_tokens: 131072
     max_output_tokens: 131072
     max_tokens: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: openai/gpt-oss-120b
 sources:
     - https://developers.openai.com/api/docs/models/gpt-oss-120b
     - https://openrouter.ai/openai/gpt-oss-120b/api
+    - https://deepinfra.com/openai/gpt-oss-120b/api
 thinking: true

--- a/providers/deepinfra/openai/gpt-oss-20b.yaml
+++ b/providers/deepinfra/openai/gpt-oss-20b.yaml
@@ -11,6 +11,11 @@ limits:
     max_input_tokens: 131072
     max_output_tokens: 131072
     max_tokens: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: openai/gpt-oss-20b
 sources:

--- a/providers/deepinfra/zai-org/GLM-4.6.yaml
+++ b/providers/deepinfra/zai-org/GLM-4.6.yaml
@@ -1,15 +1,22 @@
 costs:
-    - cache_read_input_token_cost: 7.99999993e-8
+    - cache_read_input_token_cost: 8.e-8
       input_cost_per_token: 4.3e-7
       output_cost_per_token: 0.00000174
       region: "*"
 features:
+    - function_calling
     - prompt_caching
+    - structured_output
 limits:
     context_window: 202752
     max_input_tokens: 202752
     max_output_tokens: 131072
-    max_tokens: 202752
+    max_tokens: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: zai-org/GLM-4.6
 sources:

--- a/providers/deepinfra/zai-org/GLM-4.6V.yaml
+++ b/providers/deepinfra/zai-org/GLM-4.6V.yaml
@@ -5,13 +5,15 @@ costs:
 features:
     - function_calling
 limits:
-    context_window: 131072
-    max_input_tokens: 131072
+    context_window: 128000
     max_output_tokens: 16384
-    max_tokens: 131072
+    max_tokens: 16384
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: zai-org/GLM-4.6V
 sources:

--- a/providers/deepinfra/zai-org/GLM-4.7-Flash.yaml
+++ b/providers/deepinfra/zai-org/GLM-4.7-Flash.yaml
@@ -5,10 +5,17 @@ costs:
       region: "*"
 features:
     - prompt_caching
+    - function_calling
+    - structured_output
 limits:
     context_window: 202752
     max_output_tokens: 16384
-    max_tokens: 202752
+    max_tokens: 16384
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: zai-org/GLM-4.7-Flash
 sources:

--- a/providers/deepinfra/zai-org/GLM-5.yaml
+++ b/providers/deepinfra/zai-org/GLM-5.yaml
@@ -4,11 +4,18 @@ costs:
       output_cost_per_token: 0.00000256
       region: "*"
 features:
+    - function_calling
+    - structured_output
     - prompt_caching
 limits:
     context_window: 202752
     max_output_tokens: 128000
-    max_tokens: 202752
+    max_tokens: 128000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: zai-org/GLM-5
 sources:


### PR DESCRIPTION
Auto-generated by poc-agent for provider `deepinfra`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates many DeepInfra model YAMLs that drive capability/limit selection (e.g., `max_tokens`, `context_window`, modalities, and supported features), which could affect request validation and token budgeting if any values are incorrect. No code-path changes, but config mistakes would surface at runtime when choosing models or enforcing limits.
> 
> **Overview**
> Refreshes DeepInfra provider model YAMLs, primarily by **standardizing `modalities`** (explicit `input`/`output` types like `text`, plus adding `video`/`audio`/`pdf` where supported) and updating **feature flags** (e.g., `function_calling`, `tool_choice`, `structured_output`, `prompt_caching`, `assistant_prefill`).
> 
> Adjusts **token/limit metadata** across many models (e.g., revising `max_tokens`/`max_output_tokens` to reflect actual output caps, and a few `context_window` updates) and updates **cost/pricing fields** including tiered pricing for `google/gemini-2.5-pro`. Marks `Qwen/Qwen2.5-7B-Instruct` as deprecated with an explicit `deprecationDate`, and updates/normalizes a handful of `sources` URLs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5defd601f1602db5e57f385bfaec01c79a9321d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->