### PR TITLE
feat(openrouter): update model YAMLs [bot]

### DIFF
--- a/providers/openrouter/aion-1.0-mini.yaml
+++ b/providers/openrouter/aion-1.0-mini.yaml
@@ -9,6 +9,11 @@ limits:
     context_window: 131072
     max_output_tokens: 32768
     max_tokens: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: aion-1.0-mini
 params:

--- a/providers/openrouter/aion-1.0.yaml
+++ b/providers/openrouter/aion-1.0.yaml
@@ -9,6 +9,11 @@ limits:
     context_window: 131072
     max_output_tokens: 32768
     max_tokens: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: aion-1.0
 params:

--- a/providers/openrouter/aion-labs/aion-1.0-mini.yaml
+++ b/providers/openrouter/aion-labs/aion-1.0-mini.yaml
@@ -5,6 +5,7 @@ costs:
 features:
     - tool_choice
     - system_messages
+    - function_calling
 limits:
     context_window: 131072
     max_output_tokens: 32768

--- a/providers/openrouter/aion-rp-llama-3.1-8b.yaml
+++ b/providers/openrouter/aion-rp-llama-3.1-8b.yaml
@@ -2,10 +2,18 @@ costs:
     - input_cost_per_token: 8.e-7
       output_cost_per_token: 0.0000016
       region: "*"
+features:
+    - function_calling
+    - tool_choice
 limits:
     context_window: 32768
     max_output_tokens: 32768
     max_tokens: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: aion-rp-llama-3.1-8b
 params:

--- a/providers/openrouter/alibaba/tongyi-deepresearch-30b-a3b.yaml
+++ b/providers/openrouter/alibaba/tongyi-deepresearch-30b-a3b.yaml
@@ -1,6 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 9.e-8
-      input_cost_per_token: 9.e-8
+    - input_cost_per_token: 9.e-8
       output_cost_per_token: 4.5e-7
       region: "*"
 features:
@@ -9,8 +8,6 @@ features:
     - system_messages
 limits:
     context_window: 131072
-    max_output_tokens: 131072
-    max_tokens: 131072
 modalities:
     input:
         - text

--- a/providers/openrouter/allenai/olmo-2-0325-32b-instruct.yaml
+++ b/providers/openrouter/allenai/olmo-2-0325-32b-instruct.yaml
@@ -2,6 +2,8 @@ costs:
     - input_cost_per_token: 5.e-8
       output_cost_per_token: 2.e-7
       region: "*"
+features:
+    - tool_choice
 limits:
     context_window: 128000
 modalities:

--- a/providers/openrouter/allenai/olmo-3-32b-think.yaml
+++ b/providers/openrouter/allenai/olmo-3-32b-think.yaml
@@ -2,6 +2,7 @@ costs:
     - input_cost_per_token: 1.5e-7
       output_cost_per_token: 5.e-7
       region: "*"
+deprecationDate: "2026-04-06"
 features:
     - function_calling
     - tool_choice

--- a/providers/openrouter/allenai/olmo-3.1-32b-think.yaml
+++ b/providers/openrouter/allenai/olmo-3.1-32b-think.yaml
@@ -2,6 +2,7 @@ costs:
     - input_cost_per_token: 1.5e-7
       output_cost_per_token: 5.e-7
       region: "*"
+deprecationDate: "2026-04-06"
 features:
     - structured_output
 limits:

--- a/providers/openrouter/amazon/nova-lite-v1.yaml
+++ b/providers/openrouter/amazon/nova-lite-v1.yaml
@@ -19,5 +19,7 @@ modalities:
         - text
 mode: chat
 model: amazon/nova-lite-v1
+params:
+    - key: top_k
 sources:
     - https://openrouter.ai/amazon/nova-lite-v1/api

--- a/providers/openrouter/anthropic/claude-2.yaml
+++ b/providers/openrouter/anthropic/claude-2.yaml
@@ -11,6 +11,11 @@ limits:
     context_window: 200000
     max_output_tokens: 8191
     max_tokens: 8191
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: anthropic/claude-2
 sources:

--- a/providers/openrouter/anthropic/claude-3-5-haiku-20241022.yaml
+++ b/providers/openrouter/anthropic/claude-3-5-haiku-20241022.yaml
@@ -12,11 +12,18 @@ limits:
     max_input_tokens: 200000
     max_output_tokens: 8192
     max_tokens: 8192
+    tool_use_system_prompt_tokens: 264
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: anthropic/claude-3-5-haiku-20241022
+params:
+    - key: max_tokens
+      maxValue: 8192
 sources:
     - https://openrouter.ai/anthropic/claude-3-5-haiku-20241022/api
     - https://platform.claude.com/docs/en/docs/about-claude/models

--- a/providers/openrouter/anthropic/claude-3-5-haiku.yaml
+++ b/providers/openrouter/anthropic/claude-3-5-haiku.yaml
@@ -6,13 +6,17 @@ costs:
       region: "*"
 features:
     - function_calling
+    - tool_choice
 limits:
     context_window: 200000
     max_output_tokens: 8192
     max_tokens: 8192
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: anthropic/claude-3-5-haiku
 sources:

--- a/providers/openrouter/anthropic/claude-3-sonnet.yaml
+++ b/providers/openrouter/anthropic/claude-3-sonnet.yaml
@@ -3,8 +3,10 @@ costs:
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: "*"
+deprecationDate: 2025-07-21T00:00:00.000Z
 features:
     - function_calling
+isDeprecated: true
 limits:
     context_window: 200000
 modalities:

--- a/providers/openrouter/anthropic/claude-3.5-haiku.yaml
+++ b/providers/openrouter/anthropic/claude-3.5-haiku.yaml
@@ -23,4 +23,3 @@ mode: chat
 model: anthropic/claude-3.5-haiku
 sources:
     - https://openrouter.ai/anthropic/claude-3.5-haiku/api
-thinking: false

--- a/providers/openrouter/anthropic/claude-3.5-sonnet.yaml
+++ b/providers/openrouter/anthropic/claude-3.5-sonnet.yaml
@@ -11,7 +11,6 @@ features:
     - prompt_caching
 limits:
     context_window: 200000
-    max_input_tokens: 200000
     max_output_tokens: 8192
     max_tokens: 8192
 modalities:

--- a/providers/openrouter/anthropic/claude-3.5-sonnet:beta.yaml
+++ b/providers/openrouter/anthropic/claude-3.5-sonnet:beta.yaml
@@ -15,7 +15,10 @@ limits:
     max_tokens: 8192
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: anthropic/claude-3.5-sonnet:beta
 sources:

--- a/providers/openrouter/anthropic/claude-3.7-sonnet.yaml
+++ b/providers/openrouter/anthropic/claude-3.7-sonnet.yaml
@@ -4,6 +4,7 @@ costs:
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: "*"
+deprecationDate: "2026-05-05"
 features:
     - function_calling
     - tool_choice
@@ -16,9 +17,18 @@ limits:
     max_tokens: 64000
 modalities:
     input:
+        - text
         - image
+        - pdf
+    output:
+        - text
 mode: chat
 model: anthropic/claude-3.7-sonnet
+params:
+    - defaultValue: 128
+      key: max_tokens
+      maxValue: 64000
+      minValue: 1
 sources:
     - https://openrouter.ai/anthropic/claude-3.7-sonnet/api
 thinking: true

--- a/providers/openrouter/anthropic/claude-haiku-4.5.yaml
+++ b/providers/openrouter/anthropic/claude-haiku-4.5.yaml
@@ -17,12 +17,15 @@ limits:
     max_tokens: 64000
 modalities:
     input:
-        - image
         - text
+        - image
     output:
         - text
 mode: chat
 model: anthropic/claude-haiku-4.5
+params:
+    - key: max_tokens
+      maxValue: 64000
 sources:
     - https://openrouter.ai/anthropic/claude-haiku-4.5/api
 thinking: true

--- a/providers/openrouter/anthropic/claude-sonnet-4.yaml
+++ b/providers/openrouter/anthropic/claude-sonnet-4.yaml
@@ -9,6 +9,7 @@ features:
     - tool_choice
     - prompt_caching
     - assistant_prefill
+    - structured_output
 limits:
     context_window: 200000
     max_output_tokens: 64000
@@ -22,6 +23,11 @@ modalities:
         - text
 mode: chat
 model: anthropic/claude-sonnet-4
+params:
+    - defaultValue: 128
+      key: max_tokens
+      maxValue: 64000
+      minValue: 1
 sources:
     - https://openrouter.ai/anthropic/claude-sonnet-4/api
 thinking: true

--- a/providers/openrouter/anubis-70b-v1.1.yaml
+++ b/providers/openrouter/anubis-70b-v1.1.yaml
@@ -1,5 +1,11 @@
 limits:
+    max_output_tokens: 4096
     max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: anubis-70b-v1.1
 sources:

--- a/providers/openrouter/anubis-pro-105b-v1.yaml
+++ b/providers/openrouter/anubis-pro-105b-v1.yaml
@@ -1,3 +1,8 @@
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: anubis-pro-105b-v1
 params:

--- a/providers/openrouter/arcee-ai/coder-large.yaml
+++ b/providers/openrouter/arcee-ai/coder-large.yaml
@@ -2,9 +2,6 @@ costs:
     - input_cost_per_token: 5.e-7
       output_cost_per_token: 8.e-7
       region: "*"
-features:
-    - tool_choice
-    - function_calling
 limits:
     context_window: 32768
 modalities:

--- a/providers/openrouter/arcee-ai/maestro-reasoning.yaml
+++ b/providers/openrouter/arcee-ai/maestro-reasoning.yaml
@@ -2,6 +2,9 @@ costs:
     - input_cost_per_token: 9.e-7
       output_cost_per_token: 0.0000033
       region: "*"
+features:
+    - function_calling
+    - tool_choice
 limits:
     context_window: 131072
     max_output_tokens: 32000
@@ -15,4 +18,3 @@ mode: chat
 model: arcee-ai/maestro-reasoning
 sources:
     - https://openrouter.ai/arcee-ai/maestro-reasoning/api
-thinking: true

--- a/providers/openrouter/arcee-ai/spotlight.yaml
+++ b/providers/openrouter/arcee-ai/spotlight.yaml
@@ -14,5 +14,8 @@ modalities:
         - text
 mode: chat
 model: arcee-ai/spotlight
+params:
+    - key: max_tokens
+      maxValue: 65537
 sources:
     - https://openrouter.ai/arcee-ai/spotlight/api

--- a/providers/openrouter/arcee-ai/trinity-large-preview:free.yaml
+++ b/providers/openrouter/arcee-ai/trinity-large-preview:free.yaml
@@ -1,6 +1,5 @@
 costs:
-    - input_cost_per_image: 0
-      input_cost_per_token: 0
+    - input_cost_per_token: 0
       output_cost_per_token: 0
       region: "*"
 features:

--- a/providers/openrouter/auto.yaml
+++ b/providers/openrouter/auto.yaml
@@ -4,10 +4,6 @@ costs:
       region: "*"
 limits:
     context_window: 2000000
-modalities:
-    input:
-        - audio
-        - image
 mode: chat
 model: auto
 sources:

--- a/providers/openrouter/baidu/ernie-4.5-21b-a3b-thinking.yaml
+++ b/providers/openrouter/baidu/ernie-4.5-21b-a3b-thinking.yaml
@@ -13,6 +13,11 @@ modalities:
         - text
 mode: chat
 model: baidu/ernie-4.5-21b-a3b-thinking
+params:
+    - defaultValue: 128
+      key: max_tokens
+      maxValue: 65536
+      minValue: 1
 sources:
     - https://openrouter.ai/baidu/ernie-4.5-21b-a3b-thinking/api
 thinking: true

--- a/providers/openrouter/baidu/ernie-4.5-300b-a47b.yaml
+++ b/providers/openrouter/baidu/ernie-4.5-300b-a47b.yaml
@@ -5,7 +5,7 @@ costs:
 features:
     - structured_output
 limits:
-    context_window: 123000
+    context_window: 131072
     max_output_tokens: 12000
     max_tokens: 12000
 modalities:

--- a/providers/openrouter/bytedance-seed/seed-1.6-flash.yaml
+++ b/providers/openrouter/bytedance-seed/seed-1.6-flash.yaml
@@ -2,6 +2,13 @@ costs:
     - input_cost_per_token: 7.5e-8
       output_cost_per_token: 3.e-7
       region: "*"
+      tiered_pricing:
+          input:
+              - cost_per_token: 1.e-7
+                from: 128000
+          output:
+              - cost_per_token: 8.e-7
+                from: 128000
 features:
     - function_calling
     - tool_choice

--- a/providers/openrouter/bytedance-seed/seed-1.6.yaml
+++ b/providers/openrouter/bytedance-seed/seed-1.6.yaml
@@ -2,6 +2,13 @@ costs:
     - input_cost_per_token: 2.5e-7
       output_cost_per_token: 0.000002
       region: "*"
+      tiered_pricing:
+          input:
+              - cost_per_token: 5.e-7
+                from: 128000
+          output:
+              - cost_per_token: 0.000004
+                from: 128000
 features:
     - function_calling
     - tool_choice

--- a/providers/openrouter/bytedance-seed/seed-2.0-mini.yaml
+++ b/providers/openrouter/bytedance-seed/seed-2.0-mini.yaml
@@ -2,6 +2,13 @@ costs:
     - input_cost_per_token: 1.e-7
       output_cost_per_token: 4.e-7
       region: "*"
+      tiered_pricing:
+          input:
+              - cost_per_token: 2.e-7
+                from: 128000
+          output:
+              - cost_per_token: 8.e-7
+                from: 128000
 features:
     - function_calling
     - tool_choice
@@ -21,6 +28,13 @@ modalities:
         - text
 mode: chat
 model: bytedance-seed/seed-2.0-mini
+params:
+    - defaultValue: 128
+      key: max_tokens
+      maxValue: 131072
+      minValue: 1
+    - key: reasoning_effort
+      type: string
 sources:
     - https://openrouter.ai/bytedance-seed/seed-2.0-mini/api
 thinking: true

--- a/providers/openrouter/claude-3-haiku.yaml
+++ b/providers/openrouter/claude-3-haiku.yaml
@@ -8,13 +8,17 @@ features:
     - function_calling
     - tool_choice
     - tools
+    - prompt_caching
 limits:
     context_window: 200000
     max_output_tokens: 4096
     max_tokens: 4096
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: claude-3-haiku
 sources:

--- a/providers/openrouter/claude-3-haiku:beta.yaml
+++ b/providers/openrouter/claude-3-haiku:beta.yaml
@@ -18,7 +18,10 @@ limits:
     max_tokens: 4096
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: claude-3-haiku:beta
 params:

--- a/providers/openrouter/claude-3-opus:beta.yaml
+++ b/providers/openrouter/claude-3-opus:beta.yaml
@@ -4,12 +4,14 @@ costs:
       input_cost_per_token: 0.000015
       output_cost_per_token: 0.000075
       region: "*"
+deprecationDate: 2026-01-05T00:00:00.000Z
 features:
     - function_calling
     - tools
     - tool_choice
     - system_messages
     - prompt_caching
+isDeprecated: true
 limits:
     context_window: 200000
     max_output_tokens: 4096

--- a/providers/openrouter/claude-3-sonnet.yaml
+++ b/providers/openrouter/claude-3-sonnet.yaml
@@ -12,7 +12,10 @@ limits:
     max_tokens: 4096
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: claude-3-sonnet
 params:

--- a/providers/openrouter/claude-3.5-haiku-20241022.yaml
+++ b/providers/openrouter/claude-3.5-haiku-20241022.yaml
@@ -16,12 +16,16 @@ limits:
     max_tokens: 8192
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: claude-3.5-haiku-20241022
 params:
     - key: max_tokens
       maxValue: 8192
+    - key: top_k
 sources:
     - https://openrouter.ai/anthropic/claude-3.5-haiku
     - https://openrouter.ai/anthropic/claude-3.5-haiku/api

--- a/providers/openrouter/claude-3.5-haiku.yaml
+++ b/providers/openrouter/claude-3.5-haiku.yaml
@@ -15,7 +15,10 @@ limits:
     max_tokens: 8192
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: claude-3.5-haiku
 params:

--- a/providers/openrouter/claude-3.5-haiku:beta.yaml
+++ b/providers/openrouter/claude-3.5-haiku:beta.yaml
@@ -16,7 +16,10 @@ limits:
     max_tokens: 8192
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: claude-3.5-haiku:beta
 params:

--- a/providers/openrouter/claude-3.5-sonnet-20240620.yaml
+++ b/providers/openrouter/claude-3.5-sonnet-20240620.yaml
@@ -11,7 +11,10 @@ limits:
     max_tokens: 8192
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: claude-3.5-sonnet-20240620
 params:

--- a/providers/openrouter/claude-3.5-sonnet.yaml
+++ b/providers/openrouter/claude-3.5-sonnet.yaml
@@ -8,13 +8,17 @@ features:
     - function_calling
     - tool_choice
     - tools
+    - prompt_caching
 limits:
     context_window: 200000
     max_output_tokens: 8192
     max_tokens: 8192
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: claude-3.5-sonnet
 params:

--- a/providers/openrouter/claude-3.5-sonnet:beta.yaml
+++ b/providers/openrouter/claude-3.5-sonnet:beta.yaml
@@ -15,7 +15,10 @@ limits:
     max_tokens: 8192
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: claude-3.5-sonnet:beta
 params:

--- a/providers/openrouter/claude-3.7-sonnet:beta.yaml
+++ b/providers/openrouter/claude-3.7-sonnet:beta.yaml
@@ -4,18 +4,23 @@ costs:
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: "*"
+deprecationDate: "2026-05-05"
 features:
     - tools
     - function_calling
     - prompt_caching
+    - tool_choice
 limits:
     context_window: 200000
     max_output_tokens: 64000
     max_tokens: 64000
 modalities:
     input:
+        - text
         - image
         - pdf
+    output:
+        - text
 mode: chat
 model: claude-3.7-sonnet:beta
 params:

--- a/providers/openrouter/claude-3.7-sonnet:thinking.yaml
+++ b/providers/openrouter/claude-3.7-sonnet:thinking.yaml
@@ -4,17 +4,22 @@ costs:
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: "*"
+deprecationDate: "2026-05-05"
 features:
     - function_calling
     - tool_choice
     - tools
+    - prompt_caching
 limits:
     context_window: 200000
     max_output_tokens: 64000
     max_tokens: 64000
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: claude-3.7-sonnet:thinking
 params:

--- a/providers/openrouter/claude-opus-4.yaml
+++ b/providers/openrouter/claude-opus-4.yaml
@@ -17,7 +17,10 @@ limits:
     max_tokens: 32000
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: claude-opus-4
 params:

--- a/providers/openrouter/claude-sonnet-4.yaml
+++ b/providers/openrouter/claude-sonnet-4.yaml
@@ -31,8 +31,11 @@ limits:
     max_tokens: 64000
 modalities:
     input:
+        - text
         - image
         - pdf
+    output:
+        - text
 mode: chat
 model: claude-sonnet-4
 params:

--- a/providers/openrouter/codex-mini.yaml
+++ b/providers/openrouter/codex-mini.yaml
@@ -7,7 +7,10 @@ limits:
     max_tokens: 100000
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: codex-mini
 params:
@@ -15,4 +18,5 @@ params:
       maxValue: 100000
 sources:
     - https://openrouter.ai/openai/codex-mini/api
+    - https://developers.openai.com/docs/deprecations
 thinking: true

--- a/providers/openrouter/cognitivecomputations/dolphin-mistral-24b-venice-edition:free.yaml
+++ b/providers/openrouter/cognitivecomputations/dolphin-mistral-24b-venice-edition:free.yaml
@@ -3,7 +3,9 @@ costs:
       output_cost_per_token: 0
       region: "*"
 features:
+    - function_calling
     - structured_output
+    - tool_choice
 limits:
     context_window: 32768
     max_tokens: 32768

--- a/providers/openrouter/cognitivecomputations/dolphin-mixtral-8x7b.yaml
+++ b/providers/openrouter/cognitivecomputations/dolphin-mixtral-8x7b.yaml
@@ -4,7 +4,13 @@ costs:
       region: "*"
 limits:
     context_window: 32768
+    max_output_tokens: 32768
     max_tokens: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: cognitivecomputations/dolphin-mixtral-8x7b
 sources:

--- a/providers/openrouter/command-a.yaml
+++ b/providers/openrouter/command-a.yaml
@@ -10,6 +10,11 @@ limits:
     context_window: 256000
     max_output_tokens: 8192
     max_tokens: 8192
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: command-a
 params:

--- a/providers/openrouter/command-r-03-2024.yaml
+++ b/providers/openrouter/command-r-03-2024.yaml
@@ -1,8 +1,19 @@
+costs:
+    - input_cost_per_token: 5.e-7
+      output_cost_per_token: 0.0000015
+      region: "*"
 features:
     - tools
     - function_calling
 limits:
     context_window: 128000
+    max_output_tokens: 4000
+    max_tokens: 4000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: command-r-03-2024
 params:
@@ -11,3 +22,4 @@ params:
 sources:
     - https://openrouter.ai/cohere/command-r-03-2024/api
     - https://docs.cohere.com/docs/command-r
+    - https://cohere.com/pricing

--- a/providers/openrouter/command-r-08-2024.yaml
+++ b/providers/openrouter/command-r-08-2024.yaml
@@ -11,6 +11,11 @@ limits:
     context_window: 128000
     max_output_tokens: 4000
     max_tokens: 4000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: command-r-08-2024
 params:

--- a/providers/openrouter/command-r-plus-04-2024.yaml
+++ b/providers/openrouter/command-r-plus-04-2024.yaml
@@ -10,6 +10,11 @@ limits:
     context_window: 128000
     max_output_tokens: 4000
     max_tokens: 4000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: command-r-plus-04-2024
 params:

--- a/providers/openrouter/command-r-plus-08-2024.yaml
+++ b/providers/openrouter/command-r-plus-08-2024.yaml
@@ -11,6 +11,11 @@ limits:
     context_window: 128000
     max_output_tokens: 4000
     max_tokens: 4000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: command-r-plus-08-2024
 params:

--- a/providers/openrouter/command-r-plus.yaml
+++ b/providers/openrouter/command-r-plus.yaml
@@ -12,6 +12,11 @@ limits:
     context_window: 128000
     max_output_tokens: 4000
     max_tokens: 4000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: command-r-plus
 params:

--- a/providers/openrouter/command-r.yaml
+++ b/providers/openrouter/command-r.yaml
@@ -6,6 +6,11 @@ limits:
     context_window: 128000
     max_output_tokens: 4000
     max_tokens: 4000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: command-r
 params:

--- a/providers/openrouter/command-r7b-12-2024.yaml
+++ b/providers/openrouter/command-r7b-12-2024.yaml
@@ -5,6 +5,7 @@ costs:
 features:
     - function_calling
     - tool_choice
+    - structured_output
 limits:
     context_window: 128000
     max_output_tokens: 4000

--- a/providers/openrouter/command.yaml
+++ b/providers/openrouter/command.yaml
@@ -1,3 +1,5 @@
+deprecationDate: 2025-09-15T00:00:00.000Z
+isDeprecated: true
 limits:
     context_window: 4096
     max_output_tokens: 4096

--- a/providers/openrouter/databricks/dbrx-instruct.yaml
+++ b/providers/openrouter/databricks/dbrx-instruct.yaml
@@ -6,6 +6,11 @@ limits:
     context_window: 32768
     max_output_tokens: 32768
     max_tokens: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: databricks/dbrx-instruct
 sources:

--- a/providers/openrouter/deepseek-chat-v3-0324.yaml
+++ b/providers/openrouter/deepseek-chat-v3-0324.yaml
@@ -6,8 +6,14 @@ costs:
 features:
     - tools
     - function_calling
+    - structured_output
 limits:
     context_window: 163840
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: deepseek-chat-v3-0324
 params:

--- a/providers/openrouter/deepseek-chat-v3-0324:free.yaml
+++ b/providers/openrouter/deepseek-chat-v3-0324:free.yaml
@@ -8,6 +8,13 @@ features:
     - tool_choice
 limits:
     context_window: 131072
+    max_output_tokens: 16384
+    max_tokens: 16384
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: deepseek-chat-v3-0324:free
 params:

--- a/providers/openrouter/deepseek-chat.yaml
+++ b/providers/openrouter/deepseek-chat.yaml
@@ -9,6 +9,11 @@ limits:
     context_window: 163840
     max_output_tokens: 163840
     max_tokens: 163840
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: deepseek-chat
 sources:

--- a/providers/openrouter/deepseek-prover-v2.yaml
+++ b/providers/openrouter/deepseek-prover-v2.yaml
@@ -1,6 +1,10 @@
 limits:
     context_window: 163840
-    max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: deepseek-prover-v2
 sources:

--- a/providers/openrouter/deepseek-r1-0528-qwen3-8b:free.yaml
+++ b/providers/openrouter/deepseek-r1-0528-qwen3-8b:free.yaml
@@ -6,8 +6,14 @@ limits:
     context_window: 131072
     max_output_tokens: 4096
     max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: deepseek-r1-0528-qwen3-8b:free
 sources:
     - https://openrouter.ai/deepseek/deepseek-r1-0528-qwen3-8b:free
+    - https://openrouter.ai/deepseek/deepseek-r1-0528-qwen3-8b:free/api
 thinking: true

--- a/providers/openrouter/deepseek-r1-0528.yaml
+++ b/providers/openrouter/deepseek-r1-0528.yaml
@@ -6,12 +6,21 @@ costs:
 features:
     - tools
     - function_calling
+    - structured_output
 limits:
     context_window: 163840
     max_output_tokens: 65536
     max_tokens: 65536
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: deepseek-r1-0528
+params:
+    - key: max_tokens
+      maxValue: 65536
 sources:
     - https://openrouter.ai/deepseek/deepseek-r1-0528/api
 thinking: true

--- a/providers/openrouter/deepseek-r1-0528:free.yaml
+++ b/providers/openrouter/deepseek-r1-0528:free.yaml
@@ -11,6 +11,11 @@ limits:
     max_input_tokens: 163840
     max_output_tokens: 65536
     max_tokens: 65536
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: deepseek-r1-0528:free
 sources:

--- a/providers/openrouter/deepseek-r1-distill-llama-70b.yaml
+++ b/providers/openrouter/deepseek-r1-distill-llama-70b.yaml
@@ -4,10 +4,18 @@ costs:
       region: "*"
 features:
     - tools
+    - function_calling
+    - tool_choice
+    - structured_output
 limits:
     context_window: 131072
     max_output_tokens: 16384
     max_tokens: 16384
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: deepseek-r1-distill-llama-70b
 sources:

--- a/providers/openrouter/deepseek-r1-distill-llama-70b:free.yaml
+++ b/providers/openrouter/deepseek-r1-distill-llama-70b:free.yaml
@@ -2,10 +2,17 @@ costs:
     - input_cost_per_token: 0
       output_cost_per_token: 0
       region: "*"
+features:
+    - structured_output
 limits:
     context_window: 131072
     max_output_tokens: 16384
     max_tokens: 16384
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: deepseek-r1-distill-llama-70b:free
 params:

--- a/providers/openrouter/deepseek-r1-distill-llama-8b.yaml
+++ b/providers/openrouter/deepseek-r1-distill-llama-8b.yaml
@@ -1,3 +1,8 @@
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: deepseek-r1-distill-llama-8b
 params:

--- a/providers/openrouter/deepseek-r1-distill-qwen-1.5b.yaml
+++ b/providers/openrouter/deepseek-r1-distill-qwen-1.5b.yaml
@@ -1,5 +1,10 @@
 limits:
     context_window: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: deepseek-r1-distill-qwen-1.5b
 params:

--- a/providers/openrouter/deepseek-r1-distill-qwen-14b.yaml
+++ b/providers/openrouter/deepseek-r1-distill-qwen-14b.yaml
@@ -1,5 +1,10 @@
 limits:
     context_window: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: deepseek-r1-distill-qwen-14b
 params:

--- a/providers/openrouter/deepseek-r1-distill-qwen-14b:free.yaml
+++ b/providers/openrouter/deepseek-r1-distill-qwen-14b:free.yaml
@@ -4,7 +4,11 @@ costs:
       region: "*"
 limits:
     context_window: 131072
-    max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: deepseek-r1-distill-qwen-14b:free
 sources:

--- a/providers/openrouter/deepseek-r1-distill-qwen-32b.yaml
+++ b/providers/openrouter/deepseek-r1-distill-qwen-32b.yaml
@@ -10,6 +10,11 @@ limits:
     context_window: 32768
     max_output_tokens: 32768
     max_tokens: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: deepseek-r1-distill-qwen-32b
 params:

--- a/providers/openrouter/deepseek-r1-distill-qwen-7b.yaml
+++ b/providers/openrouter/deepseek-r1-distill-qwen-7b.yaml
@@ -1,6 +1,10 @@
 limits:
     context_window: 131072
-    max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: deepseek-r1-distill-qwen-7b
 sources:

--- a/providers/openrouter/deepseek-r1.yaml
+++ b/providers/openrouter/deepseek-r1.yaml
@@ -10,6 +10,11 @@ limits:
     context_window: 64000
     max_output_tokens: 16000
     max_tokens: 16000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: deepseek-r1
 params:

--- a/providers/openrouter/deepseek-r1:free.yaml
+++ b/providers/openrouter/deepseek-r1:free.yaml
@@ -6,7 +6,11 @@ features:
     - function_calling
 limits:
     context_window: 163840
-    max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: deepseek-r1:free
 sources:

--- a/providers/openrouter/deepseek-r1t-chimera:free.yaml
+++ b/providers/openrouter/deepseek-r1t-chimera:free.yaml
@@ -6,6 +6,11 @@ limits:
     context_window: 163840
     max_output_tokens: 4096
     max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: deepseek-r1t-chimera:free
 sources:

--- a/providers/openrouter/deepseek-r1t2-chimera.yaml
+++ b/providers/openrouter/deepseek-r1t2-chimera.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_token_cost: 1.25e-7
-      input_cost_per_token: 2.5e-7
-      output_cost_per_token: 8.5e-7
+    - cache_read_input_token_cost: 1.5e-7
+      input_cost_per_token: 3.e-7
+      output_cost_per_token: 0.0000011
       region: "*"
 features:
     - function_calling
@@ -12,6 +12,11 @@ limits:
     context_window: 163840
     max_output_tokens: 163840
     max_tokens: 163840
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: deepseek-r1t2-chimera
 sources:

--- a/providers/openrouter/deepseek-r1t2-chimera:free.yaml
+++ b/providers/openrouter/deepseek-r1t2-chimera:free.yaml
@@ -7,12 +7,19 @@ features:
     - function_calling
     - tool_choice
     - structured_output
+    - prompt_caching
 limits:
     context_window: 163840
     max_output_tokens: 163840
     max_tokens: 163840
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: deepseek-r1t2-chimera:free
 sources:
     - https://openrouter.ai/tngtech/deepseek-r1t2-chimera/api
+    - https://openrouter.ai/tngtech/deepseek-r1t2-chimera:free/api
 thinking: true

--- a/providers/openrouter/deepseek-v3-base.yaml
+++ b/providers/openrouter/deepseek-v3-base.yaml
@@ -4,6 +4,11 @@ costs:
       region: "*"
 limits:
     context_window: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: deepseek-v3-base
 sources:

--- a/providers/openrouter/deepseek/deepseek-chat.yaml
+++ b/providers/openrouter/deepseek/deepseek-chat.yaml
@@ -16,5 +16,10 @@ modalities:
         - text
 mode: chat
 model: deepseek/deepseek-chat
+params:
+    - key: max_tokens
+      maxValue: 163840
 sources:
     - https://openrouter.ai/deepseek/deepseek-chat/api
+supportedModes:
+    - completion

--- a/providers/openrouter/deepseek/deepseek-r1-distill-llama-70b.yaml
+++ b/providers/openrouter/deepseek/deepseek-r1-distill-llama-70b.yaml
@@ -2,6 +2,10 @@ costs:
     - input_cost_per_token: 7.e-7
       output_cost_per_token: 8.e-7
       region: "*"
+features:
+    - function_calling
+    - tool_choice
+    - structured_output
 limits:
     context_window: 131072
     max_output_tokens: 16384

--- a/providers/openrouter/deepseek/deepseek-r1.yaml
+++ b/providers/openrouter/deepseek/deepseek-r1.yaml
@@ -5,8 +5,6 @@ costs:
 features:
     - function_calling
     - tool_choice
-    - prompt_caching
-    - assistant_prefill
 limits:
     context_window: 64000
     max_output_tokens: 16000
@@ -18,6 +16,11 @@ modalities:
         - text
 mode: chat
 model: deepseek/deepseek-r1
+params:
+    - defaultValue: 128
+      key: max_tokens
+      maxValue: 16000
+      minValue: 1
 sources:
     - https://openrouter.ai/deepseek/deepseek-r1/api
 thinking: true

--- a/providers/openrouter/deepseek/deepseek-v3.1-terminus:exacto.yaml
+++ b/providers/openrouter/deepseek/deepseek-v3.1-terminus:exacto.yaml
@@ -8,6 +8,11 @@ features:
 limits:
     context_window: 163840
     max_input_tokens: 163840
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: deepseek/deepseek-v3.1-terminus:exacto
 sources:

--- a/providers/openrouter/deepseek/deepseek-v3.2-exp.yaml
+++ b/providers/openrouter/deepseek/deepseek-v3.2-exp.yaml
@@ -19,6 +19,13 @@ modalities:
         - text
 mode: chat
 model: deepseek/deepseek-v3.2-exp
+params:
+    - defaultValue: 65536
+      key: max_tokens
+      maxValue: 65536
+      minValue: 1
+    - key: reasoning
+      type: json
 sources:
     - https://openrouter.ai/deepseek/deepseek-v3.2-exp/api
 thinking: true

--- a/providers/openrouter/deepseek/deepseek-v3.2.yaml
+++ b/providers/openrouter/deepseek/deepseek-v3.2.yaml
@@ -1,17 +1,13 @@
 costs:
-    - input_cost_per_token: 2.55e-7
-      output_cost_per_token: 4.e-7
+    - input_cost_per_token: 2.6e-7
+      output_cost_per_token: 3.8e-7
       region: "*"
 features:
     - function_calling
     - tool_choice
-    - prompt_caching
     - assistant_prefill
 limits:
     context_window: 163840
-    max_input_tokens: 163840
-    max_output_tokens: 163840
-    max_tokens: 163840
 modalities:
     input:
         - text

--- a/providers/openrouter/devstral-medium.yaml
+++ b/providers/openrouter/devstral-medium.yaml
@@ -1,5 +1,6 @@
 costs:
-    - input_cost_per_token: 4.e-7
+    - cache_read_input_token_cost: 4.e-8
+      input_cost_per_token: 4.e-7
       output_cost_per_token: 0.000002
       region: "*"
 features:
@@ -9,6 +10,11 @@ features:
     - tools
 limits:
     context_window: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: devstral-medium
 sources:

--- a/providers/openrouter/devstral-small-2505:free.yaml
+++ b/providers/openrouter/devstral-small-2505:free.yaml
@@ -2,8 +2,10 @@ costs:
     - input_cost_per_token: 0
       output_cost_per_token: 0
       region: "*"
+deprecationDate: 2025-11-30T00:00:00.000Z
 features:
     - tools
+isDeprecated: true
 limits:
     context_window: 131072
     max_input_tokens: 131072

--- a/providers/openrouter/devstral-small.yaml
+++ b/providers/openrouter/devstral-small.yaml
@@ -10,6 +10,11 @@ features:
     - system_messages
 limits:
     context_window: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: devstral-small
 sources:

--- a/providers/openrouter/dolphin-mistral-24b-venice-edition:free.yaml
+++ b/providers/openrouter/dolphin-mistral-24b-venice-edition:free.yaml
@@ -2,9 +2,16 @@ costs:
     - input_cost_per_token: 0
       output_cost_per_token: 0
       region: "*"
+features:
+    - structured_output
 limits:
     context_window: 32768
     max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: dolphin-mistral-24b-venice-edition:free
 sources:

--- a/providers/openrouter/dolphin-mixtral-8x22b.yaml
+++ b/providers/openrouter/dolphin-mixtral-8x22b.yaml
@@ -1,5 +1,10 @@
 limits:
     context_window: 65536
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: dolphin-mixtral-8x22b
 params:

--- a/providers/openrouter/dolphin3.0-mistral-24b:free.yaml
+++ b/providers/openrouter/dolphin3.0-mistral-24b:free.yaml
@@ -2,10 +2,17 @@ costs:
     - input_cost_per_token: 0
       output_cost_per_token: 0
       region: "*"
+features:
+    - function_calling
 limits:
     context_window: 32768
     max_output_tokens: 4096
     max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: dolphin3.0-mistral-24b:free
 sources:

--- a/providers/openrouter/dolphin3.0-r1-mistral-24b.yaml
+++ b/providers/openrouter/dolphin3.0-r1-mistral-24b.yaml
@@ -4,6 +4,11 @@ limits:
     context_window: 32768
     max_output_tokens: 4096
     max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: dolphin3.0-r1-mistral-24b
 sources:

--- a/providers/openrouter/dolphin3.0-r1-mistral-24b:free.yaml
+++ b/providers/openrouter/dolphin3.0-r1-mistral-24b:free.yaml
@@ -6,6 +6,11 @@ limits:
     context_window: 32768
     max_output_tokens: 4096
     max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: dolphin3.0-r1-mistral-24b:free
 sources:

--- a/providers/openrouter/ernie-4.5-300b-a47b.yaml
+++ b/providers/openrouter/ernie-4.5-300b-a47b.yaml
@@ -2,10 +2,17 @@ costs:
     - input_cost_per_token: 2.8e-7
       output_cost_per_token: 0.0000011
       region: "*"
+features:
+    - structured_output
 limits:
     context_window: 131072
     max_output_tokens: 12000
     max_tokens: 12000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: ernie-4.5-300b-a47b
 params:

--- a/providers/openrouter/essentialai/rnj-1-instruct.yaml
+++ b/providers/openrouter/essentialai/rnj-1-instruct.yaml
@@ -6,6 +6,7 @@ features:
     - function_calling
     - structured_output
     - tools
+    - tool_choice
 limits:
     context_window: 32768
 modalities:
@@ -17,3 +18,4 @@ mode: chat
 model: essentialai/rnj-1-instruct
 sources:
     - https://openrouter.ai/essentialai/rnj-1-instruct/api
+thinking: true

--- a/providers/openrouter/fimbulvetr-11b-v2.yaml
+++ b/providers/openrouter/fimbulvetr-11b-v2.yaml
@@ -1,5 +1,10 @@
 limits:
     context_window: 8192
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: fimbulvetr-11b-v2
 params:

--- a/providers/openrouter/fireworks/firellava-13b.yaml
+++ b/providers/openrouter/fireworks/firellava-13b.yaml
@@ -7,7 +7,10 @@ limits:
     max_tokens: 4096
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: fireworks/firellava-13b
 sources:

--- a/providers/openrouter/gemini-2.5-flash-lite.yaml
+++ b/providers/openrouter/gemini-2.5-flash-lite.yaml
@@ -17,8 +17,10 @@ limits:
     max_tokens: 65535
 modalities:
     input:
-        - audio
+        - text
         - image
+        - audio
+        - video
 mode: chat
 model: gemini-2.5-flash-lite
 params:

--- a/providers/openrouter/gemini-2.5-flash.yaml
+++ b/providers/openrouter/gemini-2.5-flash.yaml
@@ -21,8 +21,12 @@ limits:
     max_tokens: 65535
 modalities:
     input:
-        - audio
+        - text
         - image
+        - audio
+        - video
+    output:
+        - text
 mode: chat
 model: gemini-2.5-flash
 params:

--- a/providers/openrouter/gemini-2.5-pro.yaml
+++ b/providers/openrouter/gemini-2.5-pro.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 1.25e-7
-      cache_storage_cost_per_token_per_hour: 0.0000045
+    - cache_creation_input_token_cost: 3.75e-7
+      cache_read_input_token_cost: 1.25e-7
       input_cost_per_audio_token: 0.00000125
       input_cost_per_token: 0.00000125
       output_cost_per_token: 0.00001
@@ -8,6 +8,9 @@ costs:
       tiered_pricing:
           cache_read:
               - cost_per_token: 2.5e-7
+                from: 200000
+          cache_write:
+              - cost_per_token: 7.5e-7
                 from: 200000
           input:
               - cost_per_token: 0.0000025
@@ -28,8 +31,12 @@ limits:
     max_tokens: 65536
 modalities:
     input:
-        - audio
+        - text
         - image
+        - audio
+        - video
+    output:
+        - text
 mode: chat
 model: gemini-2.5-pro
 params:

--- a/providers/openrouter/gemini-flash-1.5-8b.yaml
+++ b/providers/openrouter/gemini-flash-1.5-8b.yaml
@@ -12,7 +12,10 @@ limits:
     max_tokens: 8192
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: gemini-flash-1.5-8b
 params:

--- a/providers/openrouter/gemini-flash-1.5.yaml
+++ b/providers/openrouter/gemini-flash-1.5.yaml
@@ -2,9 +2,14 @@ features:
     - tools
 limits:
     context_window: 1000000
+    max_output_tokens: 8192
+    max_tokens: 8192
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: gemini-flash-1.5
 params:

--- a/providers/openrouter/gemini-pro-1.5.yaml
+++ b/providers/openrouter/gemini-pro-1.5.yaml
@@ -12,7 +12,10 @@ limits:
     max_tokens: 8192
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: gemini-pro-1.5
 params:

--- a/providers/openrouter/gemma-2-27b-it.yaml
+++ b/providers/openrouter/gemma-2-27b-it.yaml
@@ -2,10 +2,19 @@ costs:
     - input_cost_per_token: 6.5e-7
       output_cost_per_token: 6.5e-7
       region: "*"
+features:
+    - function_calling
+    - structured_output
+    - tool_choice
 limits:
     context_window: 8192
     max_output_tokens: 2048
     max_tokens: 2048
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: gemma-2-27b-it
 sources:

--- a/providers/openrouter/gemma-2-9b-it.yaml
+++ b/providers/openrouter/gemma-2-9b-it.yaml
@@ -2,10 +2,19 @@ costs:
     - input_cost_per_token: 3.e-8
       output_cost_per_token: 9.e-8
       region: "*"
+features:
+    - function_calling
+    - tool_choice
+    - structured_output
 limits:
     context_window: 8192
     max_output_tokens: 8192
     max_tokens: 8192
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: gemma-2-9b-it
 params:

--- a/providers/openrouter/gemma-2-9b-it:free.yaml
+++ b/providers/openrouter/gemma-2-9b-it:free.yaml
@@ -6,6 +6,11 @@ limits:
     context_window: 8192
     max_output_tokens: 8192
     max_tokens: 8192
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: gemma-2-9b-it:free
 params:

--- a/providers/openrouter/gemma-3-12b-it.yaml
+++ b/providers/openrouter/gemma-3-12b-it.yaml
@@ -10,7 +10,10 @@ limits:
     context_window: 131072
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: gemma-3-12b-it
 params:

--- a/providers/openrouter/gemma-3-12b-it:free.yaml
+++ b/providers/openrouter/gemma-3-12b-it:free.yaml
@@ -4,14 +4,16 @@ costs:
       region: "*"
 features:
     - function_calling
-    - structured_output
 limits:
     context_window: 32768
     max_output_tokens: 8192
     max_tokens: 8192
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: gemma-3-12b-it:free
 params:

--- a/providers/openrouter/gemma-3-27b-it.yaml
+++ b/providers/openrouter/gemma-3-27b-it.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 3.e-8
-      output_cost_per_token: 1.1e-7
+    - input_cost_per_token: 8.e-8
+      output_cost_per_token: 1.6e-7
       region: "*"
 features:
     - function_calling
@@ -9,16 +9,19 @@ features:
     - structured_output
     - system_messages
 limits:
-    context_window: 128000
-    max_output_tokens: 65536
-    max_tokens: 65536
+    context_window: 131072
+    max_output_tokens: 16384
+    max_tokens: 16384
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: gemma-3-27b-it
 params:
     - key: max_tokens
-      maxValue: 65536
+      maxValue: 16384
 sources:
     - https://openrouter.ai/google/gemma-3-27b-it/api

--- a/providers/openrouter/gemma-3-27b-it:free.yaml
+++ b/providers/openrouter/gemma-3-27b-it:free.yaml
@@ -12,7 +12,10 @@ limits:
     max_tokens: 8192
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: gemma-3-27b-it:free
 params:

--- a/providers/openrouter/gemma-3-4b-it.yaml
+++ b/providers/openrouter/gemma-3-4b-it.yaml
@@ -11,7 +11,10 @@ limits:
     max_tokens: 4096
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: gemma-3-4b-it
 sources:

--- a/providers/openrouter/gemma-3-4b-it:free.yaml
+++ b/providers/openrouter/gemma-3-4b-it:free.yaml
@@ -11,7 +11,10 @@ limits:
     max_tokens: 8192
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: gemma-3-4b-it:free
 params:

--- a/providers/openrouter/gemma-3n-e2b-it:free.yaml
+++ b/providers/openrouter/gemma-3n-e2b-it:free.yaml
@@ -6,6 +6,11 @@ limits:
     context_window: 8192
     max_output_tokens: 2048
     max_tokens: 2048
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: gemma-3n-e2b-it:free
 params:

--- a/providers/openrouter/gemma-3n-e4b-it.yaml
+++ b/providers/openrouter/gemma-3n-e4b-it.yaml
@@ -6,6 +6,11 @@ limits:
     context_window: 32768
     max_output_tokens: 4096
     max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: gemma-3n-e4b-it
 sources:

--- a/providers/openrouter/gemma-3n-e4b-it:free.yaml
+++ b/providers/openrouter/gemma-3n-e4b-it:free.yaml
@@ -6,6 +6,11 @@ limits:
     context_window: 8192
     max_output_tokens: 2048
     max_tokens: 2048
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: gemma-3n-e4b-it:free
 params:

--- a/providers/openrouter/glm-4-32b.yaml
+++ b/providers/openrouter/glm-4-32b.yaml
@@ -7,6 +7,11 @@ features:
     - tool_choice
 limits:
     context_window: 128000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: glm-4-32b
 params:

--- a/providers/openrouter/glm-4.1v-9b-thinking.yaml
+++ b/providers/openrouter/glm-4.1v-9b-thinking.yaml
@@ -2,7 +2,10 @@ limits:
     context_window: 65536
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: glm-4.1v-9b-thinking
 params:

--- a/providers/openrouter/glm-4.5-air:free.yaml
+++ b/providers/openrouter/glm-4.5-air:free.yaml
@@ -10,6 +10,11 @@ limits:
     context_window: 131072
     max_output_tokens: 96000
     max_tokens: 96000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: glm-4.5-air:free
 sources:

--- a/providers/openrouter/glm-4.5.yaml
+++ b/providers/openrouter/glm-4.5.yaml
@@ -7,12 +7,20 @@ features:
     - tools
     - function_calling
     - tool_choice
+    - structured_output
 limits:
     context_window: 131072
     max_output_tokens: 98304
     max_tokens: 98304
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: glm-4.5
+params:
+    - key: reasoning
 sources:
     - https://openrouter.ai/z-ai/glm-4.5/api
 thinking: true

--- a/providers/openrouter/glm-z1-32b.yaml
+++ b/providers/openrouter/glm-z1-32b.yaml
@@ -4,7 +4,13 @@ features:
     - tools
 limits:
     context_window: 32768
+    max_output_tokens: 4096
     max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: glm-z1-32b
 sources:

--- a/providers/openrouter/glm-z1-32b:free.yaml
+++ b/providers/openrouter/glm-z1-32b:free.yaml
@@ -8,6 +8,11 @@ limits:
     context_window: 32768
     max_output_tokens: 4096
     max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: glm-z1-32b:free
 sources:

--- a/providers/openrouter/goliath-120b.yaml
+++ b/providers/openrouter/goliath-120b.yaml
@@ -6,6 +6,11 @@ limits:
     context_window: 6144
     max_output_tokens: 1024
     max_tokens: 1024
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: goliath-120b
 sources:

--- a/providers/openrouter/google/gemini-2.0-flash-001.yaml
+++ b/providers/openrouter/google/gemini-2.0-flash-001.yaml
@@ -1,10 +1,11 @@
 costs:
-    - cache_creation_input_token_cost: 8.333333e-8
-      cache_read_input_token_cost: 2.5e-8
+    - cache_read_input_token_cost: 2.5e-8
+      cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 7.e-7
       input_cost_per_token: 1.e-7
       output_cost_per_token: 4.e-7
       region: "*"
+deprecationDate: "2026-06-01"
 features:
     - function_calling
     - system_messages
@@ -18,8 +19,12 @@ limits:
     max_tokens: 8192
 modalities:
     input:
-        - audio
+        - text
         - image
+        - audio
+        - video
+    output:
+        - text
 mode: chat
 model: google/gemini-2.0-flash-001
 sources:

--- a/providers/openrouter/google/gemini-2.5-flash-image.yaml
+++ b/providers/openrouter/google/gemini-2.5-flash-image.yaml
@@ -1,8 +1,5 @@
 costs:
-    - cache_creation_input_token_cost: 8.333333333333334e-8
-      cache_read_input_token_cost: 3.e-8
-      input_cost_per_image: 3.e-7
-      input_cost_per_token: 3.e-7
+    - input_cost_per_token: 3.e-7
       output_cost_per_token: 0.0000025
       region: "*"
 features:
@@ -23,4 +20,3 @@ mode: chat
 model: google/gemini-2.5-flash-image
 sources:
     - https://openrouter.ai/google/gemini-2.5-flash-image/api
-thinking: false

--- a/providers/openrouter/google/gemini-2.5-flash-lite-preview-09-2025.yaml
+++ b/providers/openrouter/google/gemini-2.5-flash-lite-preview-09-2025.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_creation_input_token_cost: 8.333333333333334e-8
-      cache_read_input_token_cost: 1.e-8
-      input_cost_per_image: 1.e-7
+    - cache_read_input_token_cost: 1.e-8
+      cache_storage_cost_per_token_per_hour: 0.000001
+      input_cost_per_audio_token: 3.e-7
       input_cost_per_token: 1.e-7
       output_cost_per_token: 4.e-7
       region: "*"
@@ -18,9 +18,9 @@ modalities:
     input:
         - text
         - image
-        - pdf
         - audio
         - video
+        - pdf
     output:
         - text
 mode: chat

--- a/providers/openrouter/google/gemini-2.5-flash-lite.yaml
+++ b/providers/openrouter/google/gemini-2.5-flash-lite.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_creation_input_token_cost: 8.333333333333334e-8
-      cache_read_input_token_cost: 1.e-8
-      input_cost_per_image: 1.e-7
+    - cache_read_input_token_cost: 1.e-8
+      cache_storage_cost_per_token_per_hour: 0.000001
+      input_cost_per_audio_token: 3.e-7
       input_cost_per_token: 1.e-7
       output_cost_per_token: 4.e-7
       region: "*"

--- a/providers/openrouter/google/gemini-2.5-flash.yaml
+++ b/providers/openrouter/google/gemini-2.5-flash.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_creation_input_token_cost: 8.333333333333334e-8
       cache_read_input_token_cost: 3.e-8
-      input_cost_per_image: 3.e-7
+      input_cost_per_audio_token: 0.000001
       input_cost_per_token: 3.e-7
       output_cost_per_token: 0.0000025
       region: "*"
@@ -10,21 +10,25 @@ features:
     - system_messages
     - tool_choice
     - structured_output
+    - prompt_caching
 limits:
     context_window: 1048576
     max_output_tokens: 65535
     max_tokens: 65535
 modalities:
     input:
-        - pdf
-        - image
         - text
+        - image
         - audio
         - video
+        - pdf
     output:
         - text
 mode: chat
 model: google/gemini-2.5-flash
+params:
+    - key: max_tokens
+      maxValue: 65535
 sources:
     - https://openrouter.ai/google/gemini-2.5-flash/api
 thinking: true

--- a/providers/openrouter/google/gemini-2.5-pro-preview-05-06.yaml
+++ b/providers/openrouter/google/gemini-2.5-pro-preview-05-06.yaml
@@ -1,10 +1,23 @@
 costs:
     - cache_creation_input_token_cost: 3.75e-7
       cache_read_input_token_cost: 1.25e-7
-      input_cost_per_image: 0.00000125
+      input_cost_per_audio_token: 0.00000125
       input_cost_per_token: 0.00000125
       output_cost_per_token: 0.00001
       region: "*"
+      tiered_pricing:
+          cache_read:
+              - cost_per_token: 2.5e-7
+                from: 200000
+          cache_write:
+              - cost_per_token: 7.5e-7
+                from: 200000
+          input:
+              - cost_per_token: 0.0000025
+                from: 200000
+          output:
+              - cost_per_token: 0.000015
+                from: 200000
 features:
     - function_calling
     - system_messages
@@ -14,7 +27,7 @@ features:
     - tools
 limits:
     context_window: 1048576
-    max_output_tokens: 65535
+    max_output_tokens: 65536
     max_tokens: 65536
 modalities:
     input:
@@ -27,6 +40,9 @@ modalities:
         - text
 mode: chat
 model: google/gemini-2.5-pro-preview-05-06
+params:
+    - key: max_tokens
+      maxValue: 65536
 sources:
     - https://openrouter.ai/google/gemini-2.5-pro-preview-05-06/api
 thinking: true

--- a/providers/openrouter/google/gemini-2.5-pro-preview.yaml
+++ b/providers/openrouter/google/gemini-2.5-pro-preview.yaml
@@ -1,26 +1,41 @@
 costs:
     - cache_creation_input_token_cost: 3.75e-7
       cache_read_input_token_cost: 1.25e-7
-      input_cost_per_image: 0.00000125
+      input_cost_per_audio_token: 0.00000125
       input_cost_per_token: 0.00000125
       output_cost_per_token: 0.00001
       region: "*"
+      tiered_pricing:
+          cache_read:
+              - cost_per_token: 2.5e-7
+                from: 200000
+          cache_write:
+              - cost_per_token: 7.5e-7
+                from: 200000
+          input:
+              - cost_per_token: 0.0000025
+                from: 200000
+          output:
+              - cost_per_token: 0.000015
+                from: 200000
 features:
     - function_calling
     - tool_choice
     - structured_output
     - system_messages
     - tools
+    - prompt_caching
 limits:
     context_window: 1048576
     max_output_tokens: 65536
     max_tokens: 65536
 modalities:
     input:
-        - pdf
-        - image
         - text
+        - image
         - audio
+        - pdf
+        - video
     output:
         - text
 mode: chat

--- a/providers/openrouter/google/gemini-2.5-pro.yaml
+++ b/providers/openrouter/google/gemini-2.5-pro.yaml
@@ -1,15 +1,30 @@
 costs:
     - cache_creation_input_token_cost: 3.75e-7
       cache_read_input_token_cost: 1.25e-7
-      input_cost_per_image: 0.00000125
+      input_cost_per_audio_token: 0.00000125
+      input_cost_per_image_token: 0.00000125
       input_cost_per_token: 0.00000125
       output_cost_per_token: 0.00001
       region: "*"
+      tiered_pricing:
+          cache_read:
+              - cost_per_token: 2.5e-7
+                from: 200000
+          cache_write:
+              - cost_per_token: 7.5e-7
+                from: 200000
+          input:
+              - cost_per_token: 0.0000025
+                from: 200000
+          output:
+              - cost_per_token: 0.000015
+                from: 200000
 features:
     - function_calling
     - system_messages
     - tool_choice
     - structured_output
+    - prompt_caching
 limits:
     context_window: 1048576
     max_input_tokens: 1048576
@@ -26,6 +41,9 @@ modalities:
         - text
 mode: chat
 model: google/gemini-2.5-pro
+params:
+    - key: max_tokens
+      maxValue: 65536
 sources:
     - https://openrouter.ai/google/gemini-2.5-pro/api
 thinking: true

--- a/providers/openrouter/google/gemini-3-flash-preview.yaml
+++ b/providers/openrouter/google/gemini-3-flash-preview.yaml
@@ -1,7 +1,5 @@
 costs:
-    - cache_creation_input_token_cost: 8.333333333333334e-8
-      cache_read_input_token_cost: 5.e-8
-      input_cost_per_image: 5.e-7
+    - input_cost_per_audio_token: 0.000001
       input_cost_per_token: 5.e-7
       output_cost_per_token: 0.000003
       region: "*"
@@ -27,6 +25,9 @@ modalities:
         - text
 mode: chat
 model: google/gemini-3-flash-preview
+params:
+    - key: max_tokens
+      maxValue: 65536
 sources:
     - https://openrouter.ai/google/gemini-3-flash-preview/api
 thinking: true

--- a/providers/openrouter/google/gemini-3-pro-image-preview.yaml
+++ b/providers/openrouter/google/gemini-3-pro-image-preview.yaml
@@ -1,8 +1,7 @@
 costs:
-    - cache_creation_input_token_cost: 3.75e-7
-      cache_read_input_token_cost: 2.e-7
-      input_cost_per_image: 0.000002
+    - cache_read_input_token_cost: 2.e-7
       input_cost_per_token: 0.000002
+      output_cost_per_image_token: 0.00012
       output_cost_per_token: 0.000012
       region: "*"
 features:
@@ -26,4 +25,5 @@ mode: chat
 model: google/gemini-3-pro-image-preview
 sources:
     - https://openrouter.ai/google/gemini-3-pro-image-preview/api
+    - https://ai.google.dev/pricing
 thinking: true

--- a/providers/openrouter/google/gemini-3.1-flash-image-preview.yaml
+++ b/providers/openrouter/google/gemini-3.1-flash-image-preview.yaml
@@ -1,5 +1,6 @@
 costs:
     - input_cost_per_token: 5.e-7
+      output_cost_per_image_token: 0.00006
       output_cost_per_token: 0.000003
       region: "*"
 features:

--- a/providers/openrouter/google/gemini-3.1-pro-preview-customtools.yaml
+++ b/providers/openrouter/google/gemini-3.1-pro-preview-customtools.yaml
@@ -1,10 +1,17 @@
 costs:
     - cache_creation_input_token_cost: 3.75e-7
       cache_read_input_token_cost: 2.e-7
-      input_cost_per_image: 0.000002
+      input_cost_per_audio_token: 0.000002
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000012
       region: "*"
+      tiered_pricing:
+          input:
+              - cost_per_token: 0.000004
+                from: 200000
+          output:
+              - cost_per_token: 0.000018
+                from: 200000
 features:
     - function_calling
     - tool_choice
@@ -27,6 +34,11 @@ modalities:
         - text
 mode: chat
 model: google/gemini-3.1-pro-preview-customtools
+params:
+    - defaultValue: 128
+      key: max_tokens
+      maxValue: 65536
+      minValue: 1
 sources:
     - https://openrouter.ai/google/gemini-3.1-pro-preview-customtools/api
 thinking: true

--- a/providers/openrouter/google/gemini-3.1-pro-preview.yaml
+++ b/providers/openrouter/google/gemini-3.1-pro-preview.yaml
@@ -11,6 +11,8 @@ features:
     - structured_output
     - system_messages
     - tools
+    - prompt_caching
+    - code_execution
 limits:
     context_window: 1048576
     max_output_tokens: 65536
@@ -26,6 +28,13 @@ modalities:
         - text
 mode: chat
 model: google/gemini-3.1-pro-preview
+params:
+    - defaultValue: 128
+      key: max_tokens
+      maxValue: 65536
+      minValue: 1
 sources:
     - https://openrouter.ai/google/gemini-3.1-pro-preview/api
+    - https://ai.google.dev/gemini-api/docs/models/gemini-3.1-pro-preview
+    - https://ai.google.dev/pricing
 thinking: true

--- a/providers/openrouter/google/gemini-pro-1.5.yaml
+++ b/providers/openrouter/google/gemini-pro-1.5.yaml
@@ -12,7 +12,10 @@ limits:
     max_tokens: 8192
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: google/gemini-pro-1.5
 sources:

--- a/providers/openrouter/google/gemma-3-12b-it:free.yaml
+++ b/providers/openrouter/google/gemma-3-12b-it:free.yaml
@@ -4,7 +4,7 @@ costs:
       region: "*"
 features:
     - function_calling
-    - structured_output
+    - tool_choice
     - tools
 limits:
     context_window: 32768

--- a/providers/openrouter/google/gemma-3-27b-it.yaml
+++ b/providers/openrouter/google/gemma-3-27b-it.yaml
@@ -1,7 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 1.5e-8
-      input_cost_per_token: 3.e-8
-      output_cost_per_token: 1.1e-7
+    - input_cost_per_token: 8.e-8
+      output_cost_per_token: 1.6e-7
       region: "*"
 features:
     - function_calling
@@ -9,10 +8,9 @@ features:
     - tool_choice
     - tools
 limits:
-    context_window: 128000
-    max_input_tokens: 62464
-    max_output_tokens: 65536
-    max_tokens: 65536
+    context_window: 131072
+    max_output_tokens: 16384
+    max_tokens: 16384
 modalities:
     input:
         - text

--- a/providers/openrouter/google/gemma-3-27b-it:free.yaml
+++ b/providers/openrouter/google/gemma-3-27b-it:free.yaml
@@ -5,7 +5,6 @@ costs:
 features:
     - function_calling
     - tool_choice
-    - structured_output
     - system_messages
 limits:
     context_window: 131072

--- a/providers/openrouter/google/gemma-3-4b-it.yaml
+++ b/providers/openrouter/google/gemma-3-4b-it.yaml
@@ -4,6 +4,8 @@ costs:
       region: "*"
 features:
     - function_calling
+    - structured_output
+    - tool_choice
 limits:
     context_window: 131072
 modalities:

--- a/providers/openrouter/google/gemma-3-4b-it:free.yaml
+++ b/providers/openrouter/google/gemma-3-4b-it:free.yaml
@@ -2,6 +2,10 @@ costs:
     - input_cost_per_token: 0
       output_cost_per_token: 0
       region: "*"
+features:
+    - function_calling
+    - tool_choice
+    - system_messages
 limits:
     context_window: 32768
     max_output_tokens: 8192

--- a/providers/openrouter/google/palm-2-chat-bison.yaml
+++ b/providers/openrouter/google/palm-2-chat-bison.yaml
@@ -4,6 +4,11 @@ costs:
       region: "*"
 limits:
     context_window: 9216
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: google/palm-2-chat-bison
 sources:

--- a/providers/openrouter/google/palm-2-codechat-bison.yaml
+++ b/providers/openrouter/google/palm-2-codechat-bison.yaml
@@ -6,6 +6,11 @@ limits:
     context_window: 7168
     max_output_tokens: 20070
     max_tokens: 20070
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: google/palm-2-codechat-bison
 sources:

--- a/providers/openrouter/gpt-3.5-turbo-0613.yaml
+++ b/providers/openrouter/gpt-3.5-turbo-0613.yaml
@@ -5,10 +5,17 @@ costs:
 features:
     - function_calling
     - tools
+    - tool_choice
+    - structured_output
 limits:
     context_window: 4095
     max_output_tokens: 4096
     max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: gpt-3.5-turbo-0613
 params:

--- a/providers/openrouter/gpt-3.5-turbo-16k.yaml
+++ b/providers/openrouter/gpt-3.5-turbo-16k.yaml
@@ -5,11 +5,17 @@ costs:
 features:
     - function_calling
     - tools
+    - tool_choice
     - structured_output
 limits:
     context_window: 16385
     max_output_tokens: 4096
     max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: gpt-3.5-turbo-16k
 params:

--- a/providers/openrouter/gpt-3.5-turbo-instruct.yaml
+++ b/providers/openrouter/gpt-3.5-turbo-instruct.yaml
@@ -2,14 +2,18 @@ costs:
     - input_cost_per_token: 0.0000015
       output_cost_per_token: 0.000002
       region: "*"
+features:
+    - structured_output
 limits:
     context_window: 4095
     max_output_tokens: 4096
     max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: gpt-3.5-turbo-instruct
-params:
-    - key: max_tokens
-      maxValue: 4096
 sources:
     - https://openrouter.ai/openai/gpt-3.5-turbo-instruct/api

--- a/providers/openrouter/gpt-4-turbo.yaml
+++ b/providers/openrouter/gpt-4-turbo.yaml
@@ -13,7 +13,10 @@ limits:
     max_tokens: 4096
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: gpt-4-turbo
 params:

--- a/providers/openrouter/gpt-4.1-mini.yaml
+++ b/providers/openrouter/gpt-4.1-mini.yaml
@@ -13,7 +13,10 @@ limits:
     max_tokens: 32768
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: gpt-4.1-mini
 params:

--- a/providers/openrouter/gpt-4.1-nano.yaml
+++ b/providers/openrouter/gpt-4.1-nano.yaml
@@ -15,7 +15,10 @@ limits:
     max_tokens: 32768
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: gpt-4.1-nano
 params:

--- a/providers/openrouter/gpt-4.1.yaml
+++ b/providers/openrouter/gpt-4.1.yaml
@@ -8,13 +8,17 @@ features:
     - tools
     - structured_output
     - system_messages
+    - tool_choice
 limits:
     context_window: 1047576
     max_output_tokens: 32768
     max_tokens: 32768
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: gpt-4.1
 params:

--- a/providers/openrouter/gpt-4.yaml
+++ b/providers/openrouter/gpt-4.yaml
@@ -12,6 +12,11 @@ limits:
     context_window: 8191
     max_output_tokens: 4096
     max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: gpt-4
 sources:

--- a/providers/openrouter/gpt-4o-2024-05-13.yaml
+++ b/providers/openrouter/gpt-4o-2024-05-13.yaml
@@ -14,7 +14,10 @@ limits:
     max_tokens: 4096
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: gpt-4o-2024-05-13
 params:

--- a/providers/openrouter/gpt-4o-2024-08-06.yaml
+++ b/providers/openrouter/gpt-4o-2024-08-06.yaml
@@ -16,7 +16,10 @@ limits:
     max_tokens: 16384
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: gpt-4o-2024-08-06
 params:

--- a/providers/openrouter/gpt-4o-2024-11-20.yaml
+++ b/providers/openrouter/gpt-4o-2024-11-20.yaml
@@ -7,13 +7,17 @@ features:
     - function_calling
     - tools
     - tool_choice
+    - structured_output
 limits:
     context_window: 128000
     max_output_tokens: 16384
     max_tokens: 16384
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: gpt-4o-2024-11-20
 params:

--- a/providers/openrouter/gpt-4o-mini-2024-07-18.yaml
+++ b/providers/openrouter/gpt-4o-mini-2024-07-18.yaml
@@ -15,7 +15,10 @@ limits:
     max_tokens: 16384
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: gpt-4o-mini-2024-07-18
 params:

--- a/providers/openrouter/gpt-4o-mini.yaml
+++ b/providers/openrouter/gpt-4o-mini.yaml
@@ -14,7 +14,10 @@ limits:
     max_tokens: 16384
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: gpt-4o-mini
 params:

--- a/providers/openrouter/gpt-4o.yaml
+++ b/providers/openrouter/gpt-4o.yaml
@@ -16,7 +16,10 @@ limits:
     max_tokens: 16384
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: gpt-4o
 params:

--- a/providers/openrouter/gpt-4o:extended.yaml
+++ b/providers/openrouter/gpt-4o:extended.yaml
@@ -15,7 +15,10 @@ limits:
     max_tokens: 64000
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: gpt-4o:extended
 params:

--- a/providers/openrouter/gpt-oss-120b.yaml
+++ b/providers/openrouter/gpt-oss-120b.yaml
@@ -9,11 +9,18 @@ features:
     - structured_output
 limits:
     context_window: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: gpt-oss-120b
 params:
     - key: max_tokens
       maxValue: 32768
+    - defaultValue: medium
+      key: reasoning_effort
 removeParams:
     - stream
 sources:

--- a/providers/openrouter/gpt-oss-20b.yaml
+++ b/providers/openrouter/gpt-oss-20b.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 3.e-8
-      output_cost_per_token: 1.4e-7
+      output_cost_per_token: 1.1e-7
       region: "*"
 features:
     - function_calling
@@ -8,11 +8,20 @@ features:
     - structured_output
 limits:
     context_window: 131072
+    max_output_tokens: 131072
+    max_tokens: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: gpt-oss-20b
 params:
     - key: max_tokens
-      maxValue: 32768
+      maxValue: 131072
+    - key: reasoning_effort
+      type: string
 removeParams:
     - stream
 sources:

--- a/providers/openrouter/grok-2-vision-1212.yaml
+++ b/providers/openrouter/grok-2-vision-1212.yaml
@@ -2,7 +2,10 @@ limits:
     context_window: 32768
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: grok-2-vision-1212
 sources:

--- a/providers/openrouter/grok-3-beta.yaml
+++ b/providers/openrouter/grok-3-beta.yaml
@@ -11,6 +11,11 @@ features:
     - system_messages
 limits:
     context_window: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: grok-3-beta
 sources:

--- a/providers/openrouter/grok-3-mini-beta.yaml
+++ b/providers/openrouter/grok-3-mini-beta.yaml
@@ -10,7 +10,11 @@ features:
     - structured_output
 limits:
     context_window: 131072
-    max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: grok-3-mini-beta
 sources:

--- a/providers/openrouter/grok-3-mini.yaml
+++ b/providers/openrouter/grok-3-mini.yaml
@@ -9,8 +9,16 @@ features:
     - structured_output
 limits:
     context_window: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: grok-3-mini
+params:
+    - key: reasoning_effort
+      type: string
 sources:
     - https://openrouter.ai/x-ai/grok-3-mini/api
     - https://docs.x.ai/developers/models#models-and-pricing

--- a/providers/openrouter/grok-3.yaml
+++ b/providers/openrouter/grok-3.yaml
@@ -10,7 +10,11 @@ features:
     - structured_output
 limits:
     context_window: 131072
-    max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: grok-3
 sources:

--- a/providers/openrouter/grok-4.yaml
+++ b/providers/openrouter/grok-4.yaml
@@ -20,10 +20,12 @@ features:
     - prompt_caching
 limits:
     context_window: 256000
-    max_tokens: 4096
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: grok-4
 sources:

--- a/providers/openrouter/grok-vision-beta.yaml
+++ b/providers/openrouter/grok-vision-beta.yaml
@@ -2,7 +2,10 @@ limits:
     context_window: 8192
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: grok-vision-beta
 sources:

--- a/providers/openrouter/gryphe/mythomax-l2-13b.yaml
+++ b/providers/openrouter/gryphe/mythomax-l2-13b.yaml
@@ -2,6 +2,9 @@ costs:
     - input_cost_per_token: 6.e-8
       output_cost_per_token: 6.e-8
       region: "*"
+features:
+    - structured_output
+    - tool_choice
 limits:
     context_window: 4096
     max_output_tokens: 4096

--- a/providers/openrouter/hermes-2-pro-llama-3-8b.yaml
+++ b/providers/openrouter/hermes-2-pro-llama-3-8b.yaml
@@ -4,10 +4,16 @@ costs:
       region: "*"
 features:
     - function_calling
+    - structured_output
 limits:
     context_window: 8192
     max_output_tokens: 8192
     max_tokens: 8192
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: hermes-2-pro-llama-3-8b
 params:

--- a/providers/openrouter/hermes-3-llama-3.1-405b.yaml
+++ b/providers/openrouter/hermes-3-llama-3.1-405b.yaml
@@ -9,6 +9,11 @@ limits:
     context_window: 131072
     max_output_tokens: 16384
     max_tokens: 16384
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: hermes-3-llama-3.1-405b
 params:

--- a/providers/openrouter/hermes-3-llama-3.1-70b.yaml
+++ b/providers/openrouter/hermes-3-llama-3.1-70b.yaml
@@ -5,9 +5,16 @@ costs:
 features:
     - tools
     - function_calling
+    - structured_output
+    - tool_choice
 limits:
     context_window: 131072
     max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: hermes-3-llama-3.1-70b
 sources:

--- a/providers/openrouter/horizon-alpha.yaml
+++ b/providers/openrouter/horizon-alpha.yaml
@@ -2,7 +2,10 @@ features:
     - tools
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: horizon-alpha
 params:

--- a/providers/openrouter/hunyuan-a13b-instruct.yaml
+++ b/providers/openrouter/hunyuan-a13b-instruct.yaml
@@ -2,10 +2,18 @@ costs:
     - input_cost_per_token: 1.4e-7
       output_cost_per_token: 5.7e-7
       region: "*"
+features:
+    - structured_output
+    - tool_choice
 limits:
     context_window: 131072
     max_output_tokens: 131072
     max_tokens: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: hunyuan-a13b-instruct
 sources:

--- a/providers/openrouter/hunyuan-a13b-instruct:free.yaml
+++ b/providers/openrouter/hunyuan-a13b-instruct:free.yaml
@@ -5,11 +5,12 @@ costs:
 features:
     - structured_output
 limits:
-    context_window: 131072
-    max_output_tokens: 131072
-    max_tokens: 131072
+    context_window: 32768
+    max_output_tokens: 32768
+    max_tokens: 32768
 mode: chat
 model: hunyuan-a13b-instruct:free
 sources:
     - https://openrouter.ai/tencent/hunyuan-a13b-instruct:free/api
+    - https://openrouter.ai/tencent/hunyuan-a13b-instruct/api
 thinking: true

--- a/providers/openrouter/inception/mercury-2.yaml
+++ b/providers/openrouter/inception/mercury-2.yaml
@@ -19,6 +19,10 @@ modalities:
         - text
 mode: chat
 model: inception/mercury-2
+params:
+    - defaultValue: medium
+      key: reasoning_effort
+      type: string
 sources:
     - https://openrouter.ai/inception/mercury-2/api
 thinking: true

--- a/providers/openrouter/inflection-3-pi.yaml
+++ b/providers/openrouter/inflection-3-pi.yaml
@@ -8,6 +8,11 @@ limits:
     context_window: 8000
     max_output_tokens: 1024
     max_tokens: 1024
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: inflection-3-pi
 params:

--- a/providers/openrouter/inflection-3-productivity.yaml
+++ b/providers/openrouter/inflection-3-productivity.yaml
@@ -9,6 +9,11 @@ limits:
     context_window: 8000
     max_output_tokens: 1024
     max_tokens: 1024
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: inflection-3-productivity
 params:

--- a/providers/openrouter/internvl3-14b.yaml
+++ b/providers/openrouter/internvl3-14b.yaml
@@ -3,6 +3,9 @@ limits:
 modalities:
     input:
         - image
+        - text
+    output:
+        - text
 mode: chat
 model: internvl3-14b
 sources:

--- a/providers/openrouter/jamba-1.6-large.yaml
+++ b/providers/openrouter/jamba-1.6-large.yaml
@@ -2,6 +2,7 @@ costs:
     - input_cost_per_token: 0.000002
       output_cost_per_token: 0.000008
       region: "*"
+deprecationDate: "2025-08-03"
 features:
     - tools
     - function_calling
@@ -10,6 +11,11 @@ limits:
     context_window: 256000
     max_output_tokens: 4096
     max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: jamba-1.6-large
 sources:

--- a/providers/openrouter/jamba-1.6-mini.yaml
+++ b/providers/openrouter/jamba-1.6-mini.yaml
@@ -5,6 +5,13 @@ features:
     - system_messages
 limits:
     context_window: 256000
+    max_output_tokens: 4096
+    max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: jamba-1.6-mini
 params:

--- a/providers/openrouter/kimi-dev-72b:free.yaml
+++ b/providers/openrouter/kimi-dev-72b:free.yaml
@@ -4,6 +4,11 @@ costs:
       region: "*"
 limits:
     context_window: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: kimi-dev-72b:free
 sources:

--- a/providers/openrouter/kimi-k2.yaml
+++ b/providers/openrouter/kimi-k2.yaml
@@ -6,9 +6,14 @@ features:
     - function_calling
     - tools
     - tool_choice
+    - structured_output
 limits:
     context_window: 131000
-    max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: kimi-k2
 sources:

--- a/providers/openrouter/kimi-k2:free.yaml
+++ b/providers/openrouter/kimi-k2:free.yaml
@@ -10,6 +10,11 @@ limits:
     context_window: 131072
     max_output_tokens: 4096
     max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: kimi-k2:free
 sources:

--- a/providers/openrouter/kimi-vl-a3b-thinking.yaml
+++ b/providers/openrouter/kimi-vl-a3b-thinking.yaml
@@ -2,7 +2,10 @@ limits:
     context_window: 131072
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: kimi-vl-a3b-thinking
 sources:

--- a/providers/openrouter/kimi-vl-a3b-thinking:free.yaml
+++ b/providers/openrouter/kimi-vl-a3b-thinking:free.yaml
@@ -7,7 +7,10 @@ limits:
     max_tokens: 4096
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: kimi-vl-a3b-thinking:free
 sources:

--- a/providers/openrouter/kwaipilot/kat-coder-pro.yaml
+++ b/providers/openrouter/kwaipilot/kat-coder-pro.yaml
@@ -8,6 +8,7 @@ features:
     - tool_choice
     - structured_output
     - tools
+isDeprecated: true
 limits:
     context_window: 256000
     max_output_tokens: 128000

--- a/providers/openrouter/l3-euryale-70b.yaml
+++ b/providers/openrouter/l3-euryale-70b.yaml
@@ -9,6 +9,11 @@ limits:
     context_window: 8192
     max_output_tokens: 8192
     max_tokens: 8192
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: l3-euryale-70b
 params:

--- a/providers/openrouter/l3.3-euryale-70b.yaml
+++ b/providers/openrouter/l3.3-euryale-70b.yaml
@@ -5,10 +5,16 @@ costs:
 features:
     - function_calling
     - tool_choice
+    - structured_output
 limits:
     context_window: 131072
     max_output_tokens: 16384
     max_tokens: 16384
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: l3.3-euryale-70b
 sources:

--- a/providers/openrouter/lfm-3b.yaml
+++ b/providers/openrouter/lfm-3b.yaml
@@ -1,5 +1,10 @@
 limits:
     context_window: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: lfm-3b
 sources:

--- a/providers/openrouter/lfm-40b.yaml
+++ b/providers/openrouter/lfm-40b.yaml
@@ -1,5 +1,10 @@
 limits:
     context_window: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: lfm-40b
 params:

--- a/providers/openrouter/lfm-7b.yaml
+++ b/providers/openrouter/lfm-7b.yaml
@@ -6,6 +6,11 @@ limits:
     context_window: 32768
     max_output_tokens: 4096
     max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: liquid/lfm-7b
 sources:

--- a/providers/openrouter/liquid/lfm-2-24b-a2b.yaml
+++ b/providers/openrouter/liquid/lfm-2-24b-a2b.yaml
@@ -2,12 +2,8 @@ costs:
     - input_cost_per_token: 3.e-8
       output_cost_per_token: 1.2e-7
       region: "*"
-features:
-    - function_calling
-    - tool_choice
 limits:
     context_window: 32768
-    max_tokens: 32768
 modalities:
     input:
         - text

--- a/providers/openrouter/llama-3-70b-instruct.yaml
+++ b/providers/openrouter/llama-3-70b-instruct.yaml
@@ -6,10 +6,16 @@ features:
     - tools
     - function_calling
     - tool_choice
+    - structured_output
 limits:
     context_window: 8192
     max_output_tokens: 8000
     max_tokens: 8000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: llama-3-70b-instruct
 params:

--- a/providers/openrouter/llama-3-8b-instruct.yaml
+++ b/providers/openrouter/llama-3-8b-instruct.yaml
@@ -11,6 +11,11 @@ limits:
     context_window: 8192
     max_output_tokens: 16384
     max_tokens: 16384
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: llama-3-8b-instruct
 params:

--- a/providers/openrouter/llama-3-lumimaid-70b.yaml
+++ b/providers/openrouter/llama-3-lumimaid-70b.yaml
@@ -1,10 +1,12 @@
 limits:
     context_window: 8192
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: llama-3-lumimaid-70b
-params:
-    - key: max_tokens
-      maxValue: 4096
 sources:
     - https://openrouter.ai/neversleep/llama-3-lumimaid-70b/api
     - https://openrouter.ai/neversleep/llama-3-lumimaid-70b

--- a/providers/openrouter/llama-3.1-405b-instruct.yaml
+++ b/providers/openrouter/llama-3.1-405b-instruct.yaml
@@ -6,11 +6,16 @@ features:
     - tools
     - function_calling
 limits:
-    context_window: 131000
+    context_window: 131072
     max_output_tokens: 16384
     max_tokens: 16384
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
-model: llama-3.1-405b-instruct
+model: meta-llama/llama-3.1-405b-instruct
 params:
     - key: max_tokens
       maxValue: 16384

--- a/providers/openrouter/llama-3.1-405b-instruct:free.yaml
+++ b/providers/openrouter/llama-3.1-405b-instruct:free.yaml
@@ -8,6 +8,11 @@ limits:
     context_window: 131072
     max_output_tokens: 4096
     max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: llama-3.1-405b-instruct:free
 sources:

--- a/providers/openrouter/llama-3.1-405b.yaml
+++ b/providers/openrouter/llama-3.1-405b.yaml
@@ -2,13 +2,15 @@ costs:
     - input_cost_per_token: 0.000004
       output_cost_per_token: 0.000004
       region: "*"
-features:
-    - function_calling
-    - tool_choice
 limits:
     context_window: 32768
     max_output_tokens: 32768
     max_tokens: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: llama-3.1-405b
 sources:

--- a/providers/openrouter/llama-3.1-70b-instruct.yaml
+++ b/providers/openrouter/llama-3.1-70b-instruct.yaml
@@ -8,6 +8,11 @@ features:
     - tools
 limits:
     context_window: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: meta-llama/llama-3.1-70b-instruct
 params:

--- a/providers/openrouter/llama-3.1-8b-instruct.yaml
+++ b/providers/openrouter/llama-3.1-8b-instruct.yaml
@@ -10,6 +10,11 @@ limits:
     context_window: 16384
     max_output_tokens: 16384
     max_tokens: 16384
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: llama-3.1-8b-instruct
 params:

--- a/providers/openrouter/llama-3.1-lumimaid-8b.yaml
+++ b/providers/openrouter/llama-3.1-lumimaid-8b.yaml
@@ -1,5 +1,10 @@
 limits:
     context_window: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: llama-3.1-lumimaid-8b
 sources:

--- a/providers/openrouter/llama-3.1-nemotron-70b-instruct.yaml
+++ b/providers/openrouter/llama-3.1-nemotron-70b-instruct.yaml
@@ -6,10 +6,16 @@ features:
     - function_calling
     - tools
     - tool_choice
+    - structured_output
 limits:
     context_window: 131072
     max_output_tokens: 16384
     max_tokens: 16384
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: llama-3.1-nemotron-70b-instruct
 params:

--- a/providers/openrouter/llama-3.1-nemotron-ultra-253b-v1.yaml
+++ b/providers/openrouter/llama-3.1-nemotron-ultra-253b-v1.yaml
@@ -1,11 +1,19 @@
+costs:
+    - input_cost_per_token: 6.e-7
+      output_cost_per_token: 0.0000018
+      region: "*"
 features:
     - function_calling
     - tools
     - tool_choice
+    - structured_output
 limits:
     context_window: 131072
-    max_output_tokens: 4096
-    max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: llama-3.1-nemotron-ultra-253b-v1
 sources:

--- a/providers/openrouter/llama-3.1-nemotron-ultra-253b-v1:free.yaml
+++ b/providers/openrouter/llama-3.1-nemotron-ultra-253b-v1:free.yaml
@@ -4,8 +4,15 @@ costs:
       region: "*"
 features:
     - function_calling
+    - structured_output
 limits:
     context_window: 131072
+    max_input_tokens: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: llama-3.1-nemotron-ultra-253b-v1:free
 sources:

--- a/providers/openrouter/llama-3.2-11b-vision-instruct.yaml
+++ b/providers/openrouter/llama-3.2-11b-vision-instruct.yaml
@@ -8,7 +8,10 @@ limits:
     max_tokens: 16384
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: llama-3.2-11b-vision-instruct
 params:

--- a/providers/openrouter/llama-3.2-11b-vision-instruct:free.yaml
+++ b/providers/openrouter/llama-3.2-11b-vision-instruct:free.yaml
@@ -8,7 +8,10 @@ limits:
     max_tokens: 2048
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: llama-3.2-11b-vision-instruct:free
 params:

--- a/providers/openrouter/llama-3.2-1b-instruct.yaml
+++ b/providers/openrouter/llama-3.2-1b-instruct.yaml
@@ -4,6 +4,11 @@ costs:
       region: "*"
 limits:
     context_window: 60000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: llama-3.2-1b-instruct
 params:

--- a/providers/openrouter/llama-3.2-3b-instruct.yaml
+++ b/providers/openrouter/llama-3.2-3b-instruct.yaml
@@ -8,8 +8,13 @@ features:
     - tools
 limits:
     context_window: 80000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
-model: llama-3.2-3b-instruct
+model: meta-llama/llama-3.2-3b-instruct
 params:
     - key: max_tokens
       maxValue: 20000

--- a/providers/openrouter/llama-3.2-3b-instruct:free.yaml
+++ b/providers/openrouter/llama-3.2-3b-instruct:free.yaml
@@ -2,13 +2,13 @@ costs:
     - input_cost_per_token: 0
       output_cost_per_token: 0
       region: "*"
-features:
-    - function_calling
-    - tool_choice
 limits:
     context_window: 131072
-    max_output_tokens: 4096
-    max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: llama-3.2-3b-instruct:free
 sources:

--- a/providers/openrouter/llama-3.2-90b-vision-instruct.yaml
+++ b/providers/openrouter/llama-3.2-90b-vision-instruct.yaml
@@ -2,9 +2,12 @@ limits:
     context_window: 131072
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
-model: llama-3.2-90b-vision-instruct
+model: meta-llama/llama-3.2-90b-vision-instruct
 params:
     - key: max_tokens
       maxValue: 2048

--- a/providers/openrouter/llama-3.3-70b-instruct.yaml
+++ b/providers/openrouter/llama-3.3-70b-instruct.yaml
@@ -7,10 +7,16 @@ features:
     - tools
     - tool_choice
     - system_messages
+    - structured_output
 limits:
     context_window: 131072
     max_output_tokens: 16384
     max_tokens: 16384
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: llama-3.3-70b-instruct
 params:

--- a/providers/openrouter/llama-3.3-70b-instruct:free.yaml
+++ b/providers/openrouter/llama-3.3-70b-instruct:free.yaml
@@ -8,10 +8,15 @@ features:
     - tool_choice
     - system_messages
 limits:
-    context_window: 128000
-    max_output_tokens: 128000
-    max_tokens: 128000
+    context_window: 65536
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: llama-3.3-70b-instruct:free
+removeParams:
+    - response_format
 sources:
     - https://openrouter.ai/meta-llama/llama-3.3-70b-instruct:free/api

--- a/providers/openrouter/llama-3.3-nemotron-super-49b-v1.yaml
+++ b/providers/openrouter/llama-3.3-nemotron-super-49b-v1.yaml
@@ -3,6 +3,11 @@ features:
     - tool_choice
 limits:
     context_window: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: llama-3.3-nemotron-super-49b-v1
 sources:

--- a/providers/openrouter/llama-4-maverick.yaml
+++ b/providers/openrouter/llama-4-maverick.yaml
@@ -13,9 +13,12 @@ limits:
     max_tokens: 16384
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
-model: llama-4-maverick
+model: meta-llama/llama-4-maverick
 params:
     - key: max_tokens
       maxValue: 16384

--- a/providers/openrouter/llama-4-scout.yaml
+++ b/providers/openrouter/llama-4-scout.yaml
@@ -5,13 +5,17 @@ costs:
 features:
     - function_calling
     - tools
+    - structured_output
 limits:
     context_window: 327680
     max_output_tokens: 16384
     max_tokens: 16384
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: llama-4-scout
 params:

--- a/providers/openrouter/llama-guard-2-8b.yaml
+++ b/providers/openrouter/llama-guard-2-8b.yaml
@@ -6,6 +6,11 @@ limits:
     context_window: 8192
     max_output_tokens: 4096
     max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: meta-llama/llama-guard-2-8b
 sources:

--- a/providers/openrouter/llama-guard-3-8b.yaml
+++ b/providers/openrouter/llama-guard-3-8b.yaml
@@ -6,6 +6,11 @@ limits:
     context_window: 131072
     max_output_tokens: 4096
     max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: llama-guard-3-8b
 sources:

--- a/providers/openrouter/llama-guard-4-12b.yaml
+++ b/providers/openrouter/llama-guard-4-12b.yaml
@@ -8,7 +8,10 @@ limits:
     max_tokens: 4096
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: llama-guard-4-12b
 sources:

--- a/providers/openrouter/llama3.1-typhoon2-70b-instruct.yaml
+++ b/providers/openrouter/llama3.1-typhoon2-70b-instruct.yaml
@@ -2,6 +2,11 @@ features:
     - function_calling
 limits:
     context_window: 8192
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: llama3.1-typhoon2-70b-instruct
 sources:

--- a/providers/openrouter/llemma_7b.yaml
+++ b/providers/openrouter/llemma_7b.yaml
@@ -6,6 +6,11 @@ limits:
     context_window: 4096
     max_output_tokens: 4096
     max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: llemma_7b
 sources:

--- a/providers/openrouter/maestro-reasoning.yaml
+++ b/providers/openrouter/maestro-reasoning.yaml
@@ -1,5 +1,23 @@
+costs:
+    - input_cost_per_token: 9.e-7
+      output_cost_per_token: 0.0000033
+      region: "*"
+features:
+    - function_calling
+    - tool_choice
+limits:
+    context_window: 131072
+    max_output_tokens: 32000
+    max_tokens: 32000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: maestro-reasoning
 params:
     - key: max_tokens
       maxValue: 32000
+sources:
+    - https://openrouter.ai/arcee-ai/maestro-reasoning/api

--- a/providers/openrouter/magistral-medium-2506:thinking.yaml
+++ b/providers/openrouter/magistral-medium-2506:thinking.yaml
@@ -2,9 +2,11 @@ costs:
     - input_cost_per_token: 0.000002
       output_cost_per_token: 0.000005
       region: "*"
+deprecationDate: 2025-10-31T00:00:00.000Z
 features:
     - tools
     - function_calling
+isDeprecated: true
 limits:
     context_window: 40960
 mode: chat

--- a/providers/openrouter/magistral-small-2506.yaml
+++ b/providers/openrouter/magistral-small-2506.yaml
@@ -2,9 +2,11 @@ costs:
     - input_cost_per_token: 5.e-7
       output_cost_per_token: 0.0000015
       region: "*"
+deprecationDate: 2025-10-31T00:00:00.000Z
 features:
     - function_calling
     - tools
+isDeprecated: true
 limits:
     context_window: 40000
 mode: chat

--- a/providers/openrouter/magnum-v2-72b.yaml
+++ b/providers/openrouter/magnum-v2-72b.yaml
@@ -1,3 +1,4 @@
+isDeprecated: true
 limits:
     max_tokens: 4096
 mode: chat

--- a/providers/openrouter/magnum-v4-72b.yaml
+++ b/providers/openrouter/magnum-v4-72b.yaml
@@ -2,10 +2,18 @@ costs:
     - input_cost_per_token: 0.000003
       output_cost_per_token: 0.000005
       region: "*"
+features:
+    - function_calling
+    - tool_choice
 limits:
     context_window: 16384
     max_output_tokens: 2048
     max_tokens: 2048
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: magnum-v4-72b
 params:

--- a/providers/openrouter/mai-ds-r1.yaml
+++ b/providers/openrouter/mai-ds-r1.yaml
@@ -4,7 +4,11 @@ costs:
       region: "*"
 limits:
     context_window: 163840
-    max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: mai-ds-r1
 sources:

--- a/providers/openrouter/mai-ds-r1:free.yaml
+++ b/providers/openrouter/mai-ds-r1:free.yaml
@@ -6,6 +6,11 @@ limits:
     context_window: 163840
     max_output_tokens: 4096
     max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: mai-ds-r1:free
 sources:

--- a/providers/openrouter/meituan/longcat-flash-chat.yaml
+++ b/providers/openrouter/meituan/longcat-flash-chat.yaml
@@ -1,11 +1,11 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
-      input_cost_per_token: 2.e-7
+    - input_cost_per_token: 2.e-7
       output_cost_per_token: 8.e-7
       region: "*"
 features:
     - function_calling
     - tool_choice
+    - structured_output
     - tools
 limits:
     context_window: 131072

--- a/providers/openrouter/mercury-coder.yaml
+++ b/providers/openrouter/mercury-coder.yaml
@@ -11,6 +11,11 @@ limits:
     context_window: 128000
     max_output_tokens: 32000
     max_tokens: 32000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: mercury-coder
 sources:

--- a/providers/openrouter/meta-llama/codellama-34b-instruct.yaml
+++ b/providers/openrouter/meta-llama/codellama-34b-instruct.yaml
@@ -4,7 +4,11 @@ costs:
       region: "*"
 limits:
     context_window: 8192
-    max_tokens: 8192
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: meta-llama/codellama-34b-instruct
 sources:

--- a/providers/openrouter/meta-llama/llama-2-13b-chat.yaml
+++ b/providers/openrouter/meta-llama/llama-2-13b-chat.yaml
@@ -6,6 +6,11 @@ limits:
     context_window: 4096
     max_output_tokens: 4096
     max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: meta-llama/llama-2-13b-chat
 sources:

--- a/providers/openrouter/meta-llama/llama-2-70b-chat.yaml
+++ b/providers/openrouter/meta-llama/llama-2-70b-chat.yaml
@@ -7,6 +7,11 @@ features:
 limits:
     context_window: 4096
     max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: meta-llama/llama-2-70b-chat
 sources:

--- a/providers/openrouter/meta-llama/llama-3-70b-instruct:nitro.yaml
+++ b/providers/openrouter/meta-llama/llama-3-70b-instruct:nitro.yaml
@@ -10,6 +10,11 @@ limits:
     context_window: 8192
     max_output_tokens: 8000
     max_tokens: 8000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: meta-llama/llama-3-70b-instruct:nitro
 sources:

--- a/providers/openrouter/meta-llama/llama-3-8b-instruct.yaml
+++ b/providers/openrouter/meta-llama/llama-3-8b-instruct.yaml
@@ -4,9 +4,10 @@ costs:
       region: "*"
 features:
     - function_calling
+    - structured_output
+    - system_messages
     - tool_choice
     - tools
-    - system_messages
 limits:
     context_window: 8192
     max_output_tokens: 16384

--- a/providers/openrouter/meta-llama/llama-3-8b-instruct:extended.yaml
+++ b/providers/openrouter/meta-llama/llama-3-8b-instruct:extended.yaml
@@ -9,6 +9,11 @@ limits:
     context_window: 8192
     max_output_tokens: 16384
     max_tokens: 16384
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: meta-llama/llama-3-8b-instruct:extended
 sources:

--- a/providers/openrouter/meta-llama/llama-3-8b-instruct:free.yaml
+++ b/providers/openrouter/meta-llama/llama-3-8b-instruct:free.yaml
@@ -2,10 +2,17 @@ costs:
     - input_cost_per_token: 0
       output_cost_per_token: 0
       region: "*"
+features:
+    - function_calling
 limits:
     context_window: 8192
     max_output_tokens: 8192
     max_tokens: 8192
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: meta-llama/llama-3-8b-instruct:free
 sources:

--- a/providers/openrouter/meta-llama/llama-3.1-405b-instruct.yaml
+++ b/providers/openrouter/meta-llama/llama-3.1-405b-instruct.yaml
@@ -5,7 +5,12 @@ costs:
 features:
     - system_messages
 limits:
-    context_window: 131000
+    context_window: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: meta-llama/llama-3.1-405b-instruct
 sources:

--- a/providers/openrouter/meta-llama/llama-3.2-11b-vision-instruct.yaml
+++ b/providers/openrouter/meta-llama/llama-3.2-11b-vision-instruct.yaml
@@ -3,8 +3,6 @@ costs:
       output_cost_per_token: 4.9e-8
       region: "*"
 features:
-    - function_calling
-    - tool_choice
     - system_messages
 limits:
     context_window: 131072

--- a/providers/openrouter/meta-llama/llama-3.3-70b-instruct.yaml
+++ b/providers/openrouter/meta-llama/llama-3.3-70b-instruct.yaml
@@ -5,6 +5,7 @@ costs:
 features:
     - function_calling
     - tool_choice
+    - structured_output
 limits:
     context_window: 131072
     max_input_tokens: 131072

--- a/providers/openrouter/meta-llama/llama-3.3-70b-instruct:free.yaml
+++ b/providers/openrouter/meta-llama/llama-3.3-70b-instruct:free.yaml
@@ -7,9 +7,7 @@ features:
     - tool_choice
     - system_messages
 limits:
-    context_window: 128000
-    max_output_tokens: 128000
-    max_tokens: 128000
+    context_window: 65536
 modalities:
     input:
         - text

--- a/providers/openrouter/meta-llama/llama-4-scout.yaml
+++ b/providers/openrouter/meta-llama/llama-4-scout.yaml
@@ -20,5 +20,8 @@ modalities:
         - text
 mode: chat
 model: meta-llama/llama-4-scout
+params:
+    - key: max_tokens
+      maxValue: 16384
 sources:
     - https://openrouter.ai/meta-llama/llama-4-scout/api

--- a/providers/openrouter/microsoft/phi-4.yaml
+++ b/providers/openrouter/microsoft/phi-4.yaml
@@ -4,6 +4,8 @@ costs:
       region: "*"
 features:
     - structured_output
+    - function_calling
+    - tool_choice
 limits:
     context_window: 16384
     max_output_tokens: 16384

--- a/providers/openrouter/microsoft/wizardlm-2-8x22b:nitro.yaml
+++ b/providers/openrouter/microsoft/wizardlm-2-8x22b:nitro.yaml
@@ -9,6 +9,11 @@ limits:
     context_window: 65535
     max_output_tokens: 8000
     max_tokens: 8000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: microsoft/wizardlm-2-8x22b:nitro
 sources:

--- a/providers/openrouter/midnight-rose-70b.yaml
+++ b/providers/openrouter/midnight-rose-70b.yaml
@@ -2,6 +2,11 @@ limits:
     context_window: 4096
     max_output_tokens: 2048
     max_tokens: 2048
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: midnight-rose-70b
 params:

--- a/providers/openrouter/minimax-01.yaml
+++ b/providers/openrouter/minimax-01.yaml
@@ -2,13 +2,19 @@ costs:
     - input_cost_per_token: 2.e-7
       output_cost_per_token: 0.0000011
       region: "*"
+features:
+    - function_calling
+    - tool_choice
 limits:
     context_window: 1000192
     max_output_tokens: 1000192
     max_tokens: 1000192
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: minimax-01
 params:

--- a/providers/openrouter/minimax-m1.yaml
+++ b/providers/openrouter/minimax-m1.yaml
@@ -13,6 +13,11 @@ limits:
     context_window: 1000000
     max_output_tokens: 40000
     max_tokens: 40000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: minimax-m1
 params:

--- a/providers/openrouter/minimax/minimax-m1.yaml
+++ b/providers/openrouter/minimax/minimax-m1.yaml
@@ -2,6 +2,10 @@ costs:
     - input_cost_per_token: 4.e-7
       output_cost_per_token: 0.0000022
       region: "*"
+      tiered_pricing:
+          input:
+              - cost_per_token: 0.0000013
+                from: 200000
 features:
     - function_calling
     - system_messages

--- a/providers/openrouter/minimax/minimax-m2-her.yaml
+++ b/providers/openrouter/minimax/minimax-m2-her.yaml
@@ -1,10 +1,13 @@
 costs:
-    - cache_read_input_token_cost: 3.e-8
+    - cache_creation_input_token_cost: 3.75e-7
+      cache_read_input_token_cost: 3.e-8
       input_cost_per_token: 3.e-7
       output_cost_per_token: 0.0000012
       region: "*"
 features:
+    - function_calling
     - system_messages
+    - tool_choice
 limits:
     context_window: 65536
     max_output_tokens: 2048

--- a/providers/openrouter/minimax/minimax-m2.1.yaml
+++ b/providers/openrouter/minimax/minimax-m2.1.yaml
@@ -1,6 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.90000007e-8
-      input_cost_per_token: 2.7e-7
+    - input_cost_per_token: 2.7e-7
       output_cost_per_token: 9.5e-7
       region: "*"
 features:

--- a/providers/openrouter/minimax/minimax-m2.5.yaml
+++ b/providers/openrouter/minimax/minimax-m2.5.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 2.e-7
-      output_cost_per_token: 0.0000012
+      output_cost_per_token: 0.00000117
       region: "*"
 features:
     - function_calling
@@ -8,7 +8,8 @@ features:
     - structured_output
 limits:
     context_window: 196608
-    max_output_tokens: 196608
+    max_output_tokens: 65536
+    max_tokens: 65536
 modalities:
     input:
         - text

--- a/providers/openrouter/minimax/minimax-m2.yaml
+++ b/providers/openrouter/minimax/minimax-m2.yaml
@@ -7,6 +7,7 @@ features:
     - function_calling
     - tool_choice
     - prompt_caching
+    - structured_output
 limits:
     context_window: 196608
     max_input_tokens: 196608

--- a/providers/openrouter/mistral-7b-instruct-v0.1.yaml
+++ b/providers/openrouter/mistral-7b-instruct-v0.1.yaml
@@ -2,10 +2,13 @@ costs:
     - input_cost_per_token: 1.1e-7
       output_cost_per_token: 1.9e-7
       region: "*"
-features:
-    - tools
 limits:
     context_window: 2824
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: mistral-7b-instruct-v0.1
 sources:

--- a/providers/openrouter/mistral-7b-instruct-v0.2.yaml
+++ b/providers/openrouter/mistral-7b-instruct-v0.2.yaml
@@ -1,5 +1,10 @@
 limits:
     context_window: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: mistral-7b-instruct-v0.2
 sources:

--- a/providers/openrouter/mistral-7b-instruct-v0.3.yaml
+++ b/providers/openrouter/mistral-7b-instruct-v0.3.yaml
@@ -3,6 +3,11 @@ features:
     - function_calling
 limits:
     context_window: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: mistral-7b-instruct-v0.3
 params:

--- a/providers/openrouter/mistral-7b-instruct.yaml
+++ b/providers/openrouter/mistral-7b-instruct.yaml
@@ -6,6 +6,11 @@ limits:
     context_window: 32768
     max_output_tokens: 16384
     max_tokens: 16384
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: mistral-7b-instruct
 params:

--- a/providers/openrouter/mistral-7b-instruct:free.yaml
+++ b/providers/openrouter/mistral-7b-instruct:free.yaml
@@ -4,6 +4,13 @@ costs:
       region: "*"
 limits:
     context_window: 32768
+    max_output_tokens: 16384
+    max_tokens: 16384
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: mistral-7b-instruct:free
 params:

--- a/providers/openrouter/mistral-large-2407.yaml
+++ b/providers/openrouter/mistral-large-2407.yaml
@@ -1,5 +1,6 @@
 costs:
-    - input_cost_per_token: 0.000002
+    - cache_read_input_token_cost: 2.e-7
+      input_cost_per_token: 0.000002
       output_cost_per_token: 0.000006
       region: "*"
 features:

--- a/providers/openrouter/mistral-large-2411.yaml
+++ b/providers/openrouter/mistral-large-2411.yaml
@@ -1,5 +1,6 @@
 costs:
-    - input_cost_per_token: 0.000002
+    - cache_read_input_token_cost: 2.e-7
+      input_cost_per_token: 0.000002
       output_cost_per_token: 0.000006
       region: "*"
 features:
@@ -8,10 +9,16 @@ features:
     - structured_output
     - tools
     - system_messages
+    - prompt_caching
 limits:
     context_window: 131072
     max_output_tokens: 4096
     max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: mistral-large-2411
 sources:

--- a/providers/openrouter/mistral-large.yaml
+++ b/providers/openrouter/mistral-large.yaml
@@ -9,6 +9,11 @@ features:
     - structured_output
 limits:
     context_window: 128000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: mistral-large
 sources:

--- a/providers/openrouter/mistral-medium-3.yaml
+++ b/providers/openrouter/mistral-medium-3.yaml
@@ -1,5 +1,6 @@
 costs:
-    - input_cost_per_token: 4.e-7
+    - cache_read_input_token_cost: 4.e-8
+      input_cost_per_token: 4.e-7
       output_cost_per_token: 0.000002
       region: "*"
 features:
@@ -7,12 +8,17 @@ features:
     - function_calling
     - tool_choice
     - structured_output
+    - prompt_caching
 limits:
     context_window: 131072
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: mistral-medium-3
 sources:
     - https://openrouter.ai/mistralai/mistral-medium-3/api
+    - https://docs.mistral.ai/models/mistral-medium-3-25-05

--- a/providers/openrouter/mistral-nemo.yaml
+++ b/providers/openrouter/mistral-nemo.yaml
@@ -7,11 +7,20 @@ features:
     - tool_choice
     - tools
     - system_messages
+    - structured_output
 limits:
     context_window: 131072
     max_output_tokens: 16384
     max_tokens: 16384
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: mistral-nemo
+params:
+    - key: max_tokens
+      maxValue: 16384
 sources:
     - https://openrouter.ai/mistralai/mistral-nemo/api

--- a/providers/openrouter/mistral-nemo:free.yaml
+++ b/providers/openrouter/mistral-nemo:free.yaml
@@ -9,6 +9,11 @@ limits:
     context_window: 131072
     max_output_tokens: 128000
     max_tokens: 128000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: mistral-nemo:free
 params:

--- a/providers/openrouter/mistral-saba.yaml
+++ b/providers/openrouter/mistral-saba.yaml
@@ -12,6 +12,11 @@ limits:
     context_window: 32768
     max_output_tokens: 4096
     max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: mistral-saba
 sources:

--- a/providers/openrouter/mistral-small-24b-instruct-2501.yaml
+++ b/providers/openrouter/mistral-small-24b-instruct-2501.yaml
@@ -10,6 +10,11 @@ limits:
     max_input_tokens: 32768
     max_output_tokens: 16384
     max_tokens: 16384
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: mistralai/mistral-small-24b-instruct-2501
 sources:

--- a/providers/openrouter/mistral-small-24b-instruct-2501:free.yaml
+++ b/providers/openrouter/mistral-small-24b-instruct-2501:free.yaml
@@ -6,8 +6,13 @@ features:
     - function_calling
 limits:
     context_window: 32768
-    max_output_tokens: 2048
-    max_tokens: 2048
+    max_output_tokens: 16384
+    max_tokens: 16384
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: mistral-small-24b-instruct-2501:free
 sources:

--- a/providers/openrouter/mistral-small-3.1-24b-instruct.yaml
+++ b/providers/openrouter/mistral-small-3.1-24b-instruct.yaml
@@ -1,19 +1,25 @@
 costs:
-    - input_cost_per_token: 3.5e-7
-      output_cost_per_token: 5.6e-7
+    - input_cost_per_token: 3.e-8
+      output_cost_per_token: 1.1e-7
       region: "*"
 features:
     - function_calling
     - tools
+    - structured_output
 limits:
-    context_window: 128000
+    context_window: 131072
+    max_output_tokens: 131072
+    max_tokens: 131072
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: mistral-small-3.1-24b-instruct
 params:
     - key: max_tokens
-      maxValue: 96000
+      maxValue: 131072
 sources:
     - https://openrouter.ai/mistralai/mistral-small-3.1-24b-instruct/api

--- a/providers/openrouter/mistral-small-3.1-24b-instruct:free.yaml
+++ b/providers/openrouter/mistral-small-3.1-24b-instruct:free.yaml
@@ -2,6 +2,7 @@ costs:
     - input_cost_per_token: 0
       output_cost_per_token: 0
       region: "*"
+deprecationDate: "2026-03-29"
 features:
     - function_calling
     - tools
@@ -12,7 +13,10 @@ limits:
     context_window: 128000
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: mistral-small-3.1-24b-instruct:free
 sources:

--- a/providers/openrouter/mistral-small-3.2-24b-instruct.yaml
+++ b/providers/openrouter/mistral-small-3.2-24b-instruct.yaml
@@ -1,19 +1,19 @@
 costs:
-    - cache_read_input_token_cost: 3.e-8
-      input_cost_per_token: 6.e-8
-      output_cost_per_token: 1.8e-7
+    - input_cost_per_token: 7.5e-8
+      output_cost_per_token: 2.e-7
       region: "*"
 features:
     - function_calling
     - tools
     - structured_output
 limits:
-    context_window: 131072
-    max_output_tokens: 131072
-    max_tokens: 131072
+    context_window: 128000
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: mistral-small-3.2-24b-instruct
 sources:

--- a/providers/openrouter/mistral-small-3.2-24b-instruct:free.yaml
+++ b/providers/openrouter/mistral-small-3.2-24b-instruct:free.yaml
@@ -9,12 +9,13 @@ features:
     - structured_output
     - system_messages
 limits:
-    context_window: 131072
-    max_output_tokens: 131072
-    max_tokens: 131072
+    context_window: 128000
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: mistral-small-3.2-24b-instruct:free
 sources:

--- a/providers/openrouter/mistral-small.yaml
+++ b/providers/openrouter/mistral-small.yaml
@@ -10,6 +10,11 @@ limits:
     context_window: 32000
     max_output_tokens: 4096
     max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: mistral-small
 sources:

--- a/providers/openrouter/mistralai/devstral-medium.yaml
+++ b/providers/openrouter/mistralai/devstral-medium.yaml
@@ -21,4 +21,3 @@ model: mistralai/devstral-medium
 sources:
     - https://openrouter.ai/mistralai/devstral-medium/api
     - https://docs.mistral.ai/models/devstral-medium-1-0-25-07
-thinking: false

--- a/providers/openrouter/mistralai/devstral-small.yaml
+++ b/providers/openrouter/mistralai/devstral-small.yaml
@@ -5,6 +5,7 @@ costs:
       region: "*"
 features:
     - function_calling
+    - structured_output
     - tool_choice
     - tools
 limits:

--- a/providers/openrouter/mistralai/ministral-8b-2512.yaml
+++ b/providers/openrouter/mistralai/ministral-8b-2512.yaml
@@ -6,6 +6,7 @@ costs:
 features:
     - function_calling
     - tool_choice
+    - structured_output
 limits:
     context_window: 262144
     max_input_tokens: 262144

--- a/providers/openrouter/mistralai/mistral-7b-instruct.yaml
+++ b/providers/openrouter/mistralai/mistral-7b-instruct.yaml
@@ -8,6 +8,11 @@ limits:
     context_window: 32768
     max_output_tokens: 8192
     max_tokens: 8192
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: mistralai/mistral-7b-instruct
 sources:

--- a/providers/openrouter/mistralai/mistral-7b-instruct:free.yaml
+++ b/providers/openrouter/mistralai/mistral-7b-instruct:free.yaml
@@ -6,6 +6,11 @@ limits:
     context_window: 32768
     max_output_tokens: 8192
     max_tokens: 8192
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: mistralai/mistral-7b-instruct:free
 sources:

--- a/providers/openrouter/mistralai/mistral-large-2512.yaml
+++ b/providers/openrouter/mistralai/mistral-large-2512.yaml
@@ -5,6 +5,7 @@ costs:
       region: "*"
 features:
     - function_calling
+    - parallel_function_calling
     - tool_choice
     - structured_output
 limits:

--- a/providers/openrouter/mistralai/mistral-large.yaml
+++ b/providers/openrouter/mistralai/mistral-large.yaml
@@ -6,10 +6,9 @@ costs:
 features:
     - function_calling
     - tool_choice
+    - structured_output
 limits:
     context_window: 128000
-    max_output_tokens: 32000
-    max_tokens: 32000
 modalities:
     input:
         - text

--- a/providers/openrouter/mistralai/mistral-medium-3.1.yaml
+++ b/providers/openrouter/mistralai/mistral-medium-3.1.yaml
@@ -11,7 +11,6 @@ features:
     - tools
 limits:
     context_window: 131072
-    max_output_tokens: 131072
 modalities:
     input:
         - text

--- a/providers/openrouter/mistralai/mistral-small-3.1-24b-instruct.yaml
+++ b/providers/openrouter/mistralai/mistral-small-3.1-24b-instruct.yaml
@@ -1,11 +1,15 @@
 costs:
-    - input_cost_per_token: 3.5e-7
-      output_cost_per_token: 5.6e-7
+    - input_cost_per_token: 3.e-8
+      output_cost_per_token: 1.1e-7
       region: "*"
 features:
+    - function_calling
     - tool_choice
+    - structured_output
 limits:
-    context_window: 128000
+    context_window: 131072
+    max_output_tokens: 131072
+    max_tokens: 131072
 modalities:
     input:
         - text
@@ -14,5 +18,8 @@ modalities:
         - text
 mode: chat
 model: mistralai/mistral-small-3.1-24b-instruct
+params:
+    - key: max_tokens
+      maxValue: 131072
 sources:
     - https://openrouter.ai/mistralai/mistral-small-3.1-24b-instruct/api

--- a/providers/openrouter/mistralai/mistral-small-3.1-24b-instruct:free.yaml
+++ b/providers/openrouter/mistralai/mistral-small-3.1-24b-instruct:free.yaml
@@ -2,6 +2,7 @@ costs:
     - input_cost_per_token: 0
       output_cost_per_token: 0
       region: "*"
+deprecationDate: "2026-03-29"
 features:
     - function_calling
     - tool_choice

--- a/providers/openrouter/mistralai/mistral-small-3.2-24b-instruct.yaml
+++ b/providers/openrouter/mistralai/mistral-small-3.2-24b-instruct.yaml
@@ -1,16 +1,13 @@
 costs:
-    - cache_read_input_token_cost: 3.e-8
-      input_cost_per_token: 6.e-8
-      output_cost_per_token: 1.8e-7
+    - input_cost_per_token: 7.5e-8
+      output_cost_per_token: 2.e-7
       region: "*"
 features:
     - function_calling
     - tool_choice
     - structured_output
 limits:
-    context_window: 131072
-    max_output_tokens: 131072
-    max_tokens: 131072
+    context_window: 128000
 modalities:
     input:
         - image
@@ -21,3 +18,4 @@ mode: chat
 model: mistralai/mistral-small-3.2-24b-instruct
 sources:
     - https://openrouter.ai/mistralai/mistral-small-3.2-24b-instruct/api
+    - https://docs.mistral.ai/models/mistral-small-3-2-25-06

--- a/providers/openrouter/mistralai/mistral-small-creative.yaml
+++ b/providers/openrouter/mistralai/mistral-small-creative.yaml
@@ -3,6 +3,7 @@ costs:
       input_cost_per_token: 1.e-7
       output_cost_per_token: 3.e-7
       region: "*"
+deprecationDate: "2026-04-30"
 features:
     - function_calling
     - tool_choice

--- a/providers/openrouter/mistralai/pixtral-large-2411.yaml
+++ b/providers/openrouter/mistralai/pixtral-large-2411.yaml
@@ -23,4 +23,3 @@ mode: chat
 model: mistralai/pixtral-large-2411
 sources:
     - https://openrouter.ai/mistralai/pixtral-large-2411/api
-thinking: false

--- a/providers/openrouter/mistralai/voxtral-small-24b-2507.yaml
+++ b/providers/openrouter/mistralai/voxtral-small-24b-2507.yaml
@@ -1,5 +1,6 @@
 costs:
     - cache_read_input_token_cost: 1.e-8
+      input_cost_per_second: 0.0001
       input_cost_per_token: 1.e-7
       output_cost_per_token: 3.e-7
       region: "*"

--- a/providers/openrouter/mixtral-8x22b-instruct.yaml
+++ b/providers/openrouter/mixtral-8x22b-instruct.yaml
@@ -1,5 +1,6 @@
 costs:
-    - input_cost_per_token: 0.000002
+    - cache_read_input_token_cost: 2.e-7
+      input_cost_per_token: 0.000002
       output_cost_per_token: 0.000006
       region: "*"
 features:
@@ -9,6 +10,11 @@ features:
     - tool_choice
 limits:
     context_window: 65536
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: mixtral-8x22b-instruct
 sources:

--- a/providers/openrouter/mn-celeste-12b.yaml
+++ b/providers/openrouter/mn-celeste-12b.yaml
@@ -1,5 +1,10 @@
 limits:
     context_window: 32000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: mn-celeste-12b
 sources:

--- a/providers/openrouter/mn-inferor-12b.yaml
+++ b/providers/openrouter/mn-inferor-12b.yaml
@@ -1,3 +1,4 @@
+isDeprecated: true
 mode: chat
 model: mn-inferor-12b
 params:

--- a/providers/openrouter/moonshotai/kimi-k2-0905:exacto.yaml
+++ b/providers/openrouter/moonshotai/kimi-k2-0905:exacto.yaml
@@ -9,6 +9,11 @@ features:
     - tools
 limits:
     context_window: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: moonshotai/kimi-k2-0905:exacto
 params:

--- a/providers/openrouter/moonshotai/kimi-k2.yaml
+++ b/providers/openrouter/moonshotai/kimi-k2.yaml
@@ -6,10 +6,9 @@ features:
     - function_calling
     - tool_choice
     - tools
+    - structured_output
 limits:
     context_window: 131000
-    max_output_tokens: 131000
-    max_tokens: 131000
 modalities:
     input:
         - text

--- a/providers/openrouter/morph-v2.yaml
+++ b/providers/openrouter/morph-v2.yaml
@@ -1,5 +1,10 @@
 limits:
     context_window: 32000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: morph-v2
 params:

--- a/providers/openrouter/morph-v3-fast.yaml
+++ b/providers/openrouter/morph-v3-fast.yaml
@@ -7,6 +7,11 @@ limits:
     max_input_tokens: 81920
     max_output_tokens: 38000
     max_tokens: 38000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: morph-v3-fast
 params:

--- a/providers/openrouter/morph-v3-large.yaml
+++ b/providers/openrouter/morph-v3-large.yaml
@@ -6,6 +6,11 @@ limits:
     context_window: 262144
     max_output_tokens: 131072
     max_tokens: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: morph-v3-large
 params:

--- a/providers/openrouter/mythalion-13b.yaml
+++ b/providers/openrouter/mythalion-13b.yaml
@@ -1,5 +1,12 @@
 limits:
     context_window: 8192
+    max_output_tokens: 4096
+    max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: mythalion-13b
 params:

--- a/providers/openrouter/mythomax-l2-13b.yaml
+++ b/providers/openrouter/mythomax-l2-13b.yaml
@@ -9,6 +9,11 @@ limits:
     context_window: 4096
     max_output_tokens: 4096
     max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: mythomax-l2-13b
 sources:

--- a/providers/openrouter/neversleep/llama-3.1-lumimaid-8b.yaml
+++ b/providers/openrouter/neversleep/llama-3.1-lumimaid-8b.yaml
@@ -1,5 +1,10 @@
 limits:
     context_window: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: neversleep/llama-3.1-lumimaid-8b
 sources:

--- a/providers/openrouter/neversleep/noromaid-20b.yaml
+++ b/providers/openrouter/neversleep/noromaid-20b.yaml
@@ -2,6 +2,11 @@ limits:
     context_window: 8192
     max_output_tokens: 4096
     max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: neversleep/noromaid-20b
 sources:

--- a/providers/openrouter/noromaid-20b.yaml
+++ b/providers/openrouter/noromaid-20b.yaml
@@ -2,6 +2,11 @@ limits:
     context_window: 8192
     max_output_tokens: 4096
     max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: noromaid-20b
 sources:

--- a/providers/openrouter/nous-hermes-2-mixtral-8x7b-dpo.yaml
+++ b/providers/openrouter/nous-hermes-2-mixtral-8x7b-dpo.yaml
@@ -1,5 +1,10 @@
 limits:
     context_window: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: nous-hermes-2-mixtral-8x7b-dpo
 params:

--- a/providers/openrouter/nousresearch/hermes-3-llama-3.1-405b.yaml
+++ b/providers/openrouter/nousresearch/hermes-3-llama-3.1-405b.yaml
@@ -6,6 +6,7 @@ features:
     - function_calling
     - tool_choice
     - system_messages
+    - structured_output
 limits:
     context_window: 131072
     max_output_tokens: 16384

--- a/providers/openrouter/nousresearch/hermes-3-llama-3.1-70b.yaml
+++ b/providers/openrouter/nousresearch/hermes-3-llama-3.1-70b.yaml
@@ -3,11 +3,8 @@ costs:
       output_cost_per_token: 3.e-7
       region: "*"
 features:
-    - function_calling
     - structured_output
     - system_messages
-    - tools
-    - tool_choice
 limits:
     context_window: 131072
 modalities:

--- a/providers/openrouter/nousresearch/hermes-4-405b.yaml
+++ b/providers/openrouter/nousresearch/hermes-4-405b.yaml
@@ -17,6 +17,10 @@ modalities:
         - text
 mode: chat
 model: nousresearch/hermes-4-405b
+params:
+    - defaultValue: true
+      key: reasoning
+      type: boolean
 sources:
     - https://openrouter.ai/nousresearch/hermes-4-405b/api
 thinking: true

--- a/providers/openrouter/nousresearch/nous-hermes-llama2-13b.yaml
+++ b/providers/openrouter/nousresearch/nous-hermes-llama2-13b.yaml
@@ -5,6 +5,11 @@ costs:
 limits:
     context_window: 4096
     max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: nousresearch/nous-hermes-llama2-13b
 sources:

--- a/providers/openrouter/nova-lite-v1.yaml
+++ b/providers/openrouter/nova-lite-v1.yaml
@@ -12,7 +12,10 @@ limits:
     max_tokens: 5120
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: nova-lite-v1
 params:

--- a/providers/openrouter/nova-micro-v1.yaml
+++ b/providers/openrouter/nova-micro-v1.yaml
@@ -4,10 +4,17 @@ costs:
       region: "*"
 features:
     - tools
+    - tool_choice
+    - function_calling
 limits:
     context_window: 128000
     max_output_tokens: 5120
     max_tokens: 5120
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: nova-micro-v1
 params:

--- a/providers/openrouter/nova-pro-v1.yaml
+++ b/providers/openrouter/nova-pro-v1.yaml
@@ -6,13 +6,17 @@ features:
     - function_calling
     - tools
     - tool_choice
+    - structured_output
 limits:
     context_window: 300000
     max_output_tokens: 5120
     max_tokens: 5120
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: nova-pro-v1
 params:

--- a/providers/openrouter/nvidia/nemotron-3-super-120b-a12b:free.yaml
+++ b/providers/openrouter/nvidia/nemotron-3-super-120b-a12b:free.yaml
@@ -1,6 +1,5 @@
 costs:
-    - input_cost_per_image: 0
-      input_cost_per_token: 0
+    - input_cost_per_token: 0
       output_cost_per_token: 0
       region: "*"
 features:

--- a/providers/openrouter/nvidia/nemotron-nano-12b-v2-vl:free.yaml
+++ b/providers/openrouter/nvidia/nemotron-nano-12b-v2-vl:free.yaml
@@ -5,6 +5,7 @@ costs:
 limits:
     context_window: 128000
     max_output_tokens: 128000
+    max_tokens: 128000
 modalities:
     input:
         - image

--- a/providers/openrouter/o1-pro.yaml
+++ b/providers/openrouter/o1-pro.yaml
@@ -2,18 +2,29 @@ costs:
     - input_cost_per_token: 0.00015
       output_cost_per_token: 0.0006
       region: "*"
+features:
+    - structured_output
+    - tool_choice
 limits:
     context_window: 200000
     max_output_tokens: 100000
     max_tokens: 100000
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: o1-pro
 params:
     - key: max_tokens
       maxValue: 100000
+removeParams:
+    - temperature
+    - top_p
+    - stop
+    - "n"
 sources:
     - https://openrouter.ai/openai/o1-pro/api
 thinking: true

--- a/providers/openrouter/o1.yaml
+++ b/providers/openrouter/o1.yaml
@@ -14,7 +14,10 @@ limits:
     max_tokens: 100000
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: o1
 params:
@@ -22,4 +25,4 @@ params:
       maxValue: 100000
 sources:
     - https://openrouter.ai/openai/o1/api
-thinking: false
+thinking: true

--- a/providers/openrouter/o3-mini-high.yaml
+++ b/providers/openrouter/o3-mini-high.yaml
@@ -6,11 +6,17 @@ costs:
 features:
     - tools
     - function_calling
+    - tool_choice
     - structured_output
 limits:
     context_window: 200000
     max_output_tokens: 100000
     max_tokens: 100000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: o3-mini-high
 params:

--- a/providers/openrouter/o3-mini.yaml
+++ b/providers/openrouter/o3-mini.yaml
@@ -15,11 +15,19 @@ limits:
     max_input_tokens: 200000
     max_output_tokens: 100000
     max_tokens: 100000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: o3-mini
 params:
     - key: max_tokens
       maxValue: 100000
+    - defaultValue: medium
+      key: reasoning_effort
+      type: string
 sources:
     - https://openrouter.ai/openai/o3-mini/api
 thinking: true

--- a/providers/openrouter/o3-pro.yaml
+++ b/providers/openrouter/o3-pro.yaml
@@ -9,12 +9,14 @@ features:
     - structured_output
 limits:
     context_window: 200000
-    max_input_tokens: 100000
     max_output_tokens: 100000
     max_tokens: 100000
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: o3-pro
 params:

--- a/providers/openrouter/o3.yaml
+++ b/providers/openrouter/o3.yaml
@@ -14,7 +14,10 @@ limits:
     max_tokens: 100000
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: o3
 params:

--- a/providers/openrouter/o4-mini-high.yaml
+++ b/providers/openrouter/o4-mini-high.yaml
@@ -14,7 +14,10 @@ limits:
     max_tokens: 100000
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: o4-mini-high
 params:

--- a/providers/openrouter/o4-mini.yaml
+++ b/providers/openrouter/o4-mini.yaml
@@ -13,7 +13,10 @@ limits:
     max_tokens: 100000
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: o4-mini
 params:

--- a/providers/openrouter/openai/gpt-3.5-turbo-16k.yaml
+++ b/providers/openrouter/openai/gpt-3.5-turbo-16k.yaml
@@ -5,6 +5,7 @@ costs:
 features:
     - function_calling
     - tool_choice
+    - structured_output
 limits:
     context_window: 16385
     max_output_tokens: 4096

--- a/providers/openrouter/openai/gpt-3.5-turbo-instruct.yaml
+++ b/providers/openrouter/openai/gpt-3.5-turbo-instruct.yaml
@@ -2,6 +2,9 @@ costs:
     - input_cost_per_token: 0.0000015
       output_cost_per_token: 0.000002
       region: "*"
+features:
+    - structured_output
+    - tool_choice
 limits:
     context_window: 4095
     max_output_tokens: 4096

--- a/providers/openrouter/openai/gpt-4.1-2025-04-14.yaml
+++ b/providers/openrouter/openai/gpt-4.1-2025-04-14.yaml
@@ -7,6 +7,7 @@ features:
     - function_calling
     - parallel_function_calling
     - tool_choice
+    - structured_output
 limits:
     context_window: 1047576
     max_input_tokens: 1047576
@@ -14,8 +15,14 @@ limits:
     max_tokens: 32768
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: openai/gpt-4.1-2025-04-14
+params:
+    - key: max_tokens
+      maxValue: 32768
 sources:
     - https://openrouter.ai/openai/gpt-4.1-2025-04-14/api

--- a/providers/openrouter/openai/gpt-4.1-mini-2025-04-14.yaml
+++ b/providers/openrouter/openai/gpt-4.1-mini-2025-04-14.yaml
@@ -15,7 +15,10 @@ limits:
     max_tokens: 32768
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: openai/gpt-4.1-mini-2025-04-14
 sources:

--- a/providers/openrouter/openai/gpt-4.1-mini.yaml
+++ b/providers/openrouter/openai/gpt-4.1-mini.yaml
@@ -17,12 +17,14 @@ limits:
     max_tokens: 32768
 modalities:
     input:
-        - image
         - text
-        - pdf
+        - image
     output:
         - text
 mode: chat
 model: openai/gpt-4.1-mini
+params:
+    - key: max_tokens
+      maxValue: 32768
 sources:
     - https://openrouter.ai/openai/gpt-4.1-mini/api

--- a/providers/openrouter/openai/gpt-4.1-nano-2025-04-14.yaml
+++ b/providers/openrouter/openai/gpt-4.1-nano-2025-04-14.yaml
@@ -15,7 +15,10 @@ limits:
     max_tokens: 32768
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: openai/gpt-4.1-nano-2025-04-14
 sources:

--- a/providers/openrouter/openai/gpt-4.1.yaml
+++ b/providers/openrouter/openai/gpt-4.1.yaml
@@ -17,13 +17,16 @@ limits:
     max_tokens: 32768
 modalities:
     input:
-        - image
         - text
+        - image
         - pdf
     output:
         - text
 mode: chat
 model: openai/gpt-4.1
+params:
+    - key: max_tokens
+      maxValue: 32768
 sources:
     - https://openrouter.ai/openai/gpt-4.1/api
     - https://developers.openai.com/docs/pricing#gpt-4.1

--- a/providers/openrouter/openai/gpt-4o-2024-05-13.yaml
+++ b/providers/openrouter/openai/gpt-4o-2024-05-13.yaml
@@ -16,7 +16,6 @@ modalities:
     input:
         - text
         - image
-        - pdf
     output:
         - text
 mode: chat

--- a/providers/openrouter/openai/gpt-4o-2024-08-06.yaml
+++ b/providers/openrouter/openai/gpt-4o-2024-08-06.yaml
@@ -18,10 +18,14 @@ modalities:
     input:
         - text
         - image
-        - pdf
     output:
         - text
 mode: chat
 model: openai/gpt-4o-2024-08-06
+params:
+    - defaultValue: 16384
+      key: max_tokens
+      maxValue: 16384
+      minValue: 1
 sources:
     - https://openrouter.ai/openai/gpt-4o-2024-08-06/api

--- a/providers/openrouter/openai/gpt-4o-2024-11-20.yaml
+++ b/providers/openrouter/openai/gpt-4o-2024-11-20.yaml
@@ -8,6 +8,7 @@ features:
     - tools
     - tool_choice
     - system_messages
+    - structured_output
 limits:
     context_window: 128000
     max_output_tokens: 16384
@@ -16,7 +17,6 @@ modalities:
     input:
         - text
         - image
-        - pdf
     output:
         - text
 mode: chat

--- a/providers/openrouter/openai/gpt-4o-audio-preview.yaml
+++ b/providers/openrouter/openai/gpt-4o-audio-preview.yaml
@@ -1,5 +1,7 @@
 costs:
-    - input_cost_per_token: 0.0000025
+    - input_cost_per_audio_token: 0.00004
+      input_cost_per_token: 0.0000025
+      output_cost_per_audio_token: 0.00008
       output_cost_per_token: 0.00001
       region: "*"
 features:
@@ -23,4 +25,3 @@ mode: chat
 model: openai/gpt-4o-audio-preview
 sources:
     - https://openrouter.ai/openai/gpt-4o-audio-preview/api
-thinking: false

--- a/providers/openrouter/openai/gpt-4o-mini-2024-07-18.yaml
+++ b/providers/openrouter/openai/gpt-4o-mini-2024-07-18.yaml
@@ -18,7 +18,6 @@ modalities:
     input:
         - text
         - image
-        - pdf
     output:
         - text
 mode: chat

--- a/providers/openrouter/openai/gpt-4o-mini-search-preview.yaml
+++ b/providers/openrouter/openai/gpt-4o-mini-search-preview.yaml
@@ -5,6 +5,7 @@ costs:
 features:
     - system_messages
     - structured_output
+    - tool_choice
 limits:
     context_window: 128000
     max_output_tokens: 16384

--- a/providers/openrouter/openai/gpt-4o-search-preview.yaml
+++ b/providers/openrouter/openai/gpt-4o-search-preview.yaml
@@ -1,10 +1,13 @@
 costs:
-    - input_cost_per_token: 0.0000025
+    - input_cost_per_query: 0.035
+      input_cost_per_token: 0.0000025
       output_cost_per_token: 0.00001
       region: "*"
 features:
     - system_messages
     - structured_output
+    - function_calling
+    - tool_choice
 limits:
     context_window: 128000
     max_input_tokens: 128000

--- a/providers/openrouter/openai/gpt-4o:extended.yaml
+++ b/providers/openrouter/openai/gpt-4o:extended.yaml
@@ -15,7 +15,6 @@ modalities:
     input:
         - text
         - image
-        - pdf
     output:
         - text
 mode: chat

--- a/providers/openrouter/openai/gpt-5-chat.yaml
+++ b/providers/openrouter/openai/gpt-5-chat.yaml
@@ -14,9 +14,9 @@ limits:
     max_tokens: 16384
 modalities:
     input:
-        - pdf
-        - image
         - text
+        - image
+        - pdf
     output:
         - text
 mode: chat

--- a/providers/openrouter/openai/gpt-5-codex.yaml
+++ b/providers/openrouter/openai/gpt-5-codex.yaml
@@ -21,6 +21,10 @@ modalities:
         - text
 mode: chat
 model: openai/gpt-5-codex
+params:
+    - defaultValue: medium
+      key: reasoning_effort
+      type: string
 sources:
     - https://openrouter.ai/openai/gpt-5-codex/api
 thinking: true

--- a/providers/openrouter/openai/gpt-5-image-mini.yaml
+++ b/providers/openrouter/openai/gpt-5-image-mini.yaml
@@ -1,6 +1,7 @@
 costs:
     - cache_read_input_token_cost: 2.5e-7
       input_cost_per_token: 0.0000025
+      output_cost_per_image_token: 0.000008
       output_cost_per_token: 0.000002
       region: "*"
 features:

--- a/providers/openrouter/openai/gpt-5-image.yaml
+++ b/providers/openrouter/openai/gpt-5-image.yaml
@@ -1,6 +1,7 @@
 costs:
     - cache_read_input_token_cost: 0.00000125
       input_cost_per_token: 0.00001
+      output_cost_per_image_token: 0.00004
       output_cost_per_token: 0.00001
       region: "*"
 features:
@@ -16,12 +17,11 @@ limits:
     max_tokens: 128000
 modalities:
     input:
-        - image
         - text
-        - pdf
+        - image
     output:
-        - image
         - text
+        - image
 mode: chat
 model: openai/gpt-5-image
 sources:

--- a/providers/openrouter/openai/gpt-5-mini.yaml
+++ b/providers/openrouter/openai/gpt-5-mini.yaml
@@ -21,6 +21,9 @@ modalities:
         - text
 mode: chat
 model: openai/gpt-5-mini
+params:
+    - key: reasoning_effort
+      type: string
 sources:
     - https://openrouter.ai/openai/gpt-5-mini/api
 thinking: true

--- a/providers/openrouter/openai/gpt-5-nano.yaml
+++ b/providers/openrouter/openai/gpt-5-nano.yaml
@@ -22,6 +22,14 @@ modalities:
         - text
 mode: chat
 model: openai/gpt-5-nano
+params:
+    - defaultValue: 128000
+      key: max_tokens
+      maxValue: 128000
+      minValue: 1
+    - defaultValue: medium
+      key: reasoning_effort
+      type: string
 sources:
     - https://openrouter.ai/openai/gpt-5-nano/api
 thinking: true

--- a/providers/openrouter/openai/gpt-5-pro.yaml
+++ b/providers/openrouter/openai/gpt-5-pro.yaml
@@ -22,6 +22,14 @@ modalities:
         - text
 mode: chat
 model: openai/gpt-5-pro
+params:
+    - defaultValue: 128000
+      key: max_tokens
+      maxValue: 128000
+      minValue: 1
+    - defaultValue: high
+      key: reasoning_effort
+      type: string
 sources:
     - https://openrouter.ai/openai/gpt-5-pro/api
 thinking: true

--- a/providers/openrouter/openai/gpt-5.1-chat.yaml
+++ b/providers/openrouter/openai/gpt-5.1-chat.yaml
@@ -9,6 +9,7 @@ features:
     - tools
     - structured_output
     - system_messages
+    - prompt_caching
 limits:
     context_window: 128000
     max_output_tokens: 16384

--- a/providers/openrouter/openai/gpt-5.1-codex-max.yaml
+++ b/providers/openrouter/openai/gpt-5.1-codex-max.yaml
@@ -27,6 +27,8 @@ params:
       key: max_tokens
       maxValue: 128000
       minValue: 1
+    - key: reasoning_effort
+      type: string
 sources:
     - https://openrouter.ai/openai/gpt-5.1-codex-max/api
 thinking: true

--- a/providers/openrouter/openai/gpt-5.1-codex-mini.yaml
+++ b/providers/openrouter/openai/gpt-5.1-codex-mini.yaml
@@ -9,6 +9,7 @@ features:
     - tools
     - structured_output
     - system_messages
+    - prompt_caching
 limits:
     context_window: 400000
     max_input_tokens: 300000
@@ -22,6 +23,12 @@ modalities:
         - text
 mode: chat
 model: openai/gpt-5.1-codex-mini
+params:
+    - key: max_tokens
+      maxValue: 100000
+    - defaultValue: medium
+      key: reasoning_effort
+      type: string
 sources:
     - https://openrouter.ai/openai/gpt-5.1-codex-mini/api
     - https://developers.openai.com/docs/models/gpt-5.1-codex-mini

--- a/providers/openrouter/openai/gpt-5.1-codex.yaml
+++ b/providers/openrouter/openai/gpt-5.1-codex.yaml
@@ -21,6 +21,12 @@ modalities:
         - text
 mode: chat
 model: openai/gpt-5.1-codex
+params:
+    - defaultValue: 128
+      key: max_tokens
+      maxValue: 128000
+      minValue: 1
 sources:
     - https://openrouter.ai/openai/gpt-5.1-codex/api
+    - https://developers.openai.com/api/docs/models/gpt-5.1-codex
 thinking: true

--- a/providers/openrouter/openai/gpt-5.1.yaml
+++ b/providers/openrouter/openai/gpt-5.1.yaml
@@ -24,6 +24,13 @@ modalities:
         - text
 mode: chat
 model: openai/gpt-5.1
+params:
+    - defaultValue: medium
+      key: reasoning_effort
+      type: string
+    - defaultValue: null
+      key: seed
+      type: number
 sources:
     - https://openrouter.ai/openai/gpt-5.1/api
 thinking: true

--- a/providers/openrouter/openai/gpt-5.2-chat.yaml
+++ b/providers/openrouter/openai/gpt-5.2-chat.yaml
@@ -7,6 +7,7 @@ features:
     - function_calling
     - tool_choice
     - prompt_caching
+    - structured_output
 limits:
     context_window: 128000
     max_input_tokens: 128000
@@ -14,9 +15,8 @@ limits:
     max_tokens: 16384
 modalities:
     input:
-        - pdf
-        - image
         - text
+        - image
     output:
         - text
 mode: chat

--- a/providers/openrouter/openai/gpt-5.2-codex.yaml
+++ b/providers/openrouter/openai/gpt-5.2-codex.yaml
@@ -20,6 +20,10 @@ modalities:
         - text
 mode: chat
 model: openai/gpt-5.2-codex
+params:
+    - defaultValue: medium
+      key: reasoning_effort
+      type: string
 sources:
     - https://openrouter.ai/openai/gpt-5.2-codex/api
 thinking: true

--- a/providers/openrouter/openai/gpt-5.2-pro.yaml
+++ b/providers/openrouter/openai/gpt-5.2-pro.yaml
@@ -13,13 +13,21 @@ limits:
     max_tokens: 128000
 modalities:
     input:
-        - image
         - text
+        - image
         - pdf
     output:
         - text
 mode: chat
 model: openai/gpt-5.2-pro
+params:
+    - defaultValue: 128
+      key: max_tokens
+      maxValue: 128000
+      minValue: 1
+    - defaultValue: high
+      key: reasoning_effort
+      type: string
 sources:
     - https://openrouter.ai/openai/gpt-5.2-pro/api
 thinking: true

--- a/providers/openrouter/openai/gpt-5.2.yaml
+++ b/providers/openrouter/openai/gpt-5.2.yaml
@@ -22,6 +22,14 @@ modalities:
         - text
 mode: chat
 model: openai/gpt-5.2
+params:
+    - defaultValue: 128000
+      key: max_tokens
+      maxValue: 128000
+      minValue: 1
+    - defaultValue: medium
+      key: reasoning_effort
+      type: string
 sources:
     - https://openrouter.ai/openai/gpt-5.2/api
 thinking: true

--- a/providers/openrouter/openai/gpt-5.3-chat.yaml
+++ b/providers/openrouter/openai/gpt-5.3-chat.yaml
@@ -8,6 +8,7 @@ features:
     - tool_choice
     - prompt_caching
     - system_messages
+    - structured_output
 limits:
     context_window: 128000
     max_input_tokens: 111616

--- a/providers/openrouter/openai/gpt-5.4-pro.yaml
+++ b/providers/openrouter/openai/gpt-5.4-pro.yaml
@@ -2,6 +2,13 @@ costs:
     - input_cost_per_token: 0.00003
       output_cost_per_token: 0.00018
       region: "*"
+      tiered_pricing:
+          input:
+              - cost_per_token: 0.00006
+                from: 272000
+          output:
+              - cost_per_token: 0.00027
+                from: 272000
 features:
     - function_calling
     - tool_choice
@@ -27,6 +34,8 @@ params:
       key: max_tokens
       maxValue: 128000
       minValue: 1
+    - key: reasoning_effort
+      type: string
 sources:
     - https://openrouter.ai/openai/gpt-5.4-pro/api
 thinking: true

--- a/providers/openrouter/openai/gpt-5.4.yaml
+++ b/providers/openrouter/openai/gpt-5.4.yaml
@@ -3,6 +3,16 @@ costs:
       input_cost_per_token: 0.0000025
       output_cost_per_token: 0.000015
       region: "*"
+      tiered_pricing:
+          cache_read:
+              - cost_per_token: 5.e-7
+                from: 272000
+          input:
+              - cost_per_token: 0.000005
+                from: 272000
+          output:
+              - cost_per_token: 0.0000225
+                from: 272000
 features:
     - function_calling
     - tool_choice
@@ -22,6 +32,14 @@ modalities:
         - text
 mode: chat
 model: openai/gpt-5.4
+params:
+    - defaultValue: 128
+      key: max_tokens
+      maxValue: 128000
+      minValue: 1
+    - defaultValue: medium
+      key: reasoning_effort
+      type: string
 sources:
     - https://openrouter.ai/openai/gpt-5.4/api
 thinking: true

--- a/providers/openrouter/openai/gpt-5.yaml
+++ b/providers/openrouter/openai/gpt-5.yaml
@@ -7,6 +7,7 @@ features:
     - function_calling
     - tool_choice
     - structured_output
+    - prompt_caching
 limits:
     context_window: 400000
     max_input_tokens: 272000
@@ -21,6 +22,10 @@ modalities:
         - text
 mode: chat
 model: openai/gpt-5
+params:
+    - defaultValue: medium
+      key: reasoning_effort
+      type: string
 sources:
     - https://openrouter.ai/openai/gpt-5/api
 thinking: true

--- a/providers/openrouter/openai/gpt-audio-mini.yaml
+++ b/providers/openrouter/openai/gpt-audio-mini.yaml
@@ -1,5 +1,7 @@
 costs:
-    - input_cost_per_token: 6.e-7
+    - input_cost_per_audio_token: 6.e-7
+      input_cost_per_token: 6.e-7
+      output_cost_per_audio_token: 0.0000024
       output_cost_per_token: 0.0000024
       region: "*"
 features:

--- a/providers/openrouter/openai/gpt-audio.yaml
+++ b/providers/openrouter/openai/gpt-audio.yaml
@@ -1,5 +1,7 @@
 costs:
-    - input_cost_per_token: 0.0000025
+    - input_cost_per_audio_token: 0.000032
+      input_cost_per_token: 0.0000025
+      output_cost_per_audio_token: 0.000064
       output_cost_per_token: 0.00001
       region: "*"
 features:

--- a/providers/openrouter/openai/gpt-oss-120b.yaml
+++ b/providers/openrouter/openai/gpt-oss-120b.yaml
@@ -16,6 +16,10 @@ modalities:
         - text
 mode: chat
 model: openai/gpt-oss-120b
+params:
+    - defaultValue: medium
+      key: reasoning_effort
+      type: string
 sources:
     - https://openrouter.ai/openai/gpt-oss-120b/api
 thinking: true

--- a/providers/openrouter/openai/gpt-oss-120b:exacto.yaml
+++ b/providers/openrouter/openai/gpt-oss-120b:exacto.yaml
@@ -10,8 +10,17 @@ features:
     - tools
 limits:
     context_window: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: openai/gpt-oss-120b:exacto
+params:
+    - defaultValue: medium
+      key: reasoning_effort
+      type: string
 sources:
     - https://openrouter.ai/openai/gpt-oss-120b:exacto/api
 thinking: true

--- a/providers/openrouter/openai/gpt-oss-120b:free.yaml
+++ b/providers/openrouter/openai/gpt-oss-120b:free.yaml
@@ -19,6 +19,10 @@ modalities:
         - text
 mode: chat
 model: openai/gpt-oss-120b:free
+params:
+    - defaultValue: medium
+      key: reasoning_effort
+      type: string
 sources:
     - https://openrouter.ai/openai/gpt-oss-120b:free/api
 thinking: true

--- a/providers/openrouter/openai/gpt-oss-20b.yaml
+++ b/providers/openrouter/openai/gpt-oss-20b.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 3.e-8
-      output_cost_per_token: 1.4e-7
+      output_cost_per_token: 1.1e-7
       region: "*"
 features:
     - function_calling
@@ -10,8 +10,8 @@ features:
 limits:
     context_window: 131072
     max_input_tokens: 131072
-    max_output_tokens: 32768
-    max_tokens: 32768
+    max_output_tokens: 131072
+    max_tokens: 131072
 modalities:
     input:
         - text
@@ -19,6 +19,10 @@ modalities:
         - text
 mode: chat
 model: openai/gpt-oss-20b
+params:
+    - defaultValue: medium
+      key: reasoning_effort
+      type: string
 sources:
     - https://openrouter.ai/openai/gpt-oss-20b/api
 thinking: true

--- a/providers/openrouter/openai/gpt-oss-20b:free.yaml
+++ b/providers/openrouter/openai/gpt-oss-20b:free.yaml
@@ -19,6 +19,10 @@ modalities:
         - text
 mode: chat
 model: openai/gpt-oss-20b:free
+params:
+    - defaultValue: medium
+      key: reasoning_effort
+      type: string
 sources:
     - https://openrouter.ai/openai/gpt-oss-20b:free/api
 thinking: true

--- a/providers/openrouter/openai/o1-mini-2024-09-12.yaml
+++ b/providers/openrouter/openai/o1-mini-2024-09-12.yaml
@@ -2,9 +2,11 @@ costs:
     - input_cost_per_token: 0.000003
       output_cost_per_token: 0.000012
       region: "*"
+deprecationDate: 2025-10-27T00:00:00.000Z
 features:
     - function_calling
     - parallel_function_calling
+isDeprecated: true
 limits:
     context_window: 128000
     max_input_tokens: 128000

--- a/providers/openrouter/openai/o1-pro.yaml
+++ b/providers/openrouter/openai/o1-pro.yaml
@@ -12,11 +12,20 @@ modalities:
     input:
         - text
         - image
-        - pdf
     output:
         - text
 mode: chat
 model: openai/o1-pro
+params:
+    - defaultValue: 100000
+      key: max_tokens
+      maxValue: 100000
+      minValue: 1
+removeParams:
+    - temperature
+    - top_p
+    - stop
+    - "n"
 sources:
     - https://openrouter.ai/openai/o1-pro/api
 thinking: true

--- a/providers/openrouter/openai/o1.yaml
+++ b/providers/openrouter/openai/o1.yaml
@@ -24,6 +24,9 @@ modalities:
         - text
 mode: chat
 model: openai/o1
+params:
+    - key: max_tokens
+      maxValue: 100000
 sources:
     - https://openrouter.ai/openai/o1/api
 thinking: true

--- a/providers/openrouter/openai/o3-deep-research.yaml
+++ b/providers/openrouter/openai/o3-deep-research.yaml
@@ -15,8 +15,8 @@ limits:
     max_tokens: 100000
 modalities:
     input:
-        - image
         - text
+        - image
         - pdf
     output:
         - text

--- a/providers/openrouter/openai/o3-mini-high.yaml
+++ b/providers/openrouter/openai/o3-mini-high.yaml
@@ -20,6 +20,9 @@ modalities:
         - text
 mode: chat
 model: openai/o3-mini-high
+params:
+    - key: max_tokens
+      maxValue: 100000
 sources:
     - https://openrouter.ai/openai/o3-mini-high/api
 thinking: true

--- a/providers/openrouter/openai/o3.yaml
+++ b/providers/openrouter/openai/o3.yaml
@@ -22,6 +22,9 @@ modalities:
         - text
 mode: chat
 model: openai/o3
+params:
+    - key: max_tokens
+      maxValue: 100000
 sources:
     - https://openrouter.ai/openai/o3/api
 thinking: true

--- a/providers/openrouter/openai/o4-mini-high.yaml
+++ b/providers/openrouter/openai/o4-mini-high.yaml
@@ -22,6 +22,9 @@ modalities:
         - text
 mode: chat
 model: openai/o4-mini-high
+params:
+    - key: max_tokens
+      maxValue: 100000
 sources:
     - https://openrouter.ai/openai/o4-mini-high/api
 thinking: true

--- a/providers/openrouter/openai/o4-mini.yaml
+++ b/providers/openrouter/openai/o4-mini.yaml
@@ -22,6 +22,11 @@ modalities:
         - text
 mode: chat
 model: openai/o4-mini
+params:
+    - defaultValue: 100000
+      key: max_tokens
+      maxValue: 100000
+      minValue: 1
 sources:
     - https://openrouter.ai/openai/o4-mini/api
 thinking: true

--- a/providers/openrouter/openrouter/free.yaml
+++ b/providers/openrouter/openrouter/free.yaml
@@ -5,6 +5,7 @@ costs:
 features:
     - function_calling
     - tool_choice
+    - structured_output
 limits:
     context_window: 200000
 modalities:
@@ -17,3 +18,4 @@ mode: chat
 model: openrouter/free
 sources:
     - https://openrouter.ai/openrouter/free/api
+thinking: true

--- a/providers/openrouter/openrouter/healer-alpha.yaml
+++ b/providers/openrouter/openrouter/healer-alpha.yaml
@@ -8,6 +8,7 @@ features:
     - tool_choice
     - structured_output
     - system_messages
+isDeprecated: true
 limits:
     context_window: 262144
     max_input_tokens: 230144

--- a/providers/openrouter/perplexity/sonar-deep-research.yaml
+++ b/providers/openrouter/perplexity/sonar-deep-research.yaml
@@ -3,6 +3,7 @@ costs:
       output_cost_per_token: 0.000008
       region: "*"
 features:
+    - function_calling
     - system_messages
     - tool_choice
 limits:

--- a/providers/openrouter/perplexity/sonar-pro-search.yaml
+++ b/providers/openrouter/perplexity/sonar-pro-search.yaml
@@ -1,5 +1,6 @@
 costs:
-    - input_cost_per_token: 0.000003
+    - input_cost_per_request: 0.018
+      input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: "*"
 features:

--- a/providers/openrouter/perplexity/sonar-pro.yaml
+++ b/providers/openrouter/perplexity/sonar-pro.yaml
@@ -1,5 +1,6 @@
 costs:
-    - input_cost_per_token: 0.000003
+    - input_cost_per_query: 0.005
+      input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: "*"
 features:
@@ -17,6 +18,11 @@ modalities:
         - text
 mode: chat
 model: perplexity/sonar-pro
+params:
+    - defaultValue: 8000
+      key: max_tokens
+      maxValue: 8000
+      minValue: 1
 sources:
     - https://openrouter.ai/perplexity/sonar-pro/api
 thinking: false

--- a/providers/openrouter/perplexity/sonar-reasoning-pro.yaml
+++ b/providers/openrouter/perplexity/sonar-reasoning-pro.yaml
@@ -1,11 +1,10 @@
 costs:
-    - input_cost_per_token: 0.000002
+    - input_cost_per_query: 0.005
+      input_cost_per_token: 0.000002
       output_cost_per_token: 0.000008
       region: "*"
 limits:
     context_window: 128000
-    max_output_tokens: 128000
-    max_tokens: 128000
 modalities:
     input:
         - text

--- a/providers/openrouter/phi-3-medium-128k-instruct.yaml
+++ b/providers/openrouter/phi-3-medium-128k-instruct.yaml
@@ -2,7 +2,12 @@ limits:
     context_window: 128000
     max_output_tokens: 4096
     max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
-model: phi-3-medium-128k-instruct
+model: microsoft/phi-3-medium-128k-instruct
 sources:
     - https://openrouter.ai/microsoft/phi-3-medium-128k-instruct/api

--- a/providers/openrouter/phi-3-mini-128k-instruct.yaml
+++ b/providers/openrouter/phi-3-mini-128k-instruct.yaml
@@ -1,5 +1,10 @@
 limits:
     context_window: 128000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: phi-3-mini-128k-instruct
 sources:

--- a/providers/openrouter/phi-3.5-mini-128k-instruct.yaml
+++ b/providers/openrouter/phi-3.5-mini-128k-instruct.yaml
@@ -1,7 +1,10 @@
 limits:
     context_window: 128000
-    max_output_tokens: 4096
-    max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: microsoft/phi-3.5-mini-128k-instruct
 sources:

--- a/providers/openrouter/phi-4-multimodal-instruct.yaml
+++ b/providers/openrouter/phi-4-multimodal-instruct.yaml
@@ -8,7 +8,10 @@ limits:
     max_tokens: 4096
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: microsoft/phi-4-multimodal-instruct
 sources:

--- a/providers/openrouter/phi-4-reasoning-plus.yaml
+++ b/providers/openrouter/phi-4-reasoning-plus.yaml
@@ -1,7 +1,23 @@
+features:
+    - system_messages
 limits:
     context_window: 32768
+    max_output_tokens: 32768
+    max_tokens: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: phi-4-reasoning-plus
+params:
+    - defaultValue: 0.95
+      key: top_p
+    - defaultValue: 32768
+      key: max_tokens
+      maxValue: 32768
+      minValue: 1
 sources:
     - https://openrouter.ai/microsoft/phi-4-reasoning-plus/api
     - https://openrouter.ai/microsoft/phi-4-reasoning-plus/providers

--- a/providers/openrouter/phi-4.yaml
+++ b/providers/openrouter/phi-4.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 6.e-8
+    - input_cost_per_token: 6.5e-8
       output_cost_per_token: 1.4e-7
       region: "*"
 features:

--- a/providers/openrouter/pixtral-12b.yaml
+++ b/providers/openrouter/pixtral-12b.yaml
@@ -1,17 +1,18 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
+    - input_cost_per_token: 1.e-7
+      output_cost_per_token: 1.e-7
       region: "*"
 features:
     - tools
     - function_calling
 limits:
-    context_window: 4096
-    max_output_tokens: 4096
-    max_tokens: 4096
+    context_window: 32768
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: pixtral-12b
 sources:

--- a/providers/openrouter/pixtral-large-2411.yaml
+++ b/providers/openrouter/pixtral-large-2411.yaml
@@ -1,5 +1,6 @@
 costs:
-    - input_cost_per_token: 0.000002
+    - cache_read_input_token_cost: 2.e-7
+      input_cost_per_token: 0.000002
       output_cost_per_token: 0.000006
       region: "*"
 features:
@@ -13,7 +14,10 @@ limits:
     max_tokens: 4096
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: pixtral-large-2411
 sources:

--- a/providers/openrouter/pygmalionai/mythalion-13b.yaml
+++ b/providers/openrouter/pygmalionai/mythalion-13b.yaml
@@ -4,7 +4,11 @@ costs:
       region: "*"
 limits:
     context_window: 8192
-    max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: pygmalionai/mythalion-13b
 sources:

--- a/providers/openrouter/qwen-2-72b-instruct.yaml
+++ b/providers/openrouter/qwen-2-72b-instruct.yaml
@@ -1,5 +1,10 @@
 limits:
     context_window: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwen-2-72b-instruct
 params:

--- a/providers/openrouter/qwen-2.5-72b-instruct.yaml
+++ b/providers/openrouter/qwen-2.5-72b-instruct.yaml
@@ -11,6 +11,11 @@ limits:
     context_window: 32768
     max_output_tokens: 16384
     max_tokens: 16384
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwen-2.5-72b-instruct
 sources:

--- a/providers/openrouter/qwen-2.5-72b-instruct:free.yaml
+++ b/providers/openrouter/qwen-2.5-72b-instruct:free.yaml
@@ -4,10 +4,16 @@ costs:
       region: "*"
 features:
     - function_calling
+    - structured_output
 limits:
     context_window: 131072
     max_output_tokens: 8000
     max_tokens: 8000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwen-2.5-72b-instruct:free
 sources:

--- a/providers/openrouter/qwen-2.5-7b-instruct.yaml
+++ b/providers/openrouter/qwen-2.5-7b-instruct.yaml
@@ -6,10 +6,15 @@ limits:
     context_window: 32768
     max_output_tokens: 8000
     max_tokens: 8000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwen-2.5-7b-instruct
 params:
     - key: max_tokens
-      maxValue: 16384
+      maxValue: 8000
 sources:
     - https://openrouter.ai/qwen/qwen-2.5-7b-instruct/api

--- a/providers/openrouter/qwen-2.5-coder-32b-instruct.yaml
+++ b/providers/openrouter/qwen-2.5-coder-32b-instruct.yaml
@@ -1,11 +1,19 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 2.e-7
+    - input_cost_per_token: 6.6e-7
+      output_cost_per_token: 0.000001
       region: "*"
+features:
+    - function_calling
+    - tool_choice
 limits:
     context_window: 32768
     max_output_tokens: 8192
     max_tokens: 8192
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwen-2.5-coder-32b-instruct
 params:

--- a/providers/openrouter/qwen-2.5-coder-32b-instruct:free.yaml
+++ b/providers/openrouter/qwen-2.5-coder-32b-instruct:free.yaml
@@ -4,7 +4,13 @@ costs:
       region: "*"
 limits:
     context_window: 128000
+    max_output_tokens: 4096
     max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwen/qwen-2.5-coder-32b-instruct:free
 sources:

--- a/providers/openrouter/qwen-2.5-vl-7b-instruct.yaml
+++ b/providers/openrouter/qwen-2.5-vl-7b-instruct.yaml
@@ -4,10 +4,14 @@ costs:
       region: "*"
 limits:
     context_window: 32768
+    max_output_tokens: 4096
     max_tokens: 4096
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: qwen/qwen-2.5-vl-7b-instruct
 sources:

--- a/providers/openrouter/qwen-max.yaml
+++ b/providers/openrouter/qwen-max.yaml
@@ -7,11 +7,17 @@ features:
     - function_calling
     - tools
     - tool_choice
+    - structured_output
 limits:
     context_window: 32768
     max_input_tokens: 30720
     max_output_tokens: 8192
     max_tokens: 8192
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwen-max
 params:

--- a/providers/openrouter/qwen-plus.yaml
+++ b/providers/openrouter/qwen-plus.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_token_cost: 8.e-8
-      input_cost_per_token: 4.e-7
-      output_cost_per_token: 0.0000012
+    - cache_read_input_token_cost: 5.2e-8
+      input_cost_per_token: 2.6e-7
+      output_cost_per_token: 7.8e-7
       region: "*"
       tiered_pricing:
           cache_read:

--- a/providers/openrouter/qwen-vl-max.yaml
+++ b/providers/openrouter/qwen-vl-max.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 8.e-7
-      output_cost_per_token: 0.0000032
+    - input_cost_per_token: 5.2e-7
+      output_cost_per_token: 0.00000208
       region: "*"
 features:
     - function_calling
@@ -12,7 +12,10 @@ limits:
     max_tokens: 32768
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: qwen-vl-max
 params:

--- a/providers/openrouter/qwen-vl-plus.yaml
+++ b/providers/openrouter/qwen-vl-plus.yaml
@@ -6,6 +6,7 @@ costs:
 features:
     - function_calling
     - tool_choice
+    - structured_output
 limits:
     context_window: 131072
     max_input_tokens: 129024
@@ -13,7 +14,10 @@ limits:
     max_tokens: 8192
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: qwen-vl-plus
 params:

--- a/providers/openrouter/qwen/qwen-2.5-vl-7b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen-2.5-vl-7b-instruct.yaml
@@ -1,10 +1,9 @@
 costs:
-    - input_cost_per_token: 2.0000000000000002e-7
-      output_cost_per_token: 2.0000000000000002e-7
+    - input_cost_per_token: 2.e-7
+      output_cost_per_token: 2.e-7
       region: "*"
 limits:
     context_window: 32768
-    max_output_tokens: 32768
 modalities:
     input:
         - text

--- a/providers/openrouter/qwen/qwen-max.yaml
+++ b/providers/openrouter/qwen/qwen-max.yaml
@@ -7,6 +7,7 @@ features:
     - function_calling
     - tool_choice
     - tools
+    - structured_output
 limits:
     context_window: 32768
     max_output_tokens: 8192

--- a/providers/openrouter/qwen/qwen-plus-2025-07-28.yaml
+++ b/providers/openrouter/qwen/qwen-plus-2025-07-28.yaml
@@ -2,6 +2,13 @@ costs:
     - input_cost_per_token: 2.6e-7
       output_cost_per_token: 7.8e-7
       region: "*"
+      tiered_pricing:
+          input:
+              - cost_per_token: 0.0000012
+                from: 256000
+          output:
+              - cost_per_token: 0.0000036
+                from: 256000
 features:
     - function_calling
     - tool_choice

--- a/providers/openrouter/qwen/qwen-plus-2025-07-28:thinking.yaml
+++ b/providers/openrouter/qwen/qwen-plus-2025-07-28:thinking.yaml
@@ -2,6 +2,13 @@ costs:
     - input_cost_per_token: 2.6e-7
       output_cost_per_token: 7.8e-7
       region: "*"
+      tiered_pricing:
+          input:
+              - cost_per_token: 0.0000012
+                from: 256000
+          output:
+              - cost_per_token: 0.0000036
+                from: 256000
 features:
     - function_calling
     - tool_choice
@@ -20,6 +27,9 @@ modalities:
         - text
 mode: chat
 model: qwen/qwen-plus-2025-07-28:thinking
+params:
+    - key: max_tokens
+      maxValue: 32768
 sources:
     - https://openrouter.ai/qwen/qwen-plus-2025-07-28:thinking/api
 thinking: true

--- a/providers/openrouter/qwen/qwen-plus.yaml
+++ b/providers/openrouter/qwen/qwen-plus.yaml
@@ -3,6 +3,16 @@ costs:
       input_cost_per_token: 2.6e-7
       output_cost_per_token: 7.8e-7
       region: "*"
+      tiered_pricing:
+          cache_read:
+              - cost_per_token: 2.4e-7
+                from: 256000
+          input:
+              - cost_per_token: 0.0000012
+                from: 256000
+          output:
+              - cost_per_token: 0.0000036
+                from: 256000
 features:
     - function_calling
     - tool_choice
@@ -19,5 +29,10 @@ modalities:
         - text
 mode: chat
 model: qwen/qwen-plus
+params:
+    - defaultValue: 32768
+      key: max_tokens
+      maxValue: 32768
+      minValue: 1
 sources:
     - https://openrouter.ai/qwen/qwen-plus/api

--- a/providers/openrouter/qwen/qwen-vl-max.yaml
+++ b/providers/openrouter/qwen/qwen-vl-max.yaml
@@ -5,8 +5,11 @@ costs:
 features:
     - function_calling
     - structured_output
+    - tool_choice
+    - tools
 limits:
     context_window: 131072
+    max_input_tokens: 129024
     max_output_tokens: 32768
     max_tokens: 32768
 modalities:

--- a/providers/openrouter/qwen/qwen-vl-plus.yaml
+++ b/providers/openrouter/qwen/qwen-vl-plus.yaml
@@ -5,6 +5,7 @@ costs:
       region: "*"
 features:
     - tool_choice
+    - structured_output
 limits:
     context_window: 131072
     max_input_tokens: 129024

--- a/providers/openrouter/qwen/qwen2.5-coder-7b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen2.5-coder-7b-instruct.yaml
@@ -3,10 +3,7 @@ costs:
       output_cost_per_token: 9.e-8
       region: "*"
 features:
-    - function_calling
-    - tool_choice
     - structured_output
-    - tools
 limits:
     context_window: 32768
 modalities:

--- a/providers/openrouter/qwen/qwen3-235b-a22b-2507.yaml
+++ b/providers/openrouter/qwen/qwen3-235b-a22b-2507.yaml
@@ -5,6 +5,7 @@ costs:
 features:
     - function_calling
     - tool_choice
+    - structured_output
 limits:
     context_window: 262144
     max_input_tokens: 262144

--- a/providers/openrouter/qwen/qwen3-235b-a22b-thinking-2507.yaml
+++ b/providers/openrouter/qwen/qwen3-235b-a22b-thinking-2507.yaml
@@ -1,17 +1,15 @@
 costs:
-    - cache_read_input_token_cost: 5.5e-8
-      input_cost_per_token: 1.1e-7
-      output_cost_per_token: 6.e-7
+    - input_cost_per_token: 1.495e-7
+      output_cost_per_token: 0.000001495
       region: "*"
 features:
     - function_calling
     - tool_choice
     - structured_output
 limits:
-    context_window: 262144
-    max_input_tokens: 262144
-    max_output_tokens: 262144
-    max_tokens: 262144
+    context_window: 131072
+    max_output_tokens: 81920
+    max_tokens: 81920
 modalities:
     input:
         - text

--- a/providers/openrouter/qwen/qwen3-30b-a3b-instruct-2507.yaml
+++ b/providers/openrouter/qwen/qwen3-30b-a3b-instruct-2507.yaml
@@ -6,6 +6,7 @@ features:
     - function_calling
     - tool_choice
     - tools
+    - structured_output
 limits:
     context_window: 262144
     max_output_tokens: 262144

--- a/providers/openrouter/qwen/qwen3-30b-a3b-thinking-2507.yaml
+++ b/providers/openrouter/qwen/qwen3-30b-a3b-thinking-2507.yaml
@@ -1,13 +1,13 @@
 costs:
-    - input_cost_per_token: 5.1e-8
-      output_cost_per_token: 3.4e-7
+    - input_cost_per_token: 8.e-8
+      output_cost_per_token: 4.e-7
       region: "*"
 features:
     - function_calling
     - tool_choice
     - tools
 limits:
-    context_window: 32768
+    context_window: 131072
 modalities:
     input:
         - text

--- a/providers/openrouter/qwen/qwen3-30b-a3b.yaml
+++ b/providers/openrouter/qwen/qwen3-30b-a3b.yaml
@@ -6,7 +6,6 @@ features:
     - function_calling
     - tool_choice
     - tools
-    - structured_output
 limits:
     context_window: 40960
     max_output_tokens: 40960

--- a/providers/openrouter/qwen/qwen3-32b.yaml
+++ b/providers/openrouter/qwen/qwen3-32b.yaml
@@ -7,6 +7,7 @@ features:
     - function_calling
     - tool_choice
     - tools
+    - structured_output
 limits:
     context_window: 40960
     max_output_tokens: 40960

--- a/providers/openrouter/qwen/qwen3-4b:free.yaml
+++ b/providers/openrouter/qwen/qwen3-4b:free.yaml
@@ -2,6 +2,7 @@ costs:
     - input_cost_per_token: 0
       output_cost_per_token: 0
       region: "*"
+deprecationDate: "2026-03-29"
 features:
     - function_calling
     - tool_choice
@@ -10,8 +11,6 @@ features:
     - system_messages
 limits:
     context_window: 40960
-    max_output_tokens: 40960
-    max_tokens: 40960
 modalities:
     input:
         - text

--- a/providers/openrouter/qwen/qwen3-8b.yaml
+++ b/providers/openrouter/qwen/qwen3-8b.yaml
@@ -1,6 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 5.e-8
-      input_cost_per_token: 5.e-8
+    - input_cost_per_token: 5.e-8
       output_cost_per_token: 4.e-7
       region: "*"
 features:
@@ -20,6 +19,13 @@ modalities:
         - text
 mode: chat
 model: qwen/qwen3-8b
+params:
+    - defaultValue: 0.6
+      key: temperature
+    - defaultValue: 0.95
+      key: top_p
+    - defaultValue: 20
+      key: top_k
 sources:
     - https://openrouter.ai/qwen/qwen3-8b/api
 thinking: true

--- a/providers/openrouter/qwen/qwen3-coder-flash.yaml
+++ b/providers/openrouter/qwen/qwen3-coder-flash.yaml
@@ -3,6 +3,13 @@ costs:
       input_cost_per_token: 1.95e-7
       output_cost_per_token: 9.75e-7
       region: "*"
+      tiered_pricing:
+          input:
+              - cost_per_token: 3.25e-7
+                from: 32000
+          output:
+              - cost_per_token: 0.000001625
+                from: 32000
 features:
     - function_calling
     - tool_choice

--- a/providers/openrouter/qwen/qwen3-coder-next.yaml
+++ b/providers/openrouter/qwen/qwen3-coder-next.yaml
@@ -21,4 +21,3 @@ mode: chat
 model: qwen/qwen3-coder-next
 sources:
     - https://openrouter.ai/qwen/qwen3-coder-next/api
-thinking: false

--- a/providers/openrouter/qwen/qwen3-coder-plus.yaml
+++ b/providers/openrouter/qwen/qwen3-coder-plus.yaml
@@ -21,6 +21,9 @@ modalities:
         - text
 mode: chat
 model: qwen/qwen3-coder-plus
+params:
+    - key: max_tokens
+      maxValue: 65536
 sources:
     - https://openrouter.ai/qwen/qwen3-coder-plus/api
 thinking: true

--- a/providers/openrouter/qwen/qwen3-coder.yaml
+++ b/providers/openrouter/qwen/qwen3-coder.yaml
@@ -6,6 +6,7 @@ costs:
 features:
     - function_calling
     - tool_choice
+    - structured_output
 limits:
     context_window: 262144
     max_input_tokens: 262144

--- a/providers/openrouter/qwen/qwen3-coder:exacto.yaml
+++ b/providers/openrouter/qwen/qwen3-coder:exacto.yaml
@@ -6,8 +6,14 @@ costs:
 features:
     - function_calling
     - tool_choice
+    - structured_output
 limits:
     context_window: 262144
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwen/qwen3-coder:exacto
 sources:

--- a/providers/openrouter/qwen/qwen3-max-thinking.yaml
+++ b/providers/openrouter/qwen/qwen3-max-thinking.yaml
@@ -2,6 +2,13 @@ costs:
     - input_cost_per_token: 7.8e-7
       output_cost_per_token: 0.0000039
       region: "*"
+      tiered_pricing:
+          input:
+              - cost_per_token: 0.00000156
+                from: 32000
+          output:
+              - cost_per_token: 0.0000078
+                from: 32000
 features:
     - function_calling
     - tool_choice

--- a/providers/openrouter/qwen/qwen3-next-80b-a3b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen3-next-80b-a3b-instruct.yaml
@@ -4,10 +4,11 @@ costs:
       region: "*"
 features:
     - system_messages
+    - function_calling
+    - tool_choice
+    - structured_output
 limits:
-    context_window: 131072
-    max_output_tokens: 131072
-    max_tokens: 131072
+    context_window: 262144
 modalities:
     input:
         - text

--- a/providers/openrouter/qwen/qwen3-next-80b-a3b-thinking.yaml
+++ b/providers/openrouter/qwen/qwen3-next-80b-a3b-thinking.yaml
@@ -9,7 +9,7 @@ features:
     - tools
 limits:
     context_window: 131072
-    max_input_tokens: 126976
+    max_input_tokens: 131072
     max_output_tokens: 32768
     max_tokens: 32768
 modalities:

--- a/providers/openrouter/qwen/qwen3-vl-235b-a22b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen3-vl-235b-a22b-instruct.yaml
@@ -12,6 +12,7 @@ modalities:
     input:
         - text
         - image
+        - video
     output:
         - text
 mode: chat

--- a/providers/openrouter/qwen/qwen3-vl-235b-a22b-thinking.yaml
+++ b/providers/openrouter/qwen/qwen3-vl-235b-a22b-thinking.yaml
@@ -9,6 +9,7 @@ features:
 limits:
     context_window: 131072
     max_output_tokens: 32768
+    max_tokens: 32768
 modalities:
     input:
         - text

--- a/providers/openrouter/qwen/qwen3-vl-30b-a3b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen3-vl-30b-a3b-instruct.yaml
@@ -5,6 +5,7 @@ costs:
 features:
     - function_calling
     - tool_choice
+    - structured_output
 limits:
     context_window: 131072
     max_input_tokens: 129024

--- a/providers/openrouter/qwen/qwen3-vl-30b-a3b-thinking.yaml
+++ b/providers/openrouter/qwen/qwen3-vl-30b-a3b-thinking.yaml
@@ -6,6 +6,7 @@ features:
     - function_calling
     - tool_choice
     - tools
+    - structured_output
 limits:
     context_window: 131072
     max_input_tokens: 126976

--- a/providers/openrouter/qwen/qwen3.5-27b.yaml
+++ b/providers/openrouter/qwen/qwen3.5-27b.yaml
@@ -10,6 +10,7 @@ features:
     - system_messages
 limits:
     context_window: 262144
+    max_input_tokens: 258048
     max_output_tokens: 65536
     max_tokens: 65536
 modalities:

--- a/providers/openrouter/qwen/qwen3.5-397b-a17b.yaml
+++ b/providers/openrouter/qwen/qwen3.5-397b-a17b.yaml
@@ -6,6 +6,7 @@ features:
     - function_calling
     - tool_choice
     - tools
+    - structured_output
 limits:
     context_window: 262144
     max_input_tokens: 258048

--- a/providers/openrouter/qwen/qwen3.5-plus-02-15.yaml
+++ b/providers/openrouter/qwen/qwen3.5-plus-02-15.yaml
@@ -2,6 +2,13 @@ costs:
     - input_cost_per_token: 2.6e-7
       output_cost_per_token: 0.00000156
       region: "*"
+      tiered_pricing:
+          input:
+              - cost_per_token: 3.25e-7
+                from: 256000
+          output:
+              - cost_per_token: 0.00000195
+                from: 256000
 features:
     - function_calling
     - tool_choice

--- a/providers/openrouter/qwen/qwq-32b.yaml
+++ b/providers/openrouter/qwen/qwq-32b.yaml
@@ -1,13 +1,15 @@
 costs:
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 4.e-7
+      output_cost_per_token: 5.8e-7
       region: "*"
 features:
+    - function_calling
     - structured_output
+    - tool_choice
 limits:
-    context_window: 32768
-    max_output_tokens: 32768
-    max_tokens: 32768
+    context_window: 131072
+    max_output_tokens: 131072
+    max_tokens: 131072
 modalities:
     input:
         - text

--- a/providers/openrouter/qwen2.5-vl-32b-instruct.yaml
+++ b/providers/openrouter/qwen2.5-vl-32b-instruct.yaml
@@ -7,7 +7,10 @@ limits:
     max_tokens: 4096
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: qwen2.5-vl-32b-instruct
 sources:

--- a/providers/openrouter/qwen2.5-vl-32b-instruct:free.yaml
+++ b/providers/openrouter/qwen2.5-vl-32b-instruct:free.yaml
@@ -8,7 +8,10 @@ limits:
     max_tokens: 4096
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: qwen2.5-vl-32b-instruct:free
 sources:

--- a/providers/openrouter/qwen2.5-vl-72b-instruct.yaml
+++ b/providers/openrouter/qwen2.5-vl-72b-instruct.yaml
@@ -8,7 +8,10 @@ limits:
     max_tokens: 32768
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: qwen2.5-vl-72b-instruct
 sources:

--- a/providers/openrouter/qwen2.5-vl-72b-instruct:free.yaml
+++ b/providers/openrouter/qwen2.5-vl-72b-instruct:free.yaml
@@ -6,7 +6,10 @@ limits:
     context_window: 131072
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: qwen2.5-vl-72b-instruct:free
 sources:

--- a/providers/openrouter/qwen3-14b.yaml
+++ b/providers/openrouter/qwen3-14b.yaml
@@ -10,6 +10,11 @@ limits:
     context_window: 40960
     max_output_tokens: 40960
     max_tokens: 40960
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwen3-14b
 sources:

--- a/providers/openrouter/qwen3-14b:free.yaml
+++ b/providers/openrouter/qwen3-14b:free.yaml
@@ -10,6 +10,11 @@ limits:
     context_window: 40960
     max_output_tokens: 40960
     max_tokens: 40960
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwen3-14b:free
 sources:

--- a/providers/openrouter/qwen3-235b-a22b-2507.yaml
+++ b/providers/openrouter/qwen3-235b-a22b-2507.yaml
@@ -8,6 +8,11 @@ features:
     - tool_choice
 limits:
     context_window: 262144
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwen3-235b-a22b-2507
 sources:

--- a/providers/openrouter/qwen3-235b-a22b-thinking-2507.yaml
+++ b/providers/openrouter/qwen3-235b-a22b-thinking-2507.yaml
@@ -1,7 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 5.5e-8
-      input_cost_per_token: 1.1e-7
-      output_cost_per_token: 6.e-7
+    - input_cost_per_token: 1.495e-7
+      output_cost_per_token: 0.000001495
       region: "*"
 features:
     - tools
@@ -12,6 +11,11 @@ limits:
     context_window: 262144
     max_output_tokens: 81920
     max_tokens: 81920
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwen3-235b-a22b-thinking-2507
 sources:

--- a/providers/openrouter/qwen3-235b-a22b.yaml
+++ b/providers/openrouter/qwen3-235b-a22b.yaml
@@ -6,10 +6,16 @@ features:
     - tools
     - function_calling
     - tool_choice
+    - structured_output
 limits:
     context_window: 131072
     max_output_tokens: 8192
     max_tokens: 8192
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwen3-235b-a22b
 params:

--- a/providers/openrouter/qwen3-235b-a22b:free.yaml
+++ b/providers/openrouter/qwen3-235b-a22b:free.yaml
@@ -10,6 +10,11 @@ limits:
     context_window: 131072
     max_output_tokens: 8192
     max_tokens: 8192
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwen3-235b-a22b:free
 sources:

--- a/providers/openrouter/qwen3-30b-a3b-instruct-2507.yaml
+++ b/providers/openrouter/qwen3-30b-a3b-instruct-2507.yaml
@@ -11,6 +11,11 @@ limits:
     context_window: 262144
     max_output_tokens: 262144
     max_tokens: 262144
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwen3-30b-a3b-instruct-2507
 params:

--- a/providers/openrouter/qwen3-30b-a3b.yaml
+++ b/providers/openrouter/qwen3-30b-a3b.yaml
@@ -6,10 +6,16 @@ features:
     - tools
     - function_calling
     - tool_choice
+    - structured_output
 limits:
     context_window: 40960
     max_output_tokens: 40960
     max_tokens: 40960
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwen3-30b-a3b
 params:

--- a/providers/openrouter/qwen3-30b-a3b:free.yaml
+++ b/providers/openrouter/qwen3-30b-a3b:free.yaml
@@ -10,6 +10,11 @@ limits:
     context_window: 131072
     max_output_tokens: 4096
     max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwen3-30b-a3b:free
 sources:

--- a/providers/openrouter/qwen3-32b.yaml
+++ b/providers/openrouter/qwen3-32b.yaml
@@ -12,6 +12,11 @@ limits:
     context_window: 40960
     max_output_tokens: 40960
     max_tokens: 40960
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwen3-32b
 sources:

--- a/providers/openrouter/qwen3-4b:free.yaml
+++ b/providers/openrouter/qwen3-4b:free.yaml
@@ -2,6 +2,7 @@ costs:
     - input_cost_per_token: 0
       output_cost_per_token: 0
       region: "*"
+deprecationDate: "2026-03-29"
 features:
     - tools
     - function_calling
@@ -9,6 +10,11 @@ features:
     - structured_output
 limits:
     context_window: 40960
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwen3-4b:free
 sources:

--- a/providers/openrouter/qwen3-8b.yaml
+++ b/providers/openrouter/qwen3-8b.yaml
@@ -1,6 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 5.e-8
-      input_cost_per_token: 5.e-8
+    - input_cost_per_token: 5.e-8
       output_cost_per_token: 4.e-7
       region: "*"
 features:

--- a/providers/openrouter/qwen3-8b:free.yaml
+++ b/providers/openrouter/qwen3-8b:free.yaml
@@ -11,11 +11,16 @@ limits:
     max_input_tokens: 40960
     max_output_tokens: 8192
     max_tokens: 8192
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwen3-8b:free
 params:
     - key: max_tokens
-      maxValue: 40960
+      maxValue: 8192
 sources:
     - https://openrouter.ai/qwen/qwen3-8b:free/api
 thinking: true

--- a/providers/openrouter/qwen3-coder.yaml
+++ b/providers/openrouter/qwen3-coder.yaml
@@ -10,6 +10,11 @@ features:
     - tools
 limits:
     context_window: 262144
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwen3-coder
 sources:

--- a/providers/openrouter/qwen3-coder:free.yaml
+++ b/providers/openrouter/qwen3-coder:free.yaml
@@ -10,6 +10,11 @@ limits:
     context_window: 262144
     max_output_tokens: 262144
     max_tokens: 262144
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwen3-coder:free
 sources:

--- a/providers/openrouter/qwq-32b-arliai-rpr-v1.yaml
+++ b/providers/openrouter/qwq-32b-arliai-rpr-v1.yaml
@@ -1,6 +1,10 @@
 limits:
     context_window: 32768
-    max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwq-32b-arliai-rpr-v1
 sources:

--- a/providers/openrouter/qwq-32b-arliai-rpr-v1:free.yaml
+++ b/providers/openrouter/qwq-32b-arliai-rpr-v1:free.yaml
@@ -6,6 +6,11 @@ limits:
     context_window: 32768
     max_output_tokens: 4096
     max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwq-32b-arliai-rpr-v1:free
 sources:

--- a/providers/openrouter/qwq-32b.yaml
+++ b/providers/openrouter/qwq-32b.yaml
@@ -1,14 +1,19 @@
 costs:
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 4.e-7
+      output_cost_per_token: 5.8e-7
       region: "*"
 features:
     - function_calling
     - structured_output
 limits:
-    context_window: 32768
-    max_output_tokens: 32768
-    max_tokens: 32768
+    context_window: 131072
+    max_output_tokens: 131072
+    max_tokens: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwq-32b
 sources:

--- a/providers/openrouter/qwq-32b:free.yaml
+++ b/providers/openrouter/qwq-32b:free.yaml
@@ -8,6 +8,11 @@ features:
 limits:
     context_window: 131072
     max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: qwq-32b:free
 sources:

--- a/providers/openrouter/r1-1776.yaml
+++ b/providers/openrouter/r1-1776.yaml
@@ -2,6 +2,11 @@ limits:
     context_window: 128000
     max_output_tokens: 4096
     max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: r1-1776
 sources:

--- a/providers/openrouter/raifle/sorcererlm-8x22b.yaml
+++ b/providers/openrouter/raifle/sorcererlm-8x22b.yaml
@@ -1,5 +1,10 @@
 limits:
     context_window: 16000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: raifle/sorcererlm-8x22b
 sources:

--- a/providers/openrouter/reka-flash-3.yaml
+++ b/providers/openrouter/reka-flash-3.yaml
@@ -1,8 +1,41 @@
+costs:
+    - input_cost_per_image: 0.00001
+      input_cost_per_token: 8.e-7
+      output_cost_per_token: 0.000002
+      region: "*"
+features:
+    - function_calling
+    - tool_choice
+    - tools
 limits:
+    max_output_tokens: 4096
     max_tokens: 4096
+messages:
+    options:
+        - user
+        - assistant
+modalities:
+    input:
+        - text
+        - image
+        - audio
+        - video
+        - pdf
+    output:
+        - text
 mode: chat
 model: reka-flash-3
+params:
+    - defaultValue: 0.4
+      key: temperature
+      maxValue: 2
+      minValue: 0
+    - defaultValue: 0.95
+      key: top_p
+    - defaultValue: 1024
+      key: top_k
 sources:
     - https://openrouter.ai/reka-ai/reka-flash-3/api
     - https://docs.reka.ai/pricing
     - https://docs.reka.ai/chat/models
+    - https://docs.reka.ai/chat/api-reference/create

--- a/providers/openrouter/reka-flash-3:free.yaml
+++ b/providers/openrouter/reka-flash-3:free.yaml
@@ -2,11 +2,25 @@ costs:
     - input_cost_per_token: 0
       output_cost_per_token: 0
       region: "*"
+features:
+    - function_calling
+    - system_messages
 limits:
     max_tokens: 4096
+modalities:
+    input:
+        - text
+        - image
+        - audio
+        - video
+        - pdf
+    output:
+        - text
 mode: chat
 model: reka-flash-3:free
 sources:
     - https://openrouter.ai/reka/reka-flash-3:free/api
     - https://docs.reka.ai/pricing
     - https://docs.reka.ai/chat/models
+    - https://docs.reka.ai/chat/function-calling
+    - https://docs.reka.ai/chat/chat-with-image-video-and-audio

--- a/providers/openrouter/relace/relace-search.yaml
+++ b/providers/openrouter/relace/relace-search.yaml
@@ -9,7 +9,6 @@ features:
     - system_messages
 limits:
     context_window: 256000
-    max_input_tokens: 128000
     max_output_tokens: 128000
     max_tokens: 128000
 modalities:
@@ -19,5 +18,9 @@ modalities:
         - text
 mode: chat
 model: relace/relace-search
+params:
+    - defaultValue: 128
+      key: max_tokens
+      maxValue: 128000
 sources:
     - https://openrouter.ai/relace/relace-search/api

--- a/providers/openrouter/remm-slerp-l2-13b.yaml
+++ b/providers/openrouter/remm-slerp-l2-13b.yaml
@@ -2,10 +2,17 @@ costs:
     - input_cost_per_token: 4.5e-7
       output_cost_per_token: 6.5e-7
       region: "*"
+features:
+    - structured_output
 limits:
     context_window: 6144
     max_output_tokens: 4096
     max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: remm-slerp-l2-13b
 sources:

--- a/providers/openrouter/rocinante-12b.yaml
+++ b/providers/openrouter/rocinante-12b.yaml
@@ -4,10 +4,18 @@ costs:
       region: "*"
 features:
     - tools
+    - tool_choice
+    - function_calling
+    - structured_output
 limits:
     context_window: 32768
     max_output_tokens: 32768
     max_tokens: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: rocinante-12b
 sources:

--- a/providers/openrouter/router.yaml
+++ b/providers/openrouter/router.yaml
@@ -8,6 +8,9 @@ modalities:
     input:
         - audio
         - image
+        - text
+    output:
+        - text
 mode: chat
 model: router
 sources:

--- a/providers/openrouter/sarvam-m.yaml
+++ b/providers/openrouter/sarvam-m.yaml
@@ -1,7 +1,12 @@
-costs: []
 limits:
     context_window: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: sarvam-m
 sources:
     - https://openrouter.ai/sarvamai/sarvam-m/api
+thinking: true

--- a/providers/openrouter/sarvam-m:free.yaml
+++ b/providers/openrouter/sarvam-m:free.yaml
@@ -4,6 +4,11 @@ costs:
       region: "*"
 limits:
     context_window: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: sarvam-m:free
 sources:

--- a/providers/openrouter/sonar-deep-research.yaml
+++ b/providers/openrouter/sonar-deep-research.yaml
@@ -5,6 +5,11 @@ costs:
       region: "*"
 limits:
     context_window: 128000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: sonar-deep-research
 sources:

--- a/providers/openrouter/sonar-pro.yaml
+++ b/providers/openrouter/sonar-pro.yaml
@@ -12,9 +12,12 @@ limits:
     max_tokens: 8000
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
-model: sonar-pro
+model: perplexity/sonar-pro
 params:
     - key: max_tokens
       maxValue: 8000

--- a/providers/openrouter/sonar-reasoning-pro.yaml
+++ b/providers/openrouter/sonar-reasoning-pro.yaml
@@ -3,11 +3,16 @@ costs:
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000008
       region: "*"
+features:
+    - tool_choice
 limits:
     context_window: 128000
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: sonar-reasoning-pro
 sources:

--- a/providers/openrouter/sonar-reasoning.yaml
+++ b/providers/openrouter/sonar-reasoning.yaml
@@ -1,5 +1,10 @@
 limits:
     context_window: 127000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: sonar-reasoning
 sources:

--- a/providers/openrouter/sonar.yaml
+++ b/providers/openrouter/sonar.yaml
@@ -4,12 +4,16 @@ costs:
       output_cost_per_token: 0.000001
       region: "*"
 features:
+    - function_calling
     - tool_choice
 limits:
     context_window: 127072
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: sonar
 sources:

--- a/providers/openrouter/sorcererlm-8x22b.yaml
+++ b/providers/openrouter/sorcererlm-8x22b.yaml
@@ -2,6 +2,11 @@ limits:
     context_window: 16000
     max_output_tokens: 4096
     max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: sorcererlm-8x22b
 sources:

--- a/providers/openrouter/spotlight.yaml
+++ b/providers/openrouter/spotlight.yaml
@@ -1,6 +1,9 @@
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: spotlight
 params:

--- a/providers/openrouter/switchpoint/router.yaml
+++ b/providers/openrouter/switchpoint/router.yaml
@@ -4,11 +4,9 @@ costs:
       region: "*"
 features:
     - tool_choice
+    - function_calling
 limits:
     context_window: 131072
-    max_input_tokens: 131072
-    max_output_tokens: 131072
-    max_tokens: 131072
 modalities:
     input:
         - text
@@ -16,6 +14,14 @@ modalities:
         - text
 mode: chat
 model: switchpoint/router
+params:
+    - key: top_k
+    - key: seed
+    - key: reasoning
+      type: boolean
+removeParams:
+    - "n"
+    - response_format
 sources:
     - https://openrouter.ai/switchpoint/router/api
 thinking: true

--- a/providers/openrouter/thedrummer/skyfall-36b-v2.yaml
+++ b/providers/openrouter/thedrummer/skyfall-36b-v2.yaml
@@ -2,10 +2,6 @@ costs:
     - input_cost_per_token: 5.5e-7
       output_cost_per_token: 8.e-7
       region: "*"
-features:
-    - function_calling
-    - tool_choice
-    - tools
 limits:
     context_window: 32768
     max_output_tokens: 32768

--- a/providers/openrouter/tngtech/deepseek-r1t2-chimera.yaml
+++ b/providers/openrouter/tngtech/deepseek-r1t2-chimera.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_token_cost: 1.25e-7
-      input_cost_per_token: 2.5e-7
-      output_cost_per_token: 8.5e-7
+    - cache_read_input_token_cost: 1.5e-7
+      input_cost_per_token: 3.e-7
+      output_cost_per_token: 0.0000011
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/toppy-m-7b.yaml
+++ b/providers/openrouter/toppy-m-7b.yaml
@@ -1,5 +1,12 @@
 limits:
     context_window: 4096
+    max_output_tokens: 4096
+    max_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: toppy-m-7b
 params:

--- a/providers/openrouter/ui-tars-1.5-7b.yaml
+++ b/providers/openrouter/ui-tars-1.5-7b.yaml
@@ -8,7 +8,10 @@ limits:
     max_tokens: 2048
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: ui-tars-1.5-7b
 params:

--- a/providers/openrouter/undi95/remm-slerp-l2-13b.yaml
+++ b/providers/openrouter/undi95/remm-slerp-l2-13b.yaml
@@ -2,6 +2,8 @@ costs:
     - input_cost_per_token: 4.5e-7
       output_cost_per_token: 6.5e-7
       region: "*"
+features:
+    - structured_output
 limits:
     context_window: 6144
     max_output_tokens: 4096

--- a/providers/openrouter/unslopnemo-12b.yaml
+++ b/providers/openrouter/unslopnemo-12b.yaml
@@ -10,6 +10,11 @@ limits:
     context_window: 32768
     max_output_tokens: 32768
     max_tokens: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: unslopnemo-12b
 sources:

--- a/providers/openrouter/virtuoso-large.yaml
+++ b/providers/openrouter/virtuoso-large.yaml
@@ -6,10 +6,16 @@ features:
     - tools
     - function_calling
     - tool_choice
+    - structured_output
 limits:
     context_window: 131072
     max_output_tokens: 64000
     max_tokens: 64000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: virtuoso-large
 params:

--- a/providers/openrouter/wizardlm-2-8x22b.yaml
+++ b/providers/openrouter/wizardlm-2-8x22b.yaml
@@ -3,16 +3,22 @@ costs:
       output_cost_per_token: 6.2e-7
       region: "*"
 features:
+    - function_calling
     - tool_choice
 limits:
     context_window: 65535
     max_input_tokens: 57535
     max_output_tokens: 8000
     max_tokens: 8000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: wizardlm-2-8x22b
 params:
     - key: max_tokens
-      maxValue: 65536
+      maxValue: 8000
 sources:
     - https://openrouter.ai/microsoft/wizardlm-2-8x22b/api

--- a/providers/openrouter/x-ai/grok-3-mini-beta.yaml
+++ b/providers/openrouter/x-ai/grok-3-mini-beta.yaml
@@ -16,6 +16,9 @@ modalities:
         - text
 mode: chat
 model: x-ai/grok-3-mini-beta
+params:
+    - key: reasoning_effort
+      type: string
 sources:
     - https://openrouter.ai/x-ai/grok-3-mini-beta/api
     - https://docs.x.ai/developers/models#models-and-pricing

--- a/providers/openrouter/x-ai/grok-3-mini.yaml
+++ b/providers/openrouter/x-ai/grok-3-mini.yaml
@@ -10,7 +10,6 @@ features:
     - system_messages
 limits:
     context_window: 131072
-    max_tokens: 131072
 modalities:
     input:
         - text
@@ -18,6 +17,9 @@ modalities:
         - text
 mode: chat
 model: x-ai/grok-3-mini
+params:
+    - key: reasoning_effort
+      type: string
 sources:
     - https://openrouter.ai/x-ai/grok-3-mini/api
     - https://docs.x.ai/developers/models#models-and-pricing

--- a/providers/openrouter/x-ai/grok-4-fast.yaml
+++ b/providers/openrouter/x-ai/grok-4-fast.yaml
@@ -3,6 +3,13 @@ costs:
       input_cost_per_token: 2.e-7
       output_cost_per_token: 5.e-7
       region: "*"
+      tiered_pricing:
+          input:
+              - cost_per_token: 4.e-7
+                from: 128000
+          output:
+              - cost_per_token: 0.000001
+                from: 128000
 features:
     - function_calling
     - system_messages

--- a/providers/openrouter/x-ai/grok-4-fast:free.yaml
+++ b/providers/openrouter/x-ai/grok-4-fast:free.yaml
@@ -13,10 +13,14 @@ limits:
     max_tokens: 30000
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: x-ai/grok-4-fast:free
 sources:
     - https://openrouter.ai/x-ai/grok-4-fast:free/api
     - https://docs.x.ai/developers/models#models-and-pricing
+    - https://openrouter.ai/x-ai/grok-4-fast/api
 thinking: true

--- a/providers/openrouter/x-ai/grok-4.1-fast.yaml
+++ b/providers/openrouter/x-ai/grok-4.1-fast.yaml
@@ -3,6 +3,13 @@ costs:
       input_cost_per_token: 2.e-7
       output_cost_per_token: 5.e-7
       region: "*"
+      tiered_pricing:
+          input:
+              - cost_per_token: 4.e-7
+                from: 128000
+          output:
+              - cost_per_token: 0.000001
+                from: 128000
 features:
     - function_calling
     - tool_choice

--- a/providers/openrouter/x-ai/grok-4.20-beta.yaml
+++ b/providers/openrouter/x-ai/grok-4.20-beta.yaml
@@ -3,6 +3,13 @@ costs:
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000006
       region: "*"
+      tiered_pricing:
+          input:
+              - cost_per_token: 0.000004
+                from: 200000
+          output:
+              - cost_per_token: 0.000012
+                from: 200000
 features:
     - function_calling
     - tool_choice

--- a/providers/openrouter/x-ai/grok-4.20-multi-agent-beta.yaml
+++ b/providers/openrouter/x-ai/grok-4.20-multi-agent-beta.yaml
@@ -3,6 +3,13 @@ costs:
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000006
       region: "*"
+      tiered_pricing:
+          input:
+              - cost_per_token: 0.000004
+                from: 200000
+          output:
+              - cost_per_token: 0.000012
+                from: 200000
 features:
     - function_calling
     - tool_choice

--- a/providers/openrouter/x-ai/grok-4.yaml
+++ b/providers/openrouter/x-ai/grok-4.yaml
@@ -3,6 +3,13 @@ costs:
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: "*"
+      tiered_pricing:
+          input:
+              - cost_per_token: 0.000006
+                from: 128000
+          output:
+              - cost_per_token: 0.00003
+                from: 128000
 features:
     - function_calling
     - parallel_function_calling

--- a/providers/openrouter/xiaomi/mimo-v2-flash.yaml
+++ b/providers/openrouter/xiaomi/mimo-v2-flash.yaml
@@ -6,6 +6,7 @@ costs:
 features:
     - function_calling
     - tool_choice
+    - structured_output
 limits:
     context_window: 262144
     max_input_tokens: 262144

--- a/providers/openrouter/z-ai/glm-4.5.yaml
+++ b/providers/openrouter/z-ai/glm-4.5.yaml
@@ -19,6 +19,10 @@ modalities:
         - text
 mode: chat
 model: z-ai/glm-4.5
+params:
+    - defaultValue: false
+      key: reasoning
+      type: boolean
 sources:
     - https://openrouter.ai/z-ai/glm-4.5/api
 thinking: true

--- a/providers/openrouter/z-ai/glm-4.6:exacto.yaml
+++ b/providers/openrouter/z-ai/glm-4.6:exacto.yaml
@@ -10,6 +10,11 @@ limits:
     context_window: 204800
     max_output_tokens: 204800
     max_tokens: 204800
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: z-ai/glm-4.6:exacto
 sources:

--- a/providers/openrouter/z-ai/glm-4.7.yaml
+++ b/providers/openrouter/z-ai/glm-4.7.yaml
@@ -1,17 +1,18 @@
 costs:
-    - cache_read_input_token_cost: 1.9e-7
-      input_cost_per_token: 3.8e-7
-      output_cost_per_token: 0.00000198
+    - cache_read_input_token_cost: 1.95e-7
+      input_cost_per_token: 3.9e-7
+      output_cost_per_token: 0.00000175
       region: "*"
 features:
     - function_calling
     - tool_choice
     - prompt_caching
+    - structured_output
 limits:
     context_window: 202752
     max_input_tokens: 202752
-    max_output_tokens: 64000
-    max_tokens: 64000
+    max_output_tokens: 65535
+    max_tokens: 65535
 modalities:
     input:
         - text

--- a/providers/openrouter/z-ai/glm-5.yaml
+++ b/providers/openrouter/z-ai/glm-5.yaml
@@ -7,9 +7,9 @@ features:
     - tools
     - system_messages
     - tool_choice
+    - structured_output
 limits:
     context_window: 80000
-    max_input_tokens: 71680
     max_output_tokens: 131072
     max_tokens: 131072
 modalities:


### PR DESCRIPTION
Auto-generated by poc-agent for provider `openrouter`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Large, auto-generated update to OpenRouter model YAML metadata (features, modalities, limits, pricing, and deprecation flags) with low runtime risk but potential config/validation regressions if downstream expects older fields or values.
> 
> **Overview**
> **Updates OpenRouter model registry YAMLs** to reflect current provider metadata.
> 
> Across many models this adds/normalizes `modalities` (explicit text/image/audio/video/pdf I/O), updates `features` (e.g., `tool_choice`, `structured_output`, `prompt_caching`, `function_calling`), and adjusts `limits`/`params` (notably `max_tokens`, new `reasoning_effort`, and some context/output token caps).
> 
> Also refreshes pricing blocks (including new `tiered_pricing` and cache/audio/image token cost fields), updates `sources`, and marks several models as deprecated via `isDeprecated`/`deprecationDate`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 381b6cd98a9cdcab53179a3cd72808dbed76715e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->