### PR TITLE
feat(cerebras): update model YAMLs [bot]

### DIFF
--- a/providers/cerebras/gpt-oss-120b.yaml
+++ b/providers/cerebras/gpt-oss-120b.yaml
@@ -34,4 +34,5 @@ sources:
     - https://inference-docs.cerebras.ai/capabilities/reasoning
     - https://inference-docs.cerebras.ai/capabilities/prompt-caching
     - https://inference-docs.cerebras.ai/support/deprecation
+status: active
 thinking: true

--- a/providers/cerebras/llama3.1-8b.yaml
+++ b/providers/cerebras/llama3.1-8b.yaml
@@ -28,5 +28,6 @@ sources:
     - https://inference-docs.cerebras.ai/capabilities/structured-outputs
     - https://inference-docs.cerebras.ai/capabilities/prompt-caching
     - https://inference-docs.cerebras.ai/api-reference/chat-completions
+status: active
 supportedModes:
     - completion

--- a/providers/cerebras/qwen-3-235b-a22b-instruct-2507.yaml
+++ b/providers/cerebras/qwen-3-235b-a22b-instruct-2507.yaml
@@ -9,6 +9,7 @@ features:
     - structured_output
     - prompt_caching
     - system_messages
+    - json_output
 limits:
     context_window: 131072
     max_input_tokens: 131072
@@ -35,3 +36,4 @@ sources:
     - https://inference-docs.cerebras.ai/capabilities/structured-outputs
     - https://www.cerebras.ai/pricing
     - https://inference-docs.cerebras.ai/api-reference/chat-completions
+status: preview

--- a/providers/cerebras/zai-glm-4.7.yaml
+++ b/providers/cerebras/zai-glm-4.7.yaml
@@ -25,9 +25,12 @@ params:
       key: top_p
     - key: max_tokens
       maxValue: 40000
+    - key: reasoning_effort
+      type: string
 sources:
     - https://inference-docs.cerebras.ai/models/zai-glm-47
     - https://inference-docs.cerebras.ai/resources/glm-47-migration
     - https://inference-docs.cerebras.ai/capabilities/tool-use
     - https://inference-docs.cerebras.ai/capabilities/reasoning
+status: preview
 thinking: true


### PR DESCRIPTION
Auto-generated by poc-agent for provider `cerebras`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk metadata-only YAML updates; impact is limited to model selection/capability gating based on the new `status`, `json_output`, and `reasoning_effort` fields.
> 
> **Overview**
> Adds explicit `status` fields to Cerebras model configs (`active` for `gpt-oss-120b` and `llama3.1-8b`, `preview` for `qwen-3-235b-a22b-instruct-2507` and `zai-glm-4.7`).
> 
> Expands declared capabilities by adding `json_output` to Qwen 3 235B, and adds a `reasoning_effort` parameter to `zai-glm-4.7`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3700c9332b7010c89cd91c0a5bbf9d9061fca1e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->