### PR TITLE
[Community] Update model: ai21/jamba-large-1.7

### DIFF
--- a/providers/ai21/jamba-large-1.7.yaml
+++ b/providers/ai21/jamba-large-1.7.yaml
@@ -7,11 +7,10 @@ features:
     - tool_choice
     - structured_output
     - json_output
+    - prompt_caching
 limits:
     context_window: 256000
-    max_input_tokens: 256000
     max_output_tokens: 4096
-    max_tokens: 4096
 modalities:
     input:
         - text
@@ -29,12 +28,12 @@ params:
       maxValue: 2
       minValue: 0
     - defaultValue: 1
-      key: "n"
+      key: n
       maxValue: 16
       minValue: 1
 removeParams:
     - top_k
 sources:
-    - https://docs.ai21.com/docs/function-calling
-    - https://docs.ai21.com/reference/jamba-1-6-api-ref
+    - "https://docs.ai21.com/docs/function-calling"
+    - "https://docs.ai21.com/reference/jamba-1-6-api-ref"
 status: active


### PR DESCRIPTION
This PR updates the model `ai21/jamba-large-1.7` in the catalog.

Submitted via the TrueFoundry Model Catalog UI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Catalog-only metadata updates (features/limits/params formatting) with no runtime logic changes; risk is limited to potential mismatches in declared capabilities or token limits for this model.
> 
> **Overview**
> Updates the `ai21/jamba-large-1.7` model catalog YAML by **adding `prompt_caching` support**, **simplifying token limit fields** (removing `max_input_tokens`/`max_tokens` entries), and normalizing metadata formatting (unquoted `n` param key and `sources` list structure/quoting).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c2c234672d32f7a7a1c23086d2c27ddc9298c1bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->