### PR TITLE
feat(mistral-ai): add new models [bot]

### DIFF
--- a/providers/mistral-ai/codestral-2508.yaml
+++ b/providers/mistral-ai/codestral-2508.yaml
@@ -4,13 +4,16 @@ costs:
       region: "*"
 features:
     - function_calling
-    - structured_output
 limits:
-    context_window: 128000
-mode: chat
+    context_window: 256000
+mode: completion
 model: codestral-2508
+params:
+    - defaultValue: 0.3
+      key: temperature
 sources:
     - https://docs.mistral.ai/models/codestral-25-08
+status: active
 supportedModes:
     - completion
     - chat

--- a/providers/mistral-ai/codestral-embed-2505.yaml
+++ b/providers/mistral-ai/codestral-embed-2505.yaml
@@ -4,15 +4,7 @@ costs:
       region: "*"
 limits:
     context_window: 8192
-    max_input_tokens: 8192
-    output_vector_size: 1536
-modalities:
-    input:
-        - text
-        - code
-    output:
-        - embedding
-mode: embedding
+mode: unknown
 model: codestral-embed-2505
 removeParams:
     - max_tokens

--- a/providers/mistral-ai/codestral-embed.yaml
+++ b/providers/mistral-ai/codestral-embed.yaml
@@ -3,16 +3,8 @@ costs:
       input_cost_per_token_batches: 7.5e-8
       region: "*"
 limits:
-    context_window: 8000
-    max_input_tokens: 8000
-    output_vector_size: 1536
-modalities:
-    input:
-        - text
-        - code
-    output:
-        - embedding
-mode: embedding
+    context_window: 8192
+mode: unknown
 model: codestral-embed
 removeParams:
     - max_tokens

--- a/providers/mistral-ai/codestral-latest.yaml
+++ b/providers/mistral-ai/codestral-latest.yaml
@@ -4,16 +4,13 @@ costs:
       region: "*"
 features:
     - function_calling
-    - structured_output
 limits:
-    context_window: 128000
-modalities:
-    input:
-        - text
-    output:
-        - text
-mode: chat
+    context_window: 256000
+mode: completion
 model: codestral-latest
+params:
+    - defaultValue: 0.3
+      key: temperature
 sources:
     - https://docs.mistral.ai/models/codestral-25-08
 status: active

--- a/providers/mistral-ai/devstral-2512.yaml
+++ b/providers/mistral-ai/devstral-2512.yaml
@@ -4,19 +4,13 @@ costs:
       region: "*"
 features:
     - function_calling
-    - structured_output
-    - assistant_prefill
-    - json_output
 limits:
-    context_window: 256000
-modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+    context_window: 262144
 mode: chat
 model: devstral-2512
+params:
+    - defaultValue: 0.2
+      key: temperature
 sources:
     - https://docs.mistral.ai/models/devstral-2-25-12
 status: active

--- a/providers/mistral-ai/devstral-latest.yaml
+++ b/providers/mistral-ai/devstral-latest.yaml
@@ -4,19 +4,13 @@ costs:
       region: "*"
 features:
     - function_calling
-    - structured_output
-    - assistant_prefill
-    - json_output
 limits:
-    context_window: 256000
-modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+    context_window: 262144
 mode: chat
 model: devstral-latest
+params:
+    - defaultValue: 0.2
+      key: temperature
 sources:
     - https://docs.mistral.ai/models/devstral-2-25-12
 status: active

--- a/providers/mistral-ai/devstral-medium-2507.yaml
+++ b/providers/mistral-ai/devstral-medium-2507.yaml
@@ -2,19 +2,20 @@ costs:
     - input_cost_per_token: 4.e-7
       output_cost_per_token: 0.000002
       region: "*"
+deprecationDate: "2026-05-31"
 features:
     - function_calling
-    - tool_choice
-    - structured_output
-    - assistant_prefill
 isDeprecated: true
 limits:
-    context_window: 128000
-    max_input_tokens: 128000
-    max_output_tokens: 128000
-    max_tokens: 128000
+    context_window: 131072
 mode: chat
 model: devstral-medium-2507
+params:
+    - defaultValue: 0
+      key: temperature
 sources:
     - https://docs.mistral.ai/models/devstral-medium-1-0-25-07
     - https://mistral.ai/news/devstral-2507
+status: active
+supportedModes:
+    - chat

--- a/providers/mistral-ai/devstral-medium-latest.yaml
+++ b/providers/mistral-ai/devstral-medium-latest.yaml
@@ -4,16 +4,13 @@ costs:
       region: "*"
 features:
     - function_calling
-    - structured_output
 limits:
-    context_window: 128000
-modalities:
-    input:
-        - text
-    output:
-        - text
+    context_window: 262144
 mode: chat
 model: devstral-medium-latest
+params:
+    - defaultValue: 0.2
+      key: temperature
 sources:
     - https://docs.mistral.ai/models/devstral-medium-1-0-25-07
 status: active

--- a/providers/mistral-ai/devstral-small-2507.yaml
+++ b/providers/mistral-ai/devstral-small-2507.yaml
@@ -2,15 +2,17 @@ costs:
     - input_cost_per_token: 1.e-7
       output_cost_per_token: 3.e-7
       region: "*"
+deprecationDate: "2026-05-31"
 features:
     - function_calling
-    - tool_choice
-    - structured_output
-    - assistant_prefill
 isDeprecated: true
 limits:
-    max_input_tokens: 128000
-    max_output_tokens: 128000
-    max_tokens: 128000
+    context_window: 131072
 mode: chat
 model: devstral-small-2507
+params:
+    - defaultValue: 0
+      key: temperature
+status: active
+supportedModes:
+    - chat

--- a/providers/mistral-ai/labs-leanstral-2603.yaml
+++ b/providers/mistral-ai/labs-leanstral-2603.yaml
@@ -4,17 +4,18 @@ costs:
       region: "*"
 features:
     - function_calling
-    - structured_output
 limits:
-    context_window: 256000
+    context_window: 196608
 modalities:
     input:
-        - text
         - image
-    output:
-        - text
 mode: chat
 model: labs-leanstral-2603
+params:
+    - defaultValue: 1
+      key: temperature
 sources:
     - https://docs.mistral.ai/models/leanstral-26-03
-status: preview
+status: active
+supportedModes:
+    - chat

--- a/providers/mistral-ai/labs-mistral-small-creative.yaml
+++ b/providers/mistral-ai/labs-mistral-small-creative.yaml
@@ -2,23 +2,18 @@ costs:
     - input_cost_per_token: 1.e-7
       output_cost_per_token: 3.e-7
       region: "*"
+deprecationDate: "2026-04-30"
 features:
     - function_calling
-    - structured_output
-    - assistant_prefill
 limits:
-    context_window: 32000
-modalities:
-    input:
-        - text
-        - image
-        - audio
-    output:
-        - text
+    context_window: 32768
 mode: chat
 model: labs-mistral-small-creative
+params:
+    - defaultValue: 0.3
+      key: temperature
 sources:
     - https://docs.mistral.ai/models/mistral-small-creative-25-12
-status: preview
+status: active
 supportedModes:
     - chat

--- a/providers/mistral-ai/magistral-medium-2509.yaml
+++ b/providers/mistral-ai/magistral-medium-2509.yaml
@@ -4,21 +4,16 @@ costs:
       region: "*"
 features:
     - function_calling
-    - structured_output
 limits:
-    context_window: 128000
+    context_window: 131072
 modalities:
     input:
-        - text
         - image
-    output:
-        - text
 mode: chat
 model: magistral-medium-2509
 params:
-    - defaultValue: high
-      key: reasoning_effort
-      type: string
+    - defaultValue: 0.7
+      key: temperature
 sources:
     - https://docs.mistral.ai/models/magistral-medium-1-2-25-09
     - https://docs.mistral.ai/capabilities/reasoning

--- a/providers/mistral-ai/magistral-medium-latest.yaml
+++ b/providers/mistral-ai/magistral-medium-latest.yaml
@@ -4,20 +4,16 @@ costs:
       region: "*"
 features:
     - function_calling
-    - parallel_function_calling
-    - tool_choice
-    - structured_output
-    - json_output
 limits:
-    context_window: 128000
+    context_window: 131072
 modalities:
     input:
-        - text
         - image
-    output:
-        - text
 mode: chat
 model: magistral-medium-latest
+params:
+    - defaultValue: 0.7
+      key: temperature
 sources:
     - https://docs.mistral.ai/models/magistral-medium-1-2-25-09
     - https://docs.mistral.ai/capabilities/reasoning/

--- a/providers/mistral-ai/magistral-small-2509.yaml
+++ b/providers/mistral-ai/magistral-small-2509.yaml
@@ -4,18 +4,16 @@ costs:
       region: "*"
 features:
     - function_calling
-    - structured_output
-    - json_output
 limits:
-    context_window: 128000
+    context_window: 131072
 modalities:
     input:
-        - text
         - image
-    output:
-        - text
 mode: chat
 model: magistral-small-2509
+params:
+    - defaultValue: 0.7
+      key: temperature
 sources:
     - https://docs.mistral.ai/models/magistral-small-1-2-25-09
     - https://docs.mistral.ai/capabilities/reasoning/native

--- a/providers/mistral-ai/magistral-small-latest.yaml
+++ b/providers/mistral-ai/magistral-small-latest.yaml
@@ -4,23 +4,16 @@ costs:
       region: "*"
 features:
     - function_calling
-    - structured_output
 limits:
-    context_window: 128000
-    max_input_tokens: 128000
-    max_output_tokens: 128000
-    max_tokens: 128000
+    context_window: 131072
 modalities:
     input:
-        - text
         - image
-    output:
-        - text
 mode: chat
 model: magistral-small-latest
 params:
-    - key: max_tokens
-      maxValue: 128000
+    - defaultValue: 0.7
+      key: temperature
 sources:
     - https://docs.mistral.ai/models/magistral-small-1-2-25-09
     - https://docs.mistral.ai/capabilities/reasoning

--- a/providers/mistral-ai/ministral-14b-2512.yaml
+++ b/providers/mistral-ai/ministral-14b-2512.yaml
@@ -4,25 +4,16 @@ costs:
       region: "*"
 features:
     - function_calling
-    - structured_output
 limits:
-    context_window: 256000
-    max_input_tokens: 256000
-    max_output_tokens: 256000
-    max_tokens: 256000
+    context_window: 262144
 modalities:
     input:
-        - text
         - image
-    output:
-        - text
 mode: chat
 model: ministral-14b-2512
 params:
-    - defaultValue: 256
-      key: max_tokens
-      maxValue: 256000
-      minValue: 1
+    - defaultValue: 0.3
+      key: temperature
 sources:
     - https://docs.mistral.ai/models/ministral-3-14b-25-12
 status: active

--- a/providers/mistral-ai/ministral-14b-latest.yaml
+++ b/providers/mistral-ai/ministral-14b-latest.yaml
@@ -4,20 +4,16 @@ costs:
       region: "*"
 features:
     - function_calling
-    - parallel_function_calling
-    - tool_choice
-    - structured_output
-    - json_output
 limits:
-    context_window: 256000
+    context_window: 262144
 modalities:
     input:
-        - text
         - image
-    output:
-        - text
 mode: chat
 model: ministral-14b-latest
+params:
+    - defaultValue: 0.3
+      key: temperature
 sources:
     - https://docs.mistral.ai/models/ministral-3-14b-25-12
     - https://docs.mistral.ai/capabilities/function_calling

--- a/providers/mistral-ai/ministral-3b-2512.yaml
+++ b/providers/mistral-ai/ministral-3b-2512.yaml
@@ -4,20 +4,16 @@ costs:
       region: "*"
 features:
     - function_calling
-    - structured_output
 limits:
-    context_window: 256000
-    max_output_tokens: 32768
-    max_tokens: 32768
+    context_window: 131072
 modalities:
     input:
-        - text
         - image
-        - pdf
-    output:
-        - text
 mode: chat
 model: ministral-3b-2512
+params:
+    - defaultValue: 0.3
+      key: temperature
 sources:
     - https://docs.mistral.ai/models/ministral-3-3b-25-12
     - https://docs.mistral.ai/capabilities/vision/

--- a/providers/mistral-ai/ministral-3b-latest.yaml
+++ b/providers/mistral-ai/ministral-3b-latest.yaml
@@ -4,17 +4,16 @@ costs:
       region: "*"
 features:
     - function_calling
-    - structured_output
 limits:
-    context_window: 256000
+    context_window: 131072
 modalities:
     input:
-        - text
         - image
-    output:
-        - text
 mode: chat
 model: ministral-3b-latest
+params:
+    - defaultValue: 0.3
+      key: temperature
 sources:
     - https://docs.mistral.ai/models/ministral-3-3b-25-12
 status: active

--- a/providers/mistral-ai/ministral-8b-2512.yaml
+++ b/providers/mistral-ai/ministral-8b-2512.yaml
@@ -4,27 +4,18 @@ costs:
       region: "*"
 features:
     - function_calling
-    - structured_output
-    - json_output
 limits:
-    context_window: 256000
-    max_input_tokens: 256000
-    max_output_tokens: 256000
-    max_tokens: 256000
+    context_window: 262144
 modalities:
     input:
-        - text
         - image
-    output:
-        - text
 mode: chat
 model: ministral-8b-2512
 params:
-    - defaultValue: 256
-      key: max_tokens
-      maxValue: 256000
-      minValue: 1
+    - defaultValue: 0.3
+      key: temperature
 sources:
     - https://docs.mistral.ai/models/ministral-3-8b-25-12
+status: active
 supportedModes:
     - chat

--- a/providers/mistral-ai/ministral-8b-latest.yaml
+++ b/providers/mistral-ai/ministral-8b-latest.yaml
@@ -4,21 +4,16 @@ costs:
       region: "*"
 features:
     - function_calling
-    - parallel_function_calling
-    - tool_choice
-    - structured_output
-    - assistant_prefill
-    - json_output
 limits:
-    context_window: 256000
+    context_window: 262144
 modalities:
     input:
-        - text
         - image
-    output:
-        - text
 mode: chat
 model: ministral-8b-latest
+params:
+    - defaultValue: 0.3
+      key: temperature
 sources:
     - https://docs.mistral.ai/models/ministral-3-8b-25-12
     - https://docs.mistral.ai/capabilities/vision

--- a/providers/mistral-ai/mistral-embed-2312.yaml
+++ b/providers/mistral-ai/mistral-embed-2312.yaml
@@ -4,7 +4,6 @@ costs:
 isDeprecated: true
 limits:
     context_window: 8192
-    max_input_tokens: 8192
-    max_tokens: 4096
-mode: embedding
+mode: unknown
 model: mistral-embed-2312
+status: active

--- a/providers/mistral-ai/mistral-embed.yaml
+++ b/providers/mistral-ai/mistral-embed.yaml
@@ -4,7 +4,6 @@ costs:
 isDeprecated: true
 limits:
     context_window: 8192
-    max_input_tokens: 8192
-    max_tokens: 4096
-mode: embedding
+mode: unknown
 model: mistral-embed
+status: active

--- a/providers/mistral-ai/mistral-large-2411.yaml
+++ b/providers/mistral-ai/mistral-large-2411.yaml
@@ -2,15 +2,17 @@ costs:
     - input_cost_per_token: 0.000002
       output_cost_per_token: 0.000006
       region: "*"
+deprecationDate: "2026-05-31"
 features:
     - function_calling
-    - tool_choice
-    - structured_output
-    - assistant_prefill
 isDeprecated: true
 limits:
-    max_input_tokens: 128000
-    max_output_tokens: 128000
-    max_tokens: 128000
+    context_window: 131072
 mode: chat
 model: mistral-large-2411
+params:
+    - defaultValue: 0.7
+      key: temperature
+status: active
+supportedModes:
+    - chat

--- a/providers/mistral-ai/mistral-large-2512.yaml
+++ b/providers/mistral-ai/mistral-large-2512.yaml
@@ -4,25 +4,21 @@ costs:
       region: "*"
 features:
     - function_calling
-    - parallel_function_calling
-    - tool_choice
-    - structured_output
-    - assistant_prefill
-    - json_output
 limits:
-    context_window: 256000
+    context_window: 262144
 modalities:
     input:
-        - text
         - image
-        - pdf
-    output:
-        - text
 mode: chat
 model: mistral-large-2512
+params:
+    - defaultValue: 0.3
+      key: temperature
 sources:
     - https://docs.mistral.ai/models/mistral-large-3-25-12
     - https://docs.mistral.ai/capabilities/vision
     - https://docs.mistral.ai/capabilities/function_calling
     - https://docs.mistral.ai/capabilities/structured_output
 status: active
+supportedModes:
+    - chat

--- a/providers/mistral-ai/mistral-large-latest.yaml
+++ b/providers/mistral-ai/mistral-large-latest.yaml
@@ -4,31 +4,19 @@ costs:
       region: "*"
 features:
     - function_calling
-    - structured_output
-    - json_output
-    - assistant_prefill
-    - tool_choice
 limits:
-    context_window: 256000
-    max_input_tokens: 256000
-    max_output_tokens: 256000
-    max_tokens: 256000
+    context_window: 262144
 modalities:
     input:
-        - text
         - image
-        - audio
-    output:
-        - text
 mode: chat
 model: mistral-large-latest
 params:
-    - defaultValue: 256000
-      key: max_tokens
-      maxValue: 256000
-      minValue: 1
+    - defaultValue: 0.3
+      key: temperature
 sources:
     - https://docs.mistral.ai/models/mistral-large-3-25-12
+status: active
 supportedModes:
     - chat
 thinking: true

--- a/providers/mistral-ai/mistral-large-pixtral-2411.yaml
+++ b/providers/mistral-ai/mistral-large-pixtral-2411.yaml
@@ -1,3 +1,17 @@
+deprecationDate: "2026-05-31"
+features:
+    - function_calling
 isDeprecated: true
-mode: unknown
+limits:
+    context_window: 131072
+modalities:
+    input:
+        - image
+mode: chat
 model: mistral-large-pixtral-2411
+params:
+    - defaultValue: 0.7
+      key: temperature
+status: active
+supportedModes:
+    - chat

--- a/providers/mistral-ai/mistral-medium-2505.yaml
+++ b/providers/mistral-ai/mistral-medium-2505.yaml
@@ -7,13 +7,14 @@ features:
 isDeprecated: true
 limits:
     context_window: 131072
-    max_input_tokens: 128000
-    max_output_tokens: 128000
-    max_tokens: 128000
 modalities:
     input:
         - image
 mode: chat
 model: mistral-medium-2505
+params:
+    - defaultValue: 0.3
+      key: temperature
+status: active
 supportedModes:
     - chat

--- a/providers/mistral-ai/mistral-medium-2508.yaml
+++ b/providers/mistral-ai/mistral-medium-2508.yaml
@@ -4,21 +4,16 @@ costs:
       region: "*"
 features:
     - function_calling
-    - parallel_function_calling
-    - structured_output
-    - json_output
 limits:
-    context_window: 128000
+    context_window: 131072
 modalities:
     input:
-        - text
         - image
-        - audio
-        - pdf
-    output:
-        - text
 mode: chat
 model: mistral-medium-2508
+params:
+    - defaultValue: 0.3
+      key: temperature
 sources:
     - https://docs.mistral.ai/models/mistral-medium-3-1-25-08
     - https://docs.mistral.ai/capabilities/function_calling

--- a/providers/mistral-ai/mistral-medium-latest.yaml
+++ b/providers/mistral-ai/mistral-medium-latest.yaml
@@ -4,24 +4,18 @@ costs:
       region: "*"
 features:
     - function_calling
-    - structured_output
-    - json_output
 limits:
-    context_window: 128000
-    max_output_tokens: 32768
-    max_tokens: 32768
+    context_window: 131072
 modalities:
     input:
-        - text
         - image
-        - audio
-        - pdf
-    output:
-        - text
-        - audio
 mode: chat
 model: mistral-medium-latest
+params:
+    - defaultValue: 0.3
+      key: temperature
 sources:
     - https://docs.mistral.ai/models/mistral-medium-3-1-25-08
+status: active
 supportedModes:
     - chat

--- a/providers/mistral-ai/mistral-medium.yaml
+++ b/providers/mistral-ai/mistral-medium.yaml
@@ -7,15 +7,14 @@ features:
 isDeprecated: true
 limits:
     context_window: 131072
-    max_input_tokens: 32000
-    max_output_tokens: 8191
 modalities:
     input:
         - image
 mode: chat
 model: mistral-medium
 params:
-    - key: max_tokens
-      maxValue: 32768
+    - defaultValue: 0.3
+      key: temperature
+status: active
 supportedModes:
     - chat

--- a/providers/mistral-ai/mistral-moderation-2411.yaml
+++ b/providers/mistral-ai/mistral-moderation-2411.yaml
@@ -2,17 +2,10 @@ costs:
     - input_cost_per_token: 1.e-7
       output_cost_per_token: 1.e-7
       region: "*"
-features:
-    - function_calling
-    - structured_output
+deprecationDate: "2026-06-30"
 limits:
-    context_window: 8000
-modalities:
-    input:
-        - text
-    output:
-        - text
-mode: chat
+    context_window: 8192
+mode: moderation
 model: mistral-moderation-2411
 sources:
     - https://docs.mistral.ai/models/mistral-moderation-24-11

--- a/providers/mistral-ai/mistral-moderation-latest.yaml
+++ b/providers/mistral-ai/mistral-moderation-latest.yaml
@@ -1,8 +1,6 @@
+deprecationDate: "2026-06-30"
 limits:
-    context_window: 128000
-modalities:
-    input:
-        - text
+    context_window: 8192
 mode: moderation
 model: mistral-moderation-latest
 removeParams:

--- a/providers/mistral-ai/mistral-ocr-2505.yaml
+++ b/providers/mistral-ai/mistral-ocr-2505.yaml
@@ -2,6 +2,19 @@ costs:
     - input_cost_per_annotated_page: 0.003
       input_cost_per_page: 0.001
       region: "*"
+deprecationDate: "2026-05-31"
+features:
+    - function_calling
 isDeprecated: true
-mode: chat
+limits:
+    context_window: 16384
+modalities:
+    input:
+        - image
+        - pdf
+mode: unknown
 model: mistral-ocr-2505
+params:
+    - defaultValue: 0
+      key: temperature
+status: active

--- a/providers/mistral-ai/mistral-ocr-2512.yaml
+++ b/providers/mistral-ai/mistral-ocr-2512.yaml
@@ -4,19 +4,17 @@ costs:
       region: "*"
 features:
     - function_calling
-    - structured_output
 limits:
     context_window: 16384
 modalities:
     input:
-        - text
         - image
         - pdf
-        - doc
-    output:
-        - text
-mode: chat
+mode: unknown
 model: mistral-ocr-2512
+params:
+    - defaultValue: 0
+      key: temperature
 sources:
     - https://docs.mistral.ai/models/ocr-3-25-12
     - https://docs.mistral.ai/capabilities/document_ai/basic_ocr

--- a/providers/mistral-ai/mistral-ocr-latest.yaml
+++ b/providers/mistral-ai/mistral-ocr-latest.yaml
@@ -4,20 +4,17 @@ costs:
       region: "*"
 features:
     - function_calling
-    - structured_output
 limits:
     context_window: 16384
 modalities:
     input:
-        - text
         - image
         - pdf
-        - doc
-    output:
-        - text
-        - image
-mode: chat
+mode: unknown
 model: mistral-ocr-latest
+params:
+    - defaultValue: 0
+      key: temperature
 sources:
     - https://docs.mistral.ai/models/ocr-3-25-12
     - https://docs.mistral.ai/capabilities/document_ai/basic_ocr

--- a/providers/mistral-ai/mistral-small-2506.yaml
+++ b/providers/mistral-ai/mistral-small-2506.yaml
@@ -4,23 +4,16 @@ costs:
       region: "*"
 features:
     - function_calling
-    - parallel_function_calling
-    - structured_output
-    - tool_choice
-    - assistant_prefill
-    - json_output
 limits:
-    context_window: 128000
+    context_window: 131072
 modalities:
     input:
-        - text
         - image
-    output:
-        - text
 mode: chat
 model: mistral-small-2506
 params:
-    - key: reasoning_effort
+    - defaultValue: 0.3
+      key: temperature
 sources:
     - https://docs.mistral.ai/models/mistral-small-3-2-25-06
     - https://docs.mistral.ai/capabilities/vision
@@ -28,4 +21,7 @@ sources:
     - https://docs.mistral.ai/capabilities/structured_output
     - https://docs.mistral.ai/capabilities/reasoning
     - https://docs.mistral.ai/capabilities/structured_output/json_mode
+status: active
+supportedModes:
+    - chat
 thinking: true

--- a/providers/mistral-ai/mistral-small-2603.yaml
+++ b/providers/mistral-ai/mistral-small-2603.yaml
@@ -4,23 +4,20 @@ costs:
       region: "*"
 features:
     - function_calling
-    - structured_output
 limits:
-    context_window: 256000
+    context_window: 262144
 modalities:
     input:
-        - text
         - image
-        - audio
-        - pdf
-    output:
-        - text
 mode: chat
 model: mistral-small-2603
 params:
-    - key: reasoning_effort
+    - defaultValue: 0.3
+      key: temperature
 sources:
     - https://docs.mistral.ai/models/mistral-small-4-0-26-03
     - https://docs.mistral.ai/capabilities/reasoning
 status: active
+supportedModes:
+    - chat
 thinking: true

--- a/providers/mistral-ai/mistral-small-latest.yaml
+++ b/providers/mistral-ai/mistral-small-latest.yaml
@@ -4,24 +4,16 @@ costs:
       region: "*"
 features:
     - function_calling
-    - parallel_function_calling
-    - structured_output
-    - tool_choice
-    - json_output
 limits:
-    context_window: 256000
+    context_window: 262144
 modalities:
     input:
-        - text
         - image
-        - audio
-    output:
-        - text
 mode: chat
 model: mistral-small-latest
 params:
-    - key: reasoning_effort
-      type: string
+    - defaultValue: 0.3
+      key: temperature
 sources:
     - https://docs.mistral.ai/models/mistral-small-4-0-26-03
     - https://docs.mistral.ai/capabilities/vision/

--- a/providers/mistral-ai/mistral-tiny-2407.yaml
+++ b/providers/mistral-ai/mistral-tiny-2407.yaml
@@ -3,7 +3,11 @@ features:
 isDeprecated: true
 limits:
     context_window: 131072
-mode: unknown
+mode: chat
 model: mistral-tiny-2407
+params:
+    - defaultValue: 0.3
+      key: temperature
+status: active
 supportedModes:
     - chat

--- a/providers/mistral-ai/mistral-tiny-latest.yaml
+++ b/providers/mistral-ai/mistral-tiny-latest.yaml
@@ -3,7 +3,11 @@ features:
 isDeprecated: true
 limits:
     context_window: 131072
-mode: unknown
+mode: chat
 model: mistral-tiny-latest
+params:
+    - defaultValue: 0.3
+      key: temperature
+status: active
 supportedModes:
     - chat

--- a/providers/mistral-ai/mistral-vibe-cli-fast.yaml
+++ b/providers/mistral-ai/mistral-vibe-cli-fast.yaml
@@ -4,12 +4,12 @@ limits:
     context_window: 262144
 modalities:
     input:
-        - text
         - image
-    output:
-        - text
 mode: chat
 model: mistral-vibe-cli-fast
+params:
+    - defaultValue: 0.3
+      key: temperature
 sources:
     - https://docs.mistral.ai/mistral-vibe/introduction
     - https://docs.mistral.ai/mistral-vibe/local

--- a/providers/mistral-ai/mistral-vibe-cli-latest.yaml
+++ b/providers/mistral-ai/mistral-vibe-cli-latest.yaml
@@ -4,6 +4,9 @@ limits:
     context_window: 262144
 mode: chat
 model: mistral-vibe-cli-latest
+params:
+    - defaultValue: 0.2
+      key: temperature
 sources:
     - https://docs.mistral.ai/mistral-vibe/introduction
 status: active

--- a/providers/mistral-ai/mistral-vibe-cli-with-tools.yaml
+++ b/providers/mistral-ai/mistral-vibe-cli-with-tools.yaml
@@ -4,20 +4,21 @@ costs:
       region: "*"
 features:
     - function_calling
-    - structured_output
 limits:
-    context_window: 256000
+    context_window: 131072
 modalities:
     input:
-        - text
         - image
-    output:
-        - text
 mode: chat
 model: mistral-vibe-cli-with-tools
+params:
+    - defaultValue: 0.3
+      key: temperature
 sources:
     - https://docs.mistral.ai/models/devstral-2-25-12
     - https://mistral.ai/news/devstral-2-vibe-cli
     - https://docs.mistral.ai/mistral-vibe/introduction
     - https://docs.mistral.ai/mistral-vibe/introduction/configuration
 status: active
+supportedModes:
+    - chat

--- a/providers/mistral-ai/open-mistral-nemo-2407.yaml
+++ b/providers/mistral-ai/open-mistral-nemo-2407.yaml
@@ -7,13 +7,14 @@ features:
 isDeprecated: true
 limits:
     context_window: 131072
-    max_input_tokens: 128000
-    max_output_tokens: 128000
-    max_tokens: 128000
 mode: chat
 model: open-mistral-nemo-2407
+params:
+    - defaultValue: 0.3
+      key: temperature
 sources:
     - https://docs.mistral.ai/models/mistral-nemo-12b-24-07
     - https://docs.mistral.ai/getting-started/models/models_overview/
+status: active
 supportedModes:
     - chat

--- a/providers/mistral-ai/open-mistral-nemo.yaml
+++ b/providers/mistral-ai/open-mistral-nemo.yaml
@@ -7,10 +7,11 @@ features:
 isDeprecated: true
 limits:
     context_window: 131072
-    max_input_tokens: 128000
-    max_output_tokens: 128000
-    max_tokens: 128000
 mode: chat
 model: open-mistral-nemo
+params:
+    - defaultValue: 0.3
+      key: temperature
+status: active
 supportedModes:
     - chat

--- a/providers/mistral-ai/pixtral-large-2411.yaml
+++ b/providers/mistral-ai/pixtral-large-2411.yaml
@@ -2,28 +2,21 @@ costs:
     - input_cost_per_token: 0.000002
       output_cost_per_token: 0.000006
       region: "*"
+deprecationDate: "2026-05-31"
 features:
     - function_calling
-    - tool_choice
-    - structured_output
-    - assistant_prefill
 limits:
-    context_window: 128000
-    max_input_tokens: 128000
-    max_output_tokens: 128000
-    max_tokens: 128000
+    context_window: 131072
 modalities:
     input:
-        - text
         - image
-    output:
-        - text
 mode: chat
 model: pixtral-large-2411
 params:
-    - defaultValue: 256
-      key: max_tokens
-      maxValue: 128000
-      minValue: 1
+    - defaultValue: 0.7
+      key: temperature
 sources:
     - https://docs.mistral.ai/models/pixtral-large-24-11
+status: active
+supportedModes:
+    - chat

--- a/providers/mistral-ai/pixtral-large-latest.yaml
+++ b/providers/mistral-ai/pixtral-large-latest.yaml
@@ -2,18 +2,20 @@ costs:
     - input_cost_per_token: 0.000002
       output_cost_per_token: 0.000006
       region: "*"
+deprecationDate: "2026-05-31"
 features:
     - function_calling
-    - tool_choice
-    - structured_output
-    - assistant_prefill
 isDeprecated: true
 limits:
-    max_input_tokens: 128000
-    max_output_tokens: 128000
-    max_tokens: 128000
+    context_window: 131072
 modalities:
     input:
         - image
 mode: chat
 model: pixtral-large-latest
+params:
+    - defaultValue: 0.7
+      key: temperature
+status: active
+supportedModes:
+    - chat

--- a/providers/mistral-ai/voxtral-mini-2507.yaml
+++ b/providers/mistral-ai/voxtral-mini-2507.yaml
@@ -3,25 +3,16 @@ costs:
       input_cost_per_token: 4.e-8
       output_cost_per_token: 4.e-8
       region: "*"
-features:
-    - function_calling
-    - structured_output
-    - assistant_prefill
-    - system_messages
-    - tool_choice
+deprecationDate: "2026-05-31"
 limits:
-    context_window: 32000
-modalities:
-    input:
-        - text
-        - audio
-        - image
-        - doc
-        - pdf
-    output:
-        - text
-mode: chat
+    context_window: 16384
+mode: audio_transcription
 model: voxtral-mini-2507
+params:
+    - defaultValue: 0
+      key: temperature
 sources:
     - https://docs.mistral.ai/models/voxtral-mini-25-07
 status: active
+supportedModes:
+    - audio_transcription

--- a/providers/mistral-ai/voxtral-mini-2602.yaml
+++ b/providers/mistral-ai/voxtral-mini-2602.yaml
@@ -1,17 +1,13 @@
 costs:
     - input_cost_per_second: 0.00005
       region: "*"
-features:
-    - function_calling
-    - structured_output
-modalities:
-    input:
-        - audio
-        - text
-    output:
-        - text
+limits:
+    context_window: 16384
 mode: audio_transcription
 model: voxtral-mini-2602
+params:
+    - defaultValue: 0
+      key: temperature
 sources:
     - https://docs.mistral.ai/models/voxtral-mini-transcribe-26-02
 status: active

--- a/providers/mistral-ai/voxtral-mini-latest.yaml
+++ b/providers/mistral-ai/voxtral-mini-latest.yaml
@@ -3,20 +3,15 @@ costs:
       input_cost_per_token: 4.e-8
       output_cost_per_token: 4.e-8
       region: "*"
-features:
-    - function_calling
-    - structured_output
 limits:
-    context_window: 32000
-modalities:
-    input:
-        - audio
-        - text
-    output:
-        - text
-mode: chat
+    context_window: 16384
+mode: audio_transcription
 model: voxtral-mini-latest
+params:
+    - defaultValue: 0
+      key: temperature
 sources:
     - https://docs.mistral.ai/models/voxtral-mini-25-07
+status: active
 supportedModes:
     - audio_transcription

--- a/providers/mistral-ai/voxtral-mini-realtime-2602.yaml
+++ b/providers/mistral-ai/voxtral-mini-realtime-2602.yaml
@@ -1,26 +1,16 @@
 costs:
     - input_cost_per_second: 0.0001
       region: "*"
-features:
-    - function_calling
-    - structured_output
-    - assistant_prefill
-    - tool_choice
-    - system_messages
 limits:
-    context_window: 16384
-modalities:
-    input:
-        - audio
-        - text
-    output:
-        - text
-mode: chat
+    context_window: 32768
+mode: realtime
 model: voxtral-mini-realtime-2602
+params:
+    - defaultValue: 0
+      key: temperature
 sources:
     - https://docs.mistral.ai/models/voxtral-mini-transcribe-realtime-26-02
     - https://docs.mistral.ai/capabilities/audio_transcription
 status: active
 supportedModes:
     - realtime
-    - chat

--- a/providers/mistral-ai/voxtral-mini-realtime-latest.yaml
+++ b/providers/mistral-ai/voxtral-mini-realtime-latest.yaml
@@ -1,20 +1,12 @@
 costs:
     - input_cost_per_second: 0.0001
       region: "*"
-features:
-    - function_calling
-    - structured_output
 limits:
-    context_window: 16384
-modalities:
-    input:
-        - audio
-    output:
-        - text
-mode: audio_transcription
+    context_window: 32768
+mode: realtime
 model: voxtral-mini-realtime-latest
 params:
-    - defaultValue: null
+    - defaultValue: 0
       key: temperature
 removeParams:
     - top_p
@@ -23,4 +15,3 @@ sources:
 status: active
 supportedModes:
     - realtime
-    - chat

--- a/providers/mistral-ai/voxtral-mini-transcribe-2507.yaml
+++ b/providers/mistral-ai/voxtral-mini-transcribe-2507.yaml
@@ -1,15 +1,14 @@
 costs:
     - input_cost_per_second: 0.0000333333
       region: "*"
+deprecationDate: "2026-05-31"
 limits:
-    context_window: 32000
-modalities:
-    input:
-        - audio
-    output:
-        - text
+    context_window: 16384
 mode: audio_transcription
 model: voxtral-mini-transcribe-2507
+params:
+    - defaultValue: 0
+      key: temperature
 removeParams:
     - max_tokens
     - top_p
@@ -18,3 +17,5 @@ removeParams:
 sources:
     - https://docs.mistral.ai/models/voxtral-mini-transcribe-25-07
 status: active
+supportedModes:
+    - audio_transcription

--- a/providers/mistral-ai/voxtral-mini-transcribe-realtime-2602.yaml
+++ b/providers/mistral-ai/voxtral-mini-transcribe-realtime-2602.yaml
@@ -1,21 +1,15 @@
 costs:
     - input_cost_per_second: 0.0001
       region: "*"
-features:
-    - function_calling
-    - structured_output
 limits:
-    context_window: 16384
-modalities:
-    input:
-        - audio
-    output:
-        - text
-mode: audio_transcription
+    context_window: 32768
+mode: realtime
 model: voxtral-mini-transcribe-realtime-2602
+params:
+    - defaultValue: 0
+      key: temperature
 sources:
     - https://docs.mistral.ai/models/voxtral-mini-transcribe-realtime-26-02
 status: active
 supportedModes:
     - realtime
-    - chat

--- a/providers/mistral-ai/voxtral-mini-tts-2603.yaml
+++ b/providers/mistral-ai/voxtral-mini-tts-2603.yaml
@@ -1,3 +1,5 @@
+features:
+    - function_calling
 limits:
     context_window: 4096
 modalities:
@@ -11,3 +13,5 @@ params:
     - defaultValue: 0.3
       key: temperature
 status: active
+supportedModes:
+    - text_to_speech

--- a/providers/mistral-ai/voxtral-mini-tts-latest.yaml
+++ b/providers/mistral-ai/voxtral-mini-tts-latest.yaml
@@ -1,3 +1,5 @@
+features:
+    - function_calling
 limits:
     context_window: 4096
 modalities:
@@ -11,3 +13,5 @@ params:
     - defaultValue: 0.3
       key: temperature
 status: active
+supportedModes:
+    - text_to_speech

--- a/providers/mistral-ai/voxtral-small-2507.yaml
+++ b/providers/mistral-ai/voxtral-small-2507.yaml
@@ -5,18 +5,16 @@ costs:
       region: "*"
 features:
     - function_calling
-    - structured_output
-    - assistant_prefill
 limits:
     context_window: 32768
 modalities:
     input:
-        - text
         - audio
-    output:
-        - text
 mode: chat
 model: voxtral-small-2507
+params:
+    - defaultValue: 0.2
+      key: temperature
 sources:
     - https://docs.mistral.ai/models/voxtral-small-25-07
 status: active

--- a/providers/mistral-ai/voxtral-small-latest.yaml
+++ b/providers/mistral-ai/voxtral-small-latest.yaml
@@ -5,19 +5,18 @@ costs:
       region: "*"
 features:
     - function_calling
-    - structured_output
-    - assistant_prefill
 limits:
     context_window: 32768
 modalities:
     input:
-        - text
         - audio
-    output:
-        - text
 mode: chat
 model: voxtral-small-latest
+params:
+    - defaultValue: 0.2
+      key: temperature
 sources:
     - https://docs.mistral.ai/models/voxtral-small-25-07
+status: active
 supportedModes:
     - chat


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `mistral-ai`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Data-only changes to provider model metadata; main risk is misconfigured `mode`/limits leading to incorrect routing or token limit enforcement for Mistral models.
> 
> **Overview**
> Refreshes `mistral-ai` model definitions by updating **modes and limits** (notably many `context_window` adjustments plus reclassifying several models to `completion`, `moderation`, `audio_transcription`, `realtime`, `text_to_speech`, or `unknown`).
> 
> Adds/standardizes **runtime metadata** across models (e.g., `params` with default `temperature`, `status: active`, `supportedModes`, and new `deprecationDate` entries) and trims some declared capabilities/fields (e.g., removing `structured_output` and detailed `modalities` blocks in several configs).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5f6e6fec016fd919d3d5a9e54e0b96f6f047e87. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->