### PR TITLE
feat(anthropic): update model YAMLs [bot]

### DIFF
--- a/providers/anthropic/claude-4-sonnet-20250514.yaml
+++ b/providers/anthropic/claude-4-sonnet-20250514.yaml
@@ -46,4 +46,5 @@ params:
       key: max_tokens
       maxValue: 64000
       minValue: 1
+status: active
 thinking: true

--- a/providers/anthropic/claude-opus-4-1.yaml
+++ b/providers/anthropic/claude-opus-4-1.yaml
@@ -37,4 +37,5 @@ params:
 removeParams:
     - temperature
     - top_p
+status: active
 thinking: true

--- a/providers/anthropic/claude-opus-4-6.yaml
+++ b/providers/anthropic/claude-opus-4-6.yaml
@@ -31,4 +31,5 @@ model: claude-opus-4-6
 params:
     - key: max_tokens
       maxValue: 128000
+status: active
 thinking: true


### PR DESCRIPTION
Auto-generated by poc-agent for provider `anthropic`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a `status: active` field to three Anthropic model YAMLs; low risk as it’s metadata-only configuration, but it may affect model filtering/availability if `status` is used for gating.
> 
> **Overview**
> Sets `status: active` in the Anthropic provider configs for `claude-4-sonnet-20250514`, `claude-opus-4-1`, and `claude-opus-4-6`, making their YAML metadata explicitly mark them as active.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c2c5cc2028b9a4ef0a94c7ec6503e46942b5dff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->