### PR TITLE
feat(openrouter): add new models [bot]

### DIFF
--- a/providers/openrouter/arcee-ai/trinity-large-thinking.yaml
+++ b/providers/openrouter/arcee-ai/trinity-large-thinking.yaml
@@ -1,0 +1,20 @@
+costs:
+    - cache_read_input_token_cost: 6.e-8
+      input_cost_per_token: 2.5e-7
+      output_cost_per_token: 9.e-7
+      region: "*"
+limits:
+    context_window: 262144
+    max_output_tokens: 80000
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: chat
+model: arcee-ai/trinity-large-thinking
+params:
+    - defaultValue: 0.3
+      key: temperature
+    - defaultValue: 0.8
+      key: top_p

--- a/providers/openrouter/rekaai/reka-edge.yaml
+++ b/providers/openrouter/rekaai/reka-edge.yaml
@@ -1,0 +1,16 @@
+costs:
+    - input_cost_per_token: 1.e-7
+      output_cost_per_token: 1.e-7
+      region: "*"
+limits:
+    context_window: 16384
+    max_output_tokens: 16384
+modalities:
+    input:
+        - image
+        - text
+        - video
+    output:
+        - text
+mode: chat
+model: rekaai/reka-edge

--- a/providers/openrouter/z-ai/glm-5v-turbo.yaml
+++ b/providers/openrouter/z-ai/glm-5v-turbo.yaml
@@ -1,0 +1,22 @@
+costs:
+    - cache_read_input_token_cost: 2.4e-7
+      input_cost_per_token: 0.0000012
+      output_cost_per_token: 0.000004
+      region: "*"
+limits:
+    context_window: 202752
+    max_output_tokens: 131072
+modalities:
+    input:
+        - image
+        - text
+        - video
+    output:
+        - text
+mode: chat
+model: z-ai/glm-5v-turbo
+params:
+    - defaultValue: 1
+      key: temperature
+    - defaultValue: 0.95
+      key: top_p


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `openrouter`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adds three new OpenRouter model definition YAMLs (pricing/limits/modalities/default params) without touching runtime logic.
> 
> **Overview**
> Adds three new OpenRouter model configuration YAMLs: `arcee-ai/trinity-large-thinking`, `rekaai/reka-edge`, and `z-ai/glm-5v-turbo`.
> 
> Each file defines the model’s **token pricing**, **context/output limits**, and **supported modalities**; the Arcee and Z-AI entries also include default sampling params (`temperature`, `top_p`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da926d1e9cb357261fccb024ae253cdeee209f5a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->