### PR TITLE
feat(openrouter): add new models [bot]

### DIFF
--- a/providers/openrouter/mistralai/pixtral-12b.yaml
+++ b/providers/openrouter/mistralai/pixtral-12b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 1.0000000000000001e-7
-      output_cost_per_token: 1.0000000000000001e-7
+    - input_cost_per_token: 1.e-7
+      output_cost_per_token: 1.e-7
       region: "*"
 limits:
     context_window: 32768

--- a/providers/openrouter/mistralai/pixtral-12b.yaml
+++ b/providers/openrouter/mistralai/pixtral-12b.yaml
@@ -1,0 +1,17 @@
+costs:
+    - input_cost_per_token: 1.0000000000000001e-7
+      output_cost_per_token: 1.0000000000000001e-7
+      region: "*"
+limits:
+    context_window: 32768
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
+mode: chat
+model: mistralai/pixtral-12b
+params:
+    - defaultValue: 0.3
+      key: temperature

--- a/providers/openrouter/nvidia/llama-3.1-nemotron-ultra-253b-v1.yaml
+++ b/providers/openrouter/nvidia/llama-3.1-nemotron-ultra-253b-v1.yaml
@@ -1,0 +1,13 @@
+costs:
+    - input_cost_per_token: 6.e-7
+      output_cost_per_token: 0.0000018
+      region: "*"
+limits:
+    context_window: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: chat
+model: nvidia/llama-3.1-nemotron-ultra-253b-v1


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `openrouter`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only introduces new YAML model metadata (costs/limits/modalities) without changing runtime logic.
> 
> **Overview**
> Adds new OpenRouter model config entries for `mistralai/pixtral-12b` and `nvidia/llama-3.1-nemotron-ultra-253b-v1`, including token pricing and context-window limits.
> 
> `pixtral-12b` is marked as *multimodal* (text+image input) and includes a default `temperature` param; Nemotron is text-in/text-out only.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13367cf1028f30f3e59101f0b687ed93cafdfa32. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->