### PR TITLE
[Community] Update model: ai21/jamba-large-1.7

### DIFF
--- a/providers/ai21/jamba-large-1.7.yaml
+++ b/providers/ai21/jamba-large-1.7.yaml
@@ -7,11 +7,10 @@ features:
     - tool_choice
     - structured_output
     - json_output
+    - prompt_caching
 limits:
     context_window: 256000
-    max_input_tokens: 256000
     max_output_tokens: 4096
-    max_tokens: 4096
 modalities:
     input:
         - text
@@ -29,7 +28,7 @@ params:
       maxValue: 2
       minValue: 0
     - defaultValue: 1
-      key: "n"
+      key: n
       maxValue: 16
       minValue: 1
 removeParams:


### PR DESCRIPTION
This PR updates the model `ai21/jamba-large-1.7` in the catalog.

Submitted via the TrueFoundry Model Catalog UI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk metadata-only update to the model catalog; the main impact is how clients interpret supported features/limits for `ai21/jamba-large-1.7`.
> 
> **Overview**
> Updates the `ai21/jamba-large-1.7` model catalog entry by **adding `prompt_caching`** to supported features.
> 
> Cleans up the declared limits/params by removing redundant `max_input_tokens`/`max_tokens` from `limits` and normalizing the `params` key from `"n"` to `n`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03179d0971ba143c833bb621ddfc0a1115d842d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->