### PR TITLE
feat(ai21): update model YAMLs [bot]

### DIFF
--- a/providers/ai21/jamba-large-1.7.yaml
+++ b/providers/ai21/jamba-large-1.7.yaml
@@ -6,9 +6,12 @@ features:
     - function_calling
     - tool_choice
     - structured_output
+    - json_output
 limits:
     context_window: 256000
     max_input_tokens: 256000
+    max_output_tokens: 4096
+    max_tokens: 4096
 modalities:
     input:
         - text
@@ -17,6 +20,10 @@ modalities:
 mode: chat
 model: jamba-large-1.7
 params:
+    - defaultValue: 4096
+      key: max_tokens
+      maxValue: 4096
+      minValue: 1
     - defaultValue: 0.4
       key: temperature
       maxValue: 2
@@ -25,6 +32,9 @@ params:
       key: "n"
       maxValue: 16
       minValue: 1
+removeParams:
+    - top_k
 sources:
     - https://docs.ai21.com/docs/function-calling
     - https://docs.ai21.com/reference/jamba-1-6-api-ref
+status: active


### PR DESCRIPTION
Auto-generated by poc-agent for provider `ai21`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes model capability flags and token/parameter limits, which can affect request validation and defaults when calling AI21. Low code risk, but mis-specified limits/params could cause runtime API errors or altered generation behavior.
> 
> **Overview**
> Updates the `ai21` `jamba-large-1.7` model YAML to reflect new capabilities and constraints: adds `json_output`, marks the model `active`, and introduces explicit output/token limits (`max_output_tokens`/`max_tokens` set to 4096).
> 
> Adds a new configurable `max_tokens` param (default 4096) and declares `top_k` as a removed/unsupported parameter via `removeParams`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b57f52f3bfd64e329c90b278bc6a864bb6a0ef47. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->