### PR TITLE
feat(deepinfra): add new models [bot]

### DIFF
--- a/providers/deepinfra/ByteDance/Seed-2.0-pro.yaml
+++ b/providers/deepinfra/ByteDance/Seed-2.0-pro.yaml
@@ -1,0 +1,15 @@
+costs:
+    - cache_read_input_token_cost: 1.e-7
+      input_cost_per_token: 5.e-7
+      output_cost_per_token: 0.000003
+      region: "*"
+features:
+    - prompt_caching
+limits:
+    context_window: 256000
+    max_tokens: 256000
+modalities:
+    input:
+        - image
+mode: unknown
+model: ByteDance/Seed-2.0-pro

--- a/providers/deepinfra/Wan-AI/Wan2.7-Image-Edit.yaml
+++ b/providers/deepinfra/Wan-AI/Wan2.7-Image-Edit.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: Wan-AI/Wan2.7-Image-Edit


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `deepinfra`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new DeepInfra model metadata/config files only, without touching runtime logic. Main risk is incorrect model metadata (mode/costs/limits) affecting routing or billing behavior for these new models.
> 
> **Overview**
> Adds two new DeepInfra model definition YAMLs: `ByteDance/Seed-2.0-pro` (with token pricing, `prompt_caching`, 256k context/max tokens, and image input modality) and `Wan-AI/Wan2.7-Image-Edit` (basic model entry with `mode: unknown`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c5985cdf51c0ead4dec0206afe29349030d04fe0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->