### PR TITLE
feat(openrouter): add new models [bot]

### DIFF
--- a/providers/openrouter/google/lyria-3-clip-preview.yaml
+++ b/providers/openrouter/google/lyria-3-clip-preview.yaml
@@ -1,0 +1,16 @@
+costs:
+    - input_cost_per_token: 0
+      output_cost_per_token: 0
+      region: "*"
+limits:
+    context_window: 1048576
+    max_output_tokens: 65536
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
+        - audio
+mode: chat
+model: google/lyria-3-clip-preview

--- a/providers/openrouter/google/lyria-3-pro-preview.yaml
+++ b/providers/openrouter/google/lyria-3-pro-preview.yaml
@@ -1,0 +1,16 @@
+costs:
+    - input_cost_per_token: 0
+      output_cost_per_token: 0
+      region: "*"
+limits:
+    context_window: 1048576
+    max_output_tokens: 65536
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
+        - audio
+mode: chat
+model: google/lyria-3-pro-preview

--- a/providers/openrouter/kwaipilot/kat-coder-pro-v2.yaml
+++ b/providers/openrouter/kwaipilot/kat-coder-pro-v2.yaml
@@ -1,0 +1,15 @@
+costs:
+    - cache_read_input_token_cost: 6.e-8
+      input_cost_per_token: 3.e-7
+      output_cost_per_token: 0.0000012
+      region: "*"
+limits:
+    context_window: 256000
+    max_output_tokens: 80000
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: chat
+model: kwaipilot/kat-coder-pro-v2

--- a/providers/openrouter/qwen/qwen3.6-plus-preview:free.yaml
+++ b/providers/openrouter/qwen/qwen3.6-plus-preview:free.yaml
@@ -1,0 +1,14 @@
+costs:
+    - input_cost_per_token: 0
+      output_cost_per_token: 0
+      region: "*"
+limits:
+    context_window: 1000000
+    max_output_tokens: 65536
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: chat
+model: qwen/qwen3.6-plus-preview:free

--- a/providers/openrouter/rekaai/reka-flash-3.yaml
+++ b/providers/openrouter/rekaai/reka-flash-3.yaml
@@ -1,0 +1,14 @@
+costs:
+    - input_cost_per_token: 1.e-7
+      output_cost_per_token: 2.e-7
+      region: "*"
+limits:
+    context_window: 65536
+    max_output_tokens: 65536
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: chat
+model: rekaai/reka-flash-3


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `openrouter`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds new OpenRouter model YAML definitions only; no runtime logic changes, so risk is limited to config/discovery and pricing metadata accuracy.
> 
> **Overview**
> Registers five new OpenRouter chat models via YAML configs: `google/lyria-3-clip-preview`, `google/lyria-3-pro-preview` (text+image in, text+audio out), `kwaipilot/kat-coder-pro-v2`, `qwen/qwen3.6-plus-preview:free`, and `rekaai/reka-flash-3`.
> 
> Each entry specifies token limits (up to ~1M context / 65k output for the Lyria/Qwen models) and associated per-token cost metadata (including a cache-read input cost for `kat-coder-pro-v2`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bee19d4cfa4466fd31ae18b47a43572ffa6df0a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->