### PR TITLE
feat(azure-open-ai): update model YAMLs [bot]

### DIFF
--- a/providers/azure-open-ai/aoai-sora-2025-02-28.yaml
+++ b/providers/azure-open-ai/aoai-sora-2025-02-28.yaml
@@ -1,3 +1,6 @@
+costs:
+    - output_cost_per_second: 0.1
+      region: "*"
 messages:
     options: []
 modalities:

--- a/providers/azure-open-ai/aoai-sora.yaml
+++ b/providers/azure-open-ai/aoai-sora.yaml
@@ -1,3 +1,6 @@
+costs:
+    - output_cost_per_second: 0.1
+      region: "*"
 modalities:
     input:
         - text
@@ -17,4 +20,5 @@ removeParams:
     - parallel_tool_calls
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
+    - https://azure.microsoft.com/en-us/products/ai-services/video-generation
 status: preview

--- a/providers/azure-open-ai/codex-mini-2025-05-16.yaml
+++ b/providers/azure-open-ai/codex-mini-2025-05-16.yaml
@@ -6,7 +6,6 @@ costs:
 deprecationDate: "2026-11-15"
 features:
     - function_calling
-    - parallel_function_calling
     - prompt_caching
     - structured_output
     - system_messages

--- a/providers/azure-open-ai/container.yaml
+++ b/providers/azure-open-ai/container.yaml
@@ -1,2 +1,3 @@
 mode: chat
 model: container
+status: active

--- a/providers/azure-open-ai/gpt-35-turbo.yaml
+++ b/providers/azure-open-ai/gpt-35-turbo.yaml
@@ -2,9 +2,11 @@ costs:
     - input_cost_per_token: 5.e-7
       output_cost_per_token: 0.0000015
       region: "*"
+deprecationDate: "2025-02-13"
 features:
     - function_calling
     - tool_choice
+isDeprecated: true
 limits:
     max_input_tokens: 4097
     max_output_tokens: 4096

--- a/providers/azure-open-ai/gpt-4-1106-Preview.yaml
+++ b/providers/azure-open-ai/gpt-4-1106-Preview.yaml
@@ -19,5 +19,6 @@ mode: chat
 model: gpt-4-1106-Preview
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/legacy-models
+status: active
 supportedModes:
     - chat

--- a/providers/azure-open-ai/gpt-4-turbo-2024-04-09.yaml
+++ b/providers/azure-open-ai/gpt-4-turbo-2024-04-09.yaml
@@ -16,6 +16,7 @@ features:
     - parallel_function_calling
     - tool_choice
     - structured_output
+    - json_output
 limits:
     context_window: 128000
     max_input_tokens: 128000

--- a/providers/azure-open-ai/gpt-4-turbo-jp.yaml
+++ b/providers/azure-open-ai/gpt-4-turbo-jp.yaml
@@ -7,6 +7,7 @@ features:
     - parallel_function_calling
     - system_messages
     - tool_choice
+    - json_output
 limits:
     context_window: 128000
     max_input_tokens: 128000

--- a/providers/azure-open-ai/gpt-4-vision-preview.yaml
+++ b/providers/azure-open-ai/gpt-4-vision-preview.yaml
@@ -19,5 +19,6 @@ mode: chat
 model: gpt-4-vision-preview
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/legacy-models
+status: active
 supportedModes:
     - chat

--- a/providers/azure-open-ai/gpt-4.1-mini-2025-04-14.yaml
+++ b/providers/azure-open-ai/gpt-4.1-mini-2025-04-14.yaml
@@ -37,5 +37,6 @@ params:
       maxValue: 32768
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
+status: active
 supportedModes:
     - chat

--- a/providers/azure-open-ai/gpt-4.1.yaml
+++ b/providers/azure-open-ai/gpt-4.1.yaml
@@ -4,7 +4,19 @@ costs:
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000008
       output_cost_per_token_batches: 0.000004
-      region: "*"
+      region: global
+    - cache_read_input_token_cost: 5.5e-7
+      input_cost_per_token: 0.0000022
+      input_cost_per_token_batches: 0.0000011
+      output_cost_per_token: 0.0000088
+      output_cost_per_token_batches: 0.0000044
+      region: datazone_us
+    - cache_read_input_token_cost: 5.5e-7
+      input_cost_per_token: 0.0000022
+      input_cost_per_token_batches: 0.0000011
+      output_cost_per_token: 0.0000088
+      output_cost_per_token_batches: 0.0000044
+      region: datazone_eu
 deprecationDate: "2026-10-14"
 features:
     - function_calling

--- a/providers/azure-open-ai/gpt-4o-2024-08-06.yaml
+++ b/providers/azure-open-ai/gpt-4o-2024-08-06.yaml
@@ -14,6 +14,7 @@ features:
     - tool_choice
     - prompt_caching
     - structured_output
+isDeprecated: true
 limits:
     context_window: 128000
     max_input_tokens: 128000

--- a/providers/azure-open-ai/gpt-4o-2024-11-20.yaml
+++ b/providers/azure-open-ai/gpt-4o-2024-11-20.yaml
@@ -14,6 +14,7 @@ features:
     - tool_choice
     - structured_output
     - prompt_caching
+    - json_output
 limits:
     context_window: 128000
     max_input_tokens: 128000

--- a/providers/azure-open-ai/gpt-4o-audio-mai.yaml
+++ b/providers/azure-open-ai/gpt-4o-audio-mai.yaml
@@ -8,6 +8,7 @@ features:
     - function_calling
     - parallel_function_calling
     - system_messages
+    - tool_choice
 limits:
     context_window: 128000
     max_input_tokens: 128000
@@ -27,6 +28,8 @@ params:
       key: max_tokens
       maxValue: 16384
       minValue: 1
+sources:
+    - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
 status: active
 supportedModes:
     - chat

--- a/providers/azure-open-ai/gpt-4o-mini-2024-07-18.yaml
+++ b/providers/azure-open-ai/gpt-4o-mini-2024-07-18.yaml
@@ -21,6 +21,7 @@ features:
     - tool_choice
     - prompt_caching
     - structured_output
+    - json_output
 limits:
     context_window: 128000
     max_input_tokens: 128000
@@ -39,5 +40,6 @@ params:
       maxValue: 16384
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
+status: deprecated
 supportedModes:
     - chat

--- a/providers/azure-open-ai/gpt-4o-mini-transcribe.yaml
+++ b/providers/azure-open-ai/gpt-4o-mini-transcribe.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_audio_token: 0.000003
+    - input_cost_per_audio_token: 0.00000125
       input_cost_per_token: 0.00000125
       output_cost_per_token: 0.000005
       region: "*"
@@ -26,4 +26,5 @@ removeParams:
 sources:
     - https://developers.openai.com/docs/guides/speech-to-text
     - https://developers.openai.com/docs/models/gpt-4o-mini-transcribe
+    - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
 status: active

--- a/providers/azure-open-ai/gpt-4o-mini-tts.yaml
+++ b/providers/azure-open-ai/gpt-4o-mini-tts.yaml
@@ -5,9 +5,7 @@ costs:
       output_cost_per_token: 0.00001
       region: "*"
 limits:
-    max_input_tokens: 128000
-    max_output_tokens: 16384
-    max_tokens: 16384
+    max_input_tokens: 2000
 modalities:
     input:
         - text

--- a/providers/azure-open-ai/gpt-4o-mini.yaml
+++ b/providers/azure-open-ai/gpt-4o-mini.yaml
@@ -20,6 +20,7 @@ features:
     - parallel_function_calling
     - tool_choice
     - structured_output
+    - json_output
     - prompt_caching
 limits:
     context_window: 128000

--- a/providers/azure-open-ai/gpt-4o-transcribe-2025-03-20.yaml
+++ b/providers/azure-open-ai/gpt-4o-transcribe-2025-03-20.yaml
@@ -1,4 +1,13 @@
+costs:
+    - input_cost_per_audio_token: 0.000006
+      input_cost_per_token: 0.0000025
+      output_cost_per_token: 0.00001
+      region: "*"
 deprecationDate: "2026-06-01"
+limits:
+    max_input_tokens: 16000
+    max_output_tokens: 2000
+    max_tokens: 2000
 modalities:
     input:
         - audio

--- a/providers/azure-open-ai/gpt-4o-transcribe-diarize.yaml
+++ b/providers/azure-open-ai/gpt-4o-transcribe-diarize.yaml
@@ -21,6 +21,7 @@ removeParams:
     - "n"
     - stop
     - top_p
+    - response_format
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
 status: active

--- a/providers/azure-open-ai/gpt-5-codex-2025-09-15.yaml
+++ b/providers/azure-open-ai/gpt-5-codex-2025-09-15.yaml
@@ -1,9 +1,15 @@
+costs:
+    - cache_read_input_token_cost: 1.25e-7
+      input_cost_per_token: 0.00000125
+      output_cost_per_token: 0.00001
+      region: "*"
 deprecationDate: "2027-03-17"
 features:
     - function_calling
     - parallel_function_calling
     - structured_output
     - tool_choice
+    - prompt_caching
 limits:
     context_window: 400000
     max_input_tokens: 272000
@@ -13,6 +19,7 @@ modalities:
     input:
         - text
         - image
+        - pdf
     output:
         - text
 mode: chat

--- a/providers/azure-open-ai/gpt-5-nano.yaml
+++ b/providers/azure-open-ai/gpt-5-nano.yaml
@@ -1,4 +1,8 @@
 costs:
+    - cache_read_input_token_cost: 5.e-9
+      input_cost_per_token: 5.e-8
+      output_cost_per_token: 4.e-7
+      region: global
     - cache_read_input_token_cost: 5.5e-9
       input_cost_per_token: 5.5e-8
       output_cost_per_token: 4.4e-7
@@ -7,10 +11,6 @@ costs:
       input_cost_per_token: 5.5e-8
       output_cost_per_token: 4.4e-7
       region: datazone_eu
-    - cache_read_input_token_cost: 5.e-9
-      input_cost_per_token: 5.e-8
-      output_cost_per_token: 4.e-7
-      region: "*"
 deprecationDate: "2027-02-06"
 features:
     - function_calling


### PR DESCRIPTION
Auto-generated by poc-agent for provider `azure-open-ai`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily metadata updates, but changes to `status`/`isDeprecated`, pricing, and token limits can affect model selection and billing calculations if consumed by automation.
> 
> **Overview**
> Updates Azure OpenAI model YAMLs to reflect latest **pricing, capabilities, and lifecycle metadata**.
> 
> Adds/adjusts `costs` entries (including new region-specific pricing for `gpt-4.1` and `gpt-5-nano`, and new per-second video costs for `aoai-sora*`), tweaks limits (notably lowering `gpt-4o-mini-tts` `max_input_tokens`), and updates `removeParams` for transcription/diarization.
> 
> Marks/clarifies lifecycle state via `status`/`isDeprecated`/`deprecationDate` for several models (e.g., `gpt-35-turbo`, `gpt-4o-2024-08-06`, `gpt-4o-mini-2024-07-18`, `container`) and expands declared features like `json_output` and `prompt_caching` on select models.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db536bd73dd06b95799803c80572117af4d7ed40. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->