### PR TITLE
feat(google-vertex): update model YAMLs [bot]

### DIFF
--- a/providers/google-vertex/gemini-2.0-flash-lite-001.yaml
+++ b/providers/google-vertex/gemini-2.0-flash-lite-001.yaml
@@ -188,6 +188,7 @@ features:
     - prompt_caching
     - structured_output
 limits:
+    context_window: 1048576
     max_input_tokens: 1048576
     max_output_tokens: 8192
     max_tokens: 8192
@@ -219,3 +220,4 @@ params:
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-0-flash-lite
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/locations
+status: deprecated

--- a/providers/google-vertex/gemini-2.5-flash-lite.yaml
+++ b/providers/google-vertex/gemini-2.5-flash-lite.yaml
@@ -141,7 +141,6 @@ modalities:
         - audio
         - video
         - pdf
-        - doc
         - code
     output:
         - text

--- a/providers/google-vertex/gemini-3-pro-image-preview.yaml
+++ b/providers/google-vertex/gemini-3-pro-image-preview.yaml
@@ -212,6 +212,7 @@ costs:
 features:
     - system_messages
 limits:
+    context_window: 65536
     max_input_tokens: 65536
     max_output_tokens: 32768
     max_tokens: 32768
@@ -230,4 +231,5 @@ removeParams:
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/3-pro-image
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/locations
+status: preview
 thinking: true


### PR DESCRIPTION
Auto-generated by poc-agent for provider `google-vertex`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are limited to provider model YAML metadata (limits/modalities/status) with no code-path or security logic modifications. Main risk is misconfiguration causing incorrect model capability reporting.
> 
> **Overview**
> Updates Google Vertex Gemini model YAMLs to better reflect current model capabilities and lifecycle.
> 
> Adds explicit `limits.context_window` for `gemini-2.0-flash-lite-001` and `gemini-3-pro-image-preview`, marks `gemini-2.0-flash-lite-001` as `status: deprecated`, and marks `gemini-3-pro-image-preview` as `status: preview`.
> 
> Adjusts `gemini-2.5-flash-lite` input modalities by removing `doc` from the supported input types.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ef5d113ec0ae6c3bad9ff84a306dedb2a715b10. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->