### PR TITLE
[Community] Update model: anthropic/claude-4-opus-20250514

### DIFF
--- a/providers/anthropic/claude-4-opus-20250514.yaml
+++ b/providers/anthropic/claude-4-opus-20250514.yaml
@@ -1,41 +1,42 @@
-costs:
-    - cache_creation_input_token_cost: 0.00001875
-      cache_read_input_token_cost: 0.0000015
-      input_cost_per_token: 0.000015
-      input_cost_per_token_batches: 0.0000075
-      output_cost_per_token: 0.000075
-      output_cost_per_token_batches: 0.0000375
-      region: "*"
-features:
-    - function_calling
-    - parallel_function_calling
-    - tool_choice
-    - prompt_caching
-    - cache_control
-    - structured_output
-    - assistant_prefill
-    - system_messages
-limits:
-    context_window: 200000
-    max_input_tokens: 200000
-    max_output_tokens: 32000
-    max_tokens: 32000
-    tool_use_system_prompt_tokens: 346
-modalities:
-    input:
-        - text
-        - image
-        - pdf
-    output:
-        - text
-mode: chat
-model: claude-4-opus-20250514
-params:
-    - key: max_tokens
-      maxValue: 64000
-    - defaultValue: null
-      key: thinking
-removeParams:
-    - temperature
-    - top_p
-thinking: true
+{
+  "model": "claude-4-opus-20250514",
+  "mode": "chat",
+  "costs": [
+    {
+      "region": "*",
+      "input_cost_per_token": 0.000015,
+      "output_cost_per_token": 0.000075,
+      "cache_read_input_token_cost": 0.0000015,
+      "cache_creation_input_token_cost": 0.00001875,
+      "input_cost_per_token_batches": 0.0000075,
+      "output_cost_per_token_batches": 0.0000375
+    }
+  ],
+  "limits": {
+    "context_window": 200000,
+    "max_output_tokens": 32000
+  },
+  "features": [
+    "function_calling",
+    "parallel_function_calling",
+    "tool_choice",
+    "prompt_caching",
+    "cache_control",
+    "structured_output",
+    "assistant_prefill",
+    "system_messages",
+    "code_execution"
+  ],
+  "modalities": {
+    "input": [
+      "text",
+      "image",
+      "pdf"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "thinking": false,
+  "sources": []
+}


### PR DESCRIPTION
This PR updates the model `anthropic/claude-4-opus-20250514` in the catalog.

Submitted via the TrueFoundry Model Catalog UI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk catalog metadata update that may slightly change client behavior via updated feature flags and token limit fields, but does not touch runtime code paths.
> 
> **Overview**
> Updates the `providers/anthropic/claude-4-opus-20250514.yaml` model catalog entry by rewriting it from the prior YAML schema to a JSON-formatted document and adjusting the exposed metadata.
> 
> The entry now **adds `code_execution`** to `features`, **sets `thinking` to `false`**, trims limits down to `context_window` and `max_output_tokens` (removing several max token fields), and drops the old `params`/`removeParams` blocks while introducing an empty `sources` list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 813716a760ed8aeacda05fded2addc95d686f36c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->