### PR TITLE
fix: update ai21/jamba-large-1.7 - reported incorrect data

### DIFF
--- a/providers/ai21/jamba-large-1.7.yaml
+++ b/providers/ai21/jamba-large-1.7.yaml
@@ -1,30 +1,17 @@
 costs:
     - input_cost_per_token: 0.000002
       output_cost_per_token: 0.000008
-      region: "*"
+      region: '*'
 features:
     - function_calling
     - tool_choice
     - structured_output
 limits:
     context_window: 256000
-    max_input_tokens: 256000
 modalities:
     input:
         - text
     output:
         - text
-mode: chat
+mode: completion
 model: jamba-large-1.7
-params:
-    - defaultValue: 0.4
-      key: temperature
-      maxValue: 2
-      minValue: 0
-    - defaultValue: 1
-      key: "n"
-      maxValue: 16
-      minValue: 1
-sources:
-    - https://docs.ai21.com/docs/function-calling
-    - https://docs.ai21.com/reference/jamba-1-6-api-ref


### PR DESCRIPTION
## Model: `ai21/jamba-large-1.7`

**Action:** Report incorrect data

### Submitted data
```yaml
costs:
    - input_cost_per_token: 0.000002
      output_cost_per_token: 0.000008
      region: '*'
features:
    - function_calling
    - tool_choice
    - structured_output
limits:
    context_window: 256000
modalities:
    input:
        - text
    output:
        - text
mode: completion
model: jamba-large-1.7

```

### Source
Submitted via https://www.truefoundry.com/models

> Auto-generated PR. Please verify data against the provider's official pricing page before merging.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk metadata-only change: adjusts model config fields (mode/limits) and removes optional parameter/source blocks, with no runtime logic changes.
> 
> **Overview**
> Updates the `ai21/jamba-large-1.7` model definition to correct reported metadata.
> 
> The config now sets `mode: completion` (was `chat`), removes `limits.max_input_tokens`, and drops the per-model `params` and `sources` sections. Minor YAML normalization is also included (quote style for `region`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3bd9e22ec335715c071eca98c42973b8bfad6599. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->