### PR TITLE
feat(cohere): update model YAMLs [bot]

### DIFF
--- a/providers/cohere/c4ai-aya-expanse-32b.yaml
+++ b/providers/cohere/c4ai-aya-expanse-32b.yaml
@@ -17,3 +17,4 @@ mode: chat
 model: c4ai-aya-expanse-32b
 sources:
     - https://docs.cohere.com/docs/aya-expanse
+status: active

--- a/providers/cohere/c4ai-aya-vision-32b.yaml
+++ b/providers/cohere/c4ai-aya-vision-32b.yaml
@@ -21,3 +21,4 @@ params:
       minValue: 1
 sources:
     - https://docs.cohere.com/docs/aya-vision
+status: active

--- a/providers/cohere/command-a-03-2025.yaml
+++ b/providers/cohere/command-a-03-2025.yaml
@@ -4,6 +4,7 @@ costs:
       region: "*"
 features:
     - function_calling
+    - json_output
     - structured_output
     - tool_choice
 limits:
@@ -29,3 +30,4 @@ params:
 sources:
     - https://docs.cohere.com/docs/command-a
     - https://docs.cohere.com/reference/chat
+status: active

--- a/providers/cohere/command-a-reasoning-08-2025.yaml
+++ b/providers/cohere/command-a-reasoning-08-2025.yaml
@@ -6,6 +6,7 @@ features:
     - function_calling
     - structured_output
     - tool_choice
+    - json_output
 limits:
     context_window: 256000
     max_output_tokens: 32000
@@ -26,4 +27,5 @@ sources:
     - https://docs.cohere.com/docs/command-a-reasoning
     - https://docs.cohere.com/docs/reasoning
     - https://docs.cohere.com/docs/rate-limits
+status: active
 thinking: true

--- a/providers/cohere/command-a-translate-08-2025.yaml
+++ b/providers/cohere/command-a-translate-08-2025.yaml
@@ -6,7 +6,8 @@ features:
     - structured_output
     - function_calling
 limits:
-    context_window: 8000
+    context_window: 16000
+    max_input_tokens: 8000
     max_output_tokens: 8000
     max_tokens: 8000
 modalities:
@@ -24,3 +25,4 @@ params:
 sources:
     - https://docs.cohere.com/docs/command-a-translate
     - https://docs.cohere.com/changelog/2025-08-28-command-a-translate
+status: active

--- a/providers/cohere/command-a-vision-07-2025.yaml
+++ b/providers/cohere/command-a-vision-07-2025.yaml
@@ -24,3 +24,4 @@ params:
 sources:
     - https://docs.cohere.com/docs/command-a-vision
     - https://docs.cohere.com/docs/command-a
+status: active

--- a/providers/cohere/command-r-08-2024.yaml
+++ b/providers/cohere/command-r-08-2024.yaml
@@ -15,12 +15,10 @@ modalities:
         - text
     output:
         - text
-mode: completion
+mode: chat
 model: command-r-08-2024
 params:
     - key: max_tokens
       maxValue: 4000
 sources:
     - https://docs.cohere.com/docs/command-r
-supportedModes:
-    - chat

--- a/providers/cohere/command-r7b-12-2024.yaml
+++ b/providers/cohere/command-r7b-12-2024.yaml
@@ -23,3 +23,4 @@ params:
 sources:
     - https://docs.cohere.com/docs/command-r7b
     - https://docs.cohere.com/reference/chat
+status: active

--- a/providers/cohere/command-r7b-arabic-02-2025.yaml
+++ b/providers/cohere/command-r7b-arabic-02-2025.yaml
@@ -19,3 +19,4 @@ mode: chat
 model: command-r7b-arabic-02-2025
 sources:
     - https://docs.cohere.com/docs/command-r7b
+status: active

--- a/providers/cohere/embed-english-light-v3.0-image.yaml
+++ b/providers/cohere/embed-english-light-v3.0-image.yaml
@@ -3,7 +3,10 @@ limits:
     output_vector_size: 384
 modalities:
     input:
+        - text
         - image
+    output:
+        - embedding
 mode: embedding
 model: embed-english-light-v3.0-image
 removeParams:
@@ -13,3 +16,4 @@ removeParams:
 sources:
     - https://docs.cohere.com/docs/cohere-embed
     - https://docs.cohere.com/reference/embed
+status: active

--- a/providers/cohere/embed-english-light-v3.0.yaml
+++ b/providers/cohere/embed-english-light-v3.0.yaml
@@ -10,6 +10,8 @@ modalities:
     input:
         - text
         - image
+    output:
+        - embedding
 mode: embedding
 model: embed-english-light-v3.0
 removeParams:
@@ -18,3 +20,4 @@ removeParams:
 sources:
     - https://docs.cohere.com/docs/cohere-embed
     - https://docs.cohere.com/reference/embed
+status: active

--- a/providers/cohere/embed-english-v3.0-image.yaml
+++ b/providers/cohere/embed-english-v3.0-image.yaml
@@ -4,6 +4,8 @@ limits:
 modalities:
     input:
         - image
+    output:
+        - embedding
 mode: embedding
 model: embed-english-v3.0-image
 removeParams:
@@ -13,3 +15,4 @@ removeParams:
 sources:
     - https://docs.cohere.com/docs/cohere-embed
     - https://docs.cohere.com/reference/embed
+status: active

--- a/providers/cohere/embed-english-v3.0.yaml
+++ b/providers/cohere/embed-english-v3.0.yaml
@@ -11,6 +11,8 @@ modalities:
     input:
         - text
         - image
+    output:
+        - embedding
 mode: embedding
 model: embed-english-v3.0
 removeParams:
@@ -20,3 +22,4 @@ removeParams:
 sources:
     - https://docs.cohere.com/reference/embed
     - https://docs.cohere.com/docs/cohere-embed
+status: active

--- a/providers/cohere/embed-multilingual-light-v3.0-image.yaml
+++ b/providers/cohere/embed-multilingual-light-v3.0-image.yaml
@@ -5,6 +5,8 @@ modalities:
     input:
         - text
         - image
+    output:
+        - embedding
 mode: embedding
 model: embed-multilingual-light-v3.0-image
 removeParams:
@@ -14,3 +16,4 @@ removeParams:
 sources:
     - https://docs.cohere.com/docs/cohere-embed
     - https://docs.cohere.com/reference/embed
+status: active

--- a/providers/cohere/embed-multilingual-light-v3.0.yaml
+++ b/providers/cohere/embed-multilingual-light-v3.0.yaml
@@ -10,6 +10,8 @@ modalities:
     input:
         - text
         - image
+    output:
+        - embedding
 mode: embedding
 model: embed-multilingual-light-v3.0
 removeParams:
@@ -19,3 +21,4 @@ removeParams:
 sources:
     - https://docs.cohere.com/docs/cohere-embed
     - https://docs.cohere.com/v2/reference/embed
+status: active

--- a/providers/cohere/embed-multilingual-v3.0-image.yaml
+++ b/providers/cohere/embed-multilingual-v3.0-image.yaml
@@ -15,3 +15,4 @@ removeParams:
 sources:
     - https://docs.cohere.com/reference/embed
     - https://docs.cohere.com/docs/cohere-embed
+status: active

--- a/providers/cohere/embed-multilingual-v3.0.yaml
+++ b/providers/cohere/embed-multilingual-v3.0.yaml
@@ -10,6 +10,8 @@ modalities:
     input:
         - text
         - image
+    output:
+        - embedding
 mode: embedding
 model: embed-multilingual-v3.0
 removeParams:
@@ -20,3 +22,4 @@ sources:
     - https://docs.cohere.com/docs/cohere-embed
     - https://docs.cohere.com/reference/embed
     - https://docs.cohere.com/docs/how-does-cohere-pricing-work
+status: active

--- a/providers/cohere/embed-v4.0.yaml
+++ b/providers/cohere/embed-v4.0.yaml
@@ -10,6 +10,8 @@ modalities:
     input:
         - text
         - image
+    output:
+        - embedding
 mode: embedding
 model: embed-v4.0
 removeParams:
@@ -19,3 +21,4 @@ sources:
     - https://docs.cohere.com/docs/cohere-embed
     - https://docs.cohere.com/reference/embed
     - https://docs.cohere.com/changelog/embed-multimodal-v4
+status: active

--- a/providers/cohere/rerank-english-v3.0.yaml
+++ b/providers/cohere/rerank-english-v3.0.yaml
@@ -17,3 +17,4 @@ removeParams:
 sources:
     - https://docs.cohere.com/docs/rerank
     - https://docs.cohere.com/reference/rerank
+status: active

--- a/providers/cohere/rerank-multilingual-v3.0.yaml
+++ b/providers/cohere/rerank-multilingual-v3.0.yaml
@@ -5,7 +5,6 @@ costs:
       region: "*"
 limits:
     context_window: 4096
-    max_tokens: 4096
 mode: rerank
 model: rerank-multilingual-v3.0
 removeParams:
@@ -15,3 +14,4 @@ removeParams:
 sources:
     - https://docs.cohere.com/docs/rerank
     - https://docs.cohere.com/reference/rerank
+status: active

--- a/providers/cohere/rerank-v3.5.yaml
+++ b/providers/cohere/rerank-v3.5.yaml
@@ -6,6 +6,9 @@ costs:
 limits:
     context_window: 4096
     max_input_tokens: 4096
+modalities:
+    input:
+        - text
 mode: rerank
 model: rerank-v3.5
 removeParams:
@@ -16,3 +19,4 @@ sources:
     - https://docs.cohere.com/docs/rerank
     - https://docs.cohere.com/v2/reference/rerank
     - https://docs.cohere.com/docs/how-does-cohere-pricing-work
+status: active

--- a/providers/cohere/rerank-v4.0-fast.yaml
+++ b/providers/cohere/rerank-v4.0-fast.yaml
@@ -1,5 +1,5 @@
 limits:
-    context_window: 32768
+    context_window: 32000
 modalities:
     input:
         - text
@@ -12,3 +12,4 @@ removeParams:
 sources:
     - https://docs.cohere.com/docs/rerank
     - https://docs.cohere.com/reference/rerank
+status: active

--- a/providers/cohere/rerank-v4.0-pro.yaml
+++ b/providers/cohere/rerank-v4.0-pro.yaml
@@ -12,3 +12,4 @@ removeParams:
 sources:
     - https://docs.cohere.com/reference/rerank
     - https://docs.cohere.com/docs/rerank
+status: active

--- a/providers/cohere/tiny-aya-earth.yaml
+++ b/providers/cohere/tiny-aya-earth.yaml
@@ -2,7 +2,13 @@ features:
     - structured_output
 limits:
     context_window: 8000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: completion
 model: tiny-aya-earth
+status: active
 supportedModes:
     - chat

--- a/providers/cohere/tiny-aya-global.yaml
+++ b/providers/cohere/tiny-aya-global.yaml
@@ -9,5 +9,6 @@ modalities:
         - text
 mode: completion
 model: tiny-aya-global
+status: active
 supportedModes:
     - chat

--- a/providers/cohere/tiny-aya-water.yaml
+++ b/providers/cohere/tiny-aya-water.yaml
@@ -4,5 +4,6 @@ limits:
     context_window: 8000
 mode: completion
 model: tiny-aya-water
+status: active
 supportedModes:
     - chat


### PR DESCRIPTION
Auto-generated by poc-agent for provider `cohere`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates Cohere model metadata (modes, limits, modalities, and feature flags), which can change how the router selects/validates requests and what parameters are accepted. Risk is moderate because mis-specified limits/modes could break existing integrations or enable unsupported behaviors.
> 
> **Overview**
> Marks a large set of Cohere model YAMLs as `status: active` and aligns capability metadata across chat, embedding, and rerank models.
> 
> Notable behavior changes include switching `command-r-08-2024` to `mode: chat` (removing `supportedModes`), adding `json_output` to `command-a` variants, expanding `command-a-translate-08-2025` limits (adds `max_input_tokens` and increases `context_window`), and explicitly declaring embedding/rerank `modalities.output: embedding` plus missing `modalities` blocks for some models (e.g., `tiny-aya-earth`, `rerank-v3.5`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 358387f9f856753351b4a036e76c3771da391655. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->