### PR TITLE
feat(together-ai): update model YAMLs [bot]

### DIFF
--- a/providers/together-ai/ByteDance-Seed/Seedream-3.0.yaml
+++ b/providers/together-ai/ByteDance-Seed/Seedream-3.0.yaml
@@ -3,10 +3,10 @@ costs:
       region: "*"
 modalities:
     input:
+        - text
+    output:
         - image
 mode: image
 model: ByteDance-Seed/Seedream-3.0
 sources:
     - https://docs.together.ai/docs/serverless-models
-supportedModes:
-    - image

--- a/providers/together-ai/ByteDance-Seed/Seedream-4.0.yaml
+++ b/providers/together-ai/ByteDance-Seed/Seedream-4.0.yaml
@@ -3,6 +3,8 @@ costs:
       region: "*"
 modalities:
     input:
+        - text
+    output:
         - image
 mode: image
 model: ByteDance-Seed/Seedream-4.0

--- a/providers/together-ai/ByteDance/Seedance-1.0-lite.yaml
+++ b/providers/together-ai/ByteDance/Seedance-1.0-lite.yaml
@@ -1,6 +1,11 @@
 costs:
     - input_cost_per_request: 0.14
       region: "*"
+modalities:
+    input:
+        - text
+    output:
+        - video
 mode: video
 model: ByteDance/Seedance-1.0-lite
 sources:

--- a/providers/together-ai/HiDream-ai/HiDream-I1-Dev.yaml
+++ b/providers/together-ai/HiDream-ai/HiDream-I1-Dev.yaml
@@ -3,6 +3,8 @@ costs:
       region: "*"
 modalities:
     input:
+        - text
+    output:
         - image
 mode: image
 model: HiDream-ai/HiDream-I1-Dev

--- a/providers/together-ai/HiDream-ai/HiDream-I1-Fast.yaml
+++ b/providers/together-ai/HiDream-ai/HiDream-I1-Fast.yaml
@@ -2,11 +2,9 @@ costs:
     - output_cost_per_image: 0.0032
       region: "*"
 modalities:
-    input:
+    output:
         - image
 mode: image
 model: HiDream-ai/HiDream-I1-Fast
 sources:
     - https://docs.together.ai/docs/serverless-models
-supportedModes:
-    - image

--- a/providers/together-ai/HiDream-ai/HiDream-I1-Full.yaml
+++ b/providers/together-ai/HiDream-ai/HiDream-I1-Full.yaml
@@ -3,6 +3,8 @@ costs:
       region: "*"
 modalities:
     input:
+        - text
+    output:
         - image
 mode: image
 model: HiDream-ai/HiDream-I1-Full

--- a/providers/together-ai/LiquidAI/LFM2-24B-A2B-Preview.yaml
+++ b/providers/together-ai/LiquidAI/LFM2-24B-A2B-Preview.yaml
@@ -4,6 +4,11 @@ costs:
       region: "*"
 limits:
     context_window: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: LiquidAI/LFM2-24B-A2B-Preview
 sources:

--- a/providers/together-ai/LiquidAI/LFM2-24B-A2B.yaml
+++ b/providers/together-ai/LiquidAI/LFM2-24B-A2B.yaml
@@ -2,8 +2,6 @@ costs:
     - input_cost_per_token: 3.e-8
       output_cost_per_token: 1.2e-7
       region: "*"
-features:
-    - function_calling
 limits:
     context_window: 32768
 mode: chat

--- a/providers/together-ai/MiniMaxAI/MiniMax-M1-40k.yaml
+++ b/providers/together-ai/MiniMaxAI/MiniMax-M1-40k.yaml
@@ -1,3 +1,14 @@
+features:
+    - function_calling
+    - structured_output
+    - system_messages
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: MiniMaxAI/MiniMax-M1-40k
+sources:
+    - https://huggingface.co/MiniMaxAI/MiniMax-M1-40k
 thinking: true

--- a/providers/together-ai/MiniMaxAI/MiniMax-M2.1.yaml
+++ b/providers/together-ai/MiniMaxAI/MiniMax-M2.1.yaml
@@ -1,4 +1,27 @@
+features:
+    - function_calling
+    - tools
+    - tool_choice
+    - system_messages
+limits:
+    context_window: 204800
+    max_output_tokens: 10240
+    max_tokens: 10240
+messages:
+    options:
+        - system
+        - user
+        - assistant
+        - developer
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: MiniMaxAI/MiniMax-M2.1
 sources:
-    - https://together.ai/models
+    - https://www.together.ai/models/minimax-m21
+    - https://platform.minimaxi.com/docs/guides/text-generation
+    - https://platform.minimaxi.com/docs/api-reference/text-post
+thinking: true

--- a/providers/together-ai/MiniMaxAI/MiniMax-M2.yaml
+++ b/providers/together-ai/MiniMaxAI/MiniMax-M2.yaml
@@ -1,3 +1,18 @@
+costs:
+    - cache_read_input_token_cost: 6.e-8
+      input_cost_per_token: 3.e-7
+      output_cost_per_token: 0.0000012
+      region: "*"
+features:
+    - function_calling
+    - structured_output
+limits:
+    context_window: 228700
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: MiniMaxAI/MiniMax-M2
 sources:

--- a/providers/together-ai/Qwen/Qwen-Image.yaml
+++ b/providers/together-ai/Qwen/Qwen-Image.yaml
@@ -3,6 +3,8 @@ costs:
       region: "*"
 modalities:
     input:
+        - text
+    output:
         - image
 mode: image
 model: Qwen/Qwen-Image

--- a/providers/together-ai/Qwen/Qwen2-1.5B-Instruct.yaml
+++ b/providers/together-ai/Qwen/Qwen2-1.5B-Instruct.yaml
@@ -1,3 +1,8 @@
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: Qwen/Qwen2-1.5B-Instruct
 sources:

--- a/providers/together-ai/Qwen/Qwen2-7B.yaml
+++ b/providers/together-ai/Qwen/Qwen2-7B.yaml
@@ -1,2 +1,7 @@
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: completion
 model: Qwen/Qwen2-7B

--- a/providers/together-ai/Qwen/Qwen2.5-1.5B-Instruct.yaml
+++ b/providers/together-ai/Qwen/Qwen2.5-1.5B-Instruct.yaml
@@ -1,6 +1,17 @@
 features:
     - function_calling
+limits:
+    context_window: 32768
+    max_input_tokens: 24576
+    max_output_tokens: 8192
+    max_tokens: 8192
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: Qwen/Qwen2.5-1.5B-Instruct
 sources:
     - https://docs.together.ai/docs/changelog
+    - https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct

--- a/providers/together-ai/Qwen/Qwen2.5-1.5B.yaml
+++ b/providers/together-ai/Qwen/Qwen2.5-1.5B.yaml
@@ -1,3 +1,8 @@
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: completion
 model: Qwen/Qwen2.5-1.5B
 sources:

--- a/providers/together-ai/Qwen/Qwen2.5-32B-Instruct.yaml
+++ b/providers/together-ai/Qwen/Qwen2.5-32B-Instruct.yaml
@@ -1,6 +1,11 @@
 features:
     - function_calling
     - system_messages
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: Qwen/Qwen2.5-32B-Instruct
 sources:

--- a/providers/together-ai/Qwen/Qwen2.5-32B.yaml
+++ b/providers/together-ai/Qwen/Qwen2.5-32B.yaml
@@ -1,2 +1,7 @@
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: completion
 model: Qwen/Qwen2.5-32B

--- a/providers/together-ai/Qwen/Qwen2.5-3B.yaml
+++ b/providers/together-ai/Qwen/Qwen2.5-3B.yaml
@@ -2,6 +2,11 @@ limits:
     context_window: 32768
     max_output_tokens: 8192
     max_tokens: 8192
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: completion
 model: Qwen/Qwen2.5-3B
 sources:

--- a/providers/together-ai/Qwen/Qwen2.5-72B.yaml
+++ b/providers/together-ai/Qwen/Qwen2.5-72B.yaml
@@ -9,6 +9,11 @@ limits:
     max_input_tokens: 32768
     max_output_tokens: 32768
     max_tokens: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: Qwen/Qwen2.5-72B
 sources:

--- a/providers/together-ai/Qwen/Qwen2.5-7B-Instruct.yaml
+++ b/providers/together-ai/Qwen/Qwen2.5-7B-Instruct.yaml
@@ -7,5 +7,10 @@ features:
     - structured_output
 limits:
     context_window: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: Qwen/Qwen2.5-7B-Instruct

--- a/providers/together-ai/Qwen/Qwen2.5-7B.yaml
+++ b/providers/together-ai/Qwen/Qwen2.5-7B.yaml
@@ -1,2 +1,7 @@
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: completion
 model: Qwen/Qwen2.5-7B

--- a/providers/together-ai/Qwen/Qwen3-0.6B-Base.yaml
+++ b/providers/together-ai/Qwen/Qwen3-0.6B-Base.yaml
@@ -1,5 +1,10 @@
 limits:
     context_window: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: completion
 model: Qwen/Qwen3-0.6B-Base
 sources:

--- a/providers/together-ai/Qwen/Qwen3-0.6B.yaml
+++ b/providers/together-ai/Qwen/Qwen3-0.6B.yaml
@@ -5,6 +5,11 @@ limits:
     context_window: 32768
     max_output_tokens: 32768
     max_tokens: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: Qwen/Qwen3-0.6B
 sources:

--- a/providers/together-ai/Qwen/Qwen3-1.7B-Base.yaml
+++ b/providers/together-ai/Qwen/Qwen3-1.7B-Base.yaml
@@ -1,4 +1,12 @@
+limits:
+    context_window: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: completion
 model: Qwen/Qwen3-1.7B-Base
 sources:
     - https://www.together.ai/pricing
+    - https://huggingface.co/Qwen/Qwen3-1.7B-Base

--- a/providers/together-ai/Qwen/Qwen3-1.7B.yaml
+++ b/providers/together-ai/Qwen/Qwen3-1.7B.yaml
@@ -1,4 +1,18 @@
+features:
+    - function_calling
+    - system_messages
+limits:
+    context_window: 32768
+    max_output_tokens: 32768
+    max_tokens: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: Qwen/Qwen3-1.7B
 sources:
     - https://www.together.ai/pricing
+    - https://huggingface.co/Qwen/Qwen3-1.7B
+thinking: true

--- a/providers/together-ai/Qwen/Qwen3-14B-Base.yaml
+++ b/providers/together-ai/Qwen/Qwen3-14B-Base.yaml
@@ -1,5 +1,10 @@
 limits:
     context_window: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: completion
 model: Qwen/Qwen3-14B-Base
 sources:

--- a/providers/together-ai/Qwen/Qwen3-30B-A3B-Base.yaml
+++ b/providers/together-ai/Qwen/Qwen3-30B-A3B-Base.yaml
@@ -1,2 +1,7 @@
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: completion
 model: Qwen/Qwen3-30B-A3B-Base

--- a/providers/together-ai/Qwen/Qwen3-30B-A3B.yaml
+++ b/providers/together-ai/Qwen/Qwen3-30B-A3B.yaml
@@ -4,6 +4,15 @@ costs:
       region: "*"
 features:
     - function_calling
+limits:
+    context_window: 32768
+    max_output_tokens: 32768
+    max_tokens: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: Qwen/Qwen3-30B-A3B
 sources:

--- a/providers/together-ai/Qwen/Qwen3-32B-FP8.yaml
+++ b/providers/together-ai/Qwen/Qwen3-32B-FP8.yaml
@@ -2,5 +2,16 @@ features:
     - function_calling
     - tool_choice
     - system_messages
+limits:
+    context_window: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: Qwen/Qwen3-32B-FP8
+sources:
+    - https://together.ai/models/qwen3-32b
+    - https://huggingface.co/Qwen/Qwen3-32B
+thinking: true

--- a/providers/together-ai/Qwen/Qwen3-32B.yaml
+++ b/providers/together-ai/Qwen/Qwen3-32B.yaml
@@ -1,5 +1,14 @@
+features:
+    - function_calling
+    - system_messages
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: Qwen/Qwen3-32B
 sources:
     - https://together.ai/pricing
+    - https://huggingface.co/Qwen/Qwen3-32B
 thinking: true

--- a/providers/together-ai/Qwen/Qwen3-4B-Base.yaml
+++ b/providers/together-ai/Qwen/Qwen3-4B-Base.yaml
@@ -1,5 +1,10 @@
 limits:
     context_window: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: completion
 model: Qwen/Qwen3-4B-Base
 sources:

--- a/providers/together-ai/Qwen/Qwen3-4B.yaml
+++ b/providers/together-ai/Qwen/Qwen3-4B.yaml
@@ -7,6 +7,11 @@ limits:
     context_window: 32768
     max_output_tokens: 32768
     max_tokens: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: Qwen/Qwen3-4B
 sources:

--- a/providers/together-ai/Qwen/Qwen3-8B-Base.yaml
+++ b/providers/together-ai/Qwen/Qwen3-8B-Base.yaml
@@ -2,6 +2,11 @@ limits:
     context_window: 32768
     max_output_tokens: 32768
     max_tokens: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: completion
 model: Qwen/Qwen3-8B-Base
 sources:

--- a/providers/together-ai/Qwen/Qwen3-8B.yaml
+++ b/providers/together-ai/Qwen/Qwen3-8B.yaml
@@ -5,6 +5,11 @@ limits:
     context_window: 32768
     max_output_tokens: 32768
     max_tokens: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: Qwen/Qwen3-8B
 sources:

--- a/providers/together-ai/Qwen/Qwen3-Coder-30B-A3B-Instruct.yaml
+++ b/providers/together-ai/Qwen/Qwen3-Coder-30B-A3B-Instruct.yaml
@@ -2,10 +2,16 @@ features:
     - function_calling
     - tool_choice
     - system_messages
+    - structured_output
 limits:
     context_window: 262144
     max_output_tokens: 65536
     max_tokens: 65536
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: Qwen/Qwen3-Coder-30B-A3B-Instruct
 sources:

--- a/providers/together-ai/Qwen/Qwen3-VL-235B-A22B-Instruct-FP8.yaml
+++ b/providers/together-ai/Qwen/Qwen3-VL-235B-A22B-Instruct-FP8.yaml
@@ -1,6 +1,9 @@
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: Qwen/Qwen3-VL-235B-A22B-Instruct-FP8
 sources:

--- a/providers/together-ai/Qwen/Qwen3-VL-235B-A22B-Instruct.yaml
+++ b/providers/together-ai/Qwen/Qwen3-VL-235B-A22B-Instruct.yaml
@@ -1,6 +1,9 @@
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: Qwen/Qwen3-VL-235B-A22B-Instruct
 sources:

--- a/providers/together-ai/Qwen/Qwen3-VL-235B-A22B-Thinking-FP8.yaml
+++ b/providers/together-ai/Qwen/Qwen3-VL-235B-A22B-Thinking-FP8.yaml
@@ -3,7 +3,11 @@ features:
     - tool_choice
 modalities:
     input:
+        - text
         - image
+        - video
+    output:
+        - text
 mode: chat
 model: Qwen/Qwen3-VL-235B-A22B-Thinking-FP8
 sources:

--- a/providers/together-ai/Qwen/Qwen3-VL-8B-Instruct.yaml
+++ b/providers/together-ai/Qwen/Qwen3-VL-8B-Instruct.yaml
@@ -6,7 +6,10 @@ limits:
     context_window: 262144
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: Qwen/Qwen3-VL-8B-Instruct
 sources:

--- a/providers/together-ai/Qwen/Qwen3.5-27B.yaml
+++ b/providers/together-ai/Qwen/Qwen3.5-27B.yaml
@@ -1,6 +1,22 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
+    - input_cost_per_token: 1.e-7
+      output_cost_per_token: 1.5e-7
       region: "*"
-mode: unknown
+features:
+    - function_calling
+    - structured_output
+    - system_messages
+limits:
+    context_window: 262144
+modalities:
+    input:
+        - text
+        - image
+        - video
+    output:
+        - text
+mode: chat
 model: Qwen/Qwen3.5-27B
+sources:
+    - https://huggingface.co/Qwen/Qwen3.5-27B
+thinking: true

--- a/providers/together-ai/Qwen/Qwen3.5-397B-A17B-FP4.yaml
+++ b/providers/together-ai/Qwen/Qwen3.5-397B-A17B-FP4.yaml
@@ -9,7 +9,10 @@ limits:
     context_window: 262144
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: Qwen/Qwen3.5-397B-A17B-FP4
 sources:

--- a/providers/together-ai/Qwen/Qwen3.5-397B-A17B-FP8.yaml
+++ b/providers/together-ai/Qwen/Qwen3.5-397B-A17B-FP8.yaml
@@ -7,10 +7,11 @@ features:
     - structured_output
 limits:
     context_window: 262144
-    max_output_tokens: 262144
-    max_tokens: 262144
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: Qwen/Qwen3.5-397B-A17B-FP8

--- a/providers/together-ai/RunDiffusion/Juggernaut-pro-flux.yaml
+++ b/providers/together-ai/RunDiffusion/Juggernaut-pro-flux.yaml
@@ -3,10 +3,13 @@ costs:
       region: "*"
 modalities:
     input:
+        - text
+    output:
         - image
 mode: image
 model: RunDiffusion/Juggernaut-pro-flux
 sources:
     - https://together.ai/models
+    - https://docs.together.ai/docs/serverless-models
 supportedModes:
     - image

--- a/providers/together-ai/ServiceNow-AI/Apriel-1.5-15b-Thinker.yaml
+++ b/providers/together-ai/ServiceNow-AI/Apriel-1.5-15b-Thinker.yaml
@@ -6,12 +6,13 @@ limits:
     context_window: 131072
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: ServiceNow-AI/Apriel-1.5-15b-Thinker
 sources:
     - https://together.ai/pricing
     - https://huggingface.co/ServiceNow-AI/Apriel-1.5-15b-Thinker
-supportedModes:
-    - chat
 thinking: true

--- a/providers/together-ai/ServiceNow-AI/Apriel-1.6-15b-Thinker.yaml
+++ b/providers/together-ai/ServiceNow-AI/Apriel-1.6-15b-Thinker.yaml
@@ -3,6 +3,7 @@ costs:
       output_cost_per_token: 0
       region: "*"
 features:
+    - function_calling
     - structured_output
 limits:
     context_window: 131072

--- a/providers/together-ai/Virtue-AI/VirtueGuard-Text-Lite.yaml
+++ b/providers/together-ai/Virtue-AI/VirtueGuard-Text-Lite.yaml
@@ -7,6 +7,11 @@ limits:
     max_input_tokens: 32768
     max_output_tokens: 32768
     max_tokens: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: moderation
 model: Virtue-AI/VirtueGuard-Text-Lite
 supportedModes:

--- a/providers/together-ai/Wan-AI/Wan2.2-I2V-A14B.yaml
+++ b/providers/together-ai/Wan-AI/Wan2.2-I2V-A14B.yaml
@@ -4,10 +4,10 @@ costs:
 modalities:
     input:
         - image
+    output:
+        - video
 mode: video
 model: Wan-AI/Wan2.2-I2V-A14B
 sources:
     - https://docs.together.ai/docs/videos-overview
     - https://docs.together.ai/reference/create-videos
-supportedModes:
-    - video

--- a/providers/together-ai/Wan-AI/Wan2.6-image.yaml
+++ b/providers/together-ai/Wan-AI/Wan2.6-image.yaml
@@ -1,8 +1,10 @@
 costs:
-    - input_cost_per_image: 0.03146
+    - input_cost_per_image: 0.03
       region: "*"
 modalities:
     input:
+        - text
+    output:
         - image
 mode: image
 model: Wan-AI/Wan2.6-image

--- a/providers/together-ai/agentica-org/DeepCoder-14B-Preview.yaml
+++ b/providers/together-ai/agentica-org/DeepCoder-14B-Preview.yaml
@@ -1,3 +1,12 @@
+modalities:
+    input:
+        - text
+        - code
+    output:
+        - text
+        - code
 mode: chat
 model: agentica-org/DeepCoder-14B-Preview
+sources:
+    - https://huggingface.co/agentica-org/DeepCoder-14B-Preview
 thinking: true

--- a/providers/together-ai/allenai/Molmo-7B-D-0924.yaml
+++ b/providers/together-ai/allenai/Molmo-7B-D-0924.yaml
@@ -8,7 +8,10 @@ limits:
     max_tokens: 4096
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: allenai/Molmo-7B-D-0924
 sources:

--- a/providers/together-ai/arcee-ai/trinity-large-preview.yaml
+++ b/providers/together-ai/arcee-ai/trinity-large-preview.yaml
@@ -1,2 +1,15 @@
+features:
+    - function_calling
+    - system_messages
+limits:
+    context_window: 128000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: arcee-ai/trinity-large-preview
+sources:
+    - https://docs.arcee.ai/get-started/models-overview
+    - https://huggingface.co/arcee-ai/trinity-large-preview

--- a/providers/together-ai/black-forest-labs/FLUX.1-kontext-max.yaml
+++ b/providers/together-ai/black-forest-labs/FLUX.1-kontext-max.yaml
@@ -4,6 +4,8 @@ costs:
 modalities:
     input:
         - image
+    output:
+        - image
 mode: image
 model: black-forest-labs/FLUX.1-kontext-max
 sources:

--- a/providers/together-ai/black-forest-labs/FLUX.1-kontext-pro.yaml
+++ b/providers/together-ai/black-forest-labs/FLUX.1-kontext-pro.yaml
@@ -3,6 +3,9 @@ costs:
       region: "*"
 modalities:
     input:
+        - text
+        - image
+    output:
         - image
 mode: image
 model: black-forest-labs/FLUX.1-kontext-pro

--- a/providers/together-ai/black-forest-labs/FLUX.1-schnell.yaml
+++ b/providers/together-ai/black-forest-labs/FLUX.1-schnell.yaml
@@ -3,6 +3,8 @@ costs:
       region: "*"
 modalities:
     input:
+        - text
+    output:
         - image
 mode: image
 model: black-forest-labs/FLUX.1-schnell

--- a/providers/together-ai/black-forest-labs/FLUX.1.1-pro.yaml
+++ b/providers/together-ai/black-forest-labs/FLUX.1.1-pro.yaml
@@ -3,6 +3,8 @@ costs:
       region: "*"
 modalities:
     input:
+        - text
+    output:
         - image
 mode: image
 model: black-forest-labs/FLUX.1.1-pro

--- a/providers/together-ai/black-forest-labs/FLUX.2-dev.yaml
+++ b/providers/together-ai/black-forest-labs/FLUX.2-dev.yaml
@@ -1,9 +1,15 @@
+costs:
+    - input_cost_per_image: 0.0154
+      region: "*"
 modalities:
     input:
+        - image
+    output:
         - image
 mode: image
 model: black-forest-labs/FLUX.2-dev
 sources:
     - https://docs.together.ai/docs/images-overview
+    - https://together.ai/pricing
 supportedModes:
     - image

--- a/providers/together-ai/black-forest-labs/FLUX.2-flex.yaml
+++ b/providers/together-ai/black-forest-labs/FLUX.2-flex.yaml
@@ -5,10 +5,12 @@ limits:
     max_input_tokens: 32000
 modalities:
     input:
+        - text
+        - image
+    output:
         - image
 mode: image
 model: black-forest-labs/FLUX.2-flex
 sources:
     - https://docs.together.ai/docs/images-overview
-supportedModes:
-    - image
+    - https://together.ai/models

--- a/providers/together-ai/black-forest-labs/FLUX.2-pro.yaml
+++ b/providers/together-ai/black-forest-labs/FLUX.2-pro.yaml
@@ -1,15 +1,19 @@
 costs:
-    - input_cost_per_token: 7.e-8
+    - output_cost_per_image: 0.03
       region: "*"
 limits:
     max_input_tokens: 32000
 modalities:
     input:
+        - text
+        - image
+    output:
         - image
 mode: image
 model: black-forest-labs/FLUX.2-pro
 sources:
     - https://together.ai/models
     - https://docs.together.ai/docs/images-overview
+    - https://docs.together.ai/docs/quickstart-flux
 supportedModes:
     - image

--- a/providers/together-ai/canopylabs/orpheus-3b-0.1-ft.yaml
+++ b/providers/together-ai/canopylabs/orpheus-3b-0.1-ft.yaml
@@ -1,11 +1,12 @@
 costs:
-    - input_cost_per_token: 2.7e-7
-      output_cost_per_token: 8.5e-7
+    - input_cost_per_character: 0.000015
       region: "*"
 modalities:
+    input:
+        - text
     output:
         - audio
 mode: text_to_speech
 model: canopylabs/orpheus-3b-0.1-ft
-supportedModes:
-    - text_to_speech
+sources:
+    - https://docs.together.ai/docs/changelog

--- a/providers/together-ai/cartesia/sonic-2.yaml
+++ b/providers/together-ai/cartesia/sonic-2.yaml
@@ -2,6 +2,8 @@ costs:
     - input_cost_per_character: 0.000065
       region: "*"
 modalities:
+    input:
+        - text
     output:
         - audio
 mode: text_to_speech

--- a/providers/together-ai/cartesia/sonic-3.yaml
+++ b/providers/together-ai/cartesia/sonic-3.yaml
@@ -2,6 +2,8 @@ costs:
     - input_cost_per_character: 0.000065
       region: "*"
 modalities:
+    input:
+        - text
     output:
         - audio
 mode: text_to_speech

--- a/providers/together-ai/cartesia/sonic.yaml
+++ b/providers/together-ai/cartesia/sonic.yaml
@@ -2,9 +2,13 @@ costs:
     - input_cost_per_character: 0.000065
       region: "*"
 modalities:
+    input:
+        - text
     output:
         - audio
 mode: text_to_speech
 model: cartesia/sonic
+sources:
+    - https://docs.together.ai/docs/text-to-speech
 supportedModes:
     - text_to_speech

--- a/providers/together-ai/deepcogito/cogito-v1-preview-llama-70B.yaml
+++ b/providers/together-ai/deepcogito/cogito-v1-preview-llama-70B.yaml
@@ -3,6 +3,11 @@ features:
     - tools
 limits:
     context_window: 128000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: deepcogito/cogito-v1-preview-llama-70B
 sources:

--- a/providers/together-ai/deepcogito/cogito-v1-preview-llama-8B.yaml
+++ b/providers/together-ai/deepcogito/cogito-v1-preview-llama-8B.yaml
@@ -1,5 +1,21 @@
+features:
+    - function_calling
+    - parallel_function_calling
+    - system_messages
+    - tools
+messages:
+    options:
+        - system
+        - user
+        - assistant
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: deepcogito/cogito-v1-preview-llama-8B
 sources:
     - https://api.together.ai/models/deepcogito/cogito-v1-preview-llama-8B
+    - https://huggingface.co/deepcogito/cogito-v1-preview-llama-8B
 thinking: true

--- a/providers/together-ai/deepcogito/cogito-v1-preview-qwen-14B.yaml
+++ b/providers/together-ai/deepcogito/cogito-v1-preview-qwen-14B.yaml
@@ -1,2 +1,17 @@
+features:
+    - function_calling
+    - parallel_function_calling
+    - system_messages
+    - tools
+limits:
+    context_window: 128000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: deepcogito/cogito-v1-preview-qwen-14B
+sources:
+    - https://huggingface.co/deepcogito/cogito-v1-preview-qwen-14B
+thinking: true

--- a/providers/together-ai/deepcogito/cogito-v2-1-671b.yaml
+++ b/providers/together-ai/deepcogito/cogito-v2-1-671b.yaml
@@ -5,7 +5,12 @@ costs:
 features:
     - structured_output
 limits:
-    context_window: 163840
+    context_window: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: deepcogito/cogito-v2-1-671b
 supportedModes:

--- a/providers/together-ai/deepgram/aura-2.yaml
+++ b/providers/together-ai/deepgram/aura-2.yaml
@@ -1,3 +1,8 @@
+modalities:
+    input:
+        - text
+    output:
+        - audio
 mode: text_to_speech
 model: deepgram/aura-2
 sources:

--- a/providers/together-ai/deepgram/flux.yaml
+++ b/providers/together-ai/deepgram/flux.yaml
@@ -1,6 +1,8 @@
 modalities:
     input:
         - audio
+    output:
+        - text
 mode: audio_transcription
 model: deepgram/flux
 sources:

--- a/providers/together-ai/deepgram/nova-3-en.yaml
+++ b/providers/together-ai/deepgram/nova-3-en.yaml
@@ -1,6 +1,8 @@
 modalities:
     input:
         - audio
+    output:
+        - text
 mode: audio_transcription
 model: deepgram/nova-3-en
 sources:

--- a/providers/together-ai/deepgram/nova-3-multi.yaml
+++ b/providers/together-ai/deepgram/nova-3-multi.yaml
@@ -1,7 +1,10 @@
 modalities:
     input:
         - audio
+    output:
+        - text
 mode: audio_transcription
 model: deepgram/nova-3-multi
 sources:
     - https://docs.together.ai/docs/speech-to-text
+    - https://www.together.ai/pricing

--- a/providers/together-ai/deepseek-ai/DeepSeek-R1-0528.yaml
+++ b/providers/together-ai/deepseek-ai/DeepSeek-R1-0528.yaml
@@ -6,7 +6,7 @@ features:
     - function_calling
     - structured_output
 limits:
-    context_window: 163840
+    context_window: 163839
 mode: chat
 model: deepseek-ai/DeepSeek-R1-0528
 sources:

--- a/providers/together-ai/deepseek-ai/DeepSeek-R1-Distill-Qwen-7B.yaml
+++ b/providers/together-ai/deepseek-ai/DeepSeek-R1-Distill-Qwen-7B.yaml
@@ -1,3 +1,10 @@
+features:
+    - system_messages
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: deepseek-ai/DeepSeek-R1-Distill-Qwen-7B
 thinking: true

--- a/providers/together-ai/deepseek-ai/DeepSeek-V3-Base.yaml
+++ b/providers/together-ai/deepseek-ai/DeepSeek-V3-Base.yaml
@@ -1,2 +1,12 @@
+limits:
+    context_window: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: completion
 model: deepseek-ai/DeepSeek-V3-Base
+sources:
+    - https://docs.together.ai/docs/fine-tuning-models
+    - https://docs.together.ai/docs/inference-models

--- a/providers/together-ai/deepseek-ai/DeepSeek-V3.1-Base.yaml
+++ b/providers/together-ai/deepseek-ai/DeepSeek-V3.1-Base.yaml
@@ -4,6 +4,11 @@ costs:
       region: "*"
 limits:
     context_window: 128000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: completion
 model: deepseek-ai/DeepSeek-V3.1-Base
 sources:

--- a/providers/together-ai/deepseek-ai/DeepSeek-V3.2-Exp.yaml
+++ b/providers/together-ai/deepseek-ai/DeepSeek-V3.2-Exp.yaml
@@ -1,4 +1,10 @@
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: deepseek-ai/DeepSeek-V3.2-Exp
 sources:
     - https://together.ai/pricing
+    - https://huggingface.co/deepseek-ai/DeepSeek-V3.2-Exp

--- a/providers/together-ai/deepseek-ai/DeepSeek-V3.2.yaml
+++ b/providers/together-ai/deepseek-ai/DeepSeek-V3.2.yaml
@@ -5,6 +5,11 @@ limits:
     context_window: 128000
     max_output_tokens: 8192
     max_tokens: 8192
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: deepseek-ai/DeepSeek-V3.2
 sources:

--- a/providers/together-ai/google/flash-image-3.1.yaml
+++ b/providers/together-ai/google/flash-image-3.1.yaml
@@ -1,5 +1,8 @@
 modalities:
     input:
+        - text
+        - image
+    output:
         - image
 mode: image
 model: google/flash-image-3.1

--- a/providers/together-ai/google/gemma-3-12b-it.yaml
+++ b/providers/together-ai/google/gemma-3-12b-it.yaml
@@ -1,6 +1,9 @@
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: google/gemma-3-12b-it
 sources:

--- a/providers/together-ai/google/gemma-3-1b-it.yaml
+++ b/providers/together-ai/google/gemma-3-1b-it.yaml
@@ -1,2 +1,20 @@
+features:
+    - system_messages
+limits:
+    context_window: 32768
+    max_output_tokens: 8192
+    max_tokens: 8192
+messages:
+    options:
+        - system
+        - user
+        - assistant
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: google/gemma-3-1b-it
+sources:
+    - https://huggingface.co/google/gemma-3-1b-it

--- a/providers/together-ai/google/gemma-3-270m-it.yaml
+++ b/providers/together-ai/google/gemma-3-270m-it.yaml
@@ -1,2 +1,9 @@
+features:
+    - system_messages
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: google/gemma-3-270m-it

--- a/providers/together-ai/google/gemma-3-27b-it.yaml
+++ b/providers/together-ai/google/gemma-3-27b-it.yaml
@@ -1,6 +1,12 @@
+features:
+    - function_calling
+    - structured_output
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: google/gemma-3-27b-it
 sources:

--- a/providers/together-ai/google/gemma-3-27b-pt.yaml
+++ b/providers/together-ai/google/gemma-3-27b-pt.yaml
@@ -1,2 +1,7 @@
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: completion
 model: google/gemma-3-27b-pt

--- a/providers/together-ai/google/gemma-3-4b-pt.yaml
+++ b/providers/together-ai/google/gemma-3-4b-pt.yaml
@@ -1,5 +1,10 @@
 limits:
     context_window: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: completion
 model: google/gemma-3-4b-pt
 sources:

--- a/providers/together-ai/google/veo-3.0-audio.yaml
+++ b/providers/together-ai/google/veo-3.0-audio.yaml
@@ -2,9 +2,14 @@ costs:
     - input_cost_per_request: 3.2
       region: "*"
 modalities:
+    input:
+        - text
     output:
+        - video
         - audio
 mode: video
 model: google/veo-3.0-audio
+sources:
+    - https://docs.together.ai/docs/serverless-models
 supportedModes:
     - video

--- a/providers/together-ai/google/veo-3.0-fast-audio.yaml
+++ b/providers/together-ai/google/veo-3.0-fast-audio.yaml
@@ -4,6 +4,7 @@ costs:
 modalities:
     output:
         - audio
+        - video
 mode: video
 model: google/veo-3.0-fast-audio
 sources:

--- a/providers/together-ai/google/veo-3.0.yaml
+++ b/providers/together-ai/google/veo-3.0.yaml
@@ -1,6 +1,11 @@
 costs:
     - input_cost_per_request: 1.6
       region: "*"
+modalities:
+    input:
+        - text
+    output:
+        - video
 mode: video
 model: google/veo-3.0
 sources:

--- a/providers/together-ai/hexgrad/Kokoro-82M.yaml
+++ b/providers/together-ai/hexgrad/Kokoro-82M.yaml
@@ -1,11 +1,14 @@
 costs:
-    - input_cost_per_token: 2.7e-7
-      output_cost_per_token: 8.5e-7
+    - input_cost_per_character: 0.000004
       region: "*"
 modalities:
+    input:
+        - text
     output:
         - audio
 mode: text_to_speech
 model: hexgrad/Kokoro-82M
+sources:
+    - https://docs.together.ai/docs/text-to-speech
 supportedModes:
     - text_to_speech

--- a/providers/together-ai/ideogram/ideogram-3.0.yaml
+++ b/providers/together-ai/ideogram/ideogram-3.0.yaml
@@ -4,6 +4,8 @@ costs:
 modalities:
     input:
         - image
+    output:
+        - image
 mode: image
 model: ideogram/ideogram-3.0
 sources:

--- a/providers/together-ai/intfloat/multilingual-e5-large-instruct.yaml
+++ b/providers/together-ai/intfloat/multilingual-e5-large-instruct.yaml
@@ -3,6 +3,7 @@ costs:
       region: "*"
 limits:
     context_window: 514
+    output_vector_size: 1024
 mode: embedding
 model: intfloat/multilingual-e5-large-instruct
 sources:

--- a/providers/together-ai/kwaivgI/kling-2.0-master.yaml
+++ b/providers/together-ai/kwaivgI/kling-2.0-master.yaml
@@ -1,7 +1,15 @@
 costs:
     - input_cost_per_request: 0.92
       region: "*"
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - video
 mode: video
 model: kwaivgI/kling-2.0-master
+sources:
+    - https://docs.together.ai/docs/serverless-models
 supportedModes:
     - video

--- a/providers/together-ai/kwaivgI/kling-2.1-pro.yaml
+++ b/providers/together-ai/kwaivgI/kling-2.1-pro.yaml
@@ -1,9 +1,14 @@
 costs:
     - input_cost_per_request: 0.32
       region: "*"
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - video
 mode: video
 model: kwaivgI/kling-2.1-pro
 sources:
     - https://docs.together.ai/docs/serverless-models
-supportedModes:
-    - video
+    - https://docs.together.ai/docs/videos-overview

--- a/providers/together-ai/meta-llama/Llama-3-70b-hf.yaml
+++ b/providers/together-ai/meta-llama/Llama-3-70b-hf.yaml
@@ -1,3 +1,5 @@
+deprecationDate: 2024-08-22T00:00:00.000Z
+isDeprecated: true
 mode: chat
 model: meta-llama/Llama-3-70b-hf
 sources:

--- a/providers/together-ai/meta-llama/Llama-3.1-405B.yaml
+++ b/providers/together-ai/meta-llama/Llama-3.1-405B.yaml
@@ -6,6 +6,11 @@ costs:
       region: "*"
 features:
     - function_calling
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: meta-llama/Llama-3.1-405B
 sources:

--- a/providers/together-ai/meta-llama/Llama-3.1-8B-Instruct.yaml
+++ b/providers/together-ai/meta-llama/Llama-3.1-8B-Instruct.yaml
@@ -1,3 +1,8 @@
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: meta-llama/Llama-3.1-8B-Instruct
 sources:
@@ -7,3 +12,5 @@ sources:
     - https://together.ai/models
     - https://docs.together.ai/docs/dedicated-models
     - https://www.together.ai/pricing
+    - https://docs.together.ai/docs/function-calling
+    - https://docs.together.ai/docs/json-mode

--- a/providers/together-ai/meta-llama/Llama-3.2-1B-Instruct.yaml
+++ b/providers/together-ai/meta-llama/Llama-3.2-1B-Instruct.yaml
@@ -1,11 +1,21 @@
+features:
+    - function_calling
+    - system_messages
 limits:
     context_window: 131072
     max_output_tokens: 131072
     max_tokens: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
+        - code
 mode: chat
 model: meta-llama/Llama-3.2-1B-Instruct
 sources:
     - https://www.together.ai/pricing
     - https://huggingface.co/meta-llama/Llama-3.2-1B-Instruct
+    - https://docs.together.ai/docs/dedicated-models
 supportedModes:
     - chat

--- a/providers/together-ai/meta-llama/Llama-3.2-1B.yaml
+++ b/providers/together-ai/meta-llama/Llama-3.2-1B.yaml
@@ -1,2 +1,11 @@
+limits:
+    context_window: 131072
+    max_output_tokens: 131072
+    max_tokens: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: completion
 model: meta-llama/Llama-3.2-1B

--- a/providers/together-ai/meta-llama/Llama-3.2-3B-Instruct.yaml
+++ b/providers/together-ai/meta-llama/Llama-3.2-3B-Instruct.yaml
@@ -1,5 +1,7 @@
+deprecationDate: 2026-03-06T00:00:00.000Z
 features:
     - function_calling
+isDeprecated: true
 limits:
     context_window: 131072
 mode: chat

--- a/providers/together-ai/meta-llama/Llama-3.2-3B.yaml
+++ b/providers/together-ai/meta-llama/Llama-3.2-3B.yaml
@@ -1,2 +1,13 @@
+limits:
+    context_window: 131072
+    max_output_tokens: 131072
+    max_tokens: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: completion
 model: meta-llama/Llama-3.2-3B
+sources:
+    - https://huggingface.co/meta-llama/Llama-3.2-3B

--- a/providers/together-ai/meta-llama/Llama-3.3-70B-Instruct.yaml
+++ b/providers/together-ai/meta-llama/Llama-3.3-70B-Instruct.yaml
@@ -7,8 +7,12 @@ features:
     - structured_output
 limits:
     context_window: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: meta-llama/Llama-3.3-70B-Instruct
 sources:
     - https://www.together.ai/pricing
-thinking: false

--- a/providers/together-ai/meta-llama/Llama-4-Maverick-17B-128E.yaml
+++ b/providers/together-ai/meta-llama/Llama-4-Maverick-17B-128E.yaml
@@ -9,7 +9,10 @@ limits:
     context_window: 1048576
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: meta-llama/Llama-4-Maverick-17B-128E
 sources:

--- a/providers/together-ai/meta-llama/Llama-4-Scout-17B-16E-Instruct-64k.yaml
+++ b/providers/together-ai/meta-llama/Llama-4-Scout-17B-16E-Instruct-64k.yaml
@@ -1,8 +1,10 @@
+deprecationDate: 2026-02-06T00:00:00.000Z
 features:
     - function_calling
     - system_messages
     - tool_choice
     - structured_output
+isDeprecated: true
 limits:
     context_window: 65536
 modalities:

--- a/providers/together-ai/meta-llama/Meta-Llama-3.1-70B-Instruct-Reference.yaml
+++ b/providers/together-ai/meta-llama/Meta-Llama-3.1-70B-Instruct-Reference.yaml
@@ -4,6 +4,11 @@ features:
     - system_messages
 limits:
     context_window: 8192
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: meta-llama/Meta-Llama-3.1-70B-Instruct-Reference
 sources:

--- a/providers/together-ai/meta-llama/Meta-Llama-3.1-70B.yaml
+++ b/providers/together-ai/meta-llama/Meta-Llama-3.1-70B.yaml
@@ -1,3 +1,7 @@
+costs:
+    - input_cost_per_token: 8.8e-7
+      output_cost_per_token: 8.8e-7
+      region: "*"
 mode: completion
 model: meta-llama/Meta-Llama-3.1-70B
 sources:

--- a/providers/together-ai/meta-llama/Meta-Llama-3.1-8B-Instruct.yaml
+++ b/providers/together-ai/meta-llama/Meta-Llama-3.1-8B-Instruct.yaml
@@ -2,6 +2,8 @@ costs:
     - input_cost_per_token: 1.8e-7
       output_cost_per_token: 1.8e-7
       region: "*"
+deprecationDate: 2026-03-06T00:00:00.000Z
+isDeprecated: true
 limits:
     context_window: 131072
 mode: chat

--- a/providers/together-ai/minimax/hailuo-02.yaml
+++ b/providers/together-ai/minimax/hailuo-02.yaml
@@ -1,6 +1,11 @@
 costs:
     - input_cost_per_request: 0.49
       region: "*"
+modalities:
+    input:
+        - text
+    output:
+        - video
 mode: video
 model: minimax/hailuo-02
 sources:

--- a/providers/together-ai/minimax/speech-2.6-turbo.yaml
+++ b/providers/together-ai/minimax/speech-2.6-turbo.yaml
@@ -1,4 +1,6 @@
 modalities:
+    input:
+        - text
     output:
         - audio
 mode: text_to_speech

--- a/providers/together-ai/mistralai/Devstral-Small-2505.yaml
+++ b/providers/together-ai/mistralai/Devstral-Small-2505.yaml
@@ -1,6 +1,8 @@
+deprecationDate: 2025-10-31T00:00:00.000Z
 features:
     - function_calling
     - system_messages
+isDeprecated: true
 limits:
     context_window: 128000
     max_input_tokens: 128000

--- a/providers/together-ai/mistralai/Magistral-Small-2506.yaml
+++ b/providers/together-ai/mistralai/Magistral-Small-2506.yaml
@@ -1,6 +1,8 @@
+deprecationDate: 2025-10-31T00:00:00.000Z
 features:
     - function_calling
     - system_messages
+isDeprecated: true
 limits:
     context_window: 40000
 mode: chat

--- a/providers/together-ai/nim/meta/llama-3.1-70b-instruct.yaml
+++ b/providers/together-ai/nim/meta/llama-3.1-70b-instruct.yaml
@@ -1,5 +1,15 @@
 features:
     - function_calling
     - system_messages
+messages:
+    options:
+        - system
+        - user
+        - assistant
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: nim/meta/llama-3.1-70b-instruct

--- a/providers/together-ai/nim/meta/llama-3.1-8b-instruct.yaml
+++ b/providers/together-ai/nim/meta/llama-3.1-8b-instruct.yaml
@@ -1,5 +1,10 @@
 features:
     - function_calling
     - system_messages
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: nim/meta/llama-3.1-8b-instruct

--- a/providers/together-ai/nim/meta/llama-3.2-11b-vision-instruct.yaml
+++ b/providers/together-ai/nim/meta/llama-3.2-11b-vision-instruct.yaml
@@ -1,5 +1,10 @@
+features:
+    - system_messages
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: nim/meta/llama-3.2-11b-vision-instruct

--- a/providers/together-ai/nim/meta/llama-3.2-90b-vision-instruct.yaml
+++ b/providers/together-ai/nim/meta/llama-3.2-90b-vision-instruct.yaml
@@ -6,6 +6,9 @@ limits:
     max_tokens: 4096
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: nim/meta/llama-3.2-90b-vision-instruct

--- a/providers/together-ai/nim/meta/llama-3.3-70b-instruct.yaml
+++ b/providers/together-ai/nim/meta/llama-3.3-70b-instruct.yaml
@@ -5,6 +5,11 @@ limits:
     context_window: 131072
     max_output_tokens: 131072
     max_tokens: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: nim/meta/llama-3.3-70b-instruct
 sources:

--- a/providers/together-ai/nim/mistralai/mixtral-8x7b-instruct-v01.yaml
+++ b/providers/together-ai/nim/mistralai/mixtral-8x7b-instruct-v01.yaml
@@ -1,8 +1,7 @@
-features:
-    - function_calling
 limits:
     context_window: 32768
 mode: chat
 model: nim/mistralai/mixtral-8x7b-instruct-v01
 sources:
     - https://docs.together.ai/docs/dedicated-models
+    - https://docs.together.ai/docs/serverless-models

--- a/providers/together-ai/nim/nv-mistralai/mistral-nemo-12b-instruct.yaml
+++ b/providers/together-ai/nim/nv-mistralai/mistral-nemo-12b-instruct.yaml
@@ -1,5 +1,14 @@
 features:
     - function_calling
     - system_messages
+limits:
+    context_window: 128000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: nim/nv-mistralai/mistral-nemo-12b-instruct
+sources:
+    - https://mistral.ai/news/mistral-nemo

--- a/providers/together-ai/nim/nvidia/llama-3.3-nemotron-super-49b-v1.yaml
+++ b/providers/together-ai/nim/nvidia/llama-3.3-nemotron-super-49b-v1.yaml
@@ -7,6 +7,11 @@ limits:
     max_input_tokens: 131072
     max_output_tokens: 16384
     max_tokens: 16384
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: nim/nvidia/llama-3.3-nemotron-super-49b-v1
 sources:

--- a/providers/together-ai/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16.yaml
+++ b/providers/together-ai/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16.yaml
@@ -1,9 +1,17 @@
 features:
     - function_calling
+    - structured_output
 limits:
     context_window: 1000000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16
 sources:
     - https://together.ai/models/nvidia-nemotron-3-nano
     - https://www.together.ai/pricing
+    - https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16
+thinking: true

--- a/providers/together-ai/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8.yaml
+++ b/providers/together-ai/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8.yaml
@@ -6,8 +6,14 @@ features:
     - tools
 limits:
     context_window: 1000000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8
 sources:
     - https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8
+    - https://together.ai/models/nvidia-nemotron-3-super
 thinking: true

--- a/providers/together-ai/openai/sora-2-pro.yaml
+++ b/providers/together-ai/openai/sora-2-pro.yaml
@@ -1,6 +1,11 @@
 costs:
     - input_cost_per_request: 2.4
       region: "*"
+modalities:
+    input:
+        - text
+    output:
+        - video
 mode: video
 model: openai/sora-2-pro
 sources:

--- a/providers/together-ai/openai/sora-2.yaml
+++ b/providers/together-ai/openai/sora-2.yaml
@@ -1,7 +1,12 @@
 costs:
     - input_cost_per_request: 0.8
       region: "*"
+modalities:
+    input:
+        - text
+    output:
+        - video
 mode: video
 model: openai/sora-2
-supportedModes:
-    - video
+sources:
+    - https://docs.together.ai/docs/changelog

--- a/providers/together-ai/openai/whisper-large-v3.yaml
+++ b/providers/together-ai/openai/whisper-large-v3.yaml
@@ -1,7 +1,15 @@
 costs:
-    - input_cost_per_second: 0.0045
+    - input_cost_per_second: 0.000025
       region: "*"
+modalities:
+    input:
+        - audio
+    output:
+        - text
 mode: audio_transcription
 model: openai/whisper-large-v3
+sources:
+    - https://docs.together.ai/docs/changelog
 supportedModes:
     - audio_transcription
+    - audio_translation

--- a/providers/together-ai/pixverse/pixverse-v5.6.yaml
+++ b/providers/together-ai/pixverse/pixverse-v5.6.yaml
@@ -1,6 +1,11 @@
 costs:
     - input_cost_per_request: 0.3
       region: "*"
+modalities:
+    input:
+        - text
+    output:
+        - video
 mode: video
 model: pixverse/pixverse-v5.6
 sources:

--- a/providers/together-ai/pixverse/pixverse-v5.yaml
+++ b/providers/together-ai/pixverse/pixverse-v5.yaml
@@ -1,9 +1,10 @@
 costs:
     - input_cost_per_image: 0.3
       region: "*"
+modalities:
+    output:
+        - video
 mode: video
 model: pixverse/pixverse-v5
 sources:
     - https://docs.together.ai/docs/serverless-models
-supportedModes:
-    - video

--- a/providers/together-ai/rime-labs/rime-mist-v2.yaml
+++ b/providers/together-ai/rime-labs/rime-mist-v2.yaml
@@ -1,4 +1,6 @@
 modalities:
+    input:
+        - text
     output:
         - audio
 mode: text_to_speech

--- a/providers/together-ai/salesforce/sarvam-m.yaml
+++ b/providers/together-ai/salesforce/sarvam-m.yaml
@@ -1,11 +1,14 @@
 features:
     - system_messages
-    - function_calling
-    - tool_choice
 limits:
     context_window: 32768
     max_output_tokens: 8192
     max_tokens: 8192
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: salesforce/sarvam-m
 sources:

--- a/providers/together-ai/salesforce/texteval-v3-7b-qwen-b.yaml
+++ b/providers/together-ai/salesforce/texteval-v3-7b-qwen-b.yaml
@@ -1,2 +1,7 @@
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: unknown
 model: salesforce/texteval-v3-7b-qwen-b

--- a/providers/together-ai/sarvamai/sarvam-m.yaml
+++ b/providers/together-ai/sarvamai/sarvam-m.yaml
@@ -6,9 +6,15 @@ limits:
     context_window: 32768
     max_output_tokens: 16384
     max_tokens: 16384
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: sarvamai/sarvam-m
 sources:
     - https://www.together.ai/pricing
     - https://build.nvidia.com/sarvamai/sarvam-m/modelcard
+    - https://huggingface.co/sarvamai/sarvam-m
 thinking: true

--- a/providers/together-ai/sarvamai/sarvam-translate.yaml
+++ b/providers/together-ai/sarvamai/sarvam-translate.yaml
@@ -1,2 +1,16 @@
+features:
+    - system_messages
+messages:
+    options:
+        - system
+        - user
+        - assistant
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: sarvamai/sarvam-translate
+sources:
+    - https://huggingface.co/sarvamai/sarvam-translate

--- a/providers/together-ai/smarterdx/atlas-v3-spotlight.yaml
+++ b/providers/together-ai/smarterdx/atlas-v3-spotlight.yaml
@@ -1,3 +1,8 @@
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: smarterdx/atlas-v3-spotlight
 sources:

--- a/providers/together-ai/stabilityai/stable-diffusion-3-medium.yaml
+++ b/providers/together-ai/stabilityai/stable-diffusion-3-medium.yaml
@@ -4,7 +4,11 @@ costs:
 modalities:
     input:
         - image
+    output:
+        - image
 mode: image
 model: stabilityai/stable-diffusion-3-medium
+sources:
+    - https://docs.together.ai/docs/serverless-models
 supportedModes:
     - image

--- a/providers/together-ai/togethercomputer/DeepCoder-14B-Preview.yaml
+++ b/providers/together-ai/togethercomputer/DeepCoder-14B-Preview.yaml
@@ -1,3 +1,8 @@
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: togethercomputer/DeepCoder-14B-Preview
 sources:

--- a/providers/together-ai/togethercomputer/EssentialAI-RNJ-1-Instruct.yaml
+++ b/providers/together-ai/togethercomputer/EssentialAI-RNJ-1-Instruct.yaml
@@ -9,6 +9,11 @@ limits:
     context_window: 32768
     max_output_tokens: 32768
     max_tokens: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: togethercomputer/EssentialAI-RNJ-1-Instruct
 sources:

--- a/providers/together-ai/togethercomputer/deepcogito-cogito-v2-preview-llama-109B-MoE.yaml
+++ b/providers/together-ai/togethercomputer/deepcogito-cogito-v2-preview-llama-109B-MoE.yaml
@@ -4,7 +4,10 @@ features:
     - system_messages
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: togethercomputer/deepcogito-cogito-v2-preview-llama-109B-MoE
 sources:

--- a/providers/together-ai/togethercomputer/meta-llama-3.1-8B-Instruct-AWQ-INT4.yaml
+++ b/providers/together-ai/togethercomputer/meta-llama-3.1-8B-Instruct-AWQ-INT4.yaml
@@ -8,6 +8,11 @@ limits:
     context_window: 131072
     max_output_tokens: 131072
     max_tokens: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: togethercomputer/meta-llama-3.1-8B-Instruct-AWQ-INT4
 sources:

--- a/providers/together-ai/togethercomputer/nltpt-guard-w8a16.yaml
+++ b/providers/together-ai/togethercomputer/nltpt-guard-w8a16.yaml
@@ -1,2 +1,2 @@
-mode: unknown
+mode: moderation
 model: togethercomputer/nltpt-guard-w8a16

--- a/providers/together-ai/vidu/vidu-q1.yaml
+++ b/providers/together-ai/vidu/vidu-q1.yaml
@@ -1,6 +1,12 @@
 costs:
     - input_cost_per_image: 0.22
       region: "*"
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - video
 mode: video
 model: vidu/vidu-q1
 supportedModes:

--- a/providers/together-ai/zai-org/GLM-4.5V.yaml
+++ b/providers/together-ai/zai-org/GLM-4.5V.yaml
@@ -1,9 +1,14 @@
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: zai-org/GLM-4.5V
 sources:
     - https://docs.together.ai/docs/serverless-models
     - https://docs.together.ai/docs/deprecations
     - https://docs.together.ai/docs/changelog
+    - https://together.ai/pricing
+    - https://docs.together.ai/docs/vision-overview


### PR DESCRIPTION
Auto-generated by poc-agent for provider `together-ai`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily metadata/config updates, but changes to `costs`, `limits`, `mode`, and deprecation flags can affect model selection, capability gating, and billing calculations.
> 
> **Overview**
> Updates a large set of `providers/together-ai` model YAMLs to better describe capabilities and constraints, mainly by standardizing `modalities` (explicit `input`/`output`) and expanding metadata like `features`, `limits`, `messages` options, and `sources`.
> 
> Also adjusts a few model definitions and economics (e.g., updated `costs` for `openai/whisper-large-v3` and `Wan-AI/Wan2.6-image`, changed context windows for some DeepSeek/Cogito models), marks several models as deprecated via `isDeprecated`/`deprecationDate`, and fixes classification details such as setting `togethercomputer/nltpt-guard-w8a16` to `mode: moderation`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e7df5e8082a9ea9023b807451e165f84d66a9294. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->