### PR TITLE
feat(openrouter): update model YAMLs [bot]

### DIFF
--- a/providers/openrouter/anthropic/claude-3.7-sonnet.yaml
+++ b/providers/openrouter/anthropic/claude-3.7-sonnet.yaml
@@ -10,6 +10,7 @@ features:
     - tool_choice
     - assistant_prefill
     - prompt_caching
+    - structured_output
 limits:
     context_window: 200000
     max_input_tokens: 200000

--- a/providers/openrouter/deepseek-r1-0528-qwen3-8b:free.yaml
+++ b/providers/openrouter/deepseek-r1-0528-qwen3-8b:free.yaml
@@ -16,4 +16,5 @@ model: deepseek-r1-0528-qwen3-8b:free
 sources:
     - https://openrouter.ai/deepseek/deepseek-r1-0528-qwen3-8b:free
     - https://openrouter.ai/deepseek/deepseek-r1-0528-qwen3-8b:free/api
+status: active
 thinking: true

--- a/providers/openrouter/openai/gpt-4o-mini.yaml
+++ b/providers/openrouter/openai/gpt-4o-mini.yaml
@@ -17,7 +17,6 @@ modalities:
     input:
         - text
         - image
-        - pdf
     output:
         - text
 mode: chat

--- a/providers/openrouter/thedrummer/skyfall-36b-v2.yaml
+++ b/providers/openrouter/thedrummer/skyfall-36b-v2.yaml
@@ -2,6 +2,9 @@ costs:
     - input_cost_per_token: 5.5e-7
       output_cost_per_token: 8.e-7
       region: "*"
+features:
+    - function_calling
+    - tool_choice
 limits:
     context_window: 32768
     max_output_tokens: 32768


### PR DESCRIPTION
Auto-generated by poc-agent for provider `openrouter`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk metadata-only updates to OpenRouter model YAMLs (capabilities, status, and supported modalities) with no runtime logic changes.
> 
> **Overview**
> Updates OpenRouter model YAML metadata to better reflect current capabilities and availability.
> 
> Adds `structured_output` support to `anthropic/claude-3.7-sonnet`, marks `deepseek-r1-0528-qwen3-8b:free` as `status: active`, removes `pdf` from `openai/gpt-4o-mini` input modalities, and declares `function_calling`/`tool_choice` features for `thedrummer/skyfall-36b-v2`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5033c3ce9d5ef373262f0010074c286339f1a5f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->