### PR TITLE
feat(mistral-ai): update model YAMLs [bot]

### DIFF
--- a/providers/mistral-ai/codestral-embed-2505.yaml
+++ b/providers/mistral-ai/codestral-embed-2505.yaml
@@ -10,6 +10,8 @@ modalities:
     input:
         - text
         - code
+    output:
+        - embedding
 mode: embedding
 model: codestral-embed-2505
 removeParams:
@@ -22,3 +24,5 @@ removeParams:
 sources:
     - https://mistral.ai/news/codestral-embed
     - https://docs.mistral.ai/capabilities/embeddings/code_embeddings
+    - https://docs.mistral.ai/models/codestral-embed-25-05
+status: active

--- a/providers/mistral-ai/codestral-embed.yaml
+++ b/providers/mistral-ai/codestral-embed.yaml
@@ -5,10 +5,13 @@ costs:
 limits:
     context_window: 8000
     max_input_tokens: 8000
+    output_vector_size: 1536
 modalities:
     input:
         - text
         - code
+    output:
+        - embedding
 mode: embedding
 model: codestral-embed
 removeParams:
@@ -20,3 +23,5 @@ removeParams:
     - stream
 sources:
     - https://docs.mistral.ai/models/codestral-embed-25-05
+    - https://docs.mistral.ai/capabilities/embeddings/code_embeddings
+status: active

--- a/providers/mistral-ai/codestral-latest.yaml
+++ b/providers/mistral-ai/codestral-latest.yaml
@@ -16,6 +16,7 @@ mode: chat
 model: codestral-latest
 sources:
     - https://docs.mistral.ai/models/codestral-25-08
+status: active
 supportedModes:
     - completion
     - chat

--- a/providers/mistral-ai/devstral-2512.yaml
+++ b/providers/mistral-ai/devstral-2512.yaml
@@ -6,16 +6,19 @@ features:
     - function_calling
     - structured_output
     - assistant_prefill
+    - json_output
 limits:
     context_window: 256000
 modalities:
     input:
         - text
+        - image
     output:
         - text
 mode: chat
 model: devstral-2512
 sources:
     - https://docs.mistral.ai/models/devstral-2-25-12
+status: active
 supportedModes:
     - chat

--- a/providers/mistral-ai/devstral-latest.yaml
+++ b/providers/mistral-ai/devstral-latest.yaml
@@ -6,16 +6,19 @@ features:
     - function_calling
     - structured_output
     - assistant_prefill
+    - json_output
 limits:
     context_window: 256000
 modalities:
     input:
         - text
+        - image
     output:
         - text
 mode: chat
 model: devstral-latest
 sources:
     - https://docs.mistral.ai/models/devstral-2-25-12
+status: active
 supportedModes:
     - chat

--- a/providers/mistral-ai/devstral-medium-latest.yaml
+++ b/providers/mistral-ai/devstral-medium-latest.yaml
@@ -16,5 +16,6 @@ mode: chat
 model: devstral-medium-latest
 sources:
     - https://docs.mistral.ai/models/devstral-medium-1-0-25-07
+status: active
 supportedModes:
     - chat

--- a/providers/mistral-ai/devstral-small-latest.yaml
+++ b/providers/mistral-ai/devstral-small-latest.yaml
@@ -21,5 +21,6 @@ mode: chat
 model: devstral-small-latest
 sources:
     - https://docs.mistral.ai/models/devstral-small-2-25-12
+status: preview
 supportedModes:
     - completion

--- a/providers/mistral-ai/labs-devstral-small-2512.yaml
+++ b/providers/mistral-ai/labs-devstral-small-2512.yaml
@@ -15,7 +15,6 @@ limits:
 modalities:
     input:
         - text
-        - image
     output:
         - text
 mode: chat
@@ -25,3 +24,4 @@ params:
       maxValue: 256000
 sources:
     - https://docs.mistral.ai/models/devstral-small-2-25-12
+status: preview

--- a/providers/mistral-ai/labs-mistral-small-creative.yaml
+++ b/providers/mistral-ai/labs-mistral-small-creative.yaml
@@ -8,9 +8,6 @@ features:
     - assistant_prefill
 limits:
     context_window: 32000
-    max_input_tokens: 32000
-    max_output_tokens: 32000
-    max_tokens: 32000
 modalities:
     input:
         - text
@@ -22,5 +19,6 @@ mode: chat
 model: labs-mistral-small-creative
 sources:
     - https://docs.mistral.ai/models/mistral-small-creative-25-12
+status: preview
 supportedModes:
     - chat

--- a/providers/mistral-ai/magistral-medium-2509.yaml
+++ b/providers/mistral-ai/magistral-medium-2509.yaml
@@ -15,9 +15,14 @@ modalities:
         - text
 mode: chat
 model: magistral-medium-2509
+params:
+    - defaultValue: high
+      key: reasoning_effort
+      type: string
 sources:
     - https://docs.mistral.ai/models/magistral-medium-1-2-25-09
     - https://docs.mistral.ai/capabilities/reasoning
+status: active
 supportedModes:
     - chat
 thinking: true

--- a/providers/mistral-ai/magistral-medium-latest.yaml
+++ b/providers/mistral-ai/magistral-medium-latest.yaml
@@ -7,6 +7,7 @@ features:
     - parallel_function_calling
     - tool_choice
     - structured_output
+    - json_output
 limits:
     context_window: 128000
 modalities:
@@ -21,6 +22,7 @@ sources:
     - https://docs.mistral.ai/models/magistral-medium-1-2-25-09
     - https://docs.mistral.ai/capabilities/reasoning/
     - https://docs.mistral.ai/capabilities/function_calling
+status: active
 supportedModes:
     - chat
 thinking: true

--- a/providers/mistral-ai/magistral-small-2509.yaml
+++ b/providers/mistral-ai/magistral-small-2509.yaml
@@ -5,6 +5,7 @@ costs:
 features:
     - function_calling
     - structured_output
+    - json_output
 limits:
     context_window: 128000
 modalities:
@@ -18,6 +19,7 @@ model: magistral-small-2509
 sources:
     - https://docs.mistral.ai/models/magistral-small-1-2-25-09
     - https://docs.mistral.ai/capabilities/reasoning/native
+status: active
 supportedModes:
     - chat
 thinking: true

--- a/providers/mistral-ai/magistral-small-latest.yaml
+++ b/providers/mistral-ai/magistral-small-latest.yaml
@@ -25,6 +25,7 @@ sources:
     - https://docs.mistral.ai/models/magistral-small-1-2-25-09
     - https://docs.mistral.ai/capabilities/reasoning
     - https://mistral.ai/news/magistral
+status: active
 supportedModes:
     - chat
 thinking: true

--- a/providers/mistral-ai/ministral-14b-2512.yaml
+++ b/providers/mistral-ai/ministral-14b-2512.yaml
@@ -25,5 +25,6 @@ params:
       minValue: 1
 sources:
     - https://docs.mistral.ai/models/ministral-3-14b-25-12
+status: active
 supportedModes:
     - chat

--- a/providers/mistral-ai/ministral-3b-2512.yaml
+++ b/providers/mistral-ai/ministral-3b-2512.yaml
@@ -22,5 +22,6 @@ sources:
     - https://docs.mistral.ai/models/ministral-3-3b-25-12
     - https://docs.mistral.ai/capabilities/vision/
     - https://docs.mistral.ai/capabilities/function_calling/
+status: active
 supportedModes:
     - chat

--- a/providers/mistral-ai/ministral-3b-latest.yaml
+++ b/providers/mistral-ai/ministral-3b-latest.yaml
@@ -17,5 +17,6 @@ mode: chat
 model: ministral-3b-latest
 sources:
     - https://docs.mistral.ai/models/ministral-3-3b-25-12
+status: active
 supportedModes:
     - chat

--- a/providers/mistral-ai/ministral-8b-2512.yaml
+++ b/providers/mistral-ai/ministral-8b-2512.yaml
@@ -5,6 +5,7 @@ costs:
 features:
     - function_calling
     - structured_output
+    - json_output
 limits:
     context_window: 256000
     max_input_tokens: 256000

--- a/providers/mistral-ai/ministral-8b-latest.yaml
+++ b/providers/mistral-ai/ministral-8b-latest.yaml
@@ -8,6 +8,7 @@ features:
     - tool_choice
     - structured_output
     - assistant_prefill
+    - json_output
 limits:
     context_window: 256000
 modalities:
@@ -23,5 +24,6 @@ sources:
     - https://docs.mistral.ai/capabilities/vision
     - https://docs.mistral.ai/capabilities/structured_output
     - https://docs.mistral.ai/capabilities/function_calling
+status: active
 supportedModes:
     - chat

--- a/providers/mistral-ai/mistral-large-2512.yaml
+++ b/providers/mistral-ai/mistral-large-2512.yaml
@@ -8,13 +8,13 @@ features:
     - tool_choice
     - structured_output
     - assistant_prefill
+    - json_output
 limits:
     context_window: 256000
 modalities:
     input:
         - text
         - image
-        - audio
         - pdf
     output:
         - text
@@ -24,4 +24,5 @@ sources:
     - https://docs.mistral.ai/models/mistral-large-3-25-12
     - https://docs.mistral.ai/capabilities/vision
     - https://docs.mistral.ai/capabilities/function_calling
-    - https://docs.mistral.ai/capabilities/audio
+    - https://docs.mistral.ai/capabilities/structured_output
+status: active

--- a/providers/mistral-ai/mistral-large-latest.yaml
+++ b/providers/mistral-ai/mistral-large-latest.yaml
@@ -5,6 +5,9 @@ costs:
 features:
     - function_calling
     - structured_output
+    - json_output
+    - assistant_prefill
+    - tool_choice
 limits:
     context_window: 256000
     max_input_tokens: 256000
@@ -28,3 +31,4 @@ sources:
     - https://docs.mistral.ai/models/mistral-large-3-25-12
 supportedModes:
     - chat
+thinking: true

--- a/providers/mistral-ai/mistral-medium-2508.yaml
+++ b/providers/mistral-ai/mistral-medium-2508.yaml
@@ -4,7 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
+    - parallel_function_calling
     - structured_output
+    - json_output
 limits:
     context_window: 128000
 modalities:
@@ -19,5 +21,7 @@ mode: chat
 model: mistral-medium-2508
 sources:
     - https://docs.mistral.ai/models/mistral-medium-3-1-25-08
+    - https://docs.mistral.ai/capabilities/function_calling
+status: active
 supportedModes:
     - chat

--- a/providers/mistral-ai/mistral-medium-latest.yaml
+++ b/providers/mistral-ai/mistral-medium-latest.yaml
@@ -5,8 +5,11 @@ costs:
 features:
     - function_calling
     - structured_output
+    - json_output
 limits:
     context_window: 128000
+    max_output_tokens: 32768
+    max_tokens: 32768
 modalities:
     input:
         - text
@@ -15,6 +18,7 @@ modalities:
         - pdf
     output:
         - text
+        - audio
 mode: chat
 model: mistral-medium-latest
 sources:

--- a/providers/mistral-ai/mistral-moderation-2411.yaml
+++ b/providers/mistral-ai/mistral-moderation-2411.yaml
@@ -1,6 +1,10 @@
 costs:
     - input_cost_per_token: 1.e-7
+      output_cost_per_token: 1.e-7
       region: "*"
+features:
+    - function_calling
+    - structured_output
 limits:
     context_window: 8000
 modalities:
@@ -13,5 +17,6 @@ model: mistral-moderation-2411
 sources:
     - https://docs.mistral.ai/models/mistral-moderation-24-11
     - https://docs.mistral.ai/capabilities/guardrailing
+status: active
 supportedModes:
     - moderation

--- a/providers/mistral-ai/mistral-moderation-latest.yaml
+++ b/providers/mistral-ai/mistral-moderation-latest.yaml
@@ -14,5 +14,6 @@ removeParams:
     - stream
 sources:
     - https://docs.mistral.ai/capabilities/guardrailing/
+status: active
 supportedModes:
     - moderation

--- a/providers/mistral-ai/mistral-ocr-2512.yaml
+++ b/providers/mistral-ai/mistral-ocr-2512.yaml
@@ -20,3 +20,4 @@ model: mistral-ocr-2512
 sources:
     - https://docs.mistral.ai/models/ocr-3-25-12
     - https://docs.mistral.ai/capabilities/document_ai/basic_ocr
+status: active

--- a/providers/mistral-ai/mistral-ocr-latest.yaml
+++ b/providers/mistral-ai/mistral-ocr-latest.yaml
@@ -9,6 +9,7 @@ limits:
     context_window: 16384
 modalities:
     input:
+        - text
         - image
         - pdf
         - doc
@@ -21,3 +22,4 @@ sources:
     - https://docs.mistral.ai/models/ocr-3-25-12
     - https://docs.mistral.ai/capabilities/document_ai/basic_ocr
     - https://docs.mistral.ai/api/endpoint/ocr
+status: active

--- a/providers/mistral-ai/mistral-small-2506.yaml
+++ b/providers/mistral-ai/mistral-small-2506.yaml
@@ -8,6 +8,7 @@ features:
     - structured_output
     - tool_choice
     - assistant_prefill
+    - json_output
 limits:
     context_window: 128000
 modalities:
@@ -26,4 +27,5 @@ sources:
     - https://docs.mistral.ai/capabilities/function_calling
     - https://docs.mistral.ai/capabilities/structured_output
     - https://docs.mistral.ai/capabilities/reasoning
+    - https://docs.mistral.ai/capabilities/structured_output/json_mode
 thinking: true

--- a/providers/mistral-ai/mistral-small-latest.yaml
+++ b/providers/mistral-ai/mistral-small-latest.yaml
@@ -7,6 +7,7 @@ features:
     - parallel_function_calling
     - structured_output
     - tool_choice
+    - json_output
 limits:
     context_window: 256000
 modalities:
@@ -26,6 +27,7 @@ sources:
     - https://docs.mistral.ai/capabilities/vision/
     - https://docs.mistral.ai/capabilities/function_calling/
     - https://docs.mistral.ai/capabilities/reasoning/
+status: active
 supportedModes:
     - chat
 thinking: true

--- a/providers/mistral-ai/mistral-small.yaml
+++ b/providers/mistral-ai/mistral-small.yaml
@@ -8,6 +8,7 @@ features:
     - tool_choice
     - structured_output
     - assistant_prefill
+    - json_output
 limits:
     context_window: 128000
 modalities:
@@ -23,3 +24,4 @@ sources:
     - https://docs.mistral.ai/models/mistral-small-3-2-25-06
     - https://docs.mistral.ai/capabilities/vision
     - https://docs.mistral.ai/capabilities/function_calling
+status: active

--- a/providers/mistral-ai/mistral-vibe-cli-latest.yaml
+++ b/providers/mistral-ai/mistral-vibe-cli-latest.yaml
@@ -6,5 +6,6 @@ mode: chat
 model: mistral-vibe-cli-latest
 sources:
     - https://docs.mistral.ai/mistral-vibe/introduction
+status: active
 supportedModes:
     - chat

--- a/providers/mistral-ai/mistral-vibe-cli-with-tools.yaml
+++ b/providers/mistral-ai/mistral-vibe-cli-with-tools.yaml
@@ -20,3 +20,4 @@ sources:
     - https://mistral.ai/news/devstral-2-vibe-cli
     - https://docs.mistral.ai/mistral-vibe/introduction
     - https://docs.mistral.ai/mistral-vibe/introduction/configuration
+status: active

--- a/providers/mistral-ai/voxtral-mini-2507.yaml
+++ b/providers/mistral-ai/voxtral-mini-2507.yaml
@@ -15,6 +15,7 @@ modalities:
     input:
         - text
         - audio
+        - image
         - doc
         - pdf
     output:
@@ -23,3 +24,4 @@ mode: chat
 model: voxtral-mini-2507
 sources:
     - https://docs.mistral.ai/models/voxtral-mini-25-07
+status: active

--- a/providers/mistral-ai/voxtral-mini-latest.yaml
+++ b/providers/mistral-ai/voxtral-mini-latest.yaml
@@ -11,7 +11,6 @@ limits:
 modalities:
     input:
         - audio
-        - image
         - text
     output:
         - text

--- a/providers/mistral-ai/voxtral-mini-transcribe-2507.yaml
+++ b/providers/mistral-ai/voxtral-mini-transcribe-2507.yaml
@@ -17,4 +17,4 @@ removeParams:
     - stop
 sources:
     - https://docs.mistral.ai/models/voxtral-mini-transcribe-25-07
-    - https://docs.mistral.ai/capabilities/audio_transcription/offline_transcription
+status: active

--- a/providers/mistral-ai/voxtral-small-2507.yaml
+++ b/providers/mistral-ai/voxtral-small-2507.yaml
@@ -19,5 +19,6 @@ mode: chat
 model: voxtral-small-2507
 sources:
     - https://docs.mistral.ai/models/voxtral-small-25-07
+status: active
 supportedModes:
     - chat

--- a/providers/mistral-ai/voxtral-small-latest.yaml
+++ b/providers/mistral-ai/voxtral-small-latest.yaml
@@ -6,6 +6,7 @@ costs:
 features:
     - function_calling
     - structured_output
+    - assistant_prefill
 limits:
     context_window: 32768
 modalities:


### PR DESCRIPTION
Auto-generated by poc-agent for provider `mistral-ai`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only changes, but they can affect model selection/capability gating (e.g., `json_output`, modality support, token limits) for Mistral models if downstream consumers rely on these fields.
> 
> **Overview**
> Refreshes Mistral AI model definitions to align with current capabilities and lifecycle status by adding `status` (active/preview) across many YAMLs.
> 
> Updates capability metadata: adds `json_output` to several chat models, adds/adjusts modality support (e.g., embeddings now declare `output: [embedding]`, `mistral-ocr-latest` adds text input, `voxtral-mini-2507` adds image input, and some models drop previously listed image/audio inputs).
> 
> Adjusts limits/params where needed, including embedding `output_vector_size`, `mistral-medium-latest` max output/token caps and audio output, and introduces a default `reasoning_effort` param for `magistral-medium-2509`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e1690971c8e996abc95aa5f6ae80fe74a454f31b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->