### PR TITLE
feat(deepinfra): update model YAMLs [bot]

### DIFF
--- a/providers/deepinfra/NousResearch/Hermes-3-Llama-3.1-70B.yaml
+++ b/providers/deepinfra/NousResearch/Hermes-3-Llama-3.1-70B.yaml
@@ -11,8 +11,15 @@ features:
 limits:
     context_window: 131072
     max_input_tokens: 131072
+    max_output_tokens: 131072
     max_tokens: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: NousResearch/Hermes-3-Llama-3.1-70B
 sources:
     - https://deepinfra.com/NousResearch/Hermes-3-Llama-3.1-70B/api
+status: active

--- a/providers/deepinfra/Qwen/Qwen2.5-72B-Instruct.yaml
+++ b/providers/deepinfra/Qwen/Qwen2.5-72B-Instruct.yaml
@@ -7,6 +7,7 @@ features:
     - tool_choice
     - structured_output
     - prompt_caching
+    - json_output
 limits:
     context_window: 32768
     max_input_tokens: 32768
@@ -22,3 +23,4 @@ model: Qwen/Qwen2.5-72B-Instruct
 sources:
     - https://deepinfra.com/Qwen/Qwen2.5-72B-Instruct/api
     - https://huggingface.co/Qwen/Qwen2.5-72B-Instruct
+status: active

--- a/providers/deepinfra/Qwen/Qwen2.5-VL-32B-Instruct.yaml
+++ b/providers/deepinfra/Qwen/Qwen2.5-VL-32B-Instruct.yaml
@@ -20,3 +20,4 @@ model: Qwen/Qwen2.5-VL-32B-Instruct
 sources:
     - https://deepinfra.com/Qwen/Qwen2.5-VL-32B-Instruct/api
     - https://deepinfra.com/docs/advanced/function_calling
+status: active

--- a/providers/deepinfra/Qwen/Qwen3-14B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-14B.yaml
@@ -7,11 +7,18 @@ features:
     - tool_choice
     - system_messages
     - structured_output
+    - json_output
 limits:
     context_window: 40960
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: Qwen/Qwen3-14B
 sources:
     - https://deepinfra.com/Qwen/Qwen3-14B
     - https://deepinfra.com/Qwen/Qwen3-14B/api
+status: active
 thinking: true

--- a/providers/deepinfra/Qwen/Qwen3-235B-A22B-Instruct-2507.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-235B-A22B-Instruct-2507.yaml
@@ -6,6 +6,7 @@ features:
     - function_calling
     - tool_choice
     - structured_output
+    - json_output
     - prompt_caching
 limits:
     context_window: 262144
@@ -23,3 +24,4 @@ sources:
     - https://deepinfra.com/Qwen/Qwen3-235B-A22B-Instruct-2507/api
     - https://api.deepinfra.com/models/Qwen/Qwen3-235B-A22B-Instruct-2507
     - https://huggingface.co/Qwen/Qwen3-235B-A22B-Instruct-2507
+status: active

--- a/providers/deepinfra/Qwen/Qwen3-235B-A22B-Thinking-2507.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-235B-A22B-Thinking-2507.yaml
@@ -22,4 +22,5 @@ model: Qwen/Qwen3-235B-A22B-Thinking-2507
 sources:
     - https://deepinfra.com/Qwen/Qwen3-235B-A22B-Thinking-2507
     - https://huggingface.co/Qwen/Qwen3-235B-A22B-Thinking-2507
+status: active
 thinking: true

--- a/providers/deepinfra/Qwen/Qwen3-30B-A3B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-30B-A3B.yaml
@@ -9,6 +9,7 @@ features:
     - prompt_caching
 limits:
     context_window: 40960
+    max_output_tokens: 40960
     max_tokens: 40960
 modalities:
     input:

--- a/providers/deepinfra/Qwen/Qwen3-32B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-32B.yaml
@@ -8,8 +8,8 @@ features:
 limits:
     context_window: 40960
     max_input_tokens: 40960
-    max_output_tokens: 40960
-    max_tokens: 40960
+    max_output_tokens: 16384
+    max_tokens: 16384
 modalities:
     input:
         - text
@@ -22,4 +22,5 @@ sources:
     - https://deepinfra.com/Qwen/Qwen3-32B/api
     - https://deepinfra.com/docs/advanced/max_tokens_limit
     - https://huggingface.co/Qwen/Qwen3-32B
+status: active
 thinking: true

--- a/providers/deepinfra/Qwen/Qwen3-Coder-480B-A35B-Instruct-Turbo.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Coder-480B-A35B-Instruct-Turbo.yaml
@@ -22,3 +22,4 @@ sources:
     - https://huggingface.co/Qwen/Qwen3-Coder-480B-A35B-Instruct
     - https://deepinfra.com/docs/advanced/max_tokens_limit
     - https://artificialanalysis.ai/models/qwen3-coder-480b-a35b-instruct/providers
+status: active

--- a/providers/deepinfra/Qwen/Qwen3-Coder-480B-A35B-Instruct.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Coder-480B-A35B-Instruct.yaml
@@ -21,3 +21,4 @@ model: Qwen/Qwen3-Coder-480B-A35B-Instruct
 sources:
     - https://huggingface.co/Qwen/Qwen3-Coder-480B-A35B-Instruct
     - https://deepinfra.com/Qwen/Qwen3-Coder-480B-A35B-Instruct/api
+status: active

--- a/providers/deepinfra/Qwen/Qwen3-Max-Thinking.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Max-Thinking.yaml
@@ -20,7 +20,10 @@ costs:
               - cost_per_token: 0.000015
                 from: 128000
 features:
+    - function_calling
+    - json_output
     - prompt_caching
+    - structured_output
 limits:
     context_window: 256000
     max_output_tokens: 16384

--- a/providers/deepinfra/Qwen/Qwen3-Max.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Max.yaml
@@ -7,6 +7,8 @@ costs:
           cache_read:
               - cost_per_token: 4.8e-7
                 from: 32000
+              - cost_per_token: 6.e-7
+                from: 128000
           input:
               - cost_per_token: 0.0000024
                 from: 32000
@@ -19,7 +21,9 @@ costs:
                 from: 128000
 features:
     - function_calling
+    - json_output
     - prompt_caching
+    - structured_output
     - tool_choice
 limits:
     context_window: 262144
@@ -37,4 +41,4 @@ sources:
     - https://www.alibabacloud.com/help/en/model-studio/models
     - https://www.alibabacloud.com/help/en/model-studio/billing-for-model-studio
     - https://openrouter.ai/qwen/qwen3-max/api
-thinking: true
+status: active

--- a/providers/deepinfra/Qwen/Qwen3-Next-80B-A3B-Instruct.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Next-80B-A3B-Instruct.yaml
@@ -8,8 +8,8 @@ features:
 limits:
     context_window: 262144
     max_input_tokens: 262144
-    max_output_tokens: 262144
-    max_tokens: 262144
+    max_output_tokens: 16384
+    max_tokens: 16384
 modalities:
     input:
         - text

--- a/providers/deepinfra/Qwen/Qwen3-VL-235B-A22B-Instruct.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-VL-235B-A22B-Instruct.yaml
@@ -4,6 +4,7 @@ costs:
       output_cost_per_token: 8.8e-7
       region: "*"
 features:
+    - function_calling
     - prompt_caching
 limits:
     context_window: 262144
@@ -15,6 +16,8 @@ modalities:
         - text
         - image
         - video
+    output:
+        - text
 mode: chat
 model: Qwen/Qwen3-VL-235B-A22B-Instruct
 sources:

--- a/providers/deepinfra/Qwen/Qwen3-VL-30B-A3B-Instruct.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-VL-30B-A3B-Instruct.yaml
@@ -24,4 +24,5 @@ sources:
     - https://deepinfra.com/Qwen/Qwen3-VL-30B-A3B-Instruct/api
     - https://deepinfra.com/docs/advanced/max_tokens_limit
     - https://huggingface.co/Qwen/Qwen3-VL-30B-A3B-Instruct
+status: active
 thinking: true

--- a/providers/deepinfra/Sao10K/L3.1-70B-Euryale-v2.2.yaml
+++ b/providers/deepinfra/Sao10K/L3.1-70B-Euryale-v2.2.yaml
@@ -5,9 +5,16 @@ costs:
 features:
     - structured_output
     - prompt_caching
+    - json_output
 limits:
     context_window: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: Sao10K/L3.1-70B-Euryale-v2.2
 sources:
     - https://deepinfra.com/Sao10K/L3.1-70B-Euryale-v2.2
+status: active

--- a/providers/deepinfra/Sao10K/L3.3-70B-Euryale-v2.3.yaml
+++ b/providers/deepinfra/Sao10K/L3.3-70B-Euryale-v2.3.yaml
@@ -2,13 +2,20 @@ costs:
     - input_cost_per_token: 8.5e-7
       output_cost_per_token: 8.5e-7
       region: "*"
+features:
+    - json_output
+    - structured_output
 limits:
     context_window: 131072
     max_input_tokens: 131072
-    max_output_tokens: 131072
-    max_tokens: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: Sao10K/L3.3-70B-Euryale-v2.3
 sources:
     - https://deepinfra.com/Sao10K/L3.3-70B-Euryale-v2.3
     - https://deepinfra.com/Sao10K/L3.3-70B-Euryale-v2.3/api
+status: active

--- a/providers/deepinfra/allenai/Olmo-3.1-32B-Instruct.yaml
+++ b/providers/deepinfra/allenai/Olmo-3.1-32B-Instruct.yaml
@@ -17,3 +17,4 @@ model: allenai/Olmo-3.1-32B-Instruct
 sources:
     - https://deepinfra.com/allenai/Olmo-3.1-32B-Instruct
     - https://huggingface.co/allenai/Olmo-3.1-32B-Instruct
+status: active

--- a/providers/deepinfra/anthropic/claude-4-sonnet.yaml
+++ b/providers/deepinfra/anthropic/claude-4-sonnet.yaml
@@ -27,4 +27,7 @@ sources:
     - https://deepinfra.com/anthropic/claude-4-sonnet
     - https://platform.claude.com/docs/en/docs/about-claude/models
     - https://platform.claude.com/docs/en/docs/about-claude/pricing
+status: active
+supportedModes:
+    - chat
 thinking: true

--- a/providers/deepinfra/deepseek-ai/DeepSeek-OCR.yaml
+++ b/providers/deepinfra/deepseek-ai/DeepSeek-OCR.yaml
@@ -19,3 +19,4 @@ sources:
     - https://deepinfra.com/deepseek-ai/DeepSeek-OCR
     - https://huggingface.co/deepseek-ai/DeepSeek-OCR
     - https://github.com/deepseek-ai/DeepSeek-OCR
+status: active

--- a/providers/deepinfra/deepseek-ai/DeepSeek-R1-0528-Turbo.yaml
+++ b/providers/deepinfra/deepseek-ai/DeepSeek-R1-0528-Turbo.yaml
@@ -6,6 +6,7 @@ features:
     - function_calling
     - tool_choice
     - structured_output
+    - json_output
 limits:
     context_window: 32768
     max_output_tokens: 32768
@@ -20,4 +21,5 @@ model: deepseek-ai/DeepSeek-R1-0528-Turbo
 sources:
     - https://deepinfra.com/deepseek-ai/DeepSeek-R1-0528-Turbo/api
     - https://deepinfra.com/deepseek-ai/DeepSeek-R1-0528-Turbo
+status: active
 thinking: true

--- a/providers/deepinfra/deepseek-ai/DeepSeek-R1-0528.yaml
+++ b/providers/deepinfra/deepseek-ai/DeepSeek-R1-0528.yaml
@@ -22,4 +22,5 @@ model: deepseek-ai/DeepSeek-R1-0528
 sources:
     - https://deepinfra.com/deepseek-ai/DeepSeek-R1-0528/api
     - https://huggingface.co/deepseek-ai/DeepSeek-R1-0528/raw/main/config.json
+status: active
 thinking: true

--- a/providers/deepinfra/deepseek-ai/DeepSeek-R1-Distill-Llama-70B.yaml
+++ b/providers/deepinfra/deepseek-ai/DeepSeek-R1-Distill-Llama-70B.yaml
@@ -2,6 +2,10 @@ costs:
     - input_cost_per_token: 7.e-7
       output_cost_per_token: 8.e-7
       region: "*"
+features:
+    - function_calling
+    - json_output
+    - structured_output
 limits:
     context_window: 131072
     max_input_tokens: 131072

--- a/providers/deepinfra/deepseek-ai/DeepSeek-V3-0324.yaml
+++ b/providers/deepinfra/deepseek-ai/DeepSeek-V3-0324.yaml
@@ -6,11 +6,11 @@ costs:
 features:
     - prompt_caching
     - function_calling
+    - structured_output
+    - json_output
 limits:
     context_window: 163840
     max_input_tokens: 163840
-    max_output_tokens: 163840
-    max_tokens: 163840
 modalities:
     input:
         - text
@@ -20,3 +20,4 @@ mode: chat
 model: deepseek-ai/DeepSeek-V3-0324
 sources:
     - https://deepinfra.com/deepseek-ai/DeepSeek-V3-0324/api
+status: active

--- a/providers/deepinfra/deepseek-ai/DeepSeek-V3.1-Terminus.yaml
+++ b/providers/deepinfra/deepseek-ai/DeepSeek-V3.1-Terminus.yaml
@@ -10,9 +10,15 @@ limits:
     max_input_tokens: 163840
     max_output_tokens: 163840
     max_tokens: 163840
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: deepseek-ai/DeepSeek-V3.1-Terminus
 sources:
     - https://deepinfra.com/deepseek-ai/DeepSeek-V3.1-Terminus/api
     - https://openrouter.ai/deepseek/deepseek-v3.1-terminus/api
+status: active
 thinking: true

--- a/providers/deepinfra/deepseek-ai/DeepSeek-V3.1.yaml
+++ b/providers/deepinfra/deepseek-ai/DeepSeek-V3.1.yaml
@@ -4,15 +4,24 @@ costs:
       output_cost_per_token: 7.9e-7
       region: "*"
 features:
+    - function_calling
     - prompt_caching
+    - structured_output
+    - json_output
 limits:
     context_window: 163840
     max_input_tokens: 163840
     max_output_tokens: 32768
     max_tokens: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: deepseek-ai/DeepSeek-V3.1
 sources:
     - https://deepinfra.com/deepseek-ai/DeepSeek-V3.1/api
     - https://deepinfra.com/docs/advanced/max_tokens_limit
+status: active
 thinking: true

--- a/providers/deepinfra/deepseek-ai/DeepSeek-V3.2.yaml
+++ b/providers/deepinfra/deepseek-ai/DeepSeek-V3.2.yaml
@@ -7,6 +7,7 @@ features:
     - prompt_caching
     - function_calling
     - structured_output
+    - json_output
 limits:
     context_window: 163840
     max_input_tokens: 163840

--- a/providers/deepinfra/deepseek-ai/Janus-Pro-1B.yaml
+++ b/providers/deepinfra/deepseek-ai/Janus-Pro-1B.yaml
@@ -1,10 +1,12 @@
 costs:
     - input_cost_per_image: 0.0005
       region: "*"
-limits:
-    max_input_tokens: 2600
 modalities:
     input:
+        - text
+        - image
+    output:
+        - text
         - image
 mode: image
 model: deepseek-ai/Janus-Pro-1B

--- a/providers/deepinfra/google/gemini-2.5-flash.yaml
+++ b/providers/deepinfra/google/gemini-2.5-flash.yaml
@@ -6,9 +6,12 @@ features:
     - function_calling
     - tool_choice
     - structured_output
+    - json_output
 limits:
     context_window: 1000000
     max_input_tokens: 1000000
+    max_output_tokens: 65536
+    max_tokens: 65536
 modalities:
     input:
         - text
@@ -20,4 +23,5 @@ model: google/gemini-2.5-flash
 sources:
     - https://deepinfra.com/google/gemini-2.5-flash
     - https://deepinfra.com/google/gemini-2.5-flash/api
+status: active
 thinking: true

--- a/providers/deepinfra/google/gemma-3-4b-it.yaml
+++ b/providers/deepinfra/google/gemma-3-4b-it.yaml
@@ -23,3 +23,4 @@ sources:
     - https://deepinfra.com/google/gemma-3-4b-it/api
     - https://deepinfra.com/docs/advanced/max_tokens_limit
     - https://ai.google.dev/gemma/docs/core
+status: active

--- a/providers/deepinfra/meta-llama/Llama-3.2-11B-Vision-Instruct.yaml
+++ b/providers/deepinfra/meta-llama/Llama-3.2-11B-Vision-Instruct.yaml
@@ -5,6 +5,9 @@ costs:
 features:
     - function_calling
     - system_messages
+    - json_output
+    - structured_output
+    - prompt_caching
 limits:
     context_window: 131072
     max_input_tokens: 131072

--- a/providers/deepinfra/meta-llama/Llama-3.3-70B-Instruct-Turbo.yaml
+++ b/providers/deepinfra/meta-llama/Llama-3.3-70B-Instruct-Turbo.yaml
@@ -21,3 +21,4 @@ sources:
     - https://deepinfra.com/meta-llama/Llama-3.3-70B-Instruct-Turbo/api
     - https://deepinfra.com/docs/advanced/max_tokens_limit
     - https://deepinfra.com/docs/advanced/function_calling
+status: active

--- a/providers/deepinfra/meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8.yaml
+++ b/providers/deepinfra/meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8.yaml
@@ -5,6 +5,8 @@ costs:
 features:
     - function_calling
     - tool_choice
+    - structured_output
+    - json_output
 limits:
     context_window: 1048576
     max_output_tokens: 16384
@@ -20,3 +22,4 @@ model: meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8
 sources:
     - https://deepinfra.com/meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8/api
     - https://deepinfra.com/docs/advanced/max_tokens_limit
+status: active

--- a/providers/deepinfra/meta-llama/Llama-4-Scout-17B-16E-Instruct.yaml
+++ b/providers/deepinfra/meta-llama/Llama-4-Scout-17B-16E-Instruct.yaml
@@ -22,3 +22,4 @@ model: meta-llama/Llama-4-Scout-17B-16E-Instruct
 sources:
     - https://deepinfra.com/meta-llama/Llama-4-Scout-17B-16E-Instruct/api
     - https://deepinfra.com/meta-llama/Llama-4-Scout-17B-16E-Instruct
+status: active

--- a/providers/deepinfra/meta-llama/Llama-Guard-3-8B.yaml
+++ b/providers/deepinfra/meta-llama/Llama-Guard-3-8B.yaml
@@ -2,8 +2,10 @@ costs:
     - input_cost_per_token: 5.5e-8
       output_cost_per_token: 5.5e-8
       region: "*"
+deprecationDate: "2025-11-11"
 features:
     - system_messages
+isDeprecated: true
 limits:
     context_window: 131072
     max_input_tokens: 131072

--- a/providers/deepinfra/meta-llama/Llama-Guard-4-12B.yaml
+++ b/providers/deepinfra/meta-llama/Llama-Guard-4-12B.yaml
@@ -18,3 +18,4 @@ model: meta-llama/Llama-Guard-4-12B
 sources:
     - https://deepinfra.com/meta-llama/Llama-Guard-4-12B/api
     - https://deepinfra.com/meta-llama/Llama-Guard-4-12B
+status: active

--- a/providers/deepinfra/meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo.yaml
+++ b/providers/deepinfra/meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo.yaml
@@ -6,6 +6,7 @@ features:
     - function_calling
     - tool_choice
     - system_messages
+    - json_output
 limits:
     context_window: 131072
     max_input_tokens: 131072
@@ -23,3 +24,4 @@ sources:
     - https://deepinfra.com/docs/advanced/max_tokens_limit
     - https://deepinfra.com/docs/advanced/function_calling
     - https://deepinfra.com/docs/model-features
+    - https://deepinfra.com/docs/advanced/json_mode

--- a/providers/deepinfra/microsoft/phi-4.yaml
+++ b/providers/deepinfra/microsoft/phi-4.yaml
@@ -20,3 +20,4 @@ sources:
     - https://deepinfra.com/microsoft/phi-4/api
     - https://deepinfra.com/docs/advanced/max_tokens_limit
     - https://huggingface.co/microsoft/phi-4
+status: active

--- a/providers/deepinfra/mistralai/Mistral-Nemo-Instruct-2407.yaml
+++ b/providers/deepinfra/mistralai/Mistral-Nemo-Instruct-2407.yaml
@@ -6,6 +6,7 @@ features:
     - function_calling
     - tool_choice
     - structured_output
+    - json_output
 limits:
     context_window: 131072
     max_input_tokens: 131072
@@ -21,3 +22,4 @@ model: mistralai/Mistral-Nemo-Instruct-2407
 sources:
     - https://deepinfra.com/mistralai/Mistral-Nemo-Instruct-2407/api
     - https://deepinfra.com/mistralai/Mistral-Nemo-Instruct-2407
+status: active

--- a/providers/deepinfra/mistralai/Mistral-Small-24B-Instruct-2501.yaml
+++ b/providers/deepinfra/mistralai/Mistral-Small-24B-Instruct-2501.yaml
@@ -6,11 +6,10 @@ features:
     - function_calling
     - tool_choice
     - structured_output
+    - json_output
 limits:
     context_window: 32768
     max_input_tokens: 32768
-    max_output_tokens: 32768
-    max_tokens: 32768
 modalities:
     input:
         - text
@@ -22,3 +21,4 @@ sources:
     - https://deepinfra.com/mistralai/Mistral-Small-24B-Instruct-2501
     - https://deepinfra.com/mistralai/Mistral-Small-24B-Instruct-2501/api
     - https://huggingface.co/mistralai/Mistral-Small-24B-Instruct-2501
+status: active

--- a/providers/deepinfra/mistralai/Mistral-Small-3.2-24B-Instruct-2506.yaml
+++ b/providers/deepinfra/mistralai/Mistral-Small-3.2-24B-Instruct-2506.yaml
@@ -6,6 +6,7 @@ features:
     - function_calling
     - tool_choice
     - structured_output
+    - json_output
 limits:
     context_window: 128000
     max_input_tokens: 128000
@@ -22,3 +23,4 @@ model: mistralai/Mistral-Small-3.2-24B-Instruct-2506
 sources:
     - https://docs.mistral.ai/models/mistral-small-3-2-25-06
     - https://deepinfra.com/mistralai/Mistral-Small-3.2-24B-Instruct-2506/api
+status: active

--- a/providers/deepinfra/moonshotai/Kimi-K2-Instruct-0905.yaml
+++ b/providers/deepinfra/moonshotai/Kimi-K2-Instruct-0905.yaml
@@ -9,7 +9,7 @@ features:
     - tool_choice
     - system_messages
 limits:
-    context_window: 131072
+    context_window: 262144
     max_input_tokens: 262144
     max_output_tokens: 131072
     max_tokens: 131072

--- a/providers/deepinfra/moonshotai/Kimi-K2-Thinking.yaml
+++ b/providers/deepinfra/moonshotai/Kimi-K2-Thinking.yaml
@@ -5,10 +5,12 @@ costs:
       region: "*"
 features:
     - function_calling
+    - json_output
     - prompt_caching
+    - structured_output
     - system_messages
 limits:
-    context_window: 131072
+    context_window: 262144
     max_input_tokens: 262144
     max_output_tokens: 131072
     max_tokens: 131072

--- a/providers/deepinfra/moonshotai/Kimi-K2.5.yaml
+++ b/providers/deepinfra/moonshotai/Kimi-K2.5.yaml
@@ -8,6 +8,7 @@ features:
     - function_calling
     - tool_choice
     - structured_output
+    - json_output
 limits:
     context_window: 262144
     max_output_tokens: 64000
@@ -23,4 +24,5 @@ model: moonshotai/Kimi-K2.5
 sources:
     - https://deepinfra.com/moonshotai/Kimi-K2.5/api
     - https://openrouter.ai/moonshotai/kimi-k2.5/api
+status: active
 thinking: true

--- a/providers/deepinfra/nvidia/Llama-3.1-Nemotron-70B-Instruct.yaml
+++ b/providers/deepinfra/nvidia/Llama-3.1-Nemotron-70B-Instruct.yaml
@@ -21,3 +21,4 @@ model: nvidia/Llama-3.1-Nemotron-70B-Instruct
 sources:
     - https://deepinfra.com/nvidia/Llama-3.1-Nemotron-70B-Instruct/api
     - https://huggingface.co/nvidia/Llama-3.1-Nemotron-70B-Instruct
+status: active

--- a/providers/deepinfra/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B.yaml
+++ b/providers/deepinfra/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B.yaml
@@ -7,6 +7,7 @@ features:
     - prompt_caching
     - function_calling
     - structured_output
+    - json_output
 limits:
     context_window: 262144
 modalities:
@@ -18,3 +19,4 @@ mode: chat
 model: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B
 sources:
     - https://deepinfra.com/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B/api
+status: active

--- a/providers/deepinfra/nvidia/NVIDIA-Nemotron-Nano-9B-v2.yaml
+++ b/providers/deepinfra/nvidia/NVIDIA-Nemotron-Nano-9B-v2.yaml
@@ -20,4 +20,5 @@ model: nvidia/NVIDIA-Nemotron-Nano-9B-v2
 sources:
     - https://deepinfra.com/nvidia/NVIDIA-Nemotron-Nano-9B-v2/api
     - https://build.nvidia.com/nvidia/nvidia-nemotron-nano-9b-v2/modelcard
+status: active
 thinking: true

--- a/providers/deepinfra/zai-org/GLM-4.6.yaml
+++ b/providers/deepinfra/zai-org/GLM-4.6.yaml
@@ -8,8 +8,7 @@ features:
     - prompt_caching
     - structured_output
 limits:
-    context_window: 202752
-    max_input_tokens: 202752
+    context_window: 200000
     max_output_tokens: 131072
     max_tokens: 131072
 modalities:

--- a/providers/deepinfra/zai-org/GLM-4.6V.yaml
+++ b/providers/deepinfra/zai-org/GLM-4.6V.yaml
@@ -20,3 +20,4 @@ sources:
     - https://deepinfra.com/zai-org/GLM-4.6V/api
     - https://deepinfra.com/docs/advanced/max_tokens_limit
     - https://huggingface.co/zai-org/GLM-4.6V
+status: active

--- a/providers/deepinfra/zai-org/GLM-5.yaml
+++ b/providers/deepinfra/zai-org/GLM-5.yaml
@@ -9,8 +9,8 @@ features:
     - prompt_caching
 limits:
     context_window: 202752
-    max_output_tokens: 128000
-    max_tokens: 128000
+    max_output_tokens: 131072
+    max_tokens: 131072
 modalities:
     input:
         - text
@@ -21,6 +21,5 @@ model: zai-org/GLM-5
 sources:
     - https://deepinfra.com/zai-org/GLM-5/api
     - https://docs.z.ai/guides/llm/glm-5
-    - https://openrouter.ai/z-ai/glm-5/api
-    - https://artificialanalysis.ai/models/glm-5/providers
+status: active
 thinking: true


### PR DESCRIPTION
Auto-generated by poc-agent for provider `deepinfra`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily configuration-only YAML updates, but changes to `max_*_tokens`, `context_window`, and declared features (e.g., `json_output`) can alter runtime behavior and token budgeting for callers.
> 
> **Overview**
> Updates DeepInfra provider model YAMLs to reflect current **capabilities and metadata**: adds `status: active` broadly, introduces/expands `modalities` sections, and annotates more models with features like `json_output`, `structured_output`, and `function_calling`.
> 
> Adjusts several **token limits/pricing knobs** (e.g., adds missing `max_output_tokens`, reduces `max_tokens` for some Qwen models, increases `context_window` for Kimi models, adds tiered cache-read pricing for `Qwen3-Max`) and marks `meta-llama/Llama-Guard-3-8B` as deprecated via `isDeprecated` + `deprecationDate`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e23d6c74754fc98c9c649d25a2212d528895ff87. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->