### PR TITLE
chore(openrouter): deprecate stale models [bot]

### DIFF
--- a/providers/openrouter/aion-1.0-mini.yaml
+++ b/providers/openrouter/aion-1.0-mini.yaml
@@ -1,24 +1,25 @@
 costs:
-    - input_cost_per_token: 7.e-7
-      output_cost_per_token: 0.0000014
-      region: "*"
+- input_cost_per_token: 7.0e-07
+  output_cost_per_token: 1.4e-06
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
+- function_calling
+- tool_choice
 limits:
-    context_window: 131072
-    max_output_tokens: 32768
-    max_tokens: 32768
+  context_window: 131072
+  max_output_tokens: 32768
+  max_tokens: 32768
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: aion-1.0-mini
 params:
-    - key: max_tokens
-      maxValue: 32768
+- key: max_tokens
+  maxValue: 32768
 sources:
-    - https://openrouter.ai/aion-labs/aion-1.0-mini/api
+- https://openrouter.ai/aion-labs/aion-1.0-mini/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/aion-1.0.yaml
+++ b/providers/openrouter/aion-1.0.yaml
@@ -1,24 +1,25 @@
 costs:
-    - input_cost_per_token: 0.000004
-      output_cost_per_token: 0.000008
-      region: "*"
+- input_cost_per_token: 4.0e-06
+  output_cost_per_token: 8.0e-06
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
+- function_calling
+- tool_choice
 limits:
-    context_window: 131072
-    max_output_tokens: 32768
-    max_tokens: 32768
+  context_window: 131072
+  max_output_tokens: 32768
+  max_tokens: 32768
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: aion-1.0
 params:
-    - key: max_tokens
-      maxValue: 32768
+- key: max_tokens
+  maxValue: 32768
 sources:
-    - https://openrouter.ai/aion-labs/aion-1.0/api
+- https://openrouter.ai/aion-labs/aion-1.0/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/aion-rp-llama-3.1-8b.yaml
+++ b/providers/openrouter/aion-rp-llama-3.1-8b.yaml
@@ -1,23 +1,24 @@
 costs:
-    - input_cost_per_token: 8.e-7
-      output_cost_per_token: 0.0000016
-      region: "*"
+- input_cost_per_token: 8.0e-07
+  output_cost_per_token: 1.6e-06
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
+- function_calling
+- tool_choice
 limits:
-    context_window: 32768
-    max_output_tokens: 32768
-    max_tokens: 32768
+  context_window: 32768
+  max_output_tokens: 32768
+  max_tokens: 32768
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: aion-rp-llama-3.1-8b
 params:
-    - key: max_tokens
-      maxValue: 32768
+- key: max_tokens
+  maxValue: 32768
 sources:
-    - https://openrouter.ai/aion-labs/aion-rp-llama-3.1-8b/api
+- https://openrouter.ai/aion-labs/aion-rp-llama-3.1-8b/api
+status: deprecated

--- a/providers/openrouter/allenai/olmo-3.1-32b-think.yaml
+++ b/providers/openrouter/allenai/olmo-3.1-32b-think.yaml
@@ -1,22 +1,23 @@
 costs:
-    - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 5.e-7
-      region: "*"
-deprecationDate: "2026-04-06"
+- input_cost_per_token: 1.5e-07
+  output_cost_per_token: 5.0e-07
+  region: '*'
+deprecationDate: '2026-04-06'
 features:
-    - structured_output
-    - json_output
+- structured_output
+- json_output
 limits:
-    context_window: 65536
-    max_output_tokens: 65536
-    max_tokens: 65536
+  context_window: 65536
+  max_output_tokens: 65536
+  max_tokens: 65536
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: allenai/olmo-3.1-32b-think
 sources:
-    - https://openrouter.ai/allenai/olmo-3.1-32b-think/api
+- https://openrouter.ai/allenai/olmo-3.1-32b-think/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/anthropic/claude-2.yaml
+++ b/providers/openrouter/anthropic/claude-2.yaml
@@ -1,21 +1,22 @@
 costs:
-    - input_cost_per_token: 0.00001102
-      output_cost_per_token: 0.00003268
-      region: "*"
+- input_cost_per_token: 1.102e-05
+  output_cost_per_token: 3.268e-05
+  region: '*'
 features:
-    - system_messages
-    - function_calling
-    - tool_choice
+- system_messages
+- function_calling
+- tool_choice
 limits:
-    context_window: 200000
-    max_output_tokens: 8191
-    max_tokens: 8191
+  context_window: 200000
+  max_output_tokens: 8191
+  max_tokens: 8191
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: anthropic/claude-2
 sources:
-    - https://openrouter.ai/anthropic/claude-2/api
+- https://openrouter.ai/anthropic/claude-2/api
+status: deprecated

--- a/providers/openrouter/anthropic/claude-3-5-haiku-20241022.yaml
+++ b/providers/openrouter/anthropic/claude-3-5-haiku-20241022.yaml
@@ -1,30 +1,31 @@
 costs:
-    - cache_creation_input_token_cost: 0.000001
-      cache_read_input_token_cost: 8.e-8
-      input_cost_per_token: 8.e-7
-      output_cost_per_token: 0.000004
-      region: "*"
+- cache_creation_input_token_cost: 1.0e-06
+  cache_read_input_token_cost: 8.0e-08
+  input_cost_per_token: 8.0e-07
+  output_cost_per_token: 4.0e-06
+  region: '*'
 features:
-    - function_calling
-    - prompt_caching
+- function_calling
+- prompt_caching
 limits:
-    context_window: 200000
-    max_input_tokens: 200000
-    max_output_tokens: 8192
-    max_tokens: 8192
-    tool_use_system_prompt_tokens: 264
+  context_window: 200000
+  max_input_tokens: 200000
+  max_output_tokens: 8192
+  max_tokens: 8192
+  tool_use_system_prompt_tokens: 264
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: anthropic/claude-3-5-haiku-20241022
 params:
-    - key: max_tokens
-      maxValue: 8192
+- key: max_tokens
+  maxValue: 8192
 sources:
-    - https://openrouter.ai/anthropic/claude-3-5-haiku-20241022/api
-    - https://platform.claude.com/docs/en/docs/about-claude/models
-    - https://platform.claude.com/docs/en/about-claude/pricing
+- https://openrouter.ai/anthropic/claude-3-5-haiku-20241022/api
+- https://platform.claude.com/docs/en/docs/about-claude/models
+- https://platform.claude.com/docs/en/about-claude/pricing
+status: deprecated

--- a/providers/openrouter/anthropic/claude-3-5-haiku.yaml
+++ b/providers/openrouter/anthropic/claude-3-5-haiku.yaml
@@ -1,24 +1,25 @@
 costs:
-    - cache_creation_input_token_cost: 0.000001
-      cache_read_input_token_cost: 8.e-8
-      input_cost_per_token: 8.e-7
-      output_cost_per_token: 0.000004
-      region: "*"
+- cache_creation_input_token_cost: 1.0e-06
+  cache_read_input_token_cost: 8.0e-08
+  input_cost_per_token: 8.0e-07
+  output_cost_per_token: 4.0e-06
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - prompt_caching
+- function_calling
+- tool_choice
+- prompt_caching
 limits:
-    context_window: 200000
-    max_output_tokens: 8192
-    max_tokens: 8192
+  context_window: 200000
+  max_output_tokens: 8192
+  max_tokens: 8192
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: anthropic/claude-3-5-haiku
 sources:
-    - https://openrouter.ai/anthropic/claude-3-5-haiku/api
+- https://openrouter.ai/anthropic/claude-3-5-haiku/api
+status: deprecated

--- a/providers/openrouter/anthropic/claude-3-haiku-20240307.yaml
+++ b/providers/openrouter/anthropic/claude-3-haiku-20240307.yaml
@@ -1,17 +1,18 @@
 costs:
-    - input_cost_per_token: 2.5e-7
-      output_cost_per_token: 0.00000125
-      region: "*"
+- input_cost_per_token: 2.5e-07
+  output_cost_per_token: 1.25e-06
+  region: '*'
 features:
-    - function_calling
+- function_calling
 isDeprecated: true
 limits:
-    max_input_tokens: 200000
-    max_output_tokens: 4096
-    max_tokens: 4096
-    tool_use_system_prompt_tokens: 264
+  max_input_tokens: 200000
+  max_output_tokens: 4096
+  max_tokens: 4096
+  tool_use_system_prompt_tokens: 264
 modalities:
-    input:
-        - image
+  input:
+  - image
 mode: chat
 model: anthropic/claude-3-haiku-20240307
+status: deprecated

--- a/providers/openrouter/anthropic/claude-3-opus.yaml
+++ b/providers/openrouter/anthropic/claude-3-opus.yaml
@@ -1,17 +1,18 @@
 costs:
-    - input_cost_per_token: 0.000015
-      output_cost_per_token: 0.000075
-      region: "*"
+- input_cost_per_token: 1.5e-05
+  output_cost_per_token: 7.5e-05
+  region: '*'
 features:
-    - function_calling
+- function_calling
 isDeprecated: true
 limits:
-    max_input_tokens: 200000
-    max_output_tokens: 4096
-    max_tokens: 4096
-    tool_use_system_prompt_tokens: 395
+  max_input_tokens: 200000
+  max_output_tokens: 4096
+  max_tokens: 4096
+  tool_use_system_prompt_tokens: 395
 modalities:
-    input:
-        - image
+  input:
+  - image
 mode: chat
 model: anthropic/claude-3-opus
+status: deprecated

--- a/providers/openrouter/anthropic/claude-3-sonnet.yaml
+++ b/providers/openrouter/anthropic/claude-3-sonnet.yaml
@@ -1,19 +1,20 @@
 costs:
-    - input_cost_per_image: 0.0048
-      input_cost_per_token: 0.000003
-      output_cost_per_token: 0.000015
-      region: "*"
-deprecationDate: "2025-07-21"
+- input_cost_per_image: 0.0048
+  input_cost_per_token: 3.0e-06
+  output_cost_per_token: 1.5e-05
+  region: '*'
+deprecationDate: '2025-07-21'
 features:
-    - function_calling
+- function_calling
 isDeprecated: true
 limits:
-    context_window: 200000
+  context_window: 200000
 modalities:
-    input:
-        - image
+  input:
+  - image
 mode: chat
 model: anthropic/claude-3-sonnet
 sources:
-    - https://openrouter.ai/anthropic/claude-3-sonnet/api
-    - https://platform.claude.com/docs/en/docs/about-claude/models
+- https://openrouter.ai/anthropic/claude-3-sonnet/api
+- https://platform.claude.com/docs/en/docs/about-claude/models
+status: deprecated

--- a/providers/openrouter/anthropic/claude-3.5-sonnet:beta.yaml
+++ b/providers/openrouter/anthropic/claude-3.5-sonnet:beta.yaml
@@ -1,26 +1,27 @@
 costs:
-    - cache_creation_input_token_cost: 0.0000075
-      cache_read_input_token_cost: 6.e-7
-      input_cost_per_token: 0.000006
-      output_cost_per_token: 0.00003
-      region: "*"
+- cache_creation_input_token_cost: 7.5e-06
+  cache_read_input_token_cost: 6.0e-07
+  input_cost_per_token: 6.0e-06
+  output_cost_per_token: 3.0e-05
+  region: '*'
 features:
-    - function_calling
-    - prompt_caching
-    - tool_choice
+- function_calling
+- prompt_caching
+- tool_choice
 limits:
-    context_window: 200000
-    max_input_tokens: 200000
-    max_output_tokens: 8192
-    max_tokens: 8192
+  context_window: 200000
+  max_input_tokens: 200000
+  max_output_tokens: 8192
+  max_tokens: 8192
 modalities:
-    input:
-        - text
-        - image
-        - pdf
-    output:
-        - text
+  input:
+  - text
+  - image
+  - pdf
+  output:
+  - text
 mode: chat
 model: anthropic/claude-3.5-sonnet:beta
 sources:
-    - https://openrouter.ai/anthropic/claude-3.5-sonnet:beta/api
+- https://openrouter.ai/anthropic/claude-3.5-sonnet:beta/api
+status: deprecated

--- a/providers/openrouter/anthropic/claude-3.7-sonnet.yaml
+++ b/providers/openrouter/anthropic/claude-3.7-sonnet.yaml
@@ -1,35 +1,36 @@
 costs:
-    - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
-      input_cost_per_token: 0.000003
-      output_cost_per_token: 0.000015
-      region: "*"
-deprecationDate: "2026-05-05"
+- cache_creation_input_token_cost: 3.75e-06
+  cache_read_input_token_cost: 3.0e-07
+  input_cost_per_token: 3.0e-06
+  output_cost_per_token: 1.5e-05
+  region: '*'
+deprecationDate: '2026-05-05'
 features:
-    - function_calling
-    - tool_choice
-    - assistant_prefill
-    - prompt_caching
-    - structured_output
+- function_calling
+- tool_choice
+- assistant_prefill
+- prompt_caching
+- structured_output
 limits:
-    context_window: 200000
-    max_input_tokens: 200000
-    max_output_tokens: 64000
-    max_tokens: 64000
+  context_window: 200000
+  max_input_tokens: 200000
+  max_output_tokens: 64000
+  max_tokens: 64000
 modalities:
-    input:
-        - text
-        - image
-        - pdf
-    output:
-        - text
+  input:
+  - text
+  - image
+  - pdf
+  output:
+  - text
 mode: chat
 model: anthropic/claude-3.7-sonnet
 params:
-    - defaultValue: 128
-      key: max_tokens
-      maxValue: 64000
-      minValue: 1
+- defaultValue: 128
+  key: max_tokens
+  maxValue: 64000
+  minValue: 1
 sources:
-    - https://openrouter.ai/anthropic/claude-3.7-sonnet/api
+- https://openrouter.ai/anthropic/claude-3.7-sonnet/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/anthropic/claude-3.7-sonnet:beta.yaml
+++ b/providers/openrouter/anthropic/claude-3.7-sonnet:beta.yaml
@@ -1,18 +1,19 @@
 costs:
-    - input_cost_per_image: 0.0048
-      input_cost_per_token: 0.000003
-      output_cost_per_token: 0.000015
-      region: "*"
+- input_cost_per_image: 0.0048
+  input_cost_per_token: 3.0e-06
+  output_cost_per_token: 1.5e-05
+  region: '*'
 features:
-    - function_calling
+- function_calling
 isDeprecated: true
 limits:
-    max_input_tokens: 200000
-    max_output_tokens: 128000
-    max_tokens: 128000
-    tool_use_system_prompt_tokens: 159
+  max_input_tokens: 200000
+  max_output_tokens: 128000
+  max_tokens: 128000
+  tool_use_system_prompt_tokens: 159
 modalities:
-    input:
-        - image
+  input:
+  - image
 mode: chat
 model: anthropic/claude-3.7-sonnet:beta
+status: deprecated

--- a/providers/openrouter/anthropic/claude-instant-v1.yaml
+++ b/providers/openrouter/anthropic/claude-instant-v1.yaml
@@ -1,10 +1,11 @@
 costs:
-    - input_cost_per_token: 0.00000163
-      output_cost_per_token: 0.00000551
-      region: "*"
+- input_cost_per_token: 1.63e-06
+  output_cost_per_token: 5.51e-06
+  region: '*'
 isDeprecated: true
 limits:
-    max_output_tokens: 8191
-    max_tokens: 8191
+  max_output_tokens: 8191
+  max_tokens: 8191
 mode: chat
 model: anthropic/claude-instant-v1
+status: deprecated

--- a/providers/openrouter/anubis-70b-v1.1.yaml
+++ b/providers/openrouter/anubis-70b-v1.1.yaml
@@ -1,12 +1,13 @@
 limits:
-    max_output_tokens: 4096
-    max_tokens: 4096
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: anubis-70b-v1.1
 sources:
-    - https://openrouter.ai/anubis-70b-v1.1/api
+- https://openrouter.ai/anubis-70b-v1.1/api
+status: deprecated

--- a/providers/openrouter/anubis-pro-105b-v1.yaml
+++ b/providers/openrouter/anubis-pro-105b-v1.yaml
@@ -1,12 +1,13 @@
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: anubis-pro-105b-v1
 params:
-    - key: max_tokens
-      maxValue: 131072
+- key: max_tokens
+  maxValue: 131072
 sources:
-    - https://openrouter.ai/anubis-pro-105b-v1/api
+- https://openrouter.ai/anubis-pro-105b-v1/api
+status: deprecated

--- a/providers/openrouter/arcee-ai/trinity-large-preview:free.yaml
+++ b/providers/openrouter/arcee-ai/trinity-large-preview:free.yaml
@@ -1,23 +1,23 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
-deprecationDate: "2026-03-31"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
+deprecationDate: '2026-03-31'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
-    - system_messages
+- function_calling
+- tool_choice
+- structured_output
+- system_messages
 limits:
-    context_window: 131000
+  context_window: 131000
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: arcee-ai/trinity-large-preview:free
 sources:
-    - https://openrouter.ai/arcee-ai/trinity-large-preview:free/api
-    - https://openrouter.ai/arcee-ai/trinity-large-preview/api
-status: preview
+- https://openrouter.ai/arcee-ai/trinity-large-preview:free/api
+- https://openrouter.ai/arcee-ai/trinity-large-preview/api
+status: deprecated

--- a/providers/openrouter/auto.yaml
+++ b/providers/openrouter/auto.yaml
@@ -1,10 +1,11 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 limits:
-    context_window: 2000000
+  context_window: 2000000
 mode: chat
 model: auto
 sources:
-    - https://openrouter.ai/openrouter/auto/api
+- https://openrouter.ai/openrouter/auto/api
+status: deprecated

--- a/providers/openrouter/chatgpt-4o-latest.yaml
+++ b/providers/openrouter/chatgpt-4o-latest.yaml
@@ -1,9 +1,10 @@
 isDeprecated: true
 modalities:
-    input:
-        - image
+  input:
+  - image
 mode: chat
 model: chatgpt-4o-latest
 params:
-    - key: max_tokens
-      maxValue: 16384
+- key: max_tokens
+  maxValue: 16384
+status: deprecated

--- a/providers/openrouter/claude-3-haiku.yaml
+++ b/providers/openrouter/claude-3-haiku.yaml
@@ -1,24 +1,25 @@
 costs:
-    - cache_creation_input_token_cost: 3.e-7
-      cache_read_input_token_cost: 3.e-8
-      input_cost_per_token: 2.5e-7
-      output_cost_per_token: 0.00000125
-      region: "*"
+- cache_creation_input_token_cost: 3.0e-07
+  cache_read_input_token_cost: 3.0e-08
+  input_cost_per_token: 2.5e-07
+  output_cost_per_token: 1.25e-06
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - prompt_caching
+- function_calling
+- tool_choice
+- prompt_caching
 limits:
-    context_window: 200000
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 200000
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: claude-3-haiku
 sources:
-    - https://openrouter.ai/anthropic/claude-3-haiku/api
+- https://openrouter.ai/anthropic/claude-3-haiku/api
+status: deprecated

--- a/providers/openrouter/claude-3-haiku:beta.yaml
+++ b/providers/openrouter/claude-3-haiku:beta.yaml
@@ -1,30 +1,31 @@
 costs:
-    - cache_creation_input_token_cost: 3.e-7
-      cache_read_input_token_cost: 3.e-8
-      input_cost_per_token: 2.5e-7
-      output_cost_per_token: 0.00000125
-      region: "*"
+- cache_creation_input_token_cost: 3.0e-07
+  cache_read_input_token_cost: 3.0e-08
+  input_cost_per_token: 2.5e-07
+  output_cost_per_token: 1.25e-06
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - system_messages
-    - prompt_caching
-    - cache_control
-    - assistant_prefill
+- function_calling
+- tool_choice
+- system_messages
+- prompt_caching
+- cache_control
+- assistant_prefill
 limits:
-    context_window: 200000
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 200000
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: claude-3-haiku:beta
 params:
-    - key: max_tokens
-      maxValue: 4096
+- key: max_tokens
+  maxValue: 4096
 sources:
-    - https://openrouter.ai/anthropic/claude-3-haiku:beta/api
+- https://openrouter.ai/anthropic/claude-3-haiku:beta/api
+status: deprecated

--- a/providers/openrouter/claude-3-opus.yaml
+++ b/providers/openrouter/claude-3-opus.yaml
@@ -1,11 +1,12 @@
 features:
-    - function_calling
+- function_calling
 isDeprecated: true
 modalities:
-    input:
-        - image
+  input:
+  - image
 mode: chat
 model: claude-3-opus
 params:
-    - key: max_tokens
-      maxValue: 4096
+- key: max_tokens
+  maxValue: 4096
+status: deprecated

--- a/providers/openrouter/claude-3-opus:beta.yaml
+++ b/providers/openrouter/claude-3-opus:beta.yaml
@@ -1,24 +1,25 @@
 costs:
-    - cache_creation_input_token_cost: 0.00001875
-      cache_read_input_token_cost: 0.0000015
-      input_cost_per_token: 0.000015
-      output_cost_per_token: 0.000075
-      region: "*"
-deprecationDate: "2026-01-05"
+- cache_creation_input_token_cost: 1.875e-05
+  cache_read_input_token_cost: 1.5e-06
+  input_cost_per_token: 1.5e-05
+  output_cost_per_token: 7.5e-05
+  region: '*'
+deprecationDate: '2026-01-05'
 features:
-    - function_calling
-    - tool_choice
-    - system_messages
-    - prompt_caching
+- function_calling
+- tool_choice
+- system_messages
+- prompt_caching
 isDeprecated: true
 limits:
-    context_window: 200000
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 200000
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - image
+  input:
+  - image
 mode: chat
 model: claude-3-opus:beta
 sources:
-    - https://openrouter.ai/anthropic/claude-3-opus:beta/api
+- https://openrouter.ai/anthropic/claude-3-opus:beta/api
+status: deprecated

--- a/providers/openrouter/claude-3-sonnet.yaml
+++ b/providers/openrouter/claude-3-sonnet.yaml
@@ -1,24 +1,25 @@
 costs:
-    - input_cost_per_token: 0.000003
-      output_cost_per_token: 0.000015
-      region: "*"
+- input_cost_per_token: 3.0e-06
+  output_cost_per_token: 1.5e-05
+  region: '*'
 features:
-    - function_calling
-    - system_messages
+- function_calling
+- system_messages
 limits:
-    context_window: 200000
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 200000
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: claude-3-sonnet
 params:
-    - key: max_tokens
-      maxValue: 4096
+- key: max_tokens
+  maxValue: 4096
 sources:
-    - https://openrouter.ai/anthropic/claude-3-sonnet/api
+- https://openrouter.ai/anthropic/claude-3-sonnet/api
+status: deprecated

--- a/providers/openrouter/claude-3.5-haiku-20241022.yaml
+++ b/providers/openrouter/claude-3.5-haiku-20241022.yaml
@@ -1,30 +1,31 @@
 costs:
-    - cache_creation_input_token_cost: 0.000001
-      cache_read_input_token_cost: 8.e-8
-      input_cost_per_token: 8.e-7
-      output_cost_per_token: 0.000004
-      region: "*"
+- cache_creation_input_token_cost: 1.0e-06
+  cache_read_input_token_cost: 8.0e-08
+  input_cost_per_token: 8.0e-07
+  output_cost_per_token: 4.0e-06
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - prompt_caching
-    - system_messages
+- function_calling
+- tool_choice
+- prompt_caching
+- system_messages
 limits:
-    context_window: 200000
-    max_output_tokens: 8192
-    max_tokens: 8192
+  context_window: 200000
+  max_output_tokens: 8192
+  max_tokens: 8192
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: claude-3.5-haiku-20241022
 params:
-    - key: max_tokens
-      maxValue: 8192
-    - key: top_k
+- key: max_tokens
+  maxValue: 8192
+- key: top_k
 sources:
-    - https://openrouter.ai/anthropic/claude-3.5-haiku
-    - https://openrouter.ai/anthropic/claude-3.5-haiku/api
+- https://openrouter.ai/anthropic/claude-3.5-haiku
+- https://openrouter.ai/anthropic/claude-3.5-haiku/api
+status: deprecated

--- a/providers/openrouter/claude-3.5-haiku.yaml
+++ b/providers/openrouter/claude-3.5-haiku.yaml
@@ -1,27 +1,28 @@
 costs:
-    - cache_creation_input_token_cost: 0.000001
-      cache_read_input_token_cost: 8.e-8
-      input_cost_per_token: 8.e-7
-      output_cost_per_token: 0.000004
-      region: "*"
+- cache_creation_input_token_cost: 1.0e-06
+  cache_read_input_token_cost: 8.0e-08
+  input_cost_per_token: 8.0e-07
+  output_cost_per_token: 4.0e-06
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - prompt_caching
+- function_calling
+- tool_choice
+- prompt_caching
 limits:
-    context_window: 200000
-    max_output_tokens: 8192
-    max_tokens: 8192
+  context_window: 200000
+  max_output_tokens: 8192
+  max_tokens: 8192
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: claude-3.5-haiku
 params:
-    - key: max_tokens
-      maxValue: 8192
+- key: max_tokens
+  maxValue: 8192
 sources:
-    - https://openrouter.ai/anthropic/claude-3.5-haiku/api
+- https://openrouter.ai/anthropic/claude-3.5-haiku/api
+status: deprecated

--- a/providers/openrouter/claude-3.5-haiku:beta.yaml
+++ b/providers/openrouter/claude-3.5-haiku:beta.yaml
@@ -1,28 +1,29 @@
 costs:
-    - cache_creation_input_token_cost: 0.000001
-      cache_read_input_token_cost: 8.e-8
-      input_cost_per_token: 8.e-7
-      output_cost_per_token: 0.000004
-      region: "*"
+- cache_creation_input_token_cost: 1.0e-06
+  cache_read_input_token_cost: 8.0e-08
+  input_cost_per_token: 8.0e-07
+  output_cost_per_token: 4.0e-06
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - prompt_caching
-    - system_messages
+- function_calling
+- tool_choice
+- prompt_caching
+- system_messages
 limits:
-    context_window: 200000
-    max_output_tokens: 8192
-    max_tokens: 8192
+  context_window: 200000
+  max_output_tokens: 8192
+  max_tokens: 8192
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: claude-3.5-haiku:beta
 params:
-    - key: max_tokens
-      maxValue: 8192
+- key: max_tokens
+  maxValue: 8192
 sources:
-    - https://openrouter.ai/anthropic/claude-3.5-haiku:beta/api
+- https://openrouter.ai/anthropic/claude-3.5-haiku:beta/api
+status: deprecated

--- a/providers/openrouter/claude-3.5-sonnet-20240620.yaml
+++ b/providers/openrouter/claude-3.5-sonnet-20240620.yaml
@@ -1,23 +1,24 @@
 features:
-    - function_calling
-    - tool_choice
-    - system_messages
-    - prompt_caching
-    - assistant_prefill
+- function_calling
+- tool_choice
+- system_messages
+- prompt_caching
+- assistant_prefill
 limits:
-    context_window: 200000
-    max_output_tokens: 8192
-    max_tokens: 8192
+  context_window: 200000
+  max_output_tokens: 8192
+  max_tokens: 8192
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: claude-3.5-sonnet-20240620
 params:
-    - key: max_tokens
-      maxValue: 8192
+- key: max_tokens
+  maxValue: 8192
 sources:
-    - https://openrouter.ai/anthropic/claude-3.5-sonnet-20240620/api
+- https://openrouter.ai/anthropic/claude-3.5-sonnet-20240620/api
+status: deprecated

--- a/providers/openrouter/claude-3.5-sonnet-20240620:beta.yaml
+++ b/providers/openrouter/claude-3.5-sonnet-20240620:beta.yaml
@@ -1,11 +1,12 @@
 features:
-    - function_calling
+- function_calling
 isDeprecated: true
 modalities:
-    input:
-        - image
+  input:
+  - image
 mode: chat
 model: claude-3.5-sonnet-20240620:beta
 params:
-    - key: max_tokens
-      maxValue: 8192
+- key: max_tokens
+  maxValue: 8192
+status: deprecated

--- a/providers/openrouter/claude-3.5-sonnet.yaml
+++ b/providers/openrouter/claude-3.5-sonnet.yaml
@@ -1,27 +1,28 @@
 costs:
-    - cache_creation_input_token_cost: 0.0000075
-      cache_read_input_token_cost: 6.e-7
-      input_cost_per_token: 0.000006
-      output_cost_per_token: 0.00003
-      region: "*"
+- cache_creation_input_token_cost: 7.5e-06
+  cache_read_input_token_cost: 6.0e-07
+  input_cost_per_token: 6.0e-06
+  output_cost_per_token: 3.0e-05
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - prompt_caching
+- function_calling
+- tool_choice
+- prompt_caching
 limits:
-    context_window: 200000
-    max_output_tokens: 8192
-    max_tokens: 8192
+  context_window: 200000
+  max_output_tokens: 8192
+  max_tokens: 8192
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: claude-3.5-sonnet
 params:
-    - key: max_tokens
-      maxValue: 8192
+- key: max_tokens
+  maxValue: 8192
 sources:
-    - https://openrouter.ai/anthropic/claude-3.5-sonnet/api
+- https://openrouter.ai/anthropic/claude-3.5-sonnet/api
+status: deprecated

--- a/providers/openrouter/claude-3.5-sonnet:beta.yaml
+++ b/providers/openrouter/claude-3.5-sonnet:beta.yaml
@@ -1,27 +1,28 @@
 costs:
-    - cache_creation_input_token_cost: 0.0000075
-      cache_read_input_token_cost: 6.e-7
-      input_cost_per_token: 0.000006
-      output_cost_per_token: 0.00003
-      region: "*"
+- cache_creation_input_token_cost: 7.5e-06
+  cache_read_input_token_cost: 6.0e-07
+  input_cost_per_token: 6.0e-06
+  output_cost_per_token: 3.0e-05
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - prompt_caching
+- function_calling
+- tool_choice
+- prompt_caching
 limits:
-    context_window: 200000
-    max_output_tokens: 8192
-    max_tokens: 8192
+  context_window: 200000
+  max_output_tokens: 8192
+  max_tokens: 8192
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: claude-3.5-sonnet:beta
 params:
-    - key: max_tokens
-      maxValue: 8192
+- key: max_tokens
+  maxValue: 8192
 sources:
-    - https://openrouter.ai/anthropic/claude-3.5-sonnet:beta/api
+- https://openrouter.ai/anthropic/claude-3.5-sonnet:beta/api
+status: deprecated

--- a/providers/openrouter/claude-3.7-sonnet.yaml
+++ b/providers/openrouter/claude-3.7-sonnet.yaml
@@ -1,11 +1,12 @@
 features:
-    - function_calling
+- function_calling
 isDeprecated: true
 modalities:
-    input:
-        - image
+  input:
+  - image
 mode: chat
 model: claude-3.7-sonnet
 params:
-    - key: max_tokens
-      maxValue: 64000
+- key: max_tokens
+  maxValue: 64000
+status: deprecated

--- a/providers/openrouter/claude-3.7-sonnet:beta.yaml
+++ b/providers/openrouter/claude-3.7-sonnet:beta.yaml
@@ -1,30 +1,31 @@
 costs:
-    - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
-      input_cost_per_token: 0.000003
-      output_cost_per_token: 0.000015
-      region: "*"
-deprecationDate: "2026-05-05"
+- cache_creation_input_token_cost: 3.75e-06
+  cache_read_input_token_cost: 3.0e-07
+  input_cost_per_token: 3.0e-06
+  output_cost_per_token: 1.5e-05
+  region: '*'
+deprecationDate: '2026-05-05'
 features:
-    - function_calling
-    - prompt_caching
-    - tool_choice
+- function_calling
+- prompt_caching
+- tool_choice
 limits:
-    context_window: 200000
-    max_output_tokens: 64000
-    max_tokens: 64000
+  context_window: 200000
+  max_output_tokens: 64000
+  max_tokens: 64000
 modalities:
-    input:
-        - text
-        - image
-        - pdf
-    output:
-        - text
+  input:
+  - text
+  - image
+  - pdf
+  output:
+  - text
 mode: chat
 model: claude-3.7-sonnet:beta
 params:
-    - key: max_tokens
-      maxValue: 128000
+- key: max_tokens
+  maxValue: 128000
 sources:
-    - https://openrouter.ai/anthropic/claude-3.7-sonnet:beta/api
+- https://openrouter.ai/anthropic/claude-3.7-sonnet:beta/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/claude-3.7-sonnet:thinking.yaml
+++ b/providers/openrouter/claude-3.7-sonnet:thinking.yaml
@@ -1,30 +1,31 @@
 costs:
-    - cache_creation_input_token_cost: 0.000006
-      cache_read_input_token_cost: 3.e-7
-      input_cost_per_token: 0.000003
-      output_cost_per_token: 0.000015
-      region: "*"
-deprecationDate: "2026-05-05"
+- cache_creation_input_token_cost: 6.0e-06
+  cache_read_input_token_cost: 3.0e-07
+  input_cost_per_token: 3.0e-06
+  output_cost_per_token: 1.5e-05
+  region: '*'
+deprecationDate: '2026-05-05'
 features:
-    - function_calling
-    - tool_choice
-    - prompt_caching
-    - structured_output
+- function_calling
+- tool_choice
+- prompt_caching
+- structured_output
 limits:
-    context_window: 200000
-    max_output_tokens: 64000
-    max_tokens: 64000
+  context_window: 200000
+  max_output_tokens: 64000
+  max_tokens: 64000
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: claude-3.7-sonnet:thinking
 params:
-    - key: max_tokens
-      maxValue: 64000
+- key: max_tokens
+  maxValue: 64000
 sources:
-    - https://openrouter.ai/anthropic/claude-3.7-sonnet:thinking/api
+- https://openrouter.ai/anthropic/claude-3.7-sonnet:thinking/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/claude-opus-4.yaml
+++ b/providers/openrouter/claude-opus-4.yaml
@@ -1,30 +1,31 @@
 costs:
-    - cache_creation_input_token_cost: 0.00001875
-      cache_read_input_token_cost: 0.0000015
-      input_cost_per_token: 0.000015
-      output_cost_per_token: 0.000075
-      region: "*"
+- cache_creation_input_token_cost: 1.875e-05
+  cache_read_input_token_cost: 1.5e-06
+  input_cost_per_token: 1.5e-05
+  output_cost_per_token: 7.5e-05
+  region: '*'
 features:
-    - function_calling
-    - system_messages
-    - prompt_caching
-    - cache_control
-    - tool_choice
+- function_calling
+- system_messages
+- prompt_caching
+- cache_control
+- tool_choice
 limits:
-    context_window: 200000
-    max_output_tokens: 32000
-    max_tokens: 32000
+  context_window: 200000
+  max_output_tokens: 32000
+  max_tokens: 32000
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: claude-opus-4
 params:
-    - key: max_tokens
-      maxValue: 32000
+- key: max_tokens
+  maxValue: 32000
 sources:
-    - https://openrouter.ai/anthropic/claude-opus-4/api
+- https://openrouter.ai/anthropic/claude-opus-4/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/claude-sonnet-4.yaml
+++ b/providers/openrouter/claude-sonnet-4.yaml
@@ -1,46 +1,46 @@
 costs:
-    - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
-      input_cost_per_token: 0.000003
-      output_cost_per_token: 0.000015
-      region: "*"
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 6.e-7
-                from: 200000
-          cache_write:
-              - cost_per_token: 0.0000075
-                from: 200000
-          input:
-              - cost_per_token: 0.000006
-                from: 200000
-          output:
-              - cost_per_token: 0.0000225
-                from: 200000
-features:
-    - function_calling
-    - tool_choice
-    - system_messages
-    - prompt_caching
-    - cache_control
-    - assistant_prefill
-limits:
-    context_window: 200000
-    max_output_tokens: 64000
-    max_tokens: 64000
-modalities:
+- cache_creation_input_token_cost: 3.75e-06
+  cache_read_input_token_cost: 3.0e-07
+  input_cost_per_token: 3.0e-06
+  output_cost_per_token: 1.5e-05
+  region: '*'
+  tiered_pricing:
+    cache_read:
+    - cost_per_token: 6.0e-07
+      from: 200000
+    cache_write:
+    - cost_per_token: 7.5e-06
+      from: 200000
     input:
-        - text
-        - image
-        - pdf
+    - cost_per_token: 6.0e-06
+      from: 200000
     output:
-        - text
+    - cost_per_token: 2.25e-05
+      from: 200000
+features:
+- function_calling
+- tool_choice
+- system_messages
+- prompt_caching
+- cache_control
+- assistant_prefill
+limits:
+  context_window: 200000
+  max_output_tokens: 64000
+  max_tokens: 64000
+modalities:
+  input:
+  - text
+  - image
+  - pdf
+  output:
+  - text
 mode: chat
 model: claude-sonnet-4
 params:
-    - key: max_tokens
-      maxValue: 64000
+- key: max_tokens
+  maxValue: 64000
 sources:
-    - https://openrouter.ai/anthropic/claude-sonnet-4/api
-status: active
+- https://openrouter.ai/anthropic/claude-sonnet-4/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/codellama-7b-instruct-solidity.yaml
+++ b/providers/openrouter/codellama-7b-instruct-solidity.yaml
@@ -2,5 +2,6 @@ isDeprecated: true
 mode: chat
 model: codellama-7b-instruct-solidity
 params:
-    - key: max_tokens
-      maxValue: 4096
+- key: max_tokens
+  maxValue: 4096
+status: deprecated

--- a/providers/openrouter/coder-large.yaml
+++ b/providers/openrouter/coder-large.yaml
@@ -1,8 +1,9 @@
 limits:
-    max_output_tokens: 4096
-    max_tokens: 4096
+  max_output_tokens: 4096
+  max_tokens: 4096
 mode: chat
 model: coder-large
 sources:
-    - https://openrouter.ai/coder-large/api
-    - https://openrouter.ai/api/v1/models
+- https://openrouter.ai/coder-large/api
+- https://openrouter.ai/api/v1/models
+status: deprecated

--- a/providers/openrouter/codestral-2501.yaml
+++ b/providers/openrouter/codestral-2501.yaml
@@ -1,7 +1,8 @@
 features:
-    - function_calling
+- function_calling
 isDeprecated: true
 limits:
-    max_tokens: 4096
+  max_tokens: 4096
 mode: chat
 model: codestral-2501
+status: deprecated

--- a/providers/openrouter/codex-mini.yaml
+++ b/providers/openrouter/codex-mini.yaml
@@ -1,23 +1,24 @@
-deprecationDate: "2026-02-12"
+deprecationDate: '2026-02-12'
 features:
-    - function_calling
+- function_calling
 isDeprecated: true
 limits:
-    context_window: 200000
-    max_output_tokens: 100000
-    max_tokens: 100000
+  context_window: 200000
+  max_output_tokens: 100000
+  max_tokens: 100000
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: codex-mini
 params:
-    - key: max_tokens
-      maxValue: 100000
+- key: max_tokens
+  maxValue: 100000
 sources:
-    - https://openrouter.ai/openai/codex-mini/api
-    - https://developers.openai.com/docs/deprecations
+- https://openrouter.ai/openai/codex-mini/api
+- https://developers.openai.com/docs/deprecations
 thinking: true
+status: deprecated

--- a/providers/openrouter/cognitivecomputations/dolphin-mixtral-8x7b.yaml
+++ b/providers/openrouter/cognitivecomputations/dolphin-mixtral-8x7b.yaml
@@ -1,17 +1,18 @@
 costs:
-    - input_cost_per_token: 5.e-7
-      output_cost_per_token: 5.e-7
-      region: "*"
+- input_cost_per_token: 5.0e-07
+  output_cost_per_token: 5.0e-07
+  region: '*'
 limits:
-    context_window: 32768
-    max_output_tokens: 32768
-    max_tokens: 32768
+  context_window: 32768
+  max_output_tokens: 32768
+  max_tokens: 32768
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: cognitivecomputations/dolphin-mixtral-8x7b
 sources:
-    - https://openrouter.ai/cognitivecomputations/dolphin-mixtral-8x7b/api
+- https://openrouter.ai/cognitivecomputations/dolphin-mixtral-8x7b/api
+status: deprecated

--- a/providers/openrouter/cohere/command-r-plus.yaml
+++ b/providers/openrouter/cohere/command-r-plus.yaml
@@ -1,26 +1,27 @@
 costs:
-    - input_cost_per_token: 0.000003
-      output_cost_per_token: 0.000015
-      region: "*"
+- input_cost_per_token: 3.0e-06
+  output_cost_per_token: 1.5e-05
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - system_messages
-    - structured_output
+- function_calling
+- tool_choice
+- system_messages
+- structured_output
 limits:
-    context_window: 128000
-    max_output_tokens: 4000
-    max_tokens: 4000
+  context_window: 128000
+  max_output_tokens: 4000
+  max_tokens: 4000
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: cohere/command-r-plus
 params:
-    - key: max_tokens
-      maxValue: 4000
+- key: max_tokens
+  maxValue: 4000
 sources:
-    - https://openrouter.ai/cohere/command-r-plus/api
-    - https://docs.cohere.com/docs/command-r-plus
+- https://openrouter.ai/cohere/command-r-plus/api
+- https://docs.cohere.com/docs/command-r-plus
+status: deprecated

--- a/providers/openrouter/command-a.yaml
+++ b/providers/openrouter/command-a.yaml
@@ -1,28 +1,29 @@
 costs:
-    - input_cost_per_token: 0.0000025
-      output_cost_per_token: 0.00001
-      region: "*"
+- input_cost_per_token: 2.5e-06
+  output_cost_per_token: 1.0e-05
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
-    - json_output
+- function_calling
+- tool_choice
+- structured_output
+- json_output
 limits:
-    context_window: 256000
-    max_output_tokens: 8192
-    max_tokens: 8192
+  context_window: 256000
+  max_output_tokens: 8192
+  max_tokens: 8192
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: command-a
 params:
-    - defaultValue: 128
-      key: max_tokens
-      maxValue: 8192
-      minValue: 1
+- defaultValue: 128
+  key: max_tokens
+  maxValue: 8192
+  minValue: 1
 sources:
-    - https://openrouter.ai/cohere/command-a/api
-    - https://docs.cohere.com/docs/command-a
+- https://openrouter.ai/cohere/command-a/api
+- https://docs.cohere.com/docs/command-a
+status: deprecated

--- a/providers/openrouter/command-r-03-2024.yaml
+++ b/providers/openrouter/command-r-03-2024.yaml
@@ -1,25 +1,25 @@
 costs:
-    - input_cost_per_token: 5.e-7
-      output_cost_per_token: 0.0000015
-      region: "*"
+- input_cost_per_token: 5.0e-07
+  output_cost_per_token: 1.5e-06
+  region: '*'
 features:
-    - function_calling
+- function_calling
 limits:
-    context_window: 128000
-    max_output_tokens: 4000
-    max_tokens: 4000
+  context_window: 128000
+  max_output_tokens: 4000
+  max_tokens: 4000
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: command-r-03-2024
 params:
-    - key: max_tokens
-      maxValue: 4000
+- key: max_tokens
+  maxValue: 4000
 sources:
-    - https://openrouter.ai/cohere/command-r-03-2024/api
-    - https://docs.cohere.com/docs/command-r
-    - https://cohere.com/pricing
-status: active
+- https://openrouter.ai/cohere/command-r-03-2024/api
+- https://docs.cohere.com/docs/command-r
+- https://cohere.com/pricing
+status: deprecated

--- a/providers/openrouter/command-r-08-2024.yaml
+++ b/providers/openrouter/command-r-08-2024.yaml
@@ -1,26 +1,26 @@
 costs:
-    - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
-      region: "*"
+- input_cost_per_token: 1.5e-07
+  output_cost_per_token: 6.0e-07
+  region: '*'
 features:
-    - function_calling
-    - system_messages
-    - structured_output
+- function_calling
+- system_messages
+- structured_output
 limits:
-    context_window: 128000
-    max_output_tokens: 4000
-    max_tokens: 4000
+  context_window: 128000
+  max_output_tokens: 4000
+  max_tokens: 4000
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: command-r-08-2024
 params:
-    - key: max_tokens
-      maxValue: 4000
+- key: max_tokens
+  maxValue: 4000
 sources:
-    - https://openrouter.ai/cohere/command-r-08-2024/api
-    - https://docs.cohere.com/docs/command-r
-status: active
+- https://openrouter.ai/cohere/command-r-08-2024/api
+- https://docs.cohere.com/docs/command-r
+status: deprecated

--- a/providers/openrouter/command-r-plus-04-2024.yaml
+++ b/providers/openrouter/command-r-plus-04-2024.yaml
@@ -1,26 +1,27 @@
 costs:
-    - input_cost_per_token: 0.000003
-      output_cost_per_token: 0.000015
-      region: "*"
+- input_cost_per_token: 3.0e-06
+  output_cost_per_token: 1.5e-05
+  region: '*'
 features:
-    - function_calling
-    - system_messages
-    - structured_output
+- function_calling
+- system_messages
+- structured_output
 limits:
-    context_window: 128000
-    max_output_tokens: 4000
-    max_tokens: 4000
+  context_window: 128000
+  max_output_tokens: 4000
+  max_tokens: 4000
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: command-r-plus-04-2024
 params:
-    - key: max_tokens
-      maxValue: 4000
+- key: max_tokens
+  maxValue: 4000
 sources:
-    - https://openrouter.ai/cohere/command-r-plus-04-2024/api
-    - https://docs.cohere.com/docs/command-r-plus
-    - https://cohere.com/pricing
+- https://openrouter.ai/cohere/command-r-plus-04-2024/api
+- https://docs.cohere.com/docs/command-r-plus
+- https://cohere.com/pricing
+status: deprecated

--- a/providers/openrouter/command-r-plus-08-2024.yaml
+++ b/providers/openrouter/command-r-plus-08-2024.yaml
@@ -1,25 +1,26 @@
 costs:
-    - input_cost_per_token: 0.0000025
-      output_cost_per_token: 0.00001
-      region: "*"
+- input_cost_per_token: 2.5e-06
+  output_cost_per_token: 1.0e-05
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
+- function_calling
+- tool_choice
+- structured_output
 limits:
-    context_window: 128000
-    max_output_tokens: 4000
-    max_tokens: 4000
+  context_window: 128000
+  max_output_tokens: 4000
+  max_tokens: 4000
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: command-r-plus-08-2024
 params:
-    - key: max_tokens
-      maxValue: 4000
+- key: max_tokens
+  maxValue: 4000
 sources:
-    - https://openrouter.ai/cohere/command-r-plus-08-2024/api
-    - https://docs.cohere.com/docs/command-r-plus
+- https://openrouter.ai/cohere/command-r-plus-08-2024/api
+- https://docs.cohere.com/docs/command-r-plus
+status: deprecated

--- a/providers/openrouter/command-r-plus.yaml
+++ b/providers/openrouter/command-r-plus.yaml
@@ -1,26 +1,27 @@
 costs:
-    - input_cost_per_token: 0.0000025
-      output_cost_per_token: 0.00001
-      region: "*"
+- input_cost_per_token: 2.5e-06
+  output_cost_per_token: 1.0e-05
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
-    - system_messages
+- function_calling
+- tool_choice
+- structured_output
+- system_messages
 limits:
-    context_window: 128000
-    max_output_tokens: 4000
-    max_tokens: 4000
+  context_window: 128000
+  max_output_tokens: 4000
+  max_tokens: 4000
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: command-r-plus
 params:
-    - key: max_tokens
-      maxValue: 4000
+- key: max_tokens
+  maxValue: 4000
 sources:
-    - https://openrouter.ai/cohere/command-r-plus/api
-    - https://docs.cohere.com/docs/command-r-plus
+- https://openrouter.ai/cohere/command-r-plus/api
+- https://docs.cohere.com/docs/command-r-plus
+status: deprecated

--- a/providers/openrouter/command-r.yaml
+++ b/providers/openrouter/command-r.yaml
@@ -1,19 +1,20 @@
 features:
-    - function_calling
-    - system_messages
+- function_calling
+- system_messages
 limits:
-    context_window: 128000
-    max_output_tokens: 4000
-    max_tokens: 4000
+  context_window: 128000
+  max_output_tokens: 4000
+  max_tokens: 4000
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: command-r
 params:
-    - key: max_tokens
-      maxValue: 4000
+- key: max_tokens
+  maxValue: 4000
 sources:
-    - https://openrouter.ai/cohere/command-r/api
+- https://openrouter.ai/cohere/command-r/api
+status: deprecated

--- a/providers/openrouter/command-r7b-12-2024.yaml
+++ b/providers/openrouter/command-r7b-12-2024.yaml
@@ -1,25 +1,26 @@
 costs:
-    - input_cost_per_token: 3.75e-8
-      output_cost_per_token: 1.5e-7
-      region: "*"
+- input_cost_per_token: 3.75e-08
+  output_cost_per_token: 1.5e-07
+  region: '*'
 features:
-    - function_calling
-    - json_output
-    - structured_output
-    - tool_choice
+- function_calling
+- json_output
+- structured_output
+- tool_choice
 limits:
-    context_window: 128000
-    max_output_tokens: 4000
-    max_tokens: 4000
+  context_window: 128000
+  max_output_tokens: 4000
+  max_tokens: 4000
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: command-r7b-12-2024
 params:
-    - key: max_tokens
-      maxValue: 4000
+- key: max_tokens
+  maxValue: 4000
 sources:
-    - https://openrouter.ai/cohere/command-r7b-12-2024/api
+- https://openrouter.ai/cohere/command-r7b-12-2024/api
+status: deprecated

--- a/providers/openrouter/command.yaml
+++ b/providers/openrouter/command.yaml
@@ -1,14 +1,15 @@
-deprecationDate: "2025-09-15"
+deprecationDate: '2025-09-15'
 isDeprecated: true
 limits:
-    context_window: 4096
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 4096
+  max_output_tokens: 4096
+  max_tokens: 4096
 mode: chat
 model: command
 params:
-    - key: max_tokens
-      maxValue: 4000
+- key: max_tokens
+  maxValue: 4000
 sources:
-    - https://openrouter.ai/cohere/command/api
-    - https://docs.cohere.com/docs/models
+- https://openrouter.ai/cohere/command/api
+- https://docs.cohere.com/docs/models
+status: deprecated

--- a/providers/openrouter/databricks/dbrx-instruct.yaml
+++ b/providers/openrouter/databricks/dbrx-instruct.yaml
@@ -1,17 +1,18 @@
 costs:
-    - input_cost_per_token: 6.e-7
-      output_cost_per_token: 6.e-7
-      region: "*"
+- input_cost_per_token: 6.0e-07
+  output_cost_per_token: 6.0e-07
+  region: '*'
 limits:
-    context_window: 32768
-    max_output_tokens: 32768
-    max_tokens: 32768
+  context_window: 32768
+  max_output_tokens: 32768
+  max_tokens: 32768
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: databricks/dbrx-instruct
 sources:
-    - https://openrouter.ai/databricks/dbrx-instruct/api
+- https://openrouter.ai/databricks/dbrx-instruct/api
+status: deprecated

--- a/providers/openrouter/deepseek-chat-v3-0324.yaml
+++ b/providers/openrouter/deepseek-chat-v3-0324.yaml
@@ -1,22 +1,23 @@
 costs:
-    - cache_read_input_token_cost: 1.35e-7
-      input_cost_per_token: 2.e-7
-      output_cost_per_token: 7.7e-7
-      region: "*"
+- cache_read_input_token_cost: 1.35e-07
+  input_cost_per_token: 2.0e-07
+  output_cost_per_token: 7.7e-07
+  region: '*'
 features:
-    - function_calling
-    - structured_output
+- function_calling
+- structured_output
 limits:
-    context_window: 163840
+  context_window: 163840
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: deepseek-chat-v3-0324
 params:
-    - key: max_tokens
-      maxValue: 163840
+- key: max_tokens
+  maxValue: 163840
 sources:
-    - https://openrouter.ai/deepseek/deepseek-chat-v3-0324/api
+- https://openrouter.ai/deepseek/deepseek-chat-v3-0324/api
+status: deprecated

--- a/providers/openrouter/deepseek-chat-v3-0324:free.yaml
+++ b/providers/openrouter/deepseek-chat-v3-0324:free.yaml
@@ -1,23 +1,24 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
+- function_calling
+- tool_choice
 limits:
-    context_window: 131072
-    max_output_tokens: 16384
-    max_tokens: 16384
+  context_window: 131072
+  max_output_tokens: 16384
+  max_tokens: 16384
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: deepseek-chat-v3-0324:free
 params:
-    - key: max_tokens
-      maxValue: 16384
+- key: max_tokens
+  maxValue: 16384
 sources:
-    - https://openrouter.ai/deepseek/deepseek-chat-v3-0324:free
+- https://openrouter.ai/deepseek/deepseek-chat-v3-0324:free
+status: deprecated

--- a/providers/openrouter/deepseek-chat.yaml
+++ b/providers/openrouter/deepseek-chat.yaml
@@ -1,19 +1,20 @@
 costs:
-    - input_cost_per_token: 3.2e-7
-      output_cost_per_token: 8.9e-7
-      region: "*"
+- input_cost_per_token: 3.2e-07
+  output_cost_per_token: 8.9e-07
+  region: '*'
 features:
-    - function_calling
+- function_calling
 limits:
-    context_window: 163840
-    max_output_tokens: 163840
-    max_tokens: 163840
+  context_window: 163840
+  max_output_tokens: 163840
+  max_tokens: 163840
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: deepseek-chat
 sources:
-    - https://openrouter.ai/deepseek/deepseek-chat/api
+- https://openrouter.ai/deepseek/deepseek-chat/api
+status: deprecated

--- a/providers/openrouter/deepseek-prover-v2.yaml
+++ b/providers/openrouter/deepseek-prover-v2.yaml
@@ -1,11 +1,12 @@
 limits:
-    context_window: 163840
+  context_window: 163840
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: deepseek-prover-v2
 sources:
-    - https://openrouter.ai/deepseek/deepseek-prover-v2/api
+- https://openrouter.ai/deepseek/deepseek-prover-v2/api
+status: deprecated

--- a/providers/openrouter/deepseek-r1-0528-qwen3-8b.yaml
+++ b/providers/openrouter/deepseek-r1-0528-qwen3-8b.yaml
@@ -1,12 +1,13 @@
 limits:
-    context_window: 131072
+  context_window: 131072
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: deepseek-r1-0528-qwen3-8b
 sources:
-    - https://openrouter.ai/deepseek/deepseek-r1-0528-qwen3-8b/api
+- https://openrouter.ai/deepseek/deepseek-r1-0528-qwen3-8b/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/deepseek-r1-0528-qwen3-8b:free.yaml
+++ b/providers/openrouter/deepseek-r1-0528-qwen3-8b:free.yaml
@@ -1,20 +1,20 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 limits:
-    context_window: 131072
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 131072
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: deepseek-r1-0528-qwen3-8b:free
 sources:
-    - https://openrouter.ai/deepseek/deepseek-r1-0528-qwen3-8b:free
-    - https://openrouter.ai/deepseek/deepseek-r1-0528-qwen3-8b:free/api
-status: active
+- https://openrouter.ai/deepseek/deepseek-r1-0528-qwen3-8b:free
+- https://openrouter.ai/deepseek/deepseek-r1-0528-qwen3-8b:free/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/deepseek-r1-0528.yaml
+++ b/providers/openrouter/deepseek-r1-0528.yaml
@@ -1,25 +1,26 @@
 costs:
-    - cache_read_input_token_cost: 2.25e-7
-      input_cost_per_token: 4.5e-7
-      output_cost_per_token: 0.00000215
-      region: "*"
+- cache_read_input_token_cost: 2.25e-07
+  input_cost_per_token: 4.5e-07
+  output_cost_per_token: 2.15e-06
+  region: '*'
 features:
-    - function_calling
-    - structured_output
+- function_calling
+- structured_output
 limits:
-    context_window: 163840
-    max_output_tokens: 65536
-    max_tokens: 65536
+  context_window: 163840
+  max_output_tokens: 65536
+  max_tokens: 65536
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: deepseek-r1-0528
 params:
-    - key: max_tokens
-      maxValue: 65536
+- key: max_tokens
+  maxValue: 65536
 sources:
-    - https://openrouter.ai/deepseek/deepseek-r1-0528/api
+- https://openrouter.ai/deepseek/deepseek-r1-0528/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/deepseek-r1-0528:free.yaml
+++ b/providers/openrouter/deepseek-r1-0528:free.yaml
@@ -1,24 +1,25 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
+- function_calling
+- tool_choice
+- structured_output
 limits:
-    context_window: 163840
-    max_input_tokens: 163840
-    max_output_tokens: 65536
-    max_tokens: 65536
+  context_window: 163840
+  max_input_tokens: 163840
+  max_output_tokens: 65536
+  max_tokens: 65536
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: deepseek-r1-0528:free
 sources:
-    - https://openrouter.ai/deepseek/deepseek-r1-0528:free/api
-    - https://openrouter.ai/deepseek/deepseek-r1-0528:free
+- https://openrouter.ai/deepseek/deepseek-r1-0528:free/api
+- https://openrouter.ai/deepseek/deepseek-r1-0528:free
 thinking: true
+status: deprecated

--- a/providers/openrouter/deepseek-r1-distill-llama-70b.yaml
+++ b/providers/openrouter/deepseek-r1-distill-llama-70b.yaml
@@ -1,22 +1,23 @@
 costs:
-    - input_cost_per_token: 7.e-7
-      output_cost_per_token: 8.e-7
-      region: "*"
+- input_cost_per_token: 7.0e-07
+  output_cost_per_token: 8.0e-07
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
+- function_calling
+- tool_choice
+- structured_output
 limits:
-    context_window: 131072
-    max_output_tokens: 16384
-    max_tokens: 16384
+  context_window: 131072
+  max_output_tokens: 16384
+  max_tokens: 16384
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: deepseek-r1-distill-llama-70b
 sources:
-    - https://openrouter.ai/deepseek/deepseek-r1-distill-llama-70b/api
+- https://openrouter.ai/deepseek/deepseek-r1-distill-llama-70b/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/deepseek-r1-distill-llama-70b:free.yaml
+++ b/providers/openrouter/deepseek-r1-distill-llama-70b:free.yaml
@@ -1,23 +1,24 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 features:
-    - structured_output
+- structured_output
 limits:
-    context_window: 131072
-    max_output_tokens: 16384
-    max_tokens: 16384
+  context_window: 131072
+  max_output_tokens: 16384
+  max_tokens: 16384
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: deepseek-r1-distill-llama-70b:free
 params:
-    - key: max_tokens
-      maxValue: 16384
+- key: max_tokens
+  maxValue: 16384
 sources:
-    - https://openrouter.ai/deepseek/deepseek-r1-distill-llama-70b:free/api
+- https://openrouter.ai/deepseek/deepseek-r1-distill-llama-70b:free/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/deepseek-r1-distill-llama-8b.yaml
+++ b/providers/openrouter/deepseek-r1-distill-llama-8b.yaml
@@ -1,13 +1,14 @@
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: deepseek-r1-distill-llama-8b
 params:
-    - key: max_tokens
-      maxValue: 32000
+- key: max_tokens
+  maxValue: 32000
 sources:
-    - https://openrouter.ai/deepseek/deepseek-r1-distill-llama-8b/api
+- https://openrouter.ai/deepseek/deepseek-r1-distill-llama-8b/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/deepseek-r1-distill-qwen-1.5b.yaml
+++ b/providers/openrouter/deepseek-r1-distill-qwen-1.5b.yaml
@@ -1,15 +1,16 @@
 limits:
-    context_window: 131072
+  context_window: 131072
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: deepseek/deepseek-r1-distill-qwen-1.5b
 params:
-    - key: max_tokens
-      maxValue: 32768
+- key: max_tokens
+  maxValue: 32768
 sources:
-    - https://openrouter.ai/deepseek/deepseek-r1-distill-qwen-1.5b/api
+- https://openrouter.ai/deepseek/deepseek-r1-distill-qwen-1.5b/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/deepseek-r1-distill-qwen-14b.yaml
+++ b/providers/openrouter/deepseek-r1-distill-qwen-14b.yaml
@@ -1,15 +1,16 @@
 limits:
-    context_window: 131072
+  context_window: 131072
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: deepseek-r1-distill-qwen-14b
 params:
-    - key: max_tokens
-      maxValue: 32000
+- key: max_tokens
+  maxValue: 32000
 sources:
-    - https://openrouter.ai/deepseek/deepseek-r1-distill-qwen-14b/api
+- https://openrouter.ai/deepseek/deepseek-r1-distill-qwen-14b/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/deepseek-r1-distill-qwen-14b:free.yaml
+++ b/providers/openrouter/deepseek-r1-distill-qwen-14b:free.yaml
@@ -1,17 +1,17 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 limits:
-    context_window: 131072
+  context_window: 131072
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: deepseek-r1-distill-qwen-14b:free
 sources:
-    - https://openrouter.ai/deepseek/deepseek-r1-distill-qwen-14b:free/api
-status: active
+- https://openrouter.ai/deepseek/deepseek-r1-distill-qwen-14b:free/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/deepseek-r1-distill-qwen-32b.yaml
+++ b/providers/openrouter/deepseek-r1-distill-qwen-32b.yaml
@@ -1,25 +1,26 @@
 costs:
-    - input_cost_per_token: 2.9e-7
-      output_cost_per_token: 2.9e-7
-      region: "*"
+- input_cost_per_token: 2.9e-07
+  output_cost_per_token: 2.9e-07
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
+- function_calling
+- tool_choice
+- structured_output
 limits:
-    context_window: 32768
-    max_output_tokens: 32768
-    max_tokens: 32768
+  context_window: 32768
+  max_output_tokens: 32768
+  max_tokens: 32768
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: deepseek-r1-distill-qwen-32b
 params:
-    - key: max_tokens
-      maxValue: 32768
+- key: max_tokens
+  maxValue: 32768
 sources:
-    - https://openrouter.ai/deepseek/deepseek-r1-distill-qwen-32b/api
+- https://openrouter.ai/deepseek/deepseek-r1-distill-qwen-32b/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/deepseek-r1-distill-qwen-7b.yaml
+++ b/providers/openrouter/deepseek-r1-distill-qwen-7b.yaml
@@ -1,12 +1,13 @@
 limits:
-    context_window: 131072
+  context_window: 131072
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: deepseek/deepseek-r1-distill-qwen-7b
 sources:
-    - https://openrouter.ai/deepseek/deepseek-r1-distill-qwen-7b/api
+- https://openrouter.ai/deepseek/deepseek-r1-distill-qwen-7b/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/deepseek-r1.yaml
+++ b/providers/openrouter/deepseek-r1.yaml
@@ -1,24 +1,25 @@
 costs:
-    - input_cost_per_token: 7.e-7
-      output_cost_per_token: 0.0000025
-      region: "*"
+- input_cost_per_token: 7.0e-07
+  output_cost_per_token: 2.5e-06
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
+- function_calling
+- tool_choice
 limits:
-    context_window: 64000
-    max_output_tokens: 16000
-    max_tokens: 16000
+  context_window: 64000
+  max_output_tokens: 16000
+  max_tokens: 16000
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: deepseek-r1
 params:
-    - key: max_tokens
-      maxValue: 16000
+- key: max_tokens
+  maxValue: 16000
 sources:
-    - https://openrouter.ai/deepseek/deepseek-r1/api
+- https://openrouter.ai/deepseek/deepseek-r1/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/deepseek-r1:free.yaml
+++ b/providers/openrouter/deepseek-r1:free.yaml
@@ -1,18 +1,19 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 features:
-    - function_calling
+- function_calling
 limits:
-    context_window: 163840
+  context_window: 163840
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: deepseek-r1:free
 sources:
-    - https://openrouter.ai/deepseek/deepseek-r1:free/api
+- https://openrouter.ai/deepseek/deepseek-r1:free/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/deepseek-r1t-chimera:free.yaml
+++ b/providers/openrouter/deepseek-r1t-chimera:free.yaml
@@ -1,18 +1,19 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 limits:
-    context_window: 163840
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 163840
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: deepseek-r1t-chimera:free
 sources:
-    - https://openrouter.ai/tngtech/deepseek-r1t-chimera:free/api
+- https://openrouter.ai/tngtech/deepseek-r1t-chimera:free/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/deepseek-r1t2-chimera.yaml
+++ b/providers/openrouter/deepseek-r1t2-chimera.yaml
@@ -1,23 +1,24 @@
 costs:
-    - cache_read_input_token_cost: 1.5e-7
-      input_cost_per_token: 3.e-7
-      output_cost_per_token: 0.0000011
-      region: "*"
+- cache_read_input_token_cost: 1.5e-07
+  input_cost_per_token: 3.0e-07
+  output_cost_per_token: 1.1e-06
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
+- function_calling
+- tool_choice
+- structured_output
 limits:
-    context_window: 163840
-    max_output_tokens: 163840
-    max_tokens: 163840
+  context_window: 163840
+  max_output_tokens: 163840
+  max_tokens: 163840
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: deepseek-r1t2-chimera
 sources:
-    - https://openrouter.ai/tngtech/deepseek-r1t2-chimera/api
+- https://openrouter.ai/tngtech/deepseek-r1t2-chimera/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/deepseek-r1t2-chimera:free.yaml
+++ b/providers/openrouter/deepseek-r1t2-chimera:free.yaml
@@ -1,26 +1,26 @@
 costs:
-    - cache_read_input_token_cost: 0
-      input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- cache_read_input_token_cost: 0
+  input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
-    - prompt_caching
+- function_calling
+- tool_choice
+- structured_output
+- prompt_caching
 limits:
-    context_window: 163840
-    max_output_tokens: 163840
-    max_tokens: 163840
+  context_window: 163840
+  max_output_tokens: 163840
+  max_tokens: 163840
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: deepseek-r1t2-chimera:free
 sources:
-    - https://openrouter.ai/tngtech/deepseek-r1t2-chimera/api
-    - https://openrouter.ai/tngtech/deepseek-r1t2-chimera:free/api
-status: active
+- https://openrouter.ai/tngtech/deepseek-r1t2-chimera/api
+- https://openrouter.ai/tngtech/deepseek-r1t2-chimera:free/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/deepseek-v3-base.yaml
+++ b/providers/openrouter/deepseek-v3-base.yaml
@@ -1,15 +1,16 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 limits:
-    context_window: 131072
+  context_window: 131072
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: deepseek-v3-base
 sources:
-    - https://openrouter.ai/deepseek/deepseek-v3-base/api
+- https://openrouter.ai/deepseek/deepseek-v3-base/api
+status: deprecated

--- a/providers/openrouter/deepseek/deepseek-coder.yaml
+++ b/providers/openrouter/deepseek/deepseek-coder.yaml
@@ -1,11 +1,12 @@
 costs:
-    - input_cost_per_token: 1.4e-7
-      output_cost_per_token: 2.8e-7
-      region: "*"
+- input_cost_per_token: 1.4e-07
+  output_cost_per_token: 2.8e-07
+  region: '*'
 isDeprecated: true
 limits:
-    max_input_tokens: 66000
-    max_output_tokens: 4096
-    max_tokens: 4096
+  max_input_tokens: 66000
+  max_output_tokens: 4096
+  max_tokens: 4096
 mode: chat
 model: deepseek/deepseek-coder
+status: deprecated

--- a/providers/openrouter/deepseek/deepseek-v3.1-terminus:exacto.yaml
+++ b/providers/openrouter/deepseek/deepseek-v3.1-terminus:exacto.yaml
@@ -1,20 +1,21 @@
 costs:
-    - input_cost_per_token: 2.1e-7
-      output_cost_per_token: 7.9e-7
-      region: "*"
+- input_cost_per_token: 2.1e-07
+  output_cost_per_token: 7.9e-07
+  region: '*'
 features:
-    - function_calling
-    - json_output
+- function_calling
+- json_output
 limits:
-    context_window: 163840
-    max_input_tokens: 163840
+  context_window: 163840
+  max_input_tokens: 163840
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: deepseek/deepseek-v3.1-terminus:exacto
 sources:
-    - https://openrouter.ai/deepseek/deepseek-v3.1-terminus:exacto/api
+- https://openrouter.ai/deepseek/deepseek-v3.1-terminus:exacto/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/devstral-medium.yaml
+++ b/providers/openrouter/devstral-medium.yaml
@@ -1,22 +1,23 @@
 costs:
-    - cache_read_input_token_cost: 4.e-8
-      input_cost_per_token: 4.e-7
-      output_cost_per_token: 0.000002
-      region: "*"
+- cache_read_input_token_cost: 4.0e-08
+  input_cost_per_token: 4.0e-07
+  output_cost_per_token: 2.0e-06
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
-    - json_output
+- function_calling
+- tool_choice
+- structured_output
+- json_output
 limits:
-    context_window: 131072
+  context_window: 131072
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: devstral-medium
 sources:
-    - https://openrouter.ai/mistralai/devstral-medium
-    - https://openrouter.ai/mistralai/devstral-medium/api
+- https://openrouter.ai/mistralai/devstral-medium
+- https://openrouter.ai/mistralai/devstral-medium/api
+status: deprecated

--- a/providers/openrouter/devstral-small-2505.yaml
+++ b/providers/openrouter/devstral-small-2505.yaml
@@ -1,7 +1,8 @@
 features:
-    - function_calling
+- function_calling
 isDeprecated: true
 limits:
-    max_tokens: 4096
+  max_tokens: 4096
 mode: chat
 model: devstral-small-2505
+status: deprecated

--- a/providers/openrouter/devstral-small-2505:free.yaml
+++ b/providers/openrouter/devstral-small-2505:free.yaml
@@ -1,17 +1,18 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
-deprecationDate: "2025-11-30"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
+deprecationDate: '2025-11-30'
 features:
-    - function_calling
+- function_calling
 isDeprecated: true
 limits:
-    context_window: 131072
-    max_input_tokens: 131072
+  context_window: 131072
+  max_input_tokens: 131072
 mode: chat
 model: devstral-small-2505:free
 sources:
-    - https://openrouter.ai/mistralai/devstral-small-2505:free/api
-    - https://openrouter.ai/mistralai/devstral-small-2505/api
-    - https://docs.mistral.ai/getting-started/models/
+- https://openrouter.ai/mistralai/devstral-small-2505:free/api
+- https://openrouter.ai/mistralai/devstral-small-2505/api
+- https://docs.mistral.ai/getting-started/models/
+status: deprecated

--- a/providers/openrouter/devstral-small.yaml
+++ b/providers/openrouter/devstral-small.yaml
@@ -1,22 +1,23 @@
 costs:
-    - cache_read_input_token_cost: 1.e-8
-      input_cost_per_token: 1.e-7
-      output_cost_per_token: 3.e-7
-      region: "*"
+- cache_read_input_token_cost: 1.0e-08
+  input_cost_per_token: 1.0e-07
+  output_cost_per_token: 3.0e-07
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
-    - system_messages
-    - prompt_caching
+- function_calling
+- tool_choice
+- structured_output
+- system_messages
+- prompt_caching
 limits:
-    context_window: 131072
+  context_window: 131072
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: devstral-small
 sources:
-    - https://openrouter.ai/mistralai/devstral-small/api
+- https://openrouter.ai/mistralai/devstral-small/api
+status: deprecated

--- a/providers/openrouter/dolphin-mistral-24b-venice-edition:free.yaml
+++ b/providers/openrouter/dolphin-mistral-24b-venice-edition:free.yaml
@@ -1,20 +1,20 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 features:
-    - structured_output
+- structured_output
 limits:
-    context_window: 32768
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 32768
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: dolphin-mistral-24b-venice-edition:free
 sources:
-    - https://openrouter.ai/cognitivecomputations/dolphin-mistral-24b-venice-edition:free/api
-status: active
+- https://openrouter.ai/cognitivecomputations/dolphin-mistral-24b-venice-edition:free/api
+status: deprecated

--- a/providers/openrouter/dolphin-mixtral-8x22b.yaml
+++ b/providers/openrouter/dolphin-mixtral-8x22b.yaml
@@ -1,14 +1,15 @@
 limits:
-    context_window: 65536
+  context_window: 65536
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: dolphin-mixtral-8x22b
 params:
-    - key: max_tokens
-      maxValue: 8192
+- key: max_tokens
+  maxValue: 8192
 sources:
-    - https://openrouter.ai/cognitivecomputations/dolphin-mixtral-8x22b/api
+- https://openrouter.ai/cognitivecomputations/dolphin-mixtral-8x22b/api
+status: deprecated

--- a/providers/openrouter/dolphin3.0-mistral-24b:free.yaml
+++ b/providers/openrouter/dolphin3.0-mistral-24b:free.yaml
@@ -1,19 +1,20 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 features:
-    - function_calling
+- function_calling
 limits:
-    context_window: 32768
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 32768
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: dolphin3.0-mistral-24b:free
 sources:
-    - https://openrouter.ai/cognitivecomputations/dolphin3.0-mistral-24b:free/api
+- https://openrouter.ai/cognitivecomputations/dolphin3.0-mistral-24b:free/api
+status: deprecated

--- a/providers/openrouter/dolphin3.0-r1-mistral-24b.yaml
+++ b/providers/openrouter/dolphin3.0-r1-mistral-24b.yaml
@@ -1,16 +1,17 @@
 features:
-    - function_calling
+- function_calling
 limits:
-    context_window: 32768
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 32768
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: dolphin3.0-r1-mistral-24b
 sources:
-    - https://openrouter.ai/cognitivecomputations/dolphin3.0-r1-mistral-24b/api
+- https://openrouter.ai/cognitivecomputations/dolphin3.0-r1-mistral-24b/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/dolphin3.0-r1-mistral-24b:free.yaml
+++ b/providers/openrouter/dolphin3.0-r1-mistral-24b:free.yaml
@@ -1,18 +1,19 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 limits:
-    context_window: 32768
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 32768
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: dolphin3.0-r1-mistral-24b:free
 sources:
-    - https://openrouter.ai/cognitivecomputations/dolphin3.0-r1-mistral-24b:free/api
+- https://openrouter.ai/cognitivecomputations/dolphin3.0-r1-mistral-24b:free/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/ernie-4.5-300b-a47b.yaml
+++ b/providers/openrouter/ernie-4.5-300b-a47b.yaml
@@ -1,22 +1,23 @@
 costs:
-    - input_cost_per_token: 2.8e-7
-      output_cost_per_token: 0.0000011
-      region: "*"
+- input_cost_per_token: 2.8e-07
+  output_cost_per_token: 1.1e-06
+  region: '*'
 features:
-    - structured_output
+- structured_output
 limits:
-    context_window: 131072
-    max_output_tokens: 12000
-    max_tokens: 12000
+  context_window: 131072
+  max_output_tokens: 12000
+  max_tokens: 12000
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: ernie-4.5-300b-a47b
 params:
-    - key: max_tokens
-      maxValue: 12000
+- key: max_tokens
+  maxValue: 12000
 sources:
-    - https://openrouter.ai/baidu/ernie-4.5-300b-a47b/api
+- https://openrouter.ai/baidu/ernie-4.5-300b-a47b/api
+status: deprecated

--- a/providers/openrouter/fimbulvetr-11b-v2.yaml
+++ b/providers/openrouter/fimbulvetr-11b-v2.yaml
@@ -1,14 +1,15 @@
 limits:
-    context_window: 8192
+  context_window: 8192
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: fimbulvetr-11b-v2
 params:
-    - key: max_tokens
-      maxValue: 4096
+- key: max_tokens
+  maxValue: 4096
 sources:
-    - https://openrouter.ai/sao10k/fimbulvetr-11b-v2/api
+- https://openrouter.ai/sao10k/fimbulvetr-11b-v2/api
+status: deprecated

--- a/providers/openrouter/fireworks/firellava-13b.yaml
+++ b/providers/openrouter/fireworks/firellava-13b.yaml
@@ -1,17 +1,18 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 2.e-7
-      region: "*"
+- input_cost_per_token: 2.0e-07
+  output_cost_per_token: 2.0e-07
+  region: '*'
 limits:
-    context_window: 4096
-    max_tokens: 4096
+  context_window: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: fireworks/firellava-13b
 sources:
-    - https://openrouter.ai/fireworks/firellava-13b/api
+- https://openrouter.ai/fireworks/firellava-13b/api
+status: deprecated

--- a/providers/openrouter/gemini-2.0-flash-001.yaml
+++ b/providers/openrouter/gemini-2.0-flash-001.yaml
@@ -1,11 +1,12 @@
 features:
-    - function_calling
+- function_calling
 isDeprecated: true
 modalities:
-    input:
-        - image
+  input:
+  - image
 mode: chat
 model: gemini-2.0-flash-001
 params:
-    - key: max_tokens
-      maxValue: 8192
+- key: max_tokens
+  maxValue: 8192
+status: deprecated

--- a/providers/openrouter/gemini-2.0-flash-lite-001.yaml
+++ b/providers/openrouter/gemini-2.0-flash-lite-001.yaml
@@ -1,11 +1,12 @@
 features:
-    - function_calling
+- function_calling
 isDeprecated: true
 modalities:
-    input:
-        - image
+  input:
+  - image
 mode: chat
 model: gemini-2.0-flash-lite-001
 params:
-    - key: max_tokens
-      maxValue: 8192
+- key: max_tokens
+  maxValue: 8192
+status: deprecated

--- a/providers/openrouter/gemini-2.5-flash-lite.yaml
+++ b/providers/openrouter/gemini-2.5-flash-lite.yaml
@@ -1,36 +1,37 @@
 costs:
-    - cache_read_input_audio_token_cost: 3.e-8
-      cache_read_input_token_cost: 1.e-8
-      cache_storage_cost_per_token_per_hour: 0.000001
-      input_cost_per_audio_token: 3.e-7
-      input_cost_per_image_token: 1.e-7
-      input_cost_per_token: 1.e-7
-      input_cost_per_token_batches: 5.e-8
-      input_cost_per_video_token: 1.e-7
-      output_cost_per_token: 4.e-7
-      output_cost_per_token_batches: 2.e-7
-      region: "*"
+- cache_read_input_audio_token_cost: 3.0e-08
+  cache_read_input_token_cost: 1.0e-08
+  cache_storage_cost_per_token_per_hour: 1.0e-06
+  input_cost_per_audio_token: 3.0e-07
+  input_cost_per_image_token: 1.0e-07
+  input_cost_per_token: 1.0e-07
+  input_cost_per_token_batches: 5.0e-08
+  input_cost_per_video_token: 1.0e-07
+  output_cost_per_token: 4.0e-07
+  output_cost_per_token_batches: 2.0e-07
+  region: '*'
 features:
-    - function_calling
-    - structured_output
+- function_calling
+- structured_output
 limits:
-    context_window: 1048576
-    max_output_tokens: 65535
-    max_tokens: 65535
+  context_window: 1048576
+  max_output_tokens: 65535
+  max_tokens: 65535
 modalities:
-    input:
-        - text
-        - image
-        - audio
-        - video
-    output:
-        - text
+  input:
+  - text
+  - image
+  - audio
+  - video
+  output:
+  - text
 mode: chat
 model: gemini-2.5-flash-lite
 params:
-    - key: max_tokens
-      maxValue: 65535
+- key: max_tokens
+  maxValue: 65535
 sources:
-    - https://openrouter.ai/google/gemini-2.5-flash-lite/api
-    - https://ai.google.dev/gemini-api/docs/pricing
+- https://openrouter.ai/google/gemini-2.5-flash-lite/api
+- https://ai.google.dev/gemini-api/docs/pricing
 thinking: true
+status: deprecated

--- a/providers/openrouter/gemini-2.5-flash.yaml
+++ b/providers/openrouter/gemini-2.5-flash.yaml
@@ -1,36 +1,37 @@
 costs:
-    - cache_creation_input_token_cost: 8.33e-8
-      cache_read_input_token_cost: 3.e-8
-      input_cost_per_audio_token: 0.000001
-      input_cost_per_image_token: 3.e-7
-      input_cost_per_token: 3.e-7
-      input_cost_per_video_token: 3.e-7
-      output_cost_per_token: 0.0000025
-      region: "*"
+- cache_creation_input_token_cost: 8.33e-08
+  cache_read_input_token_cost: 3.0e-08
+  input_cost_per_audio_token: 1.0e-06
+  input_cost_per_image_token: 3.0e-07
+  input_cost_per_token: 3.0e-07
+  input_cost_per_video_token: 3.0e-07
+  output_cost_per_token: 2.5e-06
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
-    - system_messages
-    - prompt_caching
+- function_calling
+- tool_choice
+- structured_output
+- system_messages
+- prompt_caching
 limits:
-    context_window: 1048576
-    max_input_tokens: 1048576
-    max_output_tokens: 65535
-    max_tokens: 65535
+  context_window: 1048576
+  max_input_tokens: 1048576
+  max_output_tokens: 65535
+  max_tokens: 65535
 modalities:
-    input:
-        - text
-        - image
-        - audio
-        - video
-    output:
-        - text
+  input:
+  - text
+  - image
+  - audio
+  - video
+  output:
+  - text
 mode: chat
 model: gemini-2.5-flash
 params:
-    - key: max_tokens
-      maxValue: 65535
+- key: max_tokens
+  maxValue: 65535
 sources:
-    - https://openrouter.ai/google/gemini-2.5-flash/api
+- https://openrouter.ai/google/gemini-2.5-flash/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/gemini-2.5-pro.yaml
+++ b/providers/openrouter/gemini-2.5-pro.yaml
@@ -1,47 +1,48 @@
 costs:
-    - cache_creation_input_token_cost: 3.75e-7
-      cache_read_input_token_cost: 1.25e-7
-      input_cost_per_audio_token: 0.00000125
-      input_cost_per_token: 0.00000125
-      output_cost_per_token: 0.00001
-      region: "*"
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 2.5e-7
-                from: 200000
-          cache_write:
-              - cost_per_token: 7.5e-7
-                from: 200000
-          input:
-              - cost_per_token: 0.0000025
-                from: 200000
-          output:
-              - cost_per_token: 0.000015
-                from: 200000
-features:
-    - function_calling
-    - tool_choice
-    - structured_output
-    - prompt_caching
-    - system_messages
-    - json_output
-limits:
-    context_window: 1048576
-    max_output_tokens: 65536
-    max_tokens: 65536
-modalities:
+- cache_creation_input_token_cost: 3.75e-07
+  cache_read_input_token_cost: 1.25e-07
+  input_cost_per_audio_token: 1.25e-06
+  input_cost_per_token: 1.25e-06
+  output_cost_per_token: 1.0e-05
+  region: '*'
+  tiered_pricing:
+    cache_read:
+    - cost_per_token: 2.5e-07
+      from: 200000
+    cache_write:
+    - cost_per_token: 7.5e-07
+      from: 200000
     input:
-        - text
-        - image
-        - audio
-        - video
+    - cost_per_token: 2.5e-06
+      from: 200000
     output:
-        - text
+    - cost_per_token: 1.5e-05
+      from: 200000
+features:
+- function_calling
+- tool_choice
+- structured_output
+- prompt_caching
+- system_messages
+- json_output
+limits:
+  context_window: 1048576
+  max_output_tokens: 65536
+  max_tokens: 65536
+modalities:
+  input:
+  - text
+  - image
+  - audio
+  - video
+  output:
+  - text
 mode: chat
 model: gemini-2.5-pro
 params:
-    - key: max_tokens
-      maxValue: 65536
+- key: max_tokens
+  maxValue: 65536
 sources:
-    - https://openrouter.ai/google/gemini-2.5-pro/api
+- https://openrouter.ai/google/gemini-2.5-pro/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/gemini-flash-1.5-8b.yaml
+++ b/providers/openrouter/gemini-flash-1.5-8b.yaml
@@ -1,24 +1,25 @@
 costs:
-    - input_cost_per_token: 3.75e-8
-      output_cost_per_token: 1.5e-7
-      region: "*"
+- input_cost_per_token: 3.75e-08
+  output_cost_per_token: 1.5e-07
+  region: '*'
 features:
-    - function_calling
-    - system_messages
+- function_calling
+- system_messages
 limits:
-    context_window: 1000000
-    max_output_tokens: 8192
-    max_tokens: 8192
+  context_window: 1000000
+  max_output_tokens: 8192
+  max_tokens: 8192
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: gemini-flash-1.5-8b
 params:
-    - key: max_tokens
-      maxValue: 8192
+- key: max_tokens
+  maxValue: 8192
 sources:
-    - https://openrouter.ai/google/gemini-flash-1.5-8b/api
+- https://openrouter.ai/google/gemini-flash-1.5-8b/api
+status: deprecated

--- a/providers/openrouter/gemini-flash-1.5.yaml
+++ b/providers/openrouter/gemini-flash-1.5.yaml
@@ -1,19 +1,20 @@
 features:
-    - function_calling
+- function_calling
 limits:
-    context_window: 1000000
-    max_output_tokens: 8192
-    max_tokens: 8192
+  context_window: 1000000
+  max_output_tokens: 8192
+  max_tokens: 8192
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: gemini-flash-1.5
 params:
-    - key: max_tokens
-      maxValue: 8192
+- key: max_tokens
+  maxValue: 8192
 sources:
-    - https://openrouter.ai/google/gemini-flash-1.5/api
+- https://openrouter.ai/google/gemini-flash-1.5/api
+status: deprecated

--- a/providers/openrouter/gemini-pro-1.5.yaml
+++ b/providers/openrouter/gemini-pro-1.5.yaml
@@ -1,24 +1,25 @@
 costs:
-    - input_cost_per_token: 0.0000025
-      output_cost_per_token: 0.000005
-      region: "*"
+- input_cost_per_token: 2.5e-06
+  output_cost_per_token: 5.0e-06
+  region: '*'
 features:
-    - function_calling
-    - system_messages
+- function_calling
+- system_messages
 limits:
-    context_window: 2000000
-    max_output_tokens: 8192
-    max_tokens: 8192
+  context_window: 2000000
+  max_output_tokens: 8192
+  max_tokens: 8192
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: gemini-pro-1.5
 params:
-    - key: max_tokens
-      maxValue: 8192
+- key: max_tokens
+  maxValue: 8192
 sources:
-    - https://openrouter.ai/google/gemini-pro-1.5/api
+- https://openrouter.ai/google/gemini-pro-1.5/api
+status: deprecated

--- a/providers/openrouter/gemma-2-27b-it.yaml
+++ b/providers/openrouter/gemma-2-27b-it.yaml
@@ -1,21 +1,22 @@
 costs:
-    - input_cost_per_token: 6.5e-7
-      output_cost_per_token: 6.5e-7
-      region: "*"
+- input_cost_per_token: 6.5e-07
+  output_cost_per_token: 6.5e-07
+  region: '*'
 features:
-    - function_calling
-    - structured_output
-    - tool_choice
+- function_calling
+- structured_output
+- tool_choice
 limits:
-    context_window: 8192
-    max_output_tokens: 2048
-    max_tokens: 2048
+  context_window: 8192
+  max_output_tokens: 2048
+  max_tokens: 2048
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: gemma-2-27b-it
 sources:
-    - https://openrouter.ai/google/gemma-2-27b-it/api
+- https://openrouter.ai/google/gemma-2-27b-it/api
+status: deprecated

--- a/providers/openrouter/gemma-2-9b-it.yaml
+++ b/providers/openrouter/gemma-2-9b-it.yaml
@@ -1,24 +1,25 @@
 costs:
-    - input_cost_per_token: 3.e-8
-      output_cost_per_token: 9.e-8
-      region: "*"
+- input_cost_per_token: 3.0e-08
+  output_cost_per_token: 9.0e-08
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
+- function_calling
+- tool_choice
+- structured_output
 limits:
-    context_window: 8192
-    max_output_tokens: 8192
-    max_tokens: 8192
+  context_window: 8192
+  max_output_tokens: 8192
+  max_tokens: 8192
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: gemma-2-9b-it
 params:
-    - key: max_tokens
-      maxValue: 8192
+- key: max_tokens
+  maxValue: 8192
 sources:
-    - https://openrouter.ai/google/gemma-2-9b-it/api
+- https://openrouter.ai/google/gemma-2-9b-it/api
+status: deprecated

--- a/providers/openrouter/gemma-2-9b-it:free.yaml
+++ b/providers/openrouter/gemma-2-9b-it:free.yaml
@@ -1,20 +1,21 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 limits:
-    context_window: 8192
-    max_output_tokens: 8192
-    max_tokens: 8192
+  context_window: 8192
+  max_output_tokens: 8192
+  max_tokens: 8192
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: gemma-2-9b-it:free
 params:
-    - key: max_tokens
-      maxValue: 8192
+- key: max_tokens
+  maxValue: 8192
 sources:
-    - https://openrouter.ai/google/gemma-2-9b-it:free/api
+- https://openrouter.ai/google/gemma-2-9b-it:free/api
+status: deprecated

--- a/providers/openrouter/gemma-3-12b-it.yaml
+++ b/providers/openrouter/gemma-3-12b-it.yaml
@@ -1,23 +1,24 @@
 costs:
-    - input_cost_per_token: 4.e-8
-      output_cost_per_token: 1.3e-7
-      region: "*"
+- input_cost_per_token: 4.0e-08
+  output_cost_per_token: 1.3e-07
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
+- function_calling
+- tool_choice
+- structured_output
 limits:
-    context_window: 131072
+  context_window: 131072
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: gemma-3-12b-it
 params:
-    - key: max_tokens
-      maxValue: 8192
+- key: max_tokens
+  maxValue: 8192
 sources:
-    - https://openrouter.ai/google/gemma-3-12b-it/api
+- https://openrouter.ai/google/gemma-3-12b-it/api
+status: deprecated

--- a/providers/openrouter/gemma-3-12b-it:free.yaml
+++ b/providers/openrouter/gemma-3-12b-it:free.yaml
@@ -1,23 +1,24 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 features:
-    - function_calling
+- function_calling
 limits:
-    context_window: 32768
-    max_output_tokens: 8192
-    max_tokens: 8192
+  context_window: 32768
+  max_output_tokens: 8192
+  max_tokens: 8192
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: gemma-3-12b-it:free
 params:
-    - key: max_tokens
-      maxValue: 8192
+- key: max_tokens
+  maxValue: 8192
 sources:
-    - https://openrouter.ai/google/gemma-3-12b-it:free/api
+- https://openrouter.ai/google/gemma-3-12b-it:free/api
+status: deprecated

--- a/providers/openrouter/gemma-3-27b-it.yaml
+++ b/providers/openrouter/gemma-3-27b-it.yaml
@@ -1,26 +1,27 @@
 costs:
-    - input_cost_per_token: 8.e-8
-      output_cost_per_token: 1.6e-7
-      region: "*"
+- input_cost_per_token: 8.0e-08
+  output_cost_per_token: 1.6e-07
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
-    - system_messages
+- function_calling
+- tool_choice
+- structured_output
+- system_messages
 limits:
-    context_window: 131072
-    max_output_tokens: 16384
-    max_tokens: 16384
+  context_window: 131072
+  max_output_tokens: 16384
+  max_tokens: 16384
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: gemma-3-27b-it
 params:
-    - key: max_tokens
-      maxValue: 16384
+- key: max_tokens
+  maxValue: 16384
 sources:
-    - https://openrouter.ai/google/gemma-3-27b-it/api
+- https://openrouter.ai/google/gemma-3-27b-it/api
+status: deprecated

--- a/providers/openrouter/gemma-3-27b-it:free.yaml
+++ b/providers/openrouter/gemma-3-27b-it:free.yaml
@@ -1,23 +1,24 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 features:
-    - function_calling
+- function_calling
 limits:
-    context_window: 131072
-    max_output_tokens: 8192
-    max_tokens: 8192
+  context_window: 131072
+  max_output_tokens: 8192
+  max_tokens: 8192
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: gemma-3-27b-it:free
 params:
-    - key: max_tokens
-      maxValue: 8192
+- key: max_tokens
+  maxValue: 8192
 sources:
-    - https://openrouter.ai/google/gemma-3-27b-it:free/api
+- https://openrouter.ai/google/gemma-3-27b-it:free/api
+status: deprecated

--- a/providers/openrouter/gemma-3-4b-it.yaml
+++ b/providers/openrouter/gemma-3-4b-it.yaml
@@ -1,23 +1,24 @@
 costs:
-    - input_cost_per_token: 4.e-8
-      output_cost_per_token: 8.e-8
-      region: "*"
+- input_cost_per_token: 4.0e-08
+  output_cost_per_token: 8.0e-08
+  region: '*'
 features:
-    - function_calling
-    - structured_output
-    - tool_choice
-    - json_output
+- function_calling
+- structured_output
+- tool_choice
+- json_output
 limits:
-    context_window: 131072
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 131072
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: gemma-3-4b-it
 sources:
-    - https://openrouter.ai/google/gemma-3-4b-it/api
+- https://openrouter.ai/google/gemma-3-4b-it/api
+status: deprecated

--- a/providers/openrouter/gemma-3-4b-it:free.yaml
+++ b/providers/openrouter/gemma-3-4b-it:free.yaml
@@ -1,24 +1,25 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 features:
-    - function_calling
-    - structured_output
+- function_calling
+- structured_output
 limits:
-    context_window: 32768
-    max_output_tokens: 8192
-    max_tokens: 8192
+  context_window: 32768
+  max_output_tokens: 8192
+  max_tokens: 8192
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: gemma-3-4b-it:free
 params:
-    - key: max_tokens
-      maxValue: 8192
+- key: max_tokens
+  maxValue: 8192
 sources:
-    - https://openrouter.ai/google/gemma-3-4b-it:free/api
+- https://openrouter.ai/google/gemma-3-4b-it:free/api
+status: deprecated

--- a/providers/openrouter/gemma-3n-e2b-it:free.yaml
+++ b/providers/openrouter/gemma-3n-e2b-it:free.yaml
@@ -1,21 +1,21 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 limits:
-    context_window: 8192
-    max_output_tokens: 2048
-    max_tokens: 2048
+  context_window: 8192
+  max_output_tokens: 2048
+  max_tokens: 2048
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: gemma-3n-e2b-it:free
 params:
-    - key: max_tokens
-      maxValue: 2048
+- key: max_tokens
+  maxValue: 2048
 sources:
-    - https://openrouter.ai/google/gemma-3n-e2b-it:free/api
-status: active
+- https://openrouter.ai/google/gemma-3n-e2b-it:free/api
+status: deprecated

--- a/providers/openrouter/gemma-3n-e4b-it.yaml
+++ b/providers/openrouter/gemma-3n-e4b-it.yaml
@@ -1,17 +1,18 @@
 costs:
-    - input_cost_per_token: 2.e-8
-      output_cost_per_token: 4.e-8
-      region: "*"
+- input_cost_per_token: 2.0e-08
+  output_cost_per_token: 4.0e-08
+  region: '*'
 limits:
-    context_window: 32768
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 32768
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: gemma-3n-e4b-it
 sources:
-    - https://openrouter.ai/google/gemma-3n-e4b-it/api
+- https://openrouter.ai/google/gemma-3n-e4b-it/api
+status: deprecated

--- a/providers/openrouter/gemma-3n-e4b-it:free.yaml
+++ b/providers/openrouter/gemma-3n-e4b-it:free.yaml
@@ -1,20 +1,21 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 limits:
-    context_window: 8192
-    max_output_tokens: 2048
-    max_tokens: 2048
+  context_window: 8192
+  max_output_tokens: 2048
+  max_tokens: 2048
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: gemma-3n-e4b-it:free
 params:
-    - key: max_tokens
-      maxValue: 2048
+- key: max_tokens
+  maxValue: 2048
 sources:
-    - https://openrouter.ai/google/gemma-3n-e4b-it:free/api
+- https://openrouter.ai/google/gemma-3n-e4b-it:free/api
+status: deprecated

--- a/providers/openrouter/glm-4-32b.yaml
+++ b/providers/openrouter/glm-4-32b.yaml
@@ -1,21 +1,22 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 1.e-7
-      region: "*"
+- input_cost_per_token: 1.0e-07
+  output_cost_per_token: 1.0e-07
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
+- function_calling
+- tool_choice
 limits:
-    context_window: 128000
+  context_window: 128000
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: glm-4-32b
 params:
-    - key: max_tokens
-      maxValue: 32000
+- key: max_tokens
+  maxValue: 32000
 sources:
-    - https://openrouter.ai/z-ai/glm-4-32b/api
+- https://openrouter.ai/z-ai/glm-4-32b/api
+status: deprecated

--- a/providers/openrouter/glm-4-32b:free.yaml
+++ b/providers/openrouter/glm-4-32b:free.yaml
@@ -1,5 +1,6 @@
 isDeprecated: true
 limits:
-    max_tokens: 4096
+  max_tokens: 4096
 mode: chat
 model: glm-4-32b:free
+status: deprecated

--- a/providers/openrouter/glm-4.1v-9b-thinking.yaml
+++ b/providers/openrouter/glm-4.1v-9b-thinking.yaml
@@ -1,16 +1,17 @@
 limits:
-    context_window: 65536
+  context_window: 65536
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: glm-4.1v-9b-thinking
 params:
-    - key: max_tokens
-      maxValue: 8000
+- key: max_tokens
+  maxValue: 8000
 sources:
-    - https://openrouter.ai/THUDM/glm-4.1v-9b-thinking/api
+- https://openrouter.ai/THUDM/glm-4.1v-9b-thinking/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/glm-4.5-air.yaml
+++ b/providers/openrouter/glm-4.5-air.yaml
@@ -1,8 +1,9 @@
 features:
-    - function_calling
+- function_calling
 isDeprecated: true
 mode: chat
 model: glm-4.5-air
 params:
-    - key: max_tokens
-      maxValue: 96000
+- key: max_tokens
+  maxValue: 96000
+status: deprecated

--- a/providers/openrouter/glm-4.5-air:free.yaml
+++ b/providers/openrouter/glm-4.5-air:free.yaml
@@ -1,22 +1,23 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
+- function_calling
+- tool_choice
+- structured_output
 limits:
-    context_window: 131072
-    max_output_tokens: 96000
-    max_tokens: 96000
+  context_window: 131072
+  max_output_tokens: 96000
+  max_tokens: 96000
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: glm-4.5-air:free
 sources:
-    - https://openrouter.ai/z-ai/glm-4.5-air:free/api
+- https://openrouter.ai/z-ai/glm-4.5-air:free/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/glm-4.5.yaml
+++ b/providers/openrouter/glm-4.5.yaml
@@ -1,25 +1,26 @@
 costs:
-    - cache_read_input_token_cost: 1.1e-7
-      input_cost_per_token: 6.e-7
-      output_cost_per_token: 0.0000022
-      region: "*"
+- cache_read_input_token_cost: 1.1e-07
+  input_cost_per_token: 6.0e-07
+  output_cost_per_token: 2.2e-06
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
+- function_calling
+- tool_choice
+- structured_output
 limits:
-    context_window: 131072
-    max_output_tokens: 98304
-    max_tokens: 98304
+  context_window: 131072
+  max_output_tokens: 98304
+  max_tokens: 98304
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: glm-4.5
 params:
-    - key: reasoning
+- key: reasoning
 sources:
-    - https://openrouter.ai/z-ai/glm-4.5/api
+- https://openrouter.ai/z-ai/glm-4.5/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/glm-z1-32b.yaml
+++ b/providers/openrouter/glm-z1-32b.yaml
@@ -1,17 +1,18 @@
 features:
-    - function_calling
-    - tool_choice
+- function_calling
+- tool_choice
 limits:
-    context_window: 32768
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 32768
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: glm-z1-32b
 sources:
-    - https://openrouter.ai/thudm/glm-z1-32b/api
+- https://openrouter.ai/thudm/glm-z1-32b/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/glm-z1-32b:free.yaml
+++ b/providers/openrouter/glm-z1-32b:free.yaml
@@ -1,21 +1,22 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 features:
-    - function_calling
+- function_calling
 limits:
-    context_window: 32768
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 32768
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: glm-z1-32b:free
 sources:
-    - https://openrouter.ai/thudm/glm-z1-32b:free/api
-    - https://openrouter.ai/thudm/glm-z1-32b/api
+- https://openrouter.ai/thudm/glm-z1-32b:free/api
+- https://openrouter.ai/thudm/glm-z1-32b/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/goliath-120b.yaml
+++ b/providers/openrouter/goliath-120b.yaml
@@ -1,18 +1,18 @@
 costs:
-    - input_cost_per_token: 0.00000375
-      output_cost_per_token: 0.0000075
-      region: "*"
+- input_cost_per_token: 3.75e-06
+  output_cost_per_token: 7.5e-06
+  region: '*'
 limits:
-    context_window: 6144
-    max_output_tokens: 1024
-    max_tokens: 1024
+  context_window: 6144
+  max_output_tokens: 1024
+  max_tokens: 1024
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: goliath-120b
 sources:
-    - https://openrouter.ai/alpindale/goliath-120b/api
-status: active
+- https://openrouter.ai/alpindale/goliath-120b/api
+status: deprecated

--- a/providers/openrouter/google/gemini-2.0-flash-001.yaml
+++ b/providers/openrouter/google/gemini-2.0-flash-001.yaml
@@ -1,34 +1,35 @@
 costs:
-    - cache_creation_input_token_cost: 8.333333333333334e-8
-      cache_read_input_token_cost: 2.5e-8
-      cache_storage_cost_per_token_per_hour: 0.000001
-      input_cost_per_audio_token: 7.e-7
-      input_cost_per_token: 1.e-7
-      output_cost_per_token: 4.e-7
-      region: "*"
-deprecationDate: "2026-06-01"
+- cache_creation_input_token_cost: 8.333333333333334e-08
+  cache_read_input_token_cost: 2.5e-08
+  cache_storage_cost_per_token_per_hour: 1.0e-06
+  input_cost_per_audio_token: 7.0e-07
+  input_cost_per_token: 1.0e-07
+  output_cost_per_token: 4.0e-07
+  region: '*'
+deprecationDate: '2026-06-01'
 features:
-    - function_calling
-    - system_messages
-    - tool_choice
-    - structured_output
-    - prompt_caching
-    - json_output
+- function_calling
+- system_messages
+- tool_choice
+- structured_output
+- prompt_caching
+- json_output
 limits:
-    context_window: 1048576
-    max_input_tokens: 1048576
-    max_output_tokens: 8192
-    max_tokens: 8192
+  context_window: 1048576
+  max_input_tokens: 1048576
+  max_output_tokens: 8192
+  max_tokens: 8192
 modalities:
-    input:
-        - text
-        - image
-        - audio
-        - video
-        - pdf
-    output:
-        - text
+  input:
+  - text
+  - image
+  - audio
+  - video
+  - pdf
+  output:
+  - text
 mode: chat
 model: google/gemini-2.0-flash-001
 sources:
-    - https://openrouter.ai/google/gemini-2.0-flash-001/api
+- https://openrouter.ai/google/gemini-2.0-flash-001/api
+status: deprecated

--- a/providers/openrouter/google/gemini-pro-1.5.yaml
+++ b/providers/openrouter/google/gemini-pro-1.5.yaml
@@ -1,22 +1,23 @@
 costs:
-    - input_cost_per_image: 0.00265
-      input_cost_per_token: 0.0000025
-      output_cost_per_token: 0.0000075
-      region: "*"
+- input_cost_per_image: 0.00265
+  input_cost_per_token: 2.5e-06
+  output_cost_per_token: 7.5e-06
+  region: '*'
 features:
-    - function_calling
+- function_calling
 limits:
-    context_window: 2000000
-    max_input_tokens: 2000000
-    max_output_tokens: 8192
-    max_tokens: 8192
+  context_window: 2000000
+  max_input_tokens: 2000000
+  max_output_tokens: 8192
+  max_tokens: 8192
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: google/gemini-pro-1.5
 sources:
-    - https://openrouter.ai/google/gemini-pro-1.5/api
+- https://openrouter.ai/google/gemini-pro-1.5/api
+status: deprecated

--- a/providers/openrouter/google/gemini-pro-vision.yaml
+++ b/providers/openrouter/google/gemini-pro-vision.yaml
@@ -1,15 +1,16 @@
 costs:
-    - input_cost_per_image: 0.0025
-      input_cost_per_token: 1.25e-7
-      output_cost_per_token: 3.75e-7
-      region: "*"
+- input_cost_per_image: 0.0025
+  input_cost_per_token: 1.25e-07
+  output_cost_per_token: 3.75e-07
+  region: '*'
 features:
-    - function_calling
+- function_calling
 isDeprecated: true
 limits:
-    max_tokens: 45875
+  max_tokens: 45875
 modalities:
-    input:
-        - image
+  input:
+  - image
 mode: chat
 model: google/gemini-pro-vision
+status: deprecated

--- a/providers/openrouter/google/palm-2-chat-bison.yaml
+++ b/providers/openrouter/google/palm-2-chat-bison.yaml
@@ -1,15 +1,16 @@
 costs:
-    - input_cost_per_token: 5.e-7
-      output_cost_per_token: 5.e-7
-      region: "*"
+- input_cost_per_token: 5.0e-07
+  output_cost_per_token: 5.0e-07
+  region: '*'
 limits:
-    context_window: 9216
+  context_window: 9216
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: google/palm-2-chat-bison
 sources:
-    - https://openrouter.ai/google/palm-2-chat-bison/api
+- https://openrouter.ai/google/palm-2-chat-bison/api
+status: deprecated

--- a/providers/openrouter/google/palm-2-codechat-bison.yaml
+++ b/providers/openrouter/google/palm-2-codechat-bison.yaml
@@ -1,17 +1,18 @@
 costs:
-    - input_cost_per_token: 5.e-7
-      output_cost_per_token: 5.e-7
-      region: "*"
+- input_cost_per_token: 5.0e-07
+  output_cost_per_token: 5.0e-07
+  region: '*'
 limits:
-    context_window: 7168
-    max_output_tokens: 20070
-    max_tokens: 20070
+  context_window: 7168
+  max_output_tokens: 20070
+  max_tokens: 20070
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: google/palm-2-codechat-bison
 sources:
-    - https://openrouter.ai/google/palm-2-codechat-bison/api
+- https://openrouter.ai/google/palm-2-codechat-bison/api
+status: deprecated

--- a/providers/openrouter/gpt-3.5-turbo-0613.yaml
+++ b/providers/openrouter/gpt-3.5-turbo-0613.yaml
@@ -1,24 +1,25 @@
 costs:
-    - input_cost_per_token: 0.000001
-      output_cost_per_token: 0.000002
-      region: "*"
+- input_cost_per_token: 1.0e-06
+  output_cost_per_token: 2.0e-06
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
+- function_calling
+- tool_choice
+- structured_output
 limits:
-    context_window: 4095
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 4095
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: gpt-3.5-turbo-0613
 params:
-    - key: max_tokens
-      maxValue: 4096
+- key: max_tokens
+  maxValue: 4096
 sources:
-    - https://openrouter.ai/openai/gpt-3.5-turbo-0613/api
+- https://openrouter.ai/openai/gpt-3.5-turbo-0613/api
+status: deprecated

--- a/providers/openrouter/gpt-3.5-turbo-16k.yaml
+++ b/providers/openrouter/gpt-3.5-turbo-16k.yaml
@@ -1,24 +1,25 @@
 costs:
-    - input_cost_per_token: 0.000003
-      output_cost_per_token: 0.000004
-      region: "*"
+- input_cost_per_token: 3.0e-06
+  output_cost_per_token: 4.0e-06
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
+- function_calling
+- tool_choice
+- structured_output
 limits:
-    context_window: 16385
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 16385
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: gpt-3.5-turbo-16k
 params:
-    - key: max_tokens
-      maxValue: 4096
+- key: max_tokens
+  maxValue: 4096
 sources:
-    - https://openrouter.ai/openai/gpt-3.5-turbo-16k/api
+- https://openrouter.ai/openai/gpt-3.5-turbo-16k/api
+status: deprecated

--- a/providers/openrouter/gpt-3.5-turbo-instruct.yaml
+++ b/providers/openrouter/gpt-3.5-turbo-instruct.yaml
@@ -1,20 +1,21 @@
 costs:
-    - input_cost_per_token: 0.0000015
-      output_cost_per_token: 0.000002
-      region: "*"
+- input_cost_per_token: 1.5e-06
+  output_cost_per_token: 2.0e-06
+  region: '*'
 features:
-    - function_calling
-    - structured_output
+- function_calling
+- structured_output
 limits:
-    context_window: 4095
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 4095
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: gpt-3.5-turbo-instruct
 sources:
-    - https://openrouter.ai/openai/gpt-3.5-turbo-instruct/api
+- https://openrouter.ai/openai/gpt-3.5-turbo-instruct/api
+status: deprecated

--- a/providers/openrouter/gpt-3.5-turbo.yaml
+++ b/providers/openrouter/gpt-3.5-turbo.yaml
@@ -1,25 +1,26 @@
 costs:
-    - input_cost_per_token: 5.e-7
-      output_cost_per_token: 0.0000015
-      region: "*"
+- input_cost_per_token: 5.0e-07
+  output_cost_per_token: 1.5e-06
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
-    - system_messages
+- function_calling
+- tool_choice
+- structured_output
+- system_messages
 limits:
-    context_window: 16385
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 16385
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: gpt-3.5-turbo
 params:
-    - key: max_tokens
-      maxValue: 4096
+- key: max_tokens
+  maxValue: 4096
 sources:
-    - https://openrouter.ai/openai/gpt-3.5-turbo/api
+- https://openrouter.ai/openai/gpt-3.5-turbo/api
+status: deprecated

--- a/providers/openrouter/gpt-4-0314.yaml
+++ b/providers/openrouter/gpt-4-0314.yaml
@@ -1,8 +1,9 @@
 features:
-    - function_calling
+- function_calling
 isDeprecated: true
 mode: chat
 model: gpt-4-0314
 params:
-    - key: max_tokens
-      maxValue: 4096
+- key: max_tokens
+  maxValue: 4096
+status: deprecated

--- a/providers/openrouter/gpt-4-turbo.yaml
+++ b/providers/openrouter/gpt-4-turbo.yaml
@@ -1,27 +1,28 @@
 costs:
-    - input_cost_per_token: 0.00001
-      output_cost_per_token: 0.00003
-      region: "*"
+- input_cost_per_token: 1.0e-05
+  output_cost_per_token: 3.0e-05
+  region: '*'
 features:
-    - function_calling
-    - structured_output
-    - system_messages
-    - tool_choice
-    - json_output
+- function_calling
+- structured_output
+- system_messages
+- tool_choice
+- json_output
 limits:
-    context_window: 128000
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 128000
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: gpt-4-turbo
 params:
-    - key: max_tokens
-      maxValue: 4096
+- key: max_tokens
+  maxValue: 4096
 sources:
-    - https://openrouter.ai/openai/gpt-4-turbo/api
+- https://openrouter.ai/openai/gpt-4-turbo/api
+status: deprecated

--- a/providers/openrouter/gpt-4.1-mini.yaml
+++ b/providers/openrouter/gpt-4.1-mini.yaml
@@ -1,26 +1,27 @@
 costs:
-    - cache_read_input_token_cost: 1.e-7
-      input_cost_per_token: 4.e-7
-      output_cost_per_token: 0.0000016
-      region: "*"
+- cache_read_input_token_cost: 1.0e-07
+  input_cost_per_token: 4.0e-07
+  output_cost_per_token: 1.6e-06
+  region: '*'
 features:
-    - function_calling
-    - structured_output
-    - prompt_caching
+- function_calling
+- structured_output
+- prompt_caching
 limits:
-    context_window: 1047576
-    max_output_tokens: 32768
-    max_tokens: 32768
+  context_window: 1047576
+  max_output_tokens: 32768
+  max_tokens: 32768
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: gpt-4.1-mini
 params:
-    - key: max_tokens
-      maxValue: 32768
+- key: max_tokens
+  maxValue: 32768
 sources:
-    - https://openrouter.ai/openai/gpt-4.1-mini/api
+- https://openrouter.ai/openai/gpt-4.1-mini/api
+status: deprecated

--- a/providers/openrouter/gpt-4.1-nano.yaml
+++ b/providers/openrouter/gpt-4.1-nano.yaml
@@ -1,28 +1,29 @@
 costs:
-    - cache_read_input_token_cost: 2.5e-8
-      input_cost_per_token: 1.e-7
-      output_cost_per_token: 4.e-7
-      region: "*"
+- cache_read_input_token_cost: 2.5e-08
+  input_cost_per_token: 1.0e-07
+  output_cost_per_token: 4.0e-07
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
-    - system_messages
-    - json_output
+- function_calling
+- tool_choice
+- structured_output
+- system_messages
+- json_output
 limits:
-    context_window: 1047576
-    max_output_tokens: 32768
-    max_tokens: 32768
+  context_window: 1047576
+  max_output_tokens: 32768
+  max_tokens: 32768
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: gpt-4.1-nano
 params:
-    - key: max_tokens
-      maxValue: 32768
+- key: max_tokens
+  maxValue: 32768
 sources:
-    - https://openrouter.ai/openai/gpt-4.1-nano/api
+- https://openrouter.ai/openai/gpt-4.1-nano/api
+status: deprecated

--- a/providers/openrouter/gpt-4.1.yaml
+++ b/providers/openrouter/gpt-4.1.yaml
@@ -1,29 +1,30 @@
 costs:
-    - cache_read_input_token_cost: 5.e-7
-      input_cost_per_token: 0.000002
-      output_cost_per_token: 0.000008
-      region: "*"
+- cache_read_input_token_cost: 5.0e-07
+  input_cost_per_token: 2.0e-06
+  output_cost_per_token: 8.0e-06
+  region: '*'
 features:
-    - function_calling
-    - json_output
-    - prompt_caching
-    - structured_output
-    - system_messages
-    - tool_choice
+- function_calling
+- json_output
+- prompt_caching
+- structured_output
+- system_messages
+- tool_choice
 limits:
-    context_window: 1047576
-    max_output_tokens: 32768
-    max_tokens: 32768
+  context_window: 1047576
+  max_output_tokens: 32768
+  max_tokens: 32768
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: gpt-4.1
 params:
-    - key: max_tokens
-      maxValue: 32768
+- key: max_tokens
+  maxValue: 32768
 sources:
-    - https://openrouter.ai/openai/gpt-4.1/api
+- https://openrouter.ai/openai/gpt-4.1/api
+status: deprecated

--- a/providers/openrouter/gpt-4.yaml
+++ b/providers/openrouter/gpt-4.yaml
@@ -1,23 +1,24 @@
 costs:
-    - input_cost_per_token: 0.00003
-      output_cost_per_token: 0.00006
-      region: "*"
+- input_cost_per_token: 3.0e-05
+  output_cost_per_token: 6.0e-05
+  region: '*'
 features:
-    - function_calling
-    - system_messages
-    - tool_choice
-    - structured_output
-    - json_output
+- function_calling
+- system_messages
+- tool_choice
+- structured_output
+- json_output
 limits:
-    context_window: 8191
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 8191
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: gpt-4
 sources:
-    - https://openrouter.ai/openai/gpt-4/api
+- https://openrouter.ai/openai/gpt-4/api
+status: deprecated

--- a/providers/openrouter/gpt-4o-2024-05-13.yaml
+++ b/providers/openrouter/gpt-4o-2024-05-13.yaml
@@ -1,26 +1,27 @@
 costs:
-    - input_cost_per_token: 0.000005
-      output_cost_per_token: 0.000015
-      region: "*"
+- input_cost_per_token: 5.0e-06
+  output_cost_per_token: 1.5e-05
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
-    - system_messages
+- function_calling
+- tool_choice
+- structured_output
+- system_messages
 limits:
-    context_window: 128000
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 128000
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: gpt-4o-2024-05-13
 params:
-    - key: max_tokens
-      maxValue: 4096
+- key: max_tokens
+  maxValue: 4096
 sources:
-    - https://openrouter.ai/openai/gpt-4o-2024-05-13/api
+- https://openrouter.ai/openai/gpt-4o-2024-05-13/api
+status: deprecated

--- a/providers/openrouter/gpt-4o-2024-08-06.yaml
+++ b/providers/openrouter/gpt-4o-2024-08-06.yaml
@@ -1,28 +1,29 @@
 costs:
-    - cache_read_input_token_cost: 0.00000125
-      input_cost_per_token: 0.0000025
-      output_cost_per_token: 0.00001
-      region: "*"
+- cache_read_input_token_cost: 1.25e-06
+  input_cost_per_token: 2.5e-06
+  output_cost_per_token: 1.0e-05
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
-    - system_messages
+- function_calling
+- tool_choice
+- structured_output
+- system_messages
 limits:
-    context_window: 128000
-    max_input_tokens: 128000
-    max_output_tokens: 16384
-    max_tokens: 16384
+  context_window: 128000
+  max_input_tokens: 128000
+  max_output_tokens: 16384
+  max_tokens: 16384
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: gpt-4o-2024-08-06
 params:
-    - key: max_tokens
-      maxValue: 16384
+- key: max_tokens
+  maxValue: 16384
 sources:
-    - https://openrouter.ai/openai/gpt-4o-2024-08-06/api
+- https://openrouter.ai/openai/gpt-4o-2024-08-06/api
+status: deprecated

--- a/providers/openrouter/gpt-4o-2024-11-20.yaml
+++ b/providers/openrouter/gpt-4o-2024-11-20.yaml
@@ -1,26 +1,27 @@
 costs:
-    - cache_read_input_token_cost: 0.00000125
-      input_cost_per_token: 0.0000025
-      output_cost_per_token: 0.00001
-      region: "*"
+- cache_read_input_token_cost: 1.25e-06
+  input_cost_per_token: 2.5e-06
+  output_cost_per_token: 1.0e-05
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
+- function_calling
+- tool_choice
+- structured_output
 limits:
-    context_window: 128000
-    max_output_tokens: 16384
-    max_tokens: 16384
+  context_window: 128000
+  max_output_tokens: 16384
+  max_tokens: 16384
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: gpt-4o-2024-11-20
 params:
-    - key: max_tokens
-      maxValue: 16384
+- key: max_tokens
+  maxValue: 16384
 sources:
-    - https://openrouter.ai/openai/gpt-4o-2024-11-20/api
+- https://openrouter.ai/openai/gpt-4o-2024-11-20/api
+status: deprecated

--- a/providers/openrouter/gpt-4o-mini-2024-07-18.yaml
+++ b/providers/openrouter/gpt-4o-mini-2024-07-18.yaml
@@ -1,27 +1,28 @@
 costs:
-    - cache_read_input_token_cost: 7.5e-8
-      input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
-      region: "*"
+- cache_read_input_token_cost: 7.5e-08
+  input_cost_per_token: 1.5e-07
+  output_cost_per_token: 6.0e-07
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - system_messages
-    - structured_output
+- function_calling
+- tool_choice
+- system_messages
+- structured_output
 limits:
-    context_window: 128000
-    max_output_tokens: 16384
-    max_tokens: 16384
+  context_window: 128000
+  max_output_tokens: 16384
+  max_tokens: 16384
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: gpt-4o-mini-2024-07-18
 params:
-    - key: max_tokens
-      maxValue: 16384
+- key: max_tokens
+  maxValue: 16384
 sources:
-    - https://openrouter.ai/openai/gpt-4o-mini-2024-07-18/api
+- https://openrouter.ai/openai/gpt-4o-mini-2024-07-18/api
+status: deprecated

--- a/providers/openrouter/gpt-4o-mini.yaml
+++ b/providers/openrouter/gpt-4o-mini.yaml
@@ -1,26 +1,27 @@
 costs:
-    - cache_read_input_token_cost: 7.5e-8
-      input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
-      region: "*"
+- cache_read_input_token_cost: 7.5e-08
+  input_cost_per_token: 1.5e-07
+  output_cost_per_token: 6.0e-07
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
+- function_calling
+- tool_choice
+- structured_output
 limits:
-    context_window: 128000
-    max_output_tokens: 16384
-    max_tokens: 16384
+  context_window: 128000
+  max_output_tokens: 16384
+  max_tokens: 16384
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: gpt-4o-mini
 params:
-    - key: max_tokens
-      maxValue: 16384
+- key: max_tokens
+  maxValue: 16384
 sources:
-    - https://openrouter.ai/openai/gpt-4o-mini/api
+- https://openrouter.ai/openai/gpt-4o-mini/api
+status: deprecated

--- a/providers/openrouter/gpt-4o.yaml
+++ b/providers/openrouter/gpt-4o.yaml
@@ -1,28 +1,29 @@
 costs:
-    - cache_read_input_token_cost: 0.00000125
-      input_cost_per_token: 0.0000025
-      output_cost_per_token: 0.00001
-      region: "*"
+- cache_read_input_token_cost: 1.25e-06
+  input_cost_per_token: 2.5e-06
+  output_cost_per_token: 1.0e-05
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
-    - system_messages
-    - prompt_caching
+- function_calling
+- tool_choice
+- structured_output
+- system_messages
+- prompt_caching
 limits:
-    context_window: 128000
-    max_output_tokens: 16384
-    max_tokens: 16384
+  context_window: 128000
+  max_output_tokens: 16384
+  max_tokens: 16384
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: gpt-4o
 params:
-    - key: max_tokens
-      maxValue: 16384
+- key: max_tokens
+  maxValue: 16384
 sources:
-    - https://openrouter.ai/openai/gpt-4o/api
+- https://openrouter.ai/openai/gpt-4o/api
+status: deprecated

--- a/providers/openrouter/gpt-4o:extended.yaml
+++ b/providers/openrouter/gpt-4o:extended.yaml
@@ -1,27 +1,28 @@
 costs:
-    - input_cost_per_token: 0.000006
-      output_cost_per_token: 0.000018
-      region: "*"
+- input_cost_per_token: 6.0e-06
+  output_cost_per_token: 1.8e-05
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
-    - system_messages
+- function_calling
+- tool_choice
+- structured_output
+- system_messages
 limits:
-    context_window: 128000
-    max_input_tokens: 128000
-    max_output_tokens: 64000
-    max_tokens: 64000
+  context_window: 128000
+  max_input_tokens: 128000
+  max_output_tokens: 64000
+  max_tokens: 64000
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: gpt-4o:extended
 params:
-    - key: max_tokens
-      maxValue: 64000
+- key: max_tokens
+  maxValue: 64000
 sources:
-    - https://openrouter.ai/openai/gpt-4o:extended/api
+- https://openrouter.ai/openai/gpt-4o:extended/api
+status: deprecated

--- a/providers/openrouter/gpt-oss-120b.yaml
+++ b/providers/openrouter/gpt-oss-120b.yaml
@@ -1,27 +1,28 @@
 costs:
-    - input_cost_per_token: 3.9e-8
-      output_cost_per_token: 1.9e-7
-      region: "*"
+- input_cost_per_token: 3.9e-08
+  output_cost_per_token: 1.9e-07
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
+- function_calling
+- tool_choice
+- structured_output
 limits:
-    context_window: 131072
+  context_window: 131072
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: gpt-oss-120b
 params:
-    - key: max_tokens
-      maxValue: 32768
-    - defaultValue: medium
-      key: reasoning_effort
+- key: max_tokens
+  maxValue: 32768
+- defaultValue: medium
+  key: reasoning_effort
 removeParams:
-    - stream
+- stream
 sources:
-    - https://openrouter.ai/openai/gpt-oss-120b/api
+- https://openrouter.ai/openai/gpt-oss-120b/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/gpt-oss-20b.yaml
+++ b/providers/openrouter/gpt-oss-20b.yaml
@@ -1,30 +1,31 @@
 costs:
-    - cache_read_input_token_cost: 1.5e-8
-      input_cost_per_token: 3.e-8
-      output_cost_per_token: 1.1e-7
-      region: "*"
+- cache_read_input_token_cost: 1.5e-08
+  input_cost_per_token: 3.0e-08
+  output_cost_per_token: 1.1e-07
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
+- function_calling
+- tool_choice
+- structured_output
 limits:
-    context_window: 131072
-    max_output_tokens: 131072
-    max_tokens: 131072
+  context_window: 131072
+  max_output_tokens: 131072
+  max_tokens: 131072
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: gpt-oss-20b
 params:
-    - key: max_tokens
-      maxValue: 131072
-    - key: reasoning_effort
-      type: string
+- key: max_tokens
+  maxValue: 131072
+- key: reasoning_effort
+  type: string
 removeParams:
-    - stream
+- stream
 sources:
-    - https://openrouter.ai/openai/gpt-oss-20b/api
+- https://openrouter.ai/openai/gpt-oss-20b/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/grok-2-1212.yaml
+++ b/providers/openrouter/grok-2-1212.yaml
@@ -1,7 +1,8 @@
 features:
-    - function_calling
+- function_calling
 isDeprecated: true
 limits:
-    max_tokens: 4096
+  max_tokens: 4096
 mode: chat
 model: grok-2-1212
+status: deprecated

--- a/providers/openrouter/grok-2-vision-1212.yaml
+++ b/providers/openrouter/grok-2-vision-1212.yaml
@@ -1,13 +1,14 @@
 limits:
-    context_window: 32768
+  context_window: 32768
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: grok-2-vision-1212
 sources:
-    - https://openrouter.ai/x-ai/grok-2-vision-1212/api
-    - https://docs.x.ai/developers/models#models-and-pricing
+- https://openrouter.ai/x-ai/grok-2-vision-1212/api
+- https://docs.x.ai/developers/models#models-and-pricing
+status: deprecated

--- a/providers/openrouter/grok-3-beta.yaml
+++ b/providers/openrouter/grok-3-beta.yaml
@@ -1,22 +1,23 @@
 costs:
-    - cache_read_input_token_cost: 7.5e-7
-      input_cost_per_token: 0.000003
-      output_cost_per_token: 0.000015
-      region: "*"
+- cache_read_input_token_cost: 7.5e-07
+  input_cost_per_token: 3.0e-06
+  output_cost_per_token: 1.5e-05
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
-    - system_messages
+- function_calling
+- tool_choice
+- structured_output
+- system_messages
 limits:
-    context_window: 131072
+  context_window: 131072
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: grok-3-beta
 sources:
-    - https://openrouter.ai/x-ai/grok-3-beta/api
-    - https://docs.x.ai/developers/models#models-and-pricing
+- https://openrouter.ai/x-ai/grok-3-beta/api
+- https://docs.x.ai/developers/models#models-and-pricing
+status: deprecated

--- a/providers/openrouter/grok-3-mini-beta.yaml
+++ b/providers/openrouter/grok-3-mini-beta.yaml
@@ -1,23 +1,24 @@
 costs:
-    - cache_read_input_token_cost: 7.5e-8
-      input_cost_per_token: 3.e-7
-      output_cost_per_token: 5.e-7
-      region: "*"
+- cache_read_input_token_cost: 7.5e-08
+  input_cost_per_token: 3.0e-07
+  output_cost_per_token: 5.0e-07
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
-    - json_output
+- function_calling
+- tool_choice
+- structured_output
+- json_output
 limits:
-    context_window: 131072
+  context_window: 131072
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: grok-3-mini-beta
 sources:
-    - https://openrouter.ai/x-ai/grok-3-mini-beta/api
-    - https://docs.x.ai/developers/models#models-and-pricing
+- https://openrouter.ai/x-ai/grok-3-mini-beta/api
+- https://docs.x.ai/developers/models#models-and-pricing
 thinking: true
+status: deprecated

--- a/providers/openrouter/grok-3-mini.yaml
+++ b/providers/openrouter/grok-3-mini.yaml
@@ -1,24 +1,25 @@
 costs:
-    - cache_read_input_token_cost: 7.5e-8
-      input_cost_per_token: 3.e-7
-      output_cost_per_token: 5.e-7
-      region: "*"
+- cache_read_input_token_cost: 7.5e-08
+  input_cost_per_token: 3.0e-07
+  output_cost_per_token: 5.0e-07
+  region: '*'
 features:
-    - function_calling
-    - structured_output
+- function_calling
+- structured_output
 limits:
-    context_window: 131072
+  context_window: 131072
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: grok-3-mini
 params:
-    - key: reasoning_effort
-      type: string
+- key: reasoning_effort
+  type: string
 sources:
-    - https://openrouter.ai/x-ai/grok-3-mini/api
-    - https://docs.x.ai/developers/models#models-and-pricing
+- https://openrouter.ai/x-ai/grok-3-mini/api
+- https://docs.x.ai/developers/models#models-and-pricing
 thinking: true
+status: deprecated

--- a/providers/openrouter/grok-3.yaml
+++ b/providers/openrouter/grok-3.yaml
@@ -1,22 +1,23 @@
 costs:
-    - cache_read_input_token_cost: 7.5e-7
-      input_cost_per_token: 0.000003
-      output_cost_per_token: 0.000015
-      region: "*"
+- cache_read_input_token_cost: 7.5e-07
+  input_cost_per_token: 3.0e-06
+  output_cost_per_token: 1.5e-05
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
-    - json_output
+- function_calling
+- tool_choice
+- structured_output
+- json_output
 limits:
-    context_window: 131072
+  context_window: 131072
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: grok-3
 sources:
-    - https://openrouter.ai/x-ai/grok-3/api
-    - https://docs.x.ai/developers/models#models-and-pricing
+- https://openrouter.ai/x-ai/grok-3/api
+- https://docs.x.ai/developers/models#models-and-pricing
+status: deprecated

--- a/providers/openrouter/grok-4.yaml
+++ b/providers/openrouter/grok-4.yaml
@@ -1,33 +1,34 @@
 costs:
-    - cache_read_input_token_cost: 7.5e-7
-      input_cost_per_query: 0.005
-      input_cost_per_token: 0.000003
-      output_cost_per_token: 0.000015
-      region: "*"
-      tiered_pricing:
-          input:
-              - cost_per_token: 0.000006
-                from: 128000
-          output:
-              - cost_per_token: 0.00003
-                from: 128000
-features:
-    - function_calling
-    - parallel_function_calling
-    - tool_choice
-    - structured_output
-    - prompt_caching
-limits:
-    context_window: 256000
-modalities:
+- cache_read_input_token_cost: 7.5e-07
+  input_cost_per_query: 0.005
+  input_cost_per_token: 3.0e-06
+  output_cost_per_token: 1.5e-05
+  region: '*'
+  tiered_pricing:
     input:
-        - text
-        - image
+    - cost_per_token: 6.0e-06
+      from: 128000
     output:
-        - text
+    - cost_per_token: 3.0e-05
+      from: 128000
+features:
+- function_calling
+- parallel_function_calling
+- tool_choice
+- structured_output
+- prompt_caching
+limits:
+  context_window: 256000
+modalities:
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: grok-4
 sources:
-    - https://openrouter.ai/x-ai/grok-4/api
-    - https://docs.x.ai/developers/models#models-and-pricing
+- https://openrouter.ai/x-ai/grok-4/api
+- https://docs.x.ai/developers/models#models-and-pricing
 thinking: true
+status: deprecated

--- a/providers/openrouter/grok-vision-beta.yaml
+++ b/providers/openrouter/grok-vision-beta.yaml
@@ -1,12 +1,13 @@
 limits:
-    context_window: 8192
+  context_window: 8192
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: grok-vision-beta
 sources:
-    - https://openrouter.ai/x-ai/grok-vision-beta/api
+- https://openrouter.ai/x-ai/grok-vision-beta/api
+status: deprecated

--- a/providers/openrouter/hermes-2-pro-llama-3-8b.yaml
+++ b/providers/openrouter/hermes-2-pro-llama-3-8b.yaml
@@ -1,24 +1,25 @@
 costs:
-    - input_cost_per_token: 1.4e-7
-      output_cost_per_token: 1.4e-7
-      region: "*"
+- input_cost_per_token: 1.4e-07
+  output_cost_per_token: 1.4e-07
+  region: '*'
 features:
-    - function_calling
-    - structured_output
-    - json_output
+- function_calling
+- structured_output
+- json_output
 limits:
-    context_window: 8192
-    max_output_tokens: 8192
-    max_tokens: 8192
+  context_window: 8192
+  max_output_tokens: 8192
+  max_tokens: 8192
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: hermes-2-pro-llama-3-8b
 params:
-    - key: max_tokens
-      maxValue: 8192
+- key: max_tokens
+  maxValue: 8192
 sources:
-    - https://openrouter.ai/nousresearch/hermes-2-pro-llama-3-8b/api
+- https://openrouter.ai/nousresearch/hermes-2-pro-llama-3-8b/api
+status: deprecated

--- a/providers/openrouter/hermes-3-llama-3.1-405b.yaml
+++ b/providers/openrouter/hermes-3-llama-3.1-405b.yaml
@@ -1,23 +1,24 @@
 costs:
-    - input_cost_per_token: 0.000001
-      output_cost_per_token: 0.000001
-      region: "*"
+- input_cost_per_token: 1.0e-06
+  output_cost_per_token: 1.0e-06
+  region: '*'
 features:
-    - function_calling
-    - structured_output
+- function_calling
+- structured_output
 limits:
-    context_window: 131072
-    max_output_tokens: 16384
-    max_tokens: 16384
+  context_window: 131072
+  max_output_tokens: 16384
+  max_tokens: 16384
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: hermes-3-llama-3.1-405b
 params:
-    - key: max_tokens
-      maxValue: 16384
+- key: max_tokens
+  maxValue: 16384
 sources:
-    - https://openrouter.ai/nousresearch/hermes-3-llama-3.1-405b/api
+- https://openrouter.ai/nousresearch/hermes-3-llama-3.1-405b/api
+status: deprecated

--- a/providers/openrouter/hermes-3-llama-3.1-70b.yaml
+++ b/providers/openrouter/hermes-3-llama-3.1-70b.yaml
@@ -1,18 +1,18 @@
 costs:
-    - input_cost_per_token: 3.e-7
-      output_cost_per_token: 3.e-7
-      region: "*"
+- input_cost_per_token: 3.0e-07
+  output_cost_per_token: 3.0e-07
+  region: '*'
 limits:
-    context_window: 131072
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 131072
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: hermes-3-llama-3.1-70b
 sources:
-    - https://openrouter.ai/nousresearch/hermes-3-llama-3.1-70b/api
-status: active
+- https://openrouter.ai/nousresearch/hermes-3-llama-3.1-70b/api
+status: deprecated

--- a/providers/openrouter/horizon-alpha.yaml
+++ b/providers/openrouter/horizon-alpha.yaml
@@ -1,15 +1,16 @@
 features:
-    - function_calling
+- function_calling
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: horizon-alpha
 params:
-    - key: max_tokens
-      maxValue: 128000
+- key: max_tokens
+  maxValue: 128000
 sources:
-    - https://openrouter.ai/horizon-alpha/api
+- https://openrouter.ai/horizon-alpha/api
+status: deprecated

--- a/providers/openrouter/hunyuan-a13b-instruct.yaml
+++ b/providers/openrouter/hunyuan-a13b-instruct.yaml
@@ -1,22 +1,23 @@
 costs:
-    - input_cost_per_token: 1.4e-7
-      output_cost_per_token: 5.7e-7
-      region: "*"
+- input_cost_per_token: 1.4e-07
+  output_cost_per_token: 5.7e-07
+  region: '*'
 features:
-    - function_calling
-    - structured_output
-    - tool_choice
+- function_calling
+- structured_output
+- tool_choice
 limits:
-    context_window: 131072
-    max_output_tokens: 131072
-    max_tokens: 131072
+  context_window: 131072
+  max_output_tokens: 131072
+  max_tokens: 131072
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: hunyuan-a13b-instruct
 sources:
-    - https://openrouter.ai/tencent/hunyuan-a13b-instruct/api
+- https://openrouter.ai/tencent/hunyuan-a13b-instruct/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/hunyuan-a13b-instruct:free.yaml
+++ b/providers/openrouter/hunyuan-a13b-instruct:free.yaml
@@ -1,21 +1,22 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 features:
-    - structured_output
+- structured_output
 limits:
-    context_window: 32768
-    max_output_tokens: 32768
-    max_tokens: 32768
+  context_window: 32768
+  max_output_tokens: 32768
+  max_tokens: 32768
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: hunyuan-a13b-instruct:free
 sources:
-    - https://openrouter.ai/tencent/hunyuan-a13b-instruct:free/api
-    - https://openrouter.ai/tencent/hunyuan-a13b-instruct/api
+- https://openrouter.ai/tencent/hunyuan-a13b-instruct:free/api
+- https://openrouter.ai/tencent/hunyuan-a13b-instruct/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/inception/mercury-coder.yaml
+++ b/providers/openrouter/inception/mercury-coder.yaml
@@ -1,23 +1,23 @@
 costs:
-    - cache_read_input_token_cost: 2.5e-8
-      input_cost_per_token: 2.5e-7
-      output_cost_per_token: 7.5e-7
-      region: "*"
+- cache_read_input_token_cost: 2.5e-08
+  input_cost_per_token: 2.5e-07
+  output_cost_per_token: 7.5e-07
+  region: '*'
 features:
-    - function_calling
-    - structured_output
-    - tool_choice
+- function_calling
+- structured_output
+- tool_choice
 limits:
-    context_window: 128000
-    max_output_tokens: 32000
-    max_tokens: 32000
+  context_window: 128000
+  max_output_tokens: 32000
+  max_tokens: 32000
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: inception/mercury-coder
 sources:
-    - https://openrouter.ai/inception/mercury-coder/api
-status: active
+- https://openrouter.ai/inception/mercury-coder/api
+status: deprecated

--- a/providers/openrouter/inception/mercury.yaml
+++ b/providers/openrouter/inception/mercury.yaml
@@ -1,3 +1,4 @@
 isDeprecated: true
 mode: unknown
 model: inception/mercury
+status: deprecated

--- a/providers/openrouter/inflection-3-pi.yaml
+++ b/providers/openrouter/inflection-3-pi.yaml
@@ -1,22 +1,23 @@
 costs:
-    - input_cost_per_token: 0.0000025
-      output_cost_per_token: 0.00001
-      region: "*"
+- input_cost_per_token: 2.5e-06
+  output_cost_per_token: 1.0e-05
+  region: '*'
 features:
-    - tool_choice
+- tool_choice
 limits:
-    context_window: 8000
-    max_output_tokens: 1024
-    max_tokens: 1024
+  context_window: 8000
+  max_output_tokens: 1024
+  max_tokens: 1024
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: inflection-3-pi
 params:
-    - key: max_tokens
-      maxValue: 1024
+- key: max_tokens
+  maxValue: 1024
 sources:
-    - https://openrouter.ai/inflection/inflection-3-pi/api
+- https://openrouter.ai/inflection/inflection-3-pi/api
+status: deprecated

--- a/providers/openrouter/inflection-3-productivity.yaml
+++ b/providers/openrouter/inflection-3-productivity.yaml
@@ -1,23 +1,24 @@
 costs:
-    - input_cost_per_token: 0.0000025
-      output_cost_per_token: 0.00001
-      region: "*"
+- input_cost_per_token: 2.5e-06
+  output_cost_per_token: 1.0e-05
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
+- function_calling
+- tool_choice
 limits:
-    context_window: 8000
-    max_output_tokens: 1024
-    max_tokens: 1024
+  context_window: 8000
+  max_output_tokens: 1024
+  max_tokens: 1024
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: inflection-3-productivity
 params:
-    - key: max_tokens
-      maxValue: 1024
+- key: max_tokens
+  maxValue: 1024
 sources:
-    - https://openrouter.ai/inflection/inflection-3-productivity/api
+- https://openrouter.ai/inflection/inflection-3-productivity/api
+status: deprecated

--- a/providers/openrouter/internvl3-14b.yaml
+++ b/providers/openrouter/internvl3-14b.yaml
@@ -1,12 +1,13 @@
 limits:
-    context_window: 32000
+  context_window: 32000
 modalities:
-    input:
-        - image
-        - text
-    output:
-        - text
+  input:
+  - image
+  - text
+  output:
+  - text
 mode: chat
 model: internvl3-14b
 sources:
-    - https://openrouter.ai/opengvlab/internvl3-14b/api
+- https://openrouter.ai/opengvlab/internvl3-14b/api
+status: deprecated

--- a/providers/openrouter/jamba-1.6-large.yaml
+++ b/providers/openrouter/jamba-1.6-large.yaml
@@ -1,25 +1,26 @@
 costs:
-    - input_cost_per_token: 0.000002
-      output_cost_per_token: 0.000008
-      region: "*"
-deprecationDate: "2025-08-03"
+- input_cost_per_token: 2.0e-06
+  output_cost_per_token: 8.0e-06
+  region: '*'
+deprecationDate: '2025-08-03'
 features:
-    - function_calling
-    - structured_output
+- function_calling
+- structured_output
 isDeprecated: true
 limits:
-    context_window: 256000
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 256000
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: jamba-1.6-large
 sources:
-    - https://openrouter.ai/ai21/jamba-1.6-large/api
-    - https://docs.ai21.com/reference/jamba-1-6-api-ref
-    - https://docs.ai21.com/docs/jamba-foundation-models
-    - https://www.ai21.com/pricing
+- https://openrouter.ai/ai21/jamba-1.6-large/api
+- https://docs.ai21.com/reference/jamba-1-6-api-ref
+- https://docs.ai21.com/docs/jamba-foundation-models
+- https://www.ai21.com/pricing
+status: deprecated

--- a/providers/openrouter/jamba-1.6-mini.yaml
+++ b/providers/openrouter/jamba-1.6-mini.yaml
@@ -1,20 +1,21 @@
 features:
-    - function_calling
-    - structured_output
-    - system_messages
+- function_calling
+- structured_output
+- system_messages
 limits:
-    context_window: 256000
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 256000
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: jamba-1.6-mini
 params:
-    - key: max_tokens
-      maxValue: 4096
+- key: max_tokens
+  maxValue: 4096
 sources:
-    - https://openrouter.ai/ai21/jamba-1.6-mini/api
+- https://openrouter.ai/ai21/jamba-1.6-mini/api
+status: deprecated

--- a/providers/openrouter/jondurbin/airoboros-l2-70b-2.1.yaml
+++ b/providers/openrouter/jondurbin/airoboros-l2-70b-2.1.yaml
@@ -1,9 +1,10 @@
 costs:
-    - input_cost_per_token: 0.000013875
-      output_cost_per_token: 0.000013875
-      region: "*"
+- input_cost_per_token: 1.3875e-05
+  output_cost_per_token: 1.3875e-05
+  region: '*'
 isDeprecated: true
 limits:
-    max_tokens: 4096
+  max_tokens: 4096
 mode: chat
 model: jondurbin/airoboros-l2-70b-2.1
+status: deprecated

--- a/providers/openrouter/kimi-dev-72b:free.yaml
+++ b/providers/openrouter/kimi-dev-72b:free.yaml
@@ -1,17 +1,17 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 limits:
-    context_window: 131072
+  context_window: 131072
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: kimi-dev-72b:free
 sources:
-    - https://openrouter.ai/moonshotai/kimi-dev-72b:free/api
-status: active
+- https://openrouter.ai/moonshotai/kimi-dev-72b:free/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/kimi-k2.yaml
+++ b/providers/openrouter/kimi-k2.yaml
@@ -1,20 +1,21 @@
 costs:
-    - input_cost_per_token: 5.7e-7
-      output_cost_per_token: 0.0000023
-      region: "*"
+- input_cost_per_token: 5.7e-07
+  output_cost_per_token: 2.3e-06
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
+- function_calling
+- tool_choice
 limits:
-    context_window: 131072
-    max_output_tokens: 131072
-    max_tokens: 131072
+  context_window: 131072
+  max_output_tokens: 131072
+  max_tokens: 131072
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: kimi-k2
 sources:
-    - https://openrouter.ai/moonshotai/kimi-k2/api
+- https://openrouter.ai/moonshotai/kimi-k2/api
+status: deprecated

--- a/providers/openrouter/kimi-k2:free.yaml
+++ b/providers/openrouter/kimi-k2:free.yaml
@@ -1,21 +1,22 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
+- function_calling
+- tool_choice
 limits:
-    context_window: 131072
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 131072
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: kimi-k2:free
 sources:
-    - https://openrouter.ai/moonshotai/kimi-k2:free/api
-    - https://openrouter.ai/moonshotai/kimi-k2/api
+- https://openrouter.ai/moonshotai/kimi-k2:free/api
+- https://openrouter.ai/moonshotai/kimi-k2/api
+status: deprecated

--- a/providers/openrouter/kimi-vl-a3b-thinking.yaml
+++ b/providers/openrouter/kimi-vl-a3b-thinking.yaml
@@ -1,13 +1,14 @@
 limits:
-    context_window: 131072
+  context_window: 131072
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: kimi-vl-a3b-thinking
 sources:
-    - https://openrouter.ai/moonshotai/kimi-vl-a3b-thinking/api
+- https://openrouter.ai/moonshotai/kimi-vl-a3b-thinking/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/kimi-vl-a3b-thinking:free.yaml
+++ b/providers/openrouter/kimi-vl-a3b-thinking:free.yaml
@@ -1,19 +1,20 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 limits:
-    context_window: 131072
-    max_tokens: 4096
+  context_window: 131072
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: kimi-vl-a3b-thinking:free
 sources:
-    - https://openrouter.ai/moonshotai/kimi-vl-a3b-thinking:free/api
-    - https://openrouter.ai/moonshotai/kimi-vl-a3b-thinking:free
+- https://openrouter.ai/moonshotai/kimi-vl-a3b-thinking:free/api
+- https://openrouter.ai/moonshotai/kimi-vl-a3b-thinking:free
 thinking: true
+status: deprecated

--- a/providers/openrouter/kwaipilot/kat-coder-pro.yaml
+++ b/providers/openrouter/kwaipilot/kat-coder-pro.yaml
@@ -1,23 +1,24 @@
 costs:
-    - cache_read_input_token_cost: 4.14e-8
-      input_cost_per_token: 2.07e-7
-      output_cost_per_token: 8.28e-7
-      region: "*"
+- cache_read_input_token_cost: 4.14e-08
+  input_cost_per_token: 2.07e-07
+  output_cost_per_token: 8.28e-07
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
+- function_calling
+- tool_choice
+- structured_output
 isDeprecated: true
 limits:
-    context_window: 256000
-    max_output_tokens: 128000
-    max_tokens: 128000
+  context_window: 256000
+  max_output_tokens: 128000
+  max_tokens: 128000
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: kwaipilot/kat-coder-pro
 sources:
-    - https://openrouter.ai/kwaipilot/kat-coder-pro/api
+- https://openrouter.ai/kwaipilot/kat-coder-pro/api
+status: deprecated

--- a/providers/openrouter/l3-euryale-70b.yaml
+++ b/providers/openrouter/l3-euryale-70b.yaml
@@ -1,23 +1,24 @@
 costs:
-    - input_cost_per_token: 0.00000148
-      output_cost_per_token: 0.00000148
-      region: "*"
+- input_cost_per_token: 1.48e-06
+  output_cost_per_token: 1.48e-06
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
+- function_calling
+- tool_choice
 limits:
-    context_window: 8192
-    max_output_tokens: 8192
-    max_tokens: 8192
+  context_window: 8192
+  max_output_tokens: 8192
+  max_tokens: 8192
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: l3-euryale-70b
 params:
-    - key: max_tokens
-      maxValue: 8192
+- key: max_tokens
+  maxValue: 8192
 sources:
-    - https://openrouter.ai/sao10k/l3-euryale-70b/api
+- https://openrouter.ai/sao10k/l3-euryale-70b/api
+status: deprecated

--- a/providers/openrouter/l3-lunaris-8b.yaml
+++ b/providers/openrouter/l3-lunaris-8b.yaml
@@ -1,5 +1,6 @@
 isDeprecated: true
 limits:
-    max_tokens: 4096
+  max_tokens: 4096
 mode: chat
 model: l3-lunaris-8b
+status: deprecated

--- a/providers/openrouter/l3.1-euryale-70b.yaml
+++ b/providers/openrouter/l3.1-euryale-70b.yaml
@@ -1,25 +1,25 @@
 costs:
-    - input_cost_per_token: 8.5e-7
-      output_cost_per_token: 8.5e-7
-      region: "*"
+- input_cost_per_token: 8.5e-07
+  output_cost_per_token: 8.5e-07
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - json_output
+- function_calling
+- tool_choice
+- json_output
 limits:
-    context_window: 131072
-    max_output_tokens: 16384
-    max_tokens: 16384
+  context_window: 131072
+  max_output_tokens: 16384
+  max_tokens: 16384
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: sao10k/l3.1-euryale-70b
 params:
-    - key: max_tokens
-      maxValue: 16384
+- key: max_tokens
+  maxValue: 16384
 sources:
-    - https://openrouter.ai/sao10k/l3.1-euryale-70b/api
-status: active
+- https://openrouter.ai/sao10k/l3.1-euryale-70b/api
+status: deprecated

--- a/providers/openrouter/l3.3-euryale-70b.yaml
+++ b/providers/openrouter/l3.3-euryale-70b.yaml
@@ -1,21 +1,22 @@
 costs:
-    - input_cost_per_token: 6.5e-7
-      output_cost_per_token: 7.5e-7
-      region: "*"
+- input_cost_per_token: 6.5e-07
+  output_cost_per_token: 7.5e-07
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
+- function_calling
+- tool_choice
+- structured_output
 limits:
-    context_window: 131072
-    max_output_tokens: 16384
-    max_tokens: 16384
+  context_window: 131072
+  max_output_tokens: 16384
+  max_tokens: 16384
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: l3.3-euryale-70b
 sources:
-    - https://openrouter.ai/sao10k/l3.3-euryale-70b/api
+- https://openrouter.ai/sao10k/l3.3-euryale-70b/api
+status: deprecated

--- a/providers/openrouter/lfm-3b.yaml
+++ b/providers/openrouter/lfm-3b.yaml
@@ -1,12 +1,13 @@
 limits:
-    context_window: 32768
+  context_window: 32768
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: lfm-3b
 sources:
-    - https://openrouter.ai/liquid/lfm-3b/api
-    - https://openrouter.ai/liquid/lfm-3b
+- https://openrouter.ai/liquid/lfm-3b/api
+- https://openrouter.ai/liquid/lfm-3b
+status: deprecated

--- a/providers/openrouter/lfm-40b.yaml
+++ b/providers/openrouter/lfm-40b.yaml
@@ -1,15 +1,15 @@
 limits:
-    context_window: 32768
+  context_window: 32768
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: lfm-40b
 params:
-    - key: max_tokens
-      maxValue: 65536
+- key: max_tokens
+  maxValue: 65536
 sources:
-    - https://openrouter.ai/liquid/lfm-40b/api
-status: active
+- https://openrouter.ai/liquid/lfm-40b/api
+status: deprecated

--- a/providers/openrouter/lfm-7b.yaml
+++ b/providers/openrouter/lfm-7b.yaml
@@ -1,18 +1,18 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 limits:
-    context_window: 32768
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 32768
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: liquid/lfm-7b
 sources:
-    - https://openrouter.ai/liquid/lfm-7b/api
-status: active
+- https://openrouter.ai/liquid/lfm-7b/api
+status: deprecated

--- a/providers/openrouter/llama-3-70b-instruct.yaml
+++ b/providers/openrouter/llama-3-70b-instruct.yaml
@@ -1,24 +1,25 @@
 costs:
-    - input_cost_per_token: 5.1e-7
-      output_cost_per_token: 7.4e-7
-      region: "*"
+- input_cost_per_token: 5.1e-07
+  output_cost_per_token: 7.4e-07
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
+- function_calling
+- tool_choice
+- structured_output
 limits:
-    context_window: 8192
-    max_output_tokens: 8000
-    max_tokens: 8000
+  context_window: 8192
+  max_output_tokens: 8000
+  max_tokens: 8000
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: llama-3-70b-instruct
 params:
-    - key: max_tokens
-      maxValue: 8000
+- key: max_tokens
+  maxValue: 8000
 sources:
-    - https://openrouter.ai/meta-llama/llama-3-70b-instruct/api
+- https://openrouter.ai/meta-llama/llama-3-70b-instruct/api
+status: deprecated

--- a/providers/openrouter/llama-3-8b-instruct.yaml
+++ b/providers/openrouter/llama-3-8b-instruct.yaml
@@ -1,26 +1,27 @@
 costs:
-    - input_cost_per_token: 3.e-8
-      output_cost_per_token: 4.e-8
-      region: "*"
+- input_cost_per_token: 3.0e-08
+  output_cost_per_token: 4.0e-08
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - system_messages
-    - structured_output
-    - json_output
+- function_calling
+- tool_choice
+- system_messages
+- structured_output
+- json_output
 limits:
-    context_window: 8192
-    max_output_tokens: 16384
-    max_tokens: 16384
+  context_window: 8192
+  max_output_tokens: 16384
+  max_tokens: 16384
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: llama-3-8b-instruct
 params:
-    - key: max_tokens
-      maxValue: 16384
+- key: max_tokens
+  maxValue: 16384
 sources:
-    - https://openrouter.ai/meta-llama/llama-3-8b-instruct/api
+- https://openrouter.ai/meta-llama/llama-3-8b-instruct/api
+status: deprecated

--- a/providers/openrouter/llama-3-lumimaid-70b.yaml
+++ b/providers/openrouter/llama-3-lumimaid-70b.yaml
@@ -1,12 +1,13 @@
 limits:
-    context_window: 8192
+  context_window: 8192
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: llama-3-lumimaid-70b
 sources:
-    - https://openrouter.ai/neversleep/llama-3-lumimaid-70b/api
-    - https://openrouter.ai/neversleep/llama-3-lumimaid-70b
+- https://openrouter.ai/neversleep/llama-3-lumimaid-70b/api
+- https://openrouter.ai/neversleep/llama-3-lumimaid-70b
+status: deprecated

--- a/providers/openrouter/llama-3.1-405b-instruct.yaml
+++ b/providers/openrouter/llama-3.1-405b-instruct.yaml
@@ -1,23 +1,23 @@
 costs:
-    - input_cost_per_token: 0.000004
-      output_cost_per_token: 0.000004
-      region: "*"
+- input_cost_per_token: 4.0e-06
+  output_cost_per_token: 4.0e-06
+  region: '*'
 features:
-    - function_calling
+- function_calling
 limits:
-    context_window: 131072
-    max_output_tokens: 16384
-    max_tokens: 16384
+  context_window: 131072
+  max_output_tokens: 16384
+  max_tokens: 16384
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: meta-llama/llama-3.1-405b-instruct
 params:
-    - key: max_tokens
-      maxValue: 16384
+- key: max_tokens
+  maxValue: 16384
 sources:
-    - https://openrouter.ai/meta-llama/llama-3.1-405b-instruct/api
-status: active
+- https://openrouter.ai/meta-llama/llama-3.1-405b-instruct/api
+status: deprecated

--- a/providers/openrouter/llama-3.1-405b-instruct:free.yaml
+++ b/providers/openrouter/llama-3.1-405b-instruct:free.yaml
@@ -1,19 +1,20 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 features:
-    - function_calling
+- function_calling
 limits:
-    context_window: 131072
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 131072
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: llama-3.1-405b-instruct:free
 sources:
-    - https://openrouter.ai/meta-llama/llama-3.1-405b-instruct:free/api
+- https://openrouter.ai/meta-llama/llama-3.1-405b-instruct:free/api
+status: deprecated

--- a/providers/openrouter/llama-3.1-405b.yaml
+++ b/providers/openrouter/llama-3.1-405b.yaml
@@ -1,17 +1,18 @@
 costs:
-    - input_cost_per_token: 0.000004
-      output_cost_per_token: 0.000004
-      region: "*"
+- input_cost_per_token: 4.0e-06
+  output_cost_per_token: 4.0e-06
+  region: '*'
 limits:
-    context_window: 131072
-    max_output_tokens: 131072
-    max_tokens: 131072
+  context_window: 131072
+  max_output_tokens: 131072
+  max_tokens: 131072
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: completion
 model: llama-3.1-405b
 sources:
-    - https://openrouter.ai/meta-llama/llama-3.1-405b/api
+- https://openrouter.ai/meta-llama/llama-3.1-405b/api
+status: deprecated

--- a/providers/openrouter/llama-3.1-70b-instruct.yaml
+++ b/providers/openrouter/llama-3.1-70b-instruct.yaml
@@ -1,21 +1,22 @@
 costs:
-    - input_cost_per_token: 4.e-7
-      output_cost_per_token: 4.e-7
-      region: "*"
+- input_cost_per_token: 4.0e-07
+  output_cost_per_token: 4.0e-07
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
+- function_calling
+- tool_choice
 limits:
-    context_window: 131072
+  context_window: 131072
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: meta-llama/llama-3.1-70b-instruct
 params:
-    - key: max_tokens
-      maxValue: 16384
+- key: max_tokens
+  maxValue: 16384
 sources:
-    - https://openrouter.ai/meta-llama/llama-3.1-70b-instruct/api
+- https://openrouter.ai/meta-llama/llama-3.1-70b-instruct/api
+status: deprecated

--- a/providers/openrouter/llama-3.1-8b-instruct.yaml
+++ b/providers/openrouter/llama-3.1-8b-instruct.yaml
@@ -1,24 +1,24 @@
 costs:
-    - input_cost_per_token: 2.e-8
-      output_cost_per_token: 5.e-8
-      region: "*"
+- input_cost_per_token: 2.0e-08
+  output_cost_per_token: 5.0e-08
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
+- function_calling
+- tool_choice
 limits:
-    context_window: 16384
-    max_output_tokens: 16384
-    max_tokens: 16384
+  context_window: 16384
+  max_output_tokens: 16384
+  max_tokens: 16384
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: llama-3.1-8b-instruct
 params:
-    - key: max_tokens
-      maxValue: 16384
+- key: max_tokens
+  maxValue: 16384
 sources:
-    - https://openrouter.ai/meta-llama/llama-3.1-8b-instruct/api
-status: active
+- https://openrouter.ai/meta-llama/llama-3.1-8b-instruct/api
+status: deprecated

--- a/providers/openrouter/llama-3.1-lumimaid-8b.yaml
+++ b/providers/openrouter/llama-3.1-lumimaid-8b.yaml
@@ -1,11 +1,12 @@
 limits:
-    context_window: 131072
+  context_window: 131072
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: llama-3.1-lumimaid-8b
 sources:
-    - https://openrouter.ai/neversleep/llama-3.1-lumimaid-8b/api
+- https://openrouter.ai/neversleep/llama-3.1-lumimaid-8b/api
+status: deprecated

--- a/providers/openrouter/llama-3.1-nemotron-70b-instruct.yaml
+++ b/providers/openrouter/llama-3.1-nemotron-70b-instruct.yaml
@@ -1,26 +1,26 @@
 costs:
-    - input_cost_per_token: 0.0000012
-      output_cost_per_token: 0.0000012
-      region: "*"
+- input_cost_per_token: 1.2e-06
+  output_cost_per_token: 1.2e-06
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
-    - json_output
+- function_calling
+- tool_choice
+- structured_output
+- json_output
 limits:
-    context_window: 131072
-    max_output_tokens: 16384
-    max_tokens: 16384
+  context_window: 131072
+  max_output_tokens: 16384
+  max_tokens: 16384
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: llama-3.1-nemotron-70b-instruct
 params:
-    - key: max_tokens
-      maxValue: 16384
+- key: max_tokens
+  maxValue: 16384
 sources:
-    - https://openrouter.ai/nvidia/llama-3.1-nemotron-70b-instruct/api
-status: active
+- https://openrouter.ai/nvidia/llama-3.1-nemotron-70b-instruct/api
+status: deprecated

--- a/providers/openrouter/llama-3.1-nemotron-ultra-253b-v1.yaml
+++ b/providers/openrouter/llama-3.1-nemotron-ultra-253b-v1.yaml
@@ -1,21 +1,22 @@
 costs:
-    - input_cost_per_token: 6.e-7
-      output_cost_per_token: 0.0000018
-      region: "*"
+- input_cost_per_token: 6.0e-07
+  output_cost_per_token: 1.8e-06
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
-    - json_output
+- function_calling
+- tool_choice
+- structured_output
+- json_output
 limits:
-    context_window: 131072
+  context_window: 131072
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: llama-3.1-nemotron-ultra-253b-v1
 sources:
-    - https://openrouter.ai/nvidia/llama-3.1-nemotron-ultra-253b-v1/api
+- https://openrouter.ai/nvidia/llama-3.1-nemotron-ultra-253b-v1/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/llama-3.1-nemotron-ultra-253b-v1:free.yaml
+++ b/providers/openrouter/llama-3.1-nemotron-ultra-253b-v1:free.yaml
@@ -1,22 +1,22 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 features:
-    - function_calling
-    - structured_output
+- function_calling
+- structured_output
 limits:
-    context_window: 131072
-    max_input_tokens: 131072
+  context_window: 131072
+  max_input_tokens: 131072
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: llama-3.1-nemotron-ultra-253b-v1:free
 sources:
-    - https://openrouter.ai/nvidia/llama-3.1-nemotron-ultra-253b-v1:free/api
-    - https://openrouter.ai/nvidia/llama-3.1-nemotron-ultra-253b-v1/api
-status: active
+- https://openrouter.ai/nvidia/llama-3.1-nemotron-ultra-253b-v1:free/api
+- https://openrouter.ai/nvidia/llama-3.1-nemotron-ultra-253b-v1/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/llama-3.2-11b-vision-instruct.yaml
+++ b/providers/openrouter/llama-3.2-11b-vision-instruct.yaml
@@ -1,25 +1,25 @@
 costs:
-    - input_cost_per_token: 4.9e-8
-      output_cost_per_token: 4.9e-8
-      region: "*"
+- input_cost_per_token: 4.9e-08
+  output_cost_per_token: 4.9e-08
+  region: '*'
 features:
-    - json_output
-    - tool_choice
+- json_output
+- tool_choice
 limits:
-    context_window: 131072
-    max_output_tokens: 16384
-    max_tokens: 16384
+  context_window: 131072
+  max_output_tokens: 16384
+  max_tokens: 16384
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: llama-3.2-11b-vision-instruct
 params:
-    - key: max_tokens
-      maxValue: 16384
+- key: max_tokens
+  maxValue: 16384
 sources:
-    - https://openrouter.ai/meta-llama/llama-3.2-11b-vision-instruct/api
-status: active
+- https://openrouter.ai/meta-llama/llama-3.2-11b-vision-instruct/api
+status: deprecated

--- a/providers/openrouter/llama-3.2-11b-vision-instruct:free.yaml
+++ b/providers/openrouter/llama-3.2-11b-vision-instruct:free.yaml
@@ -1,22 +1,22 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 limits:
-    context_window: 131072
-    max_output_tokens: 2048
-    max_tokens: 2048
+  context_window: 131072
+  max_output_tokens: 2048
+  max_tokens: 2048
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: llama-3.2-11b-vision-instruct:free
 params:
-    - key: max_tokens
-      maxValue: 2048
+- key: max_tokens
+  maxValue: 2048
 sources:
-    - https://openrouter.ai/meta-llama/llama-3.2-11b-vision-instruct:free/api
-status: active
+- https://openrouter.ai/meta-llama/llama-3.2-11b-vision-instruct:free/api
+status: deprecated

--- a/providers/openrouter/llama-3.2-1b-instruct.yaml
+++ b/providers/openrouter/llama-3.2-1b-instruct.yaml
@@ -1,18 +1,19 @@
 costs:
-    - input_cost_per_token: 2.7e-8
-      output_cost_per_token: 2.e-7
-      region: "*"
+- input_cost_per_token: 2.7e-08
+  output_cost_per_token: 2.0e-07
+  region: '*'
 limits:
-    context_window: 60000
+  context_window: 60000
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: llama-3.2-1b-instruct
 params:
-    - key: max_tokens
-      maxValue: 16384
+- key: max_tokens
+  maxValue: 16384
 sources:
-    - https://openrouter.ai/meta-llama/llama-3.2-1b-instruct/api
+- https://openrouter.ai/meta-llama/llama-3.2-1b-instruct/api
+status: deprecated

--- a/providers/openrouter/llama-3.2-3b-instruct.yaml
+++ b/providers/openrouter/llama-3.2-3b-instruct.yaml
@@ -1,21 +1,22 @@
 costs:
-    - input_cost_per_token: 5.1e-8
-      output_cost_per_token: 3.4e-7
-      region: "*"
+- input_cost_per_token: 5.1e-08
+  output_cost_per_token: 3.4e-07
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
+- function_calling
+- tool_choice
 limits:
-    context_window: 80000
+  context_window: 80000
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: meta-llama/llama-3.2-3b-instruct
 params:
-    - key: max_tokens
-      maxValue: 20000
+- key: max_tokens
+  maxValue: 20000
 sources:
-    - https://openrouter.ai/meta-llama/llama-3.2-3b-instruct/api
+- https://openrouter.ai/meta-llama/llama-3.2-3b-instruct/api
+status: deprecated

--- a/providers/openrouter/llama-3.2-3b-instruct:free.yaml
+++ b/providers/openrouter/llama-3.2-3b-instruct:free.yaml
@@ -1,15 +1,16 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 limits:
-    context_window: 131072
+  context_window: 131072
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: llama-3.2-3b-instruct:free
 sources:
-    - https://openrouter.ai/meta-llama/llama-3.2-3b-instruct:free/api
+- https://openrouter.ai/meta-llama/llama-3.2-3b-instruct:free/api
+status: deprecated

--- a/providers/openrouter/llama-3.2-90b-vision-instruct.yaml
+++ b/providers/openrouter/llama-3.2-90b-vision-instruct.yaml
@@ -1,16 +1,17 @@
 limits:
-    context_window: 131072
+  context_window: 131072
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: meta-llama/llama-3.2-90b-vision-instruct
 params:
-    - key: max_tokens
-      maxValue: 2048
+- key: max_tokens
+  maxValue: 2048
 sources:
-    - https://openrouter.ai/meta-llama/llama-3.2-90b-vision-instruct/api
-    - https://openrouter.ai/meta-llama/llama-3.2-90b-vision-instruct
+- https://openrouter.ai/meta-llama/llama-3.2-90b-vision-instruct/api
+- https://openrouter.ai/meta-llama/llama-3.2-90b-vision-instruct
+status: deprecated

--- a/providers/openrouter/llama-3.3-70b-instruct.yaml
+++ b/providers/openrouter/llama-3.3-70b-instruct.yaml
@@ -1,25 +1,26 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 3.2e-7
-      region: "*"
+- input_cost_per_token: 1.0e-07
+  output_cost_per_token: 3.2e-07
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - system_messages
-    - structured_output
+- function_calling
+- tool_choice
+- system_messages
+- structured_output
 limits:
-    context_window: 131072
-    max_output_tokens: 16384
-    max_tokens: 16384
+  context_window: 131072
+  max_output_tokens: 16384
+  max_tokens: 16384
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: llama-3.3-70b-instruct
 params:
-    - key: max_tokens
-      maxValue: 16384
+- key: max_tokens
+  maxValue: 16384
 sources:
-    - https://openrouter.ai/meta-llama/llama-3.3-70b-instruct/api
+- https://openrouter.ai/meta-llama/llama-3.3-70b-instruct/api
+status: deprecated

--- a/providers/openrouter/llama-3.3-70b-instruct:free.yaml
+++ b/providers/openrouter/llama-3.3-70b-instruct:free.yaml
@@ -1,21 +1,22 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - system_messages
+- function_calling
+- tool_choice
+- system_messages
 limits:
-    context_window: 65536
+  context_window: 65536
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: llama-3.3-70b-instruct:free
 removeParams:
-    - response_format
+- response_format
 sources:
-    - https://openrouter.ai/meta-llama/llama-3.3-70b-instruct:free/api
+- https://openrouter.ai/meta-llama/llama-3.3-70b-instruct:free/api
+status: deprecated

--- a/providers/openrouter/llama-3.3-nemotron-super-49b-v1.yaml
+++ b/providers/openrouter/llama-3.3-nemotron-super-49b-v1.yaml
@@ -1,15 +1,16 @@
 features:
-    - function_calling
-    - tool_choice
+- function_calling
+- tool_choice
 limits:
-    context_window: 131072
+  context_window: 131072
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: llama-3.3-nemotron-super-49b-v1
 sources:
-    - https://openrouter.ai/nvidia/llama-3.3-nemotron-super-49b-v1/api
+- https://openrouter.ai/nvidia/llama-3.3-nemotron-super-49b-v1/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/llama-4-maverick.yaml
+++ b/providers/openrouter/llama-4-maverick.yaml
@@ -1,25 +1,26 @@
 costs:
-    - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
-      region: "*"
+- input_cost_per_token: 1.5e-07
+  output_cost_per_token: 6.0e-07
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
+- function_calling
+- tool_choice
+- structured_output
 limits:
-    context_window: 1048576
-    max_output_tokens: 16384
-    max_tokens: 16384
+  context_window: 1048576
+  max_output_tokens: 16384
+  max_tokens: 16384
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: meta-llama/llama-4-maverick
 params:
-    - key: max_tokens
-      maxValue: 16384
+- key: max_tokens
+  maxValue: 16384
 sources:
-    - https://openrouter.ai/meta-llama/llama-4-maverick/api
+- https://openrouter.ai/meta-llama/llama-4-maverick/api
+status: deprecated

--- a/providers/openrouter/llama-4-scout.yaml
+++ b/providers/openrouter/llama-4-scout.yaml
@@ -1,24 +1,25 @@
 costs:
-    - input_cost_per_token: 8.e-8
-      output_cost_per_token: 3.e-7
-      region: "*"
+- input_cost_per_token: 8.0e-08
+  output_cost_per_token: 3.0e-07
+  region: '*'
 features:
-    - function_calling
-    - structured_output
+- function_calling
+- structured_output
 limits:
-    context_window: 327680
-    max_output_tokens: 16384
-    max_tokens: 16384
+  context_window: 327680
+  max_output_tokens: 16384
+  max_tokens: 16384
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: llama-4-scout
 params:
-    - key: max_tokens
-      maxValue: 16384
+- key: max_tokens
+  maxValue: 16384
 sources:
-    - https://openrouter.ai/meta-llama/llama-4-scout/api
+- https://openrouter.ai/meta-llama/llama-4-scout/api
+status: deprecated

--- a/providers/openrouter/llama-guard-2-8b.yaml
+++ b/providers/openrouter/llama-guard-2-8b.yaml
@@ -1,18 +1,19 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 limits:
-    context_window: 8192
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 8192
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: meta-llama/llama-guard-2-8b
 sources:
-    - https://openrouter.ai/meta-llama/llama-guard-2-8b/api
-    - https://openrouter.ai/meta-llama/llama-guard-2-8b
+- https://openrouter.ai/meta-llama/llama-guard-2-8b/api
+- https://openrouter.ai/meta-llama/llama-guard-2-8b
+status: deprecated

--- a/providers/openrouter/llama-guard-3-8b.yaml
+++ b/providers/openrouter/llama-guard-3-8b.yaml
@@ -1,17 +1,18 @@
 costs:
-    - input_cost_per_token: 2.e-8
-      output_cost_per_token: 6.e-8
-      region: "*"
+- input_cost_per_token: 2.0e-08
+  output_cost_per_token: 6.0e-08
+  region: '*'
 limits:
-    context_window: 131072
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 131072
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: llama-guard-3-8b
 sources:
-    - https://openrouter.ai/meta-llama/llama-guard-3-8b/api
+- https://openrouter.ai/meta-llama/llama-guard-3-8b/api
+status: deprecated

--- a/providers/openrouter/llama-guard-4-12b.yaml
+++ b/providers/openrouter/llama-guard-4-12b.yaml
@@ -1,16 +1,17 @@
 costs:
-    - input_cost_per_token: 1.8e-7
-      output_cost_per_token: 1.8e-7
-      region: "*"
+- input_cost_per_token: 1.8e-07
+  output_cost_per_token: 1.8e-07
+  region: '*'
 limits:
-    context_window: 163840
+  context_window: 163840
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: llama-guard-4-12b
 sources:
-    - https://openrouter.ai/meta-llama/llama-guard-4-12b/api
+- https://openrouter.ai/meta-llama/llama-guard-4-12b/api
+status: deprecated

--- a/providers/openrouter/llama3.1-typhoon2-70b-instruct.yaml
+++ b/providers/openrouter/llama3.1-typhoon2-70b-instruct.yaml
@@ -1,14 +1,14 @@
 features:
-    - function_calling
+- function_calling
 limits:
-    context_window: 8192
+  context_window: 8192
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: scb10x/llama3.1-typhoon2-70b-instruct
 sources:
-    - https://openrouter.ai/scb10x/llama3.1-typhoon2-70b-instruct/api
-status: active
+- https://openrouter.ai/scb10x/llama3.1-typhoon2-70b-instruct/api
+status: deprecated

--- a/providers/openrouter/llemma_7b.yaml
+++ b/providers/openrouter/llemma_7b.yaml
@@ -1,18 +1,18 @@
 costs:
-    - input_cost_per_token: 8.e-7
-      output_cost_per_token: 0.0000012
-      region: "*"
+- input_cost_per_token: 8.0e-07
+  output_cost_per_token: 1.2e-06
+  region: '*'
 limits:
-    context_window: 4096
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 4096
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: llemma_7b
 sources:
-    - https://openrouter.ai/eleutherai/llemma_7b/api
-status: active
+- https://openrouter.ai/eleutherai/llemma_7b/api
+status: deprecated

--- a/providers/openrouter/maestro-reasoning.yaml
+++ b/providers/openrouter/maestro-reasoning.yaml
@@ -1,23 +1,24 @@
 costs:
-    - input_cost_per_token: 9.e-7
-      output_cost_per_token: 0.0000033
-      region: "*"
+- input_cost_per_token: 9.0e-07
+  output_cost_per_token: 3.3e-06
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
+- function_calling
+- tool_choice
 limits:
-    context_window: 131072
-    max_output_tokens: 32000
-    max_tokens: 32000
+  context_window: 131072
+  max_output_tokens: 32000
+  max_tokens: 32000
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: maestro-reasoning
 params:
-    - key: max_tokens
-      maxValue: 32000
+- key: max_tokens
+  maxValue: 32000
 sources:
-    - https://openrouter.ai/arcee-ai/maestro-reasoning/api
+- https://openrouter.ai/arcee-ai/maestro-reasoning/api
+status: deprecated

--- a/providers/openrouter/magistral-medium-2506.yaml
+++ b/providers/openrouter/magistral-medium-2506.yaml
@@ -1,8 +1,9 @@
 features:
-    - function_calling
+- function_calling
 isDeprecated: true
 mode: chat
 model: magistral-medium-2506
 params:
-    - key: max_tokens
-      maxValue: 40000
+- key: max_tokens
+  maxValue: 40000
+status: deprecated

--- a/providers/openrouter/magistral-medium-2506:thinking.yaml
+++ b/providers/openrouter/magistral-medium-2506:thinking.yaml
@@ -1,19 +1,20 @@
 costs:
-    - input_cost_per_token: 0.000002
-      output_cost_per_token: 0.000005
-      region: "*"
-deprecationDate: "2025-10-31"
+- input_cost_per_token: 2.0e-06
+  output_cost_per_token: 5.0e-06
+  region: '*'
+deprecationDate: '2025-10-31'
 features:
-    - function_calling
+- function_calling
 isDeprecated: true
 limits:
-    context_window: 40960
+  context_window: 40960
 mode: chat
 model: magistral-medium-2506:thinking
 params:
-    - key: max_tokens
-      maxValue: 40000
+- key: max_tokens
+  maxValue: 40000
 sources:
-    - https://openrouter.ai/mistralai/magistral-medium-2506:thinking/api
-    - https://docs.mistral.ai/getting-started/models/
+- https://openrouter.ai/mistralai/magistral-medium-2506:thinking/api
+- https://docs.mistral.ai/getting-started/models/
 thinking: true
+status: deprecated

--- a/providers/openrouter/magistral-small-2506.yaml
+++ b/providers/openrouter/magistral-small-2506.yaml
@@ -1,19 +1,20 @@
 costs:
-    - input_cost_per_token: 5.e-7
-      output_cost_per_token: 0.0000015
-      region: "*"
-deprecationDate: "2025-10-31"
+- input_cost_per_token: 5.0e-07
+  output_cost_per_token: 1.5e-06
+  region: '*'
+deprecationDate: '2025-10-31'
 features:
-    - function_calling
+- function_calling
 isDeprecated: true
 limits:
-    context_window: 40000
+  context_window: 40000
 mode: chat
 model: magistral-small-2506
 params:
-    - key: max_tokens
-      maxValue: 40000
+- key: max_tokens
+  maxValue: 40000
 sources:
-    - https://openrouter.ai/mistralai/magistral-small-2506
-    - https://docs.mistral.ai/getting-started/models/
+- https://openrouter.ai/mistralai/magistral-small-2506
+- https://docs.mistral.ai/getting-started/models/
 thinking: true
+status: deprecated

--- a/providers/openrouter/magnum-v2-72b.yaml
+++ b/providers/openrouter/magnum-v2-72b.yaml
@@ -1,7 +1,8 @@
 isDeprecated: true
 limits:
-    max_tokens: 4096
+  max_tokens: 4096
 mode: chat
 model: magnum-v2-72b
 sources:
-    - https://openrouter.ai/alpindale/magnum-v2-72b/api
+- https://openrouter.ai/alpindale/magnum-v2-72b/api
+status: deprecated

--- a/providers/openrouter/magnum-v4-72b.yaml
+++ b/providers/openrouter/magnum-v4-72b.yaml
@@ -1,21 +1,21 @@
 costs:
-    - input_cost_per_token: 0.000003
-      output_cost_per_token: 0.000005
-      region: "*"
+- input_cost_per_token: 3.0e-06
+  output_cost_per_token: 5.0e-06
+  region: '*'
 limits:
-    context_window: 16384
-    max_output_tokens: 2048
-    max_tokens: 2048
+  context_window: 16384
+  max_output_tokens: 2048
+  max_tokens: 2048
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: magnum-v4-72b
 params:
-    - key: max_tokens
-      maxValue: 2048
+- key: max_tokens
+  maxValue: 2048
 sources:
-    - https://openrouter.ai/anthracite-org/magnum-v4-72b/api
-status: active
+- https://openrouter.ai/anthracite-org/magnum-v4-72b/api
+status: deprecated

--- a/providers/openrouter/mai-ds-r1.yaml
+++ b/providers/openrouter/mai-ds-r1.yaml
@@ -1,17 +1,18 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 limits:
-    context_window: 163840
+  context_window: 163840
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: mai-ds-r1
 sources:
-    - https://openrouter.ai/microsoft/mai-ds-r1/api
-    - https://openrouter.ai/microsoft/mai-ds-r1
+- https://openrouter.ai/microsoft/mai-ds-r1/api
+- https://openrouter.ai/microsoft/mai-ds-r1
 thinking: true
+status: deprecated

--- a/providers/openrouter/mai-ds-r1:free.yaml
+++ b/providers/openrouter/mai-ds-r1:free.yaml
@@ -1,18 +1,19 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 limits:
-    context_window: 163840
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 163840
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: mai-ds-r1:free
 sources:
-    - https://openrouter.ai/microsoft/mai-ds-r1:free/api
+- https://openrouter.ai/microsoft/mai-ds-r1:free/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/mercury-coder.yaml
+++ b/providers/openrouter/mercury-coder.yaml
@@ -1,23 +1,24 @@
 costs:
-    - cache_read_input_token_cost: 2.5e-8
-      input_cost_per_token: 2.5e-7
-      output_cost_per_token: 7.5e-7
-      region: "*"
+- cache_read_input_token_cost: 2.5e-08
+  input_cost_per_token: 2.5e-07
+  output_cost_per_token: 7.5e-07
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
-    - json_output
+- function_calling
+- tool_choice
+- structured_output
+- json_output
 limits:
-    context_window: 128000
-    max_output_tokens: 32000
-    max_tokens: 32000
+  context_window: 128000
+  max_output_tokens: 32000
+  max_tokens: 32000
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: mercury-coder
 sources:
-    - https://openrouter.ai/inception/mercury-coder/api
+- https://openrouter.ai/inception/mercury-coder/api
+status: deprecated

--- a/providers/openrouter/mercury.yaml
+++ b/providers/openrouter/mercury.yaml
@@ -2,5 +2,6 @@ isDeprecated: true
 mode: chat
 model: mercury
 params:
-    - key: max_tokens
-      maxValue: 16000
+- key: max_tokens
+  maxValue: 16000
+status: deprecated

--- a/providers/openrouter/meta-llama/codellama-34b-instruct.yaml
+++ b/providers/openrouter/meta-llama/codellama-34b-instruct.yaml
@@ -1,16 +1,17 @@
 costs:
-    - input_cost_per_token: 5.e-7
-      output_cost_per_token: 5.e-7
-      region: "*"
+- input_cost_per_token: 5.0e-07
+  output_cost_per_token: 5.0e-07
+  region: '*'
 limits:
-    context_window: 8192
-    max_input_tokens: 8192
+  context_window: 8192
+  max_input_tokens: 8192
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: meta-llama/codellama-34b-instruct
 sources:
-    - https://openrouter.ai/meta-llama/codellama-34b-instruct/api
+- https://openrouter.ai/meta-llama/codellama-34b-instruct/api
+status: deprecated

--- a/providers/openrouter/meta-llama/llama-2-13b-chat.yaml
+++ b/providers/openrouter/meta-llama/llama-2-13b-chat.yaml
@@ -1,17 +1,18 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 2.e-7
-      region: "*"
+- input_cost_per_token: 2.0e-07
+  output_cost_per_token: 2.0e-07
+  region: '*'
 limits:
-    context_window: 4096
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 4096
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: meta-llama/llama-2-13b-chat
 sources:
-    - https://openrouter.ai/meta-llama/llama-2-13b-chat/api
+- https://openrouter.ai/meta-llama/llama-2-13b-chat/api
+status: deprecated

--- a/providers/openrouter/meta-llama/llama-2-70b-chat.yaml
+++ b/providers/openrouter/meta-llama/llama-2-70b-chat.yaml
@@ -1,18 +1,19 @@
 costs:
-    - input_cost_per_token: 0.0000015
-      output_cost_per_token: 0.0000015
-      region: "*"
+- input_cost_per_token: 1.5e-06
+  output_cost_per_token: 1.5e-06
+  region: '*'
 features:
-    - system_messages
+- system_messages
 limits:
-    context_window: 4096
-    max_tokens: 4096
+  context_window: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: meta-llama/llama-2-70b-chat
 sources:
-    - https://openrouter.ai/meta-llama/llama-2-70b-chat/api
+- https://openrouter.ai/meta-llama/llama-2-70b-chat/api
+status: deprecated

--- a/providers/openrouter/meta-llama/llama-3-70b-instruct:nitro.yaml
+++ b/providers/openrouter/meta-llama/llama-3-70b-instruct:nitro.yaml
@@ -1,21 +1,22 @@
 costs:
-    - input_cost_per_token: 5.1e-7
-      output_cost_per_token: 7.4e-7
-      region: "*"
+- input_cost_per_token: 5.1e-07
+  output_cost_per_token: 7.4e-07
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
+- function_calling
+- tool_choice
+- structured_output
 limits:
-    context_window: 8192
-    max_output_tokens: 8000
-    max_tokens: 8000
+  context_window: 8192
+  max_output_tokens: 8000
+  max_tokens: 8000
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: meta-llama/llama-3-70b-instruct:nitro
 sources:
-    - https://openrouter.ai/meta-llama/llama-3-70b-instruct:nitro/api
+- https://openrouter.ai/meta-llama/llama-3-70b-instruct:nitro/api
+status: deprecated

--- a/providers/openrouter/meta-llama/llama-3-8b-instruct:extended.yaml
+++ b/providers/openrouter/meta-llama/llama-3-8b-instruct:extended.yaml
@@ -1,20 +1,21 @@
 costs:
-    - input_cost_per_token: 2.25e-7
-      output_cost_per_token: 0.00000225
-      region: "*"
+- input_cost_per_token: 2.25e-07
+  output_cost_per_token: 2.25e-06
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
+- function_calling
+- tool_choice
 limits:
-    context_window: 8192
-    max_output_tokens: 16384
-    max_tokens: 16384
+  context_window: 8192
+  max_output_tokens: 16384
+  max_tokens: 16384
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: meta-llama/llama-3-8b-instruct:extended
 sources:
-    - https://openrouter.ai/meta-llama/llama-3-8b-instruct:extended/api
+- https://openrouter.ai/meta-llama/llama-3-8b-instruct:extended/api
+status: deprecated

--- a/providers/openrouter/meta-llama/llama-3-8b-instruct:free.yaml
+++ b/providers/openrouter/meta-llama/llama-3-8b-instruct:free.yaml
@@ -1,19 +1,20 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 features:
-    - function_calling
+- function_calling
 limits:
-    context_window: 8192
-    max_output_tokens: 8192
-    max_tokens: 8192
+  context_window: 8192
+  max_output_tokens: 8192
+  max_tokens: 8192
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: meta-llama/llama-3-8b-instruct:free
 sources:
-    - https://openrouter.ai/meta-llama/llama-3-8b-instruct:free/api
+- https://openrouter.ai/meta-llama/llama-3-8b-instruct:free/api
+status: deprecated

--- a/providers/openrouter/meta-llama/llama-3.1-405b-instruct.yaml
+++ b/providers/openrouter/meta-llama/llama-3.1-405b-instruct.yaml
@@ -1,17 +1,18 @@
 costs:
-    - input_cost_per_token: 0.000004
-      output_cost_per_token: 0.000004
-      region: "*"
+- input_cost_per_token: 4.0e-06
+  output_cost_per_token: 4.0e-06
+  region: '*'
 features:
-    - system_messages
+- system_messages
 limits:
-    context_window: 131072
+  context_window: 131072
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: meta-llama/llama-3.1-405b-instruct
 sources:
-    - https://openrouter.ai/meta-llama/llama-3.1-405b-instruct/api
+- https://openrouter.ai/meta-llama/llama-3.1-405b-instruct/api
+status: deprecated

--- a/providers/openrouter/meta-llama/llama-3.1-405b.yaml
+++ b/providers/openrouter/meta-llama/llama-3.1-405b.yaml
@@ -1,16 +1,16 @@
 costs:
-    - input_cost_per_token: 0.000004
-      output_cost_per_token: 0.000004
-      region: "*"
+- input_cost_per_token: 4.0e-06
+  output_cost_per_token: 4.0e-06
+  region: '*'
 limits:
-    context_window: 131072
+  context_window: 131072
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: meta-llama/llama-3.1-405b
 sources:
-    - https://openrouter.ai/meta-llama/llama-3.1-405b/api
-status: active
+- https://openrouter.ai/meta-llama/llama-3.1-405b/api
+status: deprecated

--- a/providers/openrouter/microsoft/wizardlm-2-8x22b:nitro.yaml
+++ b/providers/openrouter/microsoft/wizardlm-2-8x22b:nitro.yaml
@@ -1,20 +1,21 @@
 costs:
-    - input_cost_per_token: 6.2e-7
-      output_cost_per_token: 6.2e-7
-      region: "*"
+- input_cost_per_token: 6.2e-07
+  output_cost_per_token: 6.2e-07
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
+- function_calling
+- tool_choice
 limits:
-    context_window: 65535
-    max_output_tokens: 8000
-    max_tokens: 8000
+  context_window: 65535
+  max_output_tokens: 8000
+  max_tokens: 8000
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: microsoft/wizardlm-2-8x22b:nitro
 sources:
-    - https://openrouter.ai/microsoft/wizardlm-2-8x22b:nitro/api
+- https://openrouter.ai/microsoft/wizardlm-2-8x22b:nitro/api
+status: deprecated

--- a/providers/openrouter/midnight-rose-70b.yaml
+++ b/providers/openrouter/midnight-rose-70b.yaml
@@ -1,16 +1,17 @@
 limits:
-    context_window: 4096
-    max_output_tokens: 2048
-    max_tokens: 2048
+  context_window: 4096
+  max_output_tokens: 2048
+  max_tokens: 2048
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: midnight-rose-70b
 params:
-    - key: max_tokens
-      maxValue: 2048
+- key: max_tokens
+  maxValue: 2048
 sources:
-    - https://openrouter.ai/sophosympatheia/midnight-rose-70b/api
+- https://openrouter.ai/sophosympatheia/midnight-rose-70b/api
+status: deprecated

--- a/providers/openrouter/minimax-01.yaml
+++ b/providers/openrouter/minimax-01.yaml
@@ -1,25 +1,25 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 0.0000011
-      region: "*"
+- input_cost_per_token: 2.0e-07
+  output_cost_per_token: 1.1e-06
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
+- function_calling
+- tool_choice
 limits:
-    context_window: 1000192
-    max_output_tokens: 1000192
-    max_tokens: 1000192
+  context_window: 1000192
+  max_output_tokens: 1000192
+  max_tokens: 1000192
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: minimax-01
 params:
-    - key: max_tokens
-      maxValue: 1000192
+- key: max_tokens
+  maxValue: 1000192
 sources:
-    - https://openrouter.ai/minimax/minimax-01/api
-status: active
+- https://openrouter.ai/minimax/minimax-01/api
+status: deprecated

--- a/providers/openrouter/minimax-m1.yaml
+++ b/providers/openrouter/minimax-m1.yaml
@@ -1,28 +1,29 @@
 costs:
-    - input_cost_per_token: 4.e-7
-      output_cost_per_token: 0.0000022
-      region: "*"
-      tiered_pricing:
-          input:
-              - cost_per_token: 0.0000013
-                from: 200000
-features:
-    - function_calling
-    - tool_choice
-limits:
-    context_window: 1000000
-    max_output_tokens: 40000
-    max_tokens: 40000
-modalities:
+- input_cost_per_token: 4.0e-07
+  output_cost_per_token: 2.2e-06
+  region: '*'
+  tiered_pricing:
     input:
-        - text
-    output:
-        - text
+    - cost_per_token: 1.3e-06
+      from: 200000
+features:
+- function_calling
+- tool_choice
+limits:
+  context_window: 1000000
+  max_output_tokens: 40000
+  max_tokens: 40000
+modalities:
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: minimax-m1
 params:
-    - key: max_tokens
-      maxValue: 40000
+- key: max_tokens
+  maxValue: 40000
 sources:
-    - https://openrouter.ai/minimax/minimax-m1/api
+- https://openrouter.ai/minimax/minimax-m1/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/ministral-3b.yaml
+++ b/providers/openrouter/ministral-3b.yaml
@@ -1,7 +1,8 @@
 features:
-    - function_calling
+- function_calling
 isDeprecated: true
 limits:
-    max_tokens: 4096
+  max_tokens: 4096
 mode: chat
 model: ministral-3b
+status: deprecated

--- a/providers/openrouter/ministral-8b.yaml
+++ b/providers/openrouter/ministral-8b.yaml
@@ -1,7 +1,8 @@
 features:
-    - function_calling
+- function_calling
 isDeprecated: true
 limits:
-    max_tokens: 4096
+  max_tokens: 4096
 mode: chat
 model: ministral-8b
+status: deprecated

--- a/providers/openrouter/mistral-7b-instruct-v0.1.yaml
+++ b/providers/openrouter/mistral-7b-instruct-v0.1.yaml
@@ -1,15 +1,16 @@
 costs:
-    - input_cost_per_token: 1.1e-7
-      output_cost_per_token: 1.9e-7
-      region: "*"
+- input_cost_per_token: 1.1e-07
+  output_cost_per_token: 1.9e-07
+  region: '*'
 limits:
-    context_window: 2824
+  context_window: 2824
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: mistral-7b-instruct-v0.1
 sources:
-    - https://openrouter.ai/mistralai/mistral-7b-instruct-v0.1/api
+- https://openrouter.ai/mistralai/mistral-7b-instruct-v0.1/api
+status: deprecated

--- a/providers/openrouter/mistral-7b-instruct-v0.2.yaml
+++ b/providers/openrouter/mistral-7b-instruct-v0.2.yaml
@@ -1,11 +1,12 @@
 limits:
-    context_window: 32768
+  context_window: 32768
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: mistral-7b-instruct-v0.2
 sources:
-    - https://openrouter.ai/mistralai/mistral-7b-instruct-v0.2/api
+- https://openrouter.ai/mistralai/mistral-7b-instruct-v0.2/api
+status: deprecated

--- a/providers/openrouter/mistral-7b-instruct-v0.3.yaml
+++ b/providers/openrouter/mistral-7b-instruct-v0.3.yaml
@@ -1,16 +1,17 @@
 features:
-    - function_calling
+- function_calling
 limits:
-    context_window: 32768
+  context_window: 32768
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: mistral-7b-instruct-v0.3
 params:
-    - key: max_tokens
-      maxValue: 16384
+- key: max_tokens
+  maxValue: 16384
 sources:
-    - https://openrouter.ai/mistralai/mistral-7b-instruct-v0.3/api
+- https://openrouter.ai/mistralai/mistral-7b-instruct-v0.3/api
+status: deprecated

--- a/providers/openrouter/mistral-7b-instruct.yaml
+++ b/providers/openrouter/mistral-7b-instruct.yaml
@@ -1,21 +1,21 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 limits:
-    context_window: 32768
-    max_output_tokens: 16384
-    max_tokens: 16384
+  context_window: 32768
+  max_output_tokens: 16384
+  max_tokens: 16384
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: mistral-7b-instruct
 params:
-    - key: max_tokens
-      maxValue: 16384
+- key: max_tokens
+  maxValue: 16384
 sources:
-    - https://openrouter.ai/mistralai/mistral-7b-instruct/api
-status: active
+- https://openrouter.ai/mistralai/mistral-7b-instruct/api
+status: deprecated

--- a/providers/openrouter/mistral-7b-instruct:free.yaml
+++ b/providers/openrouter/mistral-7b-instruct:free.yaml
@@ -1,21 +1,21 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 limits:
-    context_window: 32768
-    max_output_tokens: 16384
-    max_tokens: 16384
+  context_window: 32768
+  max_output_tokens: 16384
+  max_tokens: 16384
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: mistral-7b-instruct:free
 params:
-    - key: max_tokens
-      maxValue: 16384
+- key: max_tokens
+  maxValue: 16384
 sources:
-    - https://openrouter.ai/mistralai/mistral-7b-instruct:free/api
-status: active
+- https://openrouter.ai/mistralai/mistral-7b-instruct:free/api
+status: deprecated

--- a/providers/openrouter/mistral-large-2407.yaml
+++ b/providers/openrouter/mistral-large-2407.yaml
@@ -1,23 +1,24 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
-      input_cost_per_token: 0.000002
-      output_cost_per_token: 0.000006
-      region: "*"
+- cache_read_input_token_cost: 2.0e-07
+  input_cost_per_token: 2.0e-06
+  output_cost_per_token: 6.0e-06
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
-    - system_messages
+- function_calling
+- tool_choice
+- structured_output
+- system_messages
 limits:
-    context_window: 131072
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 131072
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: mistral-large-2407
 sources:
-    - https://openrouter.ai/mistralai/mistral-large-2407/api
+- https://openrouter.ai/mistralai/mistral-large-2407/api
+status: deprecated

--- a/providers/openrouter/mistral-large-2411.yaml
+++ b/providers/openrouter/mistral-large-2411.yaml
@@ -1,25 +1,26 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
-      input_cost_per_token: 0.000002
-      output_cost_per_token: 0.000006
-      region: "*"
+- cache_read_input_token_cost: 2.0e-07
+  input_cost_per_token: 2.0e-06
+  output_cost_per_token: 6.0e-06
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
-    - system_messages
-    - prompt_caching
-    - json_output
+- function_calling
+- tool_choice
+- structured_output
+- system_messages
+- prompt_caching
+- json_output
 limits:
-    context_window: 131072
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 131072
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: mistral-large-2411
 sources:
-    - https://openrouter.ai/mistralai/mistral-large-2411/api
+- https://openrouter.ai/mistralai/mistral-large-2411/api
+status: deprecated

--- a/providers/openrouter/mistral-large.yaml
+++ b/providers/openrouter/mistral-large.yaml
@@ -1,21 +1,22 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
-      input_cost_per_token: 0.000002
-      output_cost_per_token: 0.000006
-      region: "*"
+- cache_read_input_token_cost: 2.0e-07
+  input_cost_per_token: 2.0e-06
+  output_cost_per_token: 6.0e-06
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
-    - prompt_caching
+- function_calling
+- tool_choice
+- structured_output
+- prompt_caching
 limits:
-    context_window: 128000
+  context_window: 128000
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: mistral-large
 sources:
-    - https://openrouter.ai/mistralai/mistral-large/api
+- https://openrouter.ai/mistralai/mistral-large/api
+status: deprecated

--- a/providers/openrouter/mistral-medium-3.yaml
+++ b/providers/openrouter/mistral-medium-3.yaml
@@ -1,24 +1,24 @@
 costs:
-    - cache_read_input_token_cost: 4.e-8
-      input_cost_per_token: 4.e-7
-      output_cost_per_token: 0.000002
-      region: "*"
+- cache_read_input_token_cost: 4.0e-08
+  input_cost_per_token: 4.0e-07
+  output_cost_per_token: 2.0e-06
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
-    - prompt_caching
+- function_calling
+- tool_choice
+- structured_output
+- prompt_caching
 limits:
-    context_window: 131072
+  context_window: 131072
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: mistral-medium-3
 sources:
-    - https://openrouter.ai/mistralai/mistral-medium-3/api
-    - https://docs.mistral.ai/models/mistral-medium-3-25-05
-status: active
+- https://openrouter.ai/mistralai/mistral-medium-3/api
+- https://docs.mistral.ai/models/mistral-medium-3-25-05
+status: deprecated

--- a/providers/openrouter/mistral-nemo.yaml
+++ b/providers/openrouter/mistral-nemo.yaml
@@ -1,25 +1,26 @@
 costs:
-    - input_cost_per_token: 2.e-8
-      output_cost_per_token: 4.e-8
-      region: "*"
+- input_cost_per_token: 2.0e-08
+  output_cost_per_token: 4.0e-08
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - system_messages
-    - structured_output
+- function_calling
+- tool_choice
+- system_messages
+- structured_output
 limits:
-    context_window: 131072
-    max_output_tokens: 16384
-    max_tokens: 16384
+  context_window: 131072
+  max_output_tokens: 16384
+  max_tokens: 16384
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: mistral-nemo
 params:
-    - key: max_tokens
-      maxValue: 16384
+- key: max_tokens
+  maxValue: 16384
 sources:
-    - https://openrouter.ai/mistralai/mistral-nemo/api
+- https://openrouter.ai/mistralai/mistral-nemo/api
+status: deprecated

--- a/providers/openrouter/mistral-nemo:free.yaml
+++ b/providers/openrouter/mistral-nemo:free.yaml
@@ -1,26 +1,26 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 features:
-    - function_calling
-    - system_messages
-    - structured_output
-    - json_output
+- function_calling
+- system_messages
+- structured_output
+- json_output
 limits:
-    context_window: 131072
-    max_output_tokens: 128000
-    max_tokens: 128000
+  context_window: 131072
+  max_output_tokens: 128000
+  max_tokens: 128000
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: mistral-nemo:free
 params:
-    - key: max_tokens
-      maxValue: 128000
+- key: max_tokens
+  maxValue: 128000
 sources:
-    - https://openrouter.ai/mistralai/mistral-nemo:free/api
-status: active
+- https://openrouter.ai/mistralai/mistral-nemo:free/api
+status: deprecated

--- a/providers/openrouter/mistral-saba.yaml
+++ b/providers/openrouter/mistral-saba.yaml
@@ -1,22 +1,23 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 6.e-7
-      region: "*"
+- input_cost_per_token: 2.0e-07
+  output_cost_per_token: 6.0e-07
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
-    - system_messages
+- function_calling
+- tool_choice
+- structured_output
+- system_messages
 limits:
-    context_window: 32768
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 32768
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: mistral-saba
 sources:
-    - https://openrouter.ai/mistralai/mistral-saba/api
+- https://openrouter.ai/mistralai/mistral-saba/api
+status: deprecated

--- a/providers/openrouter/mistral-small-24b-instruct-2501.yaml
+++ b/providers/openrouter/mistral-small-24b-instruct-2501.yaml
@@ -1,19 +1,19 @@
 costs:
-    - input_cost_per_token: 5.e-8
-      output_cost_per_token: 8.e-8
-      region: "*"
+- input_cost_per_token: 5.0e-08
+  output_cost_per_token: 8.0e-08
+  region: '*'
 limits:
-    context_window: 32768
-    max_input_tokens: 32768
-    max_output_tokens: 16384
-    max_tokens: 16384
+  context_window: 32768
+  max_input_tokens: 32768
+  max_output_tokens: 16384
+  max_tokens: 16384
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: mistralai/mistral-small-24b-instruct-2501
 sources:
-    - https://openrouter.ai/mistralai/mistral-small-24b-instruct-2501/api
-status: active
+- https://openrouter.ai/mistralai/mistral-small-24b-instruct-2501/api
+status: deprecated

--- a/providers/openrouter/mistral-small-24b-instruct-2501:free.yaml
+++ b/providers/openrouter/mistral-small-24b-instruct-2501:free.yaml
@@ -1,22 +1,22 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 features:
-    - function_calling
-    - json_output
+- function_calling
+- json_output
 limits:
-    context_window: 32768
-    max_output_tokens: 16384
-    max_tokens: 16384
+  context_window: 32768
+  max_output_tokens: 16384
+  max_tokens: 16384
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: mistral-small-24b-instruct-2501:free
 sources:
-    - https://openrouter.ai/mistralai/mistral-small-24b-instruct-2501:free
-    - https://openrouter.ai/api/v1/models
-status: active
+- https://openrouter.ai/mistralai/mistral-small-24b-instruct-2501:free
+- https://openrouter.ai/api/v1/models
+status: deprecated

--- a/providers/openrouter/mistral-small-3.1-24b-instruct.yaml
+++ b/providers/openrouter/mistral-small-3.1-24b-instruct.yaml
@@ -1,26 +1,27 @@
 costs:
-    - cache_read_input_token_cost: 1.5e-8
-      input_cost_per_token: 3.e-8
-      output_cost_per_token: 1.1e-7
-      region: "*"
+- cache_read_input_token_cost: 1.5e-08
+  input_cost_per_token: 3.0e-08
+  output_cost_per_token: 1.1e-07
+  region: '*'
 features:
-    - function_calling
-    - structured_output
-    - prompt_caching
+- function_calling
+- structured_output
+- prompt_caching
 limits:
-    context_window: 131072
-    max_output_tokens: 131072
-    max_tokens: 131072
+  context_window: 131072
+  max_output_tokens: 131072
+  max_tokens: 131072
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: mistral-small-3.1-24b-instruct
 params:
-    - key: max_tokens
-      maxValue: 131072
+- key: max_tokens
+  maxValue: 131072
 sources:
-    - https://openrouter.ai/mistralai/mistral-small-3.1-24b-instruct/api
+- https://openrouter.ai/mistralai/mistral-small-3.1-24b-instruct/api
+status: deprecated

--- a/providers/openrouter/mistral-small-3.1-24b-instruct:free.yaml
+++ b/providers/openrouter/mistral-small-3.1-24b-instruct:free.yaml
@@ -1,21 +1,22 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
-    - system_messages
+- function_calling
+- tool_choice
+- structured_output
+- system_messages
 limits:
-    context_window: 128000
+  context_window: 128000
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: mistral-small-3.1-24b-instruct:free
 sources:
-    - https://openrouter.ai/mistralai/mistral-small-3.1-24b-instruct:free/api
+- https://openrouter.ai/mistralai/mistral-small-3.1-24b-instruct:free/api
+status: deprecated

--- a/providers/openrouter/mistral-small-3.2-24b-instruct.yaml
+++ b/providers/openrouter/mistral-small-3.2-24b-instruct.yaml
@@ -1,19 +1,20 @@
 costs:
-    - input_cost_per_token: 7.5e-8
-      output_cost_per_token: 2.e-7
-      region: "*"
+- input_cost_per_token: 7.5e-08
+  output_cost_per_token: 2.0e-07
+  region: '*'
 features:
-    - function_calling
-    - structured_output
+- function_calling
+- structured_output
 limits:
-    context_window: 128000
+  context_window: 128000
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: mistral-small-3.2-24b-instruct
 sources:
-    - https://openrouter.ai/mistralai/mistral-small-3.2-24b-instruct/api
+- https://openrouter.ai/mistralai/mistral-small-3.2-24b-instruct/api
+status: deprecated

--- a/providers/openrouter/mistral-small-3.2-24b-instruct:free.yaml
+++ b/providers/openrouter/mistral-small-3.2-24b-instruct:free.yaml
@@ -1,21 +1,22 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
-    - system_messages
+- function_calling
+- tool_choice
+- structured_output
+- system_messages
 limits:
-    context_window: 128000
+  context_window: 128000
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: mistral-small-3.2-24b-instruct:free
 sources:
-    - https://openrouter.ai/mistralai/mistral-small-3.2-24b-instruct:free/api
+- https://openrouter.ai/mistralai/mistral-small-3.2-24b-instruct:free/api
+status: deprecated

--- a/providers/openrouter/mistral-small.yaml
+++ b/providers/openrouter/mistral-small.yaml
@@ -1,21 +1,22 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 3.e-7
-      region: "*"
+- input_cost_per_token: 1.0e-07
+  output_cost_per_token: 3.0e-07
+  region: '*'
 features:
-    - function_calling
-    - system_messages
+- function_calling
+- system_messages
 limits:
-    context_window: 32000
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 32000
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: mistral-small
 sources:
-    - https://openrouter.ai/mistralai/mistral-small/api
-    - https://docs.mistral.ai/getting-started/models/
+- https://openrouter.ai/mistralai/mistral-small/api
+- https://docs.mistral.ai/getting-started/models/
+status: deprecated

--- a/providers/openrouter/mistral-tiny.yaml
+++ b/providers/openrouter/mistral-tiny.yaml
@@ -1,7 +1,8 @@
 features:
-    - function_calling
+- function_calling
 isDeprecated: true
 limits:
-    max_tokens: 4096
+  max_tokens: 4096
 mode: chat
 model: mistral-tiny
+status: deprecated

--- a/providers/openrouter/mistralai/devstral-2512:free.yaml
+++ b/providers/openrouter/mistralai/devstral-2512:free.yaml
@@ -1,14 +1,15 @@
 costs:
-    - input_cost_per_image: 0
-      input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_image: 0
+  input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 features:
-    - function_calling
+- function_calling
 isDeprecated: true
 limits:
-    max_input_tokens: 262144
-    max_output_tokens: 262144
-    max_tokens: 262144
+  max_input_tokens: 262144
+  max_output_tokens: 262144
+  max_tokens: 262144
 mode: chat
 model: mistralai/devstral-2512:free
+status: deprecated

--- a/providers/openrouter/mistralai/mistral-7b-instruct.yaml
+++ b/providers/openrouter/mistralai/mistral-7b-instruct.yaml
@@ -1,19 +1,20 @@
 costs:
-    - input_cost_per_token: 1.3e-7
-      output_cost_per_token: 1.3e-7
-      region: "*"
+- input_cost_per_token: 1.3e-07
+  output_cost_per_token: 1.3e-07
+  region: '*'
 features:
-    - tool_choice
+- tool_choice
 limits:
-    context_window: 32768
-    max_output_tokens: 8192
-    max_tokens: 8192
+  context_window: 32768
+  max_output_tokens: 8192
+  max_tokens: 8192
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: mistralai/mistral-7b-instruct
 sources:
-    - https://openrouter.ai/mistralai/mistral-7b-instruct/api
+- https://openrouter.ai/mistralai/mistral-7b-instruct/api
+status: deprecated

--- a/providers/openrouter/mistralai/mistral-7b-instruct:free.yaml
+++ b/providers/openrouter/mistralai/mistral-7b-instruct:free.yaml
@@ -1,18 +1,18 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 limits:
-    context_window: 32768
-    max_output_tokens: 8192
-    max_tokens: 8192
+  context_window: 32768
+  max_output_tokens: 8192
+  max_tokens: 8192
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: mistralai/mistral-7b-instruct:free
 sources:
-    - https://openrouter.ai/mistralai/mistral-7b-instruct:free/api
-status: active
+- https://openrouter.ai/mistralai/mistral-7b-instruct:free/api
+status: deprecated

--- a/providers/openrouter/mistralai/mistral-small-3.1-24b-instruct:free.yaml
+++ b/providers/openrouter/mistralai/mistral-small-3.1-24b-instruct:free.yaml
@@ -1,21 +1,22 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
-    - system_messages
+- function_calling
+- tool_choice
+- structured_output
+- system_messages
 limits:
-    context_window: 128000
+  context_window: 128000
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: mistralai/mistral-small-3.1-24b-instruct:free
 sources:
-    - https://openrouter.ai/mistralai/mistral-small-3.1-24b-instruct:free/api
+- https://openrouter.ai/mistralai/mistral-small-3.1-24b-instruct:free/api
+status: deprecated

--- a/providers/openrouter/mistralai/mistral-small-creative.yaml
+++ b/providers/openrouter/mistralai/mistral-small-creative.yaml
@@ -1,21 +1,22 @@
 costs:
-    - cache_read_input_token_cost: 1.e-8
-      input_cost_per_token: 1.e-7
-      output_cost_per_token: 3.e-7
-      region: "*"
-deprecationDate: "2026-04-30"
+- cache_read_input_token_cost: 1.0e-08
+  input_cost_per_token: 1.0e-07
+  output_cost_per_token: 3.0e-07
+  region: '*'
+deprecationDate: '2026-04-30'
 features:
-    - function_calling
-    - tool_choice
-    - system_messages
+- function_calling
+- tool_choice
+- system_messages
 limits:
-    context_window: 32768
+  context_window: 32768
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: mistralai/mistral-small-creative
 sources:
-    - https://openrouter.ai/mistralai/mistral-small-creative/api
+- https://openrouter.ai/mistralai/mistral-small-creative/api
+status: deprecated

--- a/providers/openrouter/mistralai/pixtral-12b.yaml
+++ b/providers/openrouter/mistralai/pixtral-12b.yaml
@@ -1,22 +1,23 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 1.e-7
-      region: "*"
+- input_cost_per_token: 1.0e-07
+  output_cost_per_token: 1.0e-07
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
+- function_calling
+- tool_choice
 limits:
-    context_window: 32768
+  context_window: 32768
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: mistralai/pixtral-12b
 params:
-    - defaultValue: 0.3
-      key: temperature
+- defaultValue: 0.3
+  key: temperature
 sources:
-    - https://openrouter.ai/mistralai/pixtral-12b/api
+- https://openrouter.ai/mistralai/pixtral-12b/api
+status: deprecated

--- a/providers/openrouter/mixtral-8x22b-instruct.yaml
+++ b/providers/openrouter/mixtral-8x22b-instruct.yaml
@@ -1,21 +1,22 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
-      input_cost_per_token: 0.000002
-      output_cost_per_token: 0.000006
-      region: "*"
+- cache_read_input_token_cost: 2.0e-07
+  input_cost_per_token: 2.0e-06
+  output_cost_per_token: 6.0e-06
+  region: '*'
 features:
-    - function_calling
-    - json_output
-    - structured_output
-    - tool_choice
+- function_calling
+- json_output
+- structured_output
+- tool_choice
 limits:
-    context_window: 65536
+  context_window: 65536
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: mixtral-8x22b-instruct
 sources:
-    - https://openrouter.ai/mistralai/mixtral-8x22b-instruct/api
+- https://openrouter.ai/mistralai/mixtral-8x22b-instruct/api
+status: deprecated

--- a/providers/openrouter/mixtral-8x7b-instruct.yaml
+++ b/providers/openrouter/mixtral-8x7b-instruct.yaml
@@ -1,26 +1,26 @@
 costs:
-    - input_cost_per_token: 5.4e-7
-      output_cost_per_token: 5.4e-7
-      region: "*"
+- input_cost_per_token: 5.4e-07
+  output_cost_per_token: 5.4e-07
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
-    - json_output
+- function_calling
+- tool_choice
+- structured_output
+- json_output
 limits:
-    context_window: 32768
-    max_output_tokens: 16384
-    max_tokens: 16384
+  context_window: 32768
+  max_output_tokens: 16384
+  max_tokens: 16384
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: mixtral-8x7b-instruct
 params:
-    - key: max_tokens
-      maxValue: 16384
+- key: max_tokens
+  maxValue: 16384
 sources:
-    - https://openrouter.ai/mistralai/mixtral-8x7b-instruct/api
-status: active
+- https://openrouter.ai/mistralai/mixtral-8x7b-instruct/api
+status: deprecated

--- a/providers/openrouter/mn-celeste-12b.yaml
+++ b/providers/openrouter/mn-celeste-12b.yaml
@@ -1,12 +1,12 @@
 limits:
-    context_window: 32000
+  context_window: 32000
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: mn-celeste-12b
 sources:
-    - https://openrouter.ai/nothingiisreal/mn-celeste-12b/api
-status: active
+- https://openrouter.ai/nothingiisreal/mn-celeste-12b/api
+status: deprecated

--- a/providers/openrouter/mn-inferor-12b.yaml
+++ b/providers/openrouter/mn-inferor-12b.yaml
@@ -2,7 +2,8 @@ isDeprecated: true
 mode: chat
 model: mn-inferor-12b
 params:
-    - key: max_tokens
-      maxValue: 4096
+- key: max_tokens
+  maxValue: 4096
 sources:
-    - https://openrouter.ai/mn-inferor-12b/api
+- https://openrouter.ai/mn-inferor-12b/api
+status: deprecated

--- a/providers/openrouter/moonshotai/kimi-k2-0905:exacto.yaml
+++ b/providers/openrouter/moonshotai/kimi-k2-0905:exacto.yaml
@@ -1,23 +1,23 @@
 costs:
-    - cache_read_input_token_cost: 1.5e-7
-      input_cost_per_token: 4.e-7
-      output_cost_per_token: 0.000002
-      region: "*"
+- cache_read_input_token_cost: 1.5e-07
+  input_cost_per_token: 4.0e-07
+  output_cost_per_token: 2.0e-06
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
+- function_calling
+- tool_choice
 limits:
-    context_window: 131072
+  context_window: 131072
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: moonshotai/kimi-k2-0905:exacto
 params:
-    - defaultValue: 0.7
-      key: temperature
+- defaultValue: 0.7
+  key: temperature
 sources:
-    - https://openrouter.ai/moonshotai/kimi-k2-0905:exacto/api
-status: active
+- https://openrouter.ai/moonshotai/kimi-k2-0905:exacto/api
+status: deprecated

--- a/providers/openrouter/morph-v2.yaml
+++ b/providers/openrouter/morph-v2.yaml
@@ -1,19 +1,20 @@
 limits:
-    context_window: 32000
+  context_window: 32000
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: morph-v2
 params:
-    - key: max_tokens
-      maxValue: 16000
+- key: max_tokens
+  maxValue: 16000
 removeParams:
-    - top_p
-    - "n"
-    - response_format
+- top_p
+- n
+- response_format
 sources:
-    - https://openrouter.ai/morph/morph-v2/api
-    - https://docs.morphllm.com/
+- https://openrouter.ai/morph/morph-v2/api
+- https://docs.morphllm.com/
+status: deprecated

--- a/providers/openrouter/morph-v3-fast.yaml
+++ b/providers/openrouter/morph-v3-fast.yaml
@@ -1,27 +1,27 @@
 costs:
-    - input_cost_per_token: 8.e-7
-      output_cost_per_token: 0.0000012
-      region: "*"
+- input_cost_per_token: 8.0e-07
+  output_cost_per_token: 1.2e-06
+  region: '*'
 limits:
-    context_window: 81920
-    max_input_tokens: 81920
-    max_output_tokens: 38000
-    max_tokens: 38000
+  context_window: 81920
+  max_input_tokens: 81920
+  max_output_tokens: 38000
+  max_tokens: 38000
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: morph-v3-fast
 params:
-    - key: max_tokens
-      maxValue: 38000
+- key: max_tokens
+  maxValue: 38000
 removeParams:
-    - top_p
-    - "n"
-    - response_format
+- top_p
+- n
+- response_format
 sources:
-    - https://openrouter.ai/morph/morph-v3-fast/api
-    - https://docs.morphllm.com/quickstart
-status: active
+- https://openrouter.ai/morph/morph-v3-fast/api
+- https://docs.morphllm.com/quickstart
+status: deprecated

--- a/providers/openrouter/morph-v3-large.yaml
+++ b/providers/openrouter/morph-v3-large.yaml
@@ -1,21 +1,21 @@
 costs:
-    - input_cost_per_token: 9.e-7
-      output_cost_per_token: 0.0000019
-      region: "*"
+- input_cost_per_token: 9.0e-07
+  output_cost_per_token: 1.9e-06
+  region: '*'
 limits:
-    context_window: 262144
-    max_output_tokens: 131072
-    max_tokens: 131072
+  context_window: 262144
+  max_output_tokens: 131072
+  max_tokens: 131072
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: morph-v3-large
 params:
-    - key: max_tokens
-      maxValue: 131072
+- key: max_tokens
+  maxValue: 131072
 sources:
-    - https://openrouter.ai/morph/morph-v3-large/api
-status: active
+- https://openrouter.ai/morph/morph-v3-large/api
+status: deprecated

--- a/providers/openrouter/mythalion-13b.yaml
+++ b/providers/openrouter/mythalion-13b.yaml
@@ -1,16 +1,17 @@
 limits:
-    context_window: 8192
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 8192
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: mythalion-13b
 params:
-    - key: max_tokens
-      maxValue: 4096
+- key: max_tokens
+  maxValue: 4096
 sources:
-    - https://openrouter.ai/pygmalionai/mythalion-13b/api
+- https://openrouter.ai/pygmalionai/mythalion-13b/api
+status: deprecated

--- a/providers/openrouter/mythomax-l2-13b.yaml
+++ b/providers/openrouter/mythomax-l2-13b.yaml
@@ -1,20 +1,21 @@
 costs:
-    - input_cost_per_token: 6.e-8
-      output_cost_per_token: 6.e-8
-      region: "*"
+- input_cost_per_token: 6.0e-08
+  output_cost_per_token: 6.0e-08
+  region: '*'
 features:
-    - structured_output
-    - tool_choice
+- structured_output
+- tool_choice
 limits:
-    context_window: 4096
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 4096
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: mythomax-l2-13b
 sources:
-    - https://openrouter.ai/gryphe/mythomax-l2-13b/api
+- https://openrouter.ai/gryphe/mythomax-l2-13b/api
+status: deprecated

--- a/providers/openrouter/neversleep/llama-3.1-lumimaid-8b.yaml
+++ b/providers/openrouter/neversleep/llama-3.1-lumimaid-8b.yaml
@@ -1,11 +1,12 @@
 limits:
-    context_window: 131072
+  context_window: 131072
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: neversleep/llama-3.1-lumimaid-8b
 sources:
-    - https://openrouter.ai/neversleep/llama-3.1-lumimaid-8b/api
+- https://openrouter.ai/neversleep/llama-3.1-lumimaid-8b/api
+status: deprecated

--- a/providers/openrouter/neversleep/noromaid-20b.yaml
+++ b/providers/openrouter/neversleep/noromaid-20b.yaml
@@ -1,13 +1,14 @@
 limits:
-    context_window: 8192
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 8192
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: neversleep/noromaid-20b
 sources:
-    - https://openrouter.ai/neversleep/noromaid-20b/api
+- https://openrouter.ai/neversleep/noromaid-20b/api
+status: deprecated

--- a/providers/openrouter/noromaid-20b.yaml
+++ b/providers/openrouter/noromaid-20b.yaml
@@ -1,13 +1,14 @@
 limits:
-    context_window: 8192
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 8192
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: noromaid-20b
 sources:
-    - https://openrouter.ai/neversleep/noromaid-20b/api
+- https://openrouter.ai/neversleep/noromaid-20b/api
+status: deprecated

--- a/providers/openrouter/nous-hermes-2-mixtral-8x7b-dpo.yaml
+++ b/providers/openrouter/nous-hermes-2-mixtral-8x7b-dpo.yaml
@@ -1,14 +1,15 @@
 limits:
-    context_window: 32768
+  context_window: 32768
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: nous-hermes-2-mixtral-8x7b-dpo
 params:
-    - key: max_tokens
-      maxValue: 2048
+- key: max_tokens
+  maxValue: 2048
 sources:
-    - https://openrouter.ai/nousresearch/nous-hermes-2-mixtral-8x7b-dpo/api
+- https://openrouter.ai/nousresearch/nous-hermes-2-mixtral-8x7b-dpo/api
+status: deprecated

--- a/providers/openrouter/nousresearch/nous-hermes-llama2-13b.yaml
+++ b/providers/openrouter/nousresearch/nous-hermes-llama2-13b.yaml
@@ -1,16 +1,17 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 2.e-7
-      region: "*"
+- input_cost_per_token: 2.0e-07
+  output_cost_per_token: 2.0e-07
+  region: '*'
 limits:
-    context_window: 4096
-    max_tokens: 4096
+  context_window: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: nousresearch/nous-hermes-llama2-13b
 sources:
-    - https://openrouter.ai/nousresearch/nous-hermes-llama2-13b/api
+- https://openrouter.ai/nousresearch/nous-hermes-llama2-13b/api
+status: deprecated

--- a/providers/openrouter/nova-lite-v1.yaml
+++ b/providers/openrouter/nova-lite-v1.yaml
@@ -1,24 +1,25 @@
 costs:
-    - input_cost_per_token: 6.e-8
-      output_cost_per_token: 2.4e-7
-      region: "*"
+- input_cost_per_token: 6.0e-08
+  output_cost_per_token: 2.4e-07
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
+- function_calling
+- tool_choice
 limits:
-    context_window: 300000
-    max_output_tokens: 5120
-    max_tokens: 5120
+  context_window: 300000
+  max_output_tokens: 5120
+  max_tokens: 5120
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: nova-lite-v1
 params:
-    - key: max_tokens
-      maxValue: 5120
+- key: max_tokens
+  maxValue: 5120
 sources:
-    - https://openrouter.ai/amazon/nova-lite-v1/api
+- https://openrouter.ai/amazon/nova-lite-v1/api
+status: deprecated

--- a/providers/openrouter/nova-micro-v1.yaml
+++ b/providers/openrouter/nova-micro-v1.yaml
@@ -1,23 +1,24 @@
 costs:
-    - input_cost_per_token: 3.5e-8
-      output_cost_per_token: 1.4e-7
-      region: "*"
+- input_cost_per_token: 3.5e-08
+  output_cost_per_token: 1.4e-07
+  region: '*'
 features:
-    - tool_choice
-    - function_calling
+- tool_choice
+- function_calling
 limits:
-    context_window: 128000
-    max_output_tokens: 5120
-    max_tokens: 5120
+  context_window: 128000
+  max_output_tokens: 5120
+  max_tokens: 5120
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: nova-micro-v1
 params:
-    - key: max_tokens
-      maxValue: 5120
+- key: max_tokens
+  maxValue: 5120
 sources:
-    - https://openrouter.ai/amazon/nova-micro-v1/api
+- https://openrouter.ai/amazon/nova-micro-v1/api
+status: deprecated

--- a/providers/openrouter/nova-pro-v1.yaml
+++ b/providers/openrouter/nova-pro-v1.yaml
@@ -1,25 +1,26 @@
 costs:
-    - input_cost_per_token: 8.e-7
-      output_cost_per_token: 0.0000032
-      region: "*"
+- input_cost_per_token: 8.0e-07
+  output_cost_per_token: 3.2e-06
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
+- function_calling
+- tool_choice
+- structured_output
 limits:
-    context_window: 300000
-    max_output_tokens: 5120
-    max_tokens: 5120
+  context_window: 300000
+  max_output_tokens: 5120
+  max_tokens: 5120
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: nova-pro-v1
 params:
-    - key: max_tokens
-      maxValue: 5120
+- key: max_tokens
+  maxValue: 5120
 sources:
-    - https://openrouter.ai/amazon/nova-pro-v1/api
+- https://openrouter.ai/amazon/nova-pro-v1/api
+status: deprecated

--- a/providers/openrouter/o1-mini-2024-09-12.yaml
+++ b/providers/openrouter/o1-mini-2024-09-12.yaml
@@ -2,5 +2,6 @@ isDeprecated: true
 mode: chat
 model: o1-mini-2024-09-12
 params:
-    - key: max_tokens
-      maxValue: 65536
+- key: max_tokens
+  maxValue: 65536
+status: deprecated

--- a/providers/openrouter/o1-mini.yaml
+++ b/providers/openrouter/o1-mini.yaml
@@ -2,5 +2,6 @@ isDeprecated: true
 mode: chat
 model: o1-mini
 params:
-    - key: max_tokens
-      maxValue: 65536
+- key: max_tokens
+  maxValue: 65536
+status: deprecated

--- a/providers/openrouter/o1-pro.yaml
+++ b/providers/openrouter/o1-pro.yaml
@@ -1,30 +1,31 @@
 costs:
-    - input_cost_per_token: 0.00015
-      output_cost_per_token: 0.0006
-      region: "*"
+- input_cost_per_token: 0.00015
+  output_cost_per_token: 0.0006
+  region: '*'
 features:
-    - structured_output
-    - tool_choice
+- structured_output
+- tool_choice
 limits:
-    context_window: 200000
-    max_output_tokens: 100000
-    max_tokens: 100000
+  context_window: 200000
+  max_output_tokens: 100000
+  max_tokens: 100000
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: o1-pro
 params:
-    - key: max_tokens
-      maxValue: 100000
+- key: max_tokens
+  maxValue: 100000
 removeParams:
-    - temperature
-    - top_p
-    - stop
-    - "n"
+- temperature
+- top_p
+- stop
+- n
 sources:
-    - https://openrouter.ai/openai/o1-pro/api
+- https://openrouter.ai/openai/o1-pro/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/o1.yaml
+++ b/providers/openrouter/o1.yaml
@@ -1,27 +1,28 @@
 costs:
-    - cache_read_input_token_cost: 0.0000075
-      input_cost_per_token: 0.000015
-      output_cost_per_token: 0.00006
-      region: "*"
+- cache_read_input_token_cost: 7.5e-06
+  input_cost_per_token: 1.5e-05
+  output_cost_per_token: 6.0e-05
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
+- function_calling
+- tool_choice
+- structured_output
 limits:
-    context_window: 200000
-    max_output_tokens: 100000
-    max_tokens: 100000
+  context_window: 200000
+  max_output_tokens: 100000
+  max_tokens: 100000
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: o1
 params:
-    - key: max_tokens
-      maxValue: 100000
+- key: max_tokens
+  maxValue: 100000
 sources:
-    - https://openrouter.ai/openai/o1/api
+- https://openrouter.ai/openai/o1/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/o3-mini-high.yaml
+++ b/providers/openrouter/o3-mini-high.yaml
@@ -1,26 +1,27 @@
 costs:
-    - cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 0.0000011
-      output_cost_per_token: 0.0000044
-      region: "*"
+- cache_read_input_token_cost: 5.5e-07
+  input_cost_per_token: 1.1e-06
+  output_cost_per_token: 4.4e-06
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
+- function_calling
+- tool_choice
+- structured_output
 limits:
-    context_window: 200000
-    max_output_tokens: 100000
-    max_tokens: 100000
+  context_window: 200000
+  max_output_tokens: 100000
+  max_tokens: 100000
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: o3-mini-high
 params:
-    - key: max_tokens
-      maxValue: 100000
+- key: max_tokens
+  maxValue: 100000
 sources:
-    - https://openrouter.ai/openai/o3-mini-high/api
+- https://openrouter.ai/openai/o3-mini-high/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/o3-mini.yaml
+++ b/providers/openrouter/o3-mini.yaml
@@ -1,32 +1,33 @@
 costs:
-    - cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 0.0000011
-      output_cost_per_token: 0.0000044
-      region: "*"
+- cache_read_input_token_cost: 5.5e-07
+  input_cost_per_token: 1.1e-06
+  output_cost_per_token: 4.4e-06
+  region: '*'
 features:
-    - function_calling
-    - structured_output
-    - tool_choice
-    - system_messages
-    - prompt_caching
+- function_calling
+- structured_output
+- tool_choice
+- system_messages
+- prompt_caching
 limits:
-    context_window: 200000
-    max_input_tokens: 200000
-    max_output_tokens: 100000
-    max_tokens: 100000
+  context_window: 200000
+  max_input_tokens: 200000
+  max_output_tokens: 100000
+  max_tokens: 100000
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: o3-mini
 params:
-    - key: max_tokens
-      maxValue: 100000
-    - defaultValue: medium
-      key: reasoning_effort
-      type: string
+- key: max_tokens
+  maxValue: 100000
+- defaultValue: medium
+  key: reasoning_effort
+  type: string
 sources:
-    - https://openrouter.ai/openai/o3-mini/api
+- https://openrouter.ai/openai/o3-mini/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/o3-pro.yaml
+++ b/providers/openrouter/o3-pro.yaml
@@ -1,26 +1,27 @@
 costs:
-    - input_cost_per_token: 0.00002
-      output_cost_per_token: 0.00008
-      region: "*"
+- input_cost_per_token: 2.0e-05
+  output_cost_per_token: 8.0e-05
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
+- function_calling
+- tool_choice
+- structured_output
 limits:
-    context_window: 200000
-    max_output_tokens: 100000
-    max_tokens: 100000
+  context_window: 200000
+  max_output_tokens: 100000
+  max_tokens: 100000
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: o3-pro
 params:
-    - key: max_tokens
-      maxValue: 100000
+- key: max_tokens
+  maxValue: 100000
 sources:
-    - https://openrouter.ai/openai/o3-pro/api
+- https://openrouter.ai/openai/o3-pro/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/o3.yaml
+++ b/providers/openrouter/o3.yaml
@@ -1,27 +1,28 @@
 costs:
-    - cache_read_input_token_cost: 5.e-7
-      input_cost_per_token: 0.000002
-      output_cost_per_token: 0.000008
-      region: "*"
+- cache_read_input_token_cost: 5.0e-07
+  input_cost_per_token: 2.0e-06
+  output_cost_per_token: 8.0e-06
+  region: '*'
 features:
-    - function_calling
-    - structured_output
+- function_calling
+- structured_output
 limits:
-    context_window: 200000
-    max_input_tokens: 200000
-    max_output_tokens: 100000
-    max_tokens: 100000
+  context_window: 200000
+  max_input_tokens: 200000
+  max_output_tokens: 100000
+  max_tokens: 100000
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: o3
 params:
-    - key: max_tokens
-      maxValue: 100000
+- key: max_tokens
+  maxValue: 100000
 sources:
-    - https://openrouter.ai/openai/o3/api
+- https://openrouter.ai/openai/o3/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/o4-mini-high.yaml
+++ b/providers/openrouter/o4-mini-high.yaml
@@ -1,27 +1,28 @@
 costs:
-    - cache_read_input_token_cost: 2.75e-7
-      input_cost_per_token: 0.0000011
-      output_cost_per_token: 0.0000044
-      region: "*"
+- cache_read_input_token_cost: 2.75e-07
+  input_cost_per_token: 1.1e-06
+  output_cost_per_token: 4.4e-06
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
+- function_calling
+- tool_choice
+- structured_output
 limits:
-    context_window: 200000
-    max_output_tokens: 100000
-    max_tokens: 100000
+  context_window: 200000
+  max_output_tokens: 100000
+  max_tokens: 100000
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: o4-mini-high
 params:
-    - key: max_tokens
-      maxValue: 100000
+- key: max_tokens
+  maxValue: 100000
 sources:
-    - https://openrouter.ai/openai/o4-mini-high/api
+- https://openrouter.ai/openai/o4-mini-high/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/o4-mini.yaml
+++ b/providers/openrouter/o4-mini.yaml
@@ -1,29 +1,29 @@
 costs:
-    - cache_read_input_token_cost: 2.75e-7
-      input_cost_per_token: 0.0000011
-      output_cost_per_token: 0.0000044
-      region: "*"
+- cache_read_input_token_cost: 2.75e-07
+  input_cost_per_token: 1.1e-06
+  output_cost_per_token: 4.4e-06
+  region: '*'
 features:
-    - function_calling
-    - structured_output
-    - tool_choice
-    - json_output
+- function_calling
+- structured_output
+- tool_choice
+- json_output
 limits:
-    context_window: 200000
-    max_output_tokens: 100000
-    max_tokens: 100000
+  context_window: 200000
+  max_output_tokens: 100000
+  max_tokens: 100000
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: o4-mini
 params:
-    - key: max_tokens
-      maxValue: 100000
+- key: max_tokens
+  maxValue: 100000
 sources:
-    - https://openrouter.ai/openai/o4-mini/api
-status: active
+- https://openrouter.ai/openai/o4-mini/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/openai/gpt-4.1-2025-04-14.yaml
+++ b/providers/openrouter/openai/gpt-4.1-2025-04-14.yaml
@@ -1,28 +1,29 @@
 costs:
-    - cache_read_input_token_cost: 5.e-7
-      input_cost_per_token: 0.000002
-      output_cost_per_token: 0.000008
-      region: "*"
+- cache_read_input_token_cost: 5.0e-07
+  input_cost_per_token: 2.0e-06
+  output_cost_per_token: 8.0e-06
+  region: '*'
 features:
-    - function_calling
-    - parallel_function_calling
-    - tool_choice
-    - structured_output
+- function_calling
+- parallel_function_calling
+- tool_choice
+- structured_output
 limits:
-    context_window: 1047576
-    max_input_tokens: 1047576
-    max_output_tokens: 32768
-    max_tokens: 32768
+  context_window: 1047576
+  max_input_tokens: 1047576
+  max_output_tokens: 32768
+  max_tokens: 32768
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: openai/gpt-4.1-2025-04-14
 params:
-    - key: max_tokens
-      maxValue: 32768
+- key: max_tokens
+  maxValue: 32768
 sources:
-    - https://openrouter.ai/openai/gpt-4.1-2025-04-14/api
+- https://openrouter.ai/openai/gpt-4.1-2025-04-14/api
+status: deprecated

--- a/providers/openrouter/openai/gpt-4.1-mini-2025-04-14.yaml
+++ b/providers/openrouter/openai/gpt-4.1-mini-2025-04-14.yaml
@@ -1,26 +1,26 @@
 costs:
-    - cache_read_input_token_cost: 1.e-7
-      input_cost_per_token: 4.e-7
-      output_cost_per_token: 0.0000016
-      region: "*"
+- cache_read_input_token_cost: 1.0e-07
+  input_cost_per_token: 4.0e-07
+  output_cost_per_token: 1.6e-06
+  region: '*'
 features:
-    - function_calling
-    - parallel_function_calling
-    - tool_choice
-    - structured_output
+- function_calling
+- parallel_function_calling
+- tool_choice
+- structured_output
 limits:
-    context_window: 1047576
-    max_input_tokens: 1047576
-    max_output_tokens: 32768
-    max_tokens: 32768
+  context_window: 1047576
+  max_input_tokens: 1047576
+  max_output_tokens: 32768
+  max_tokens: 32768
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: openai/gpt-4.1-mini-2025-04-14
 sources:
-    - https://openrouter.ai/openai/gpt-4.1-mini-2025-04-14/api
-status: active
+- https://openrouter.ai/openai/gpt-4.1-mini-2025-04-14/api
+status: deprecated

--- a/providers/openrouter/openai/gpt-4.1-nano-2025-04-14.yaml
+++ b/providers/openrouter/openai/gpt-4.1-nano-2025-04-14.yaml
@@ -1,25 +1,26 @@
 costs:
-    - cache_read_input_token_cost: 2.5e-8
-      input_cost_per_token: 1.e-7
-      output_cost_per_token: 4.e-7
-      region: "*"
+- cache_read_input_token_cost: 2.5e-08
+  input_cost_per_token: 1.0e-07
+  output_cost_per_token: 4.0e-07
+  region: '*'
 features:
-    - function_calling
-    - parallel_function_calling
-    - structured_output
-    - prompt_caching
-    - tool_choice
+- function_calling
+- parallel_function_calling
+- structured_output
+- prompt_caching
+- tool_choice
 limits:
-    context_window: 1047576
-    max_output_tokens: 32768
-    max_tokens: 32768
+  context_window: 1047576
+  max_output_tokens: 32768
+  max_tokens: 32768
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: openai/gpt-4.1-nano-2025-04-14
 sources:
-    - https://openrouter.ai/openai/gpt-4.1-nano-2025-04-14/api
+- https://openrouter.ai/openai/gpt-4.1-nano-2025-04-14/api
+status: deprecated

--- a/providers/openrouter/openai/gpt-oss-120b:exacto.yaml
+++ b/providers/openrouter/openai/gpt-oss-120b:exacto.yaml
@@ -1,25 +1,26 @@
 costs:
-    - input_cost_per_token: 3.9e-8
-      output_cost_per_token: 1.9e-7
-      region: "*"
+- input_cost_per_token: 3.9e-08
+  output_cost_per_token: 1.9e-07
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
-    - system_messages
+- function_calling
+- tool_choice
+- structured_output
+- system_messages
 limits:
-    context_window: 131072
+  context_window: 131072
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: openai/gpt-oss-120b:exacto
 params:
-    - defaultValue: medium
-      key: reasoning_effort
-      type: string
+- defaultValue: medium
+  key: reasoning_effort
+  type: string
 sources:
-    - https://openrouter.ai/openai/gpt-oss-120b:exacto/api
+- https://openrouter.ai/openai/gpt-oss-120b:exacto/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/openai/o1-mini-2024-09-12.yaml
+++ b/providers/openrouter/openai/o1-mini-2024-09-12.yaml
@@ -1,19 +1,20 @@
 costs:
-    - input_cost_per_token: 0.000003
-      output_cost_per_token: 0.000012
-      region: "*"
-deprecationDate: "2025-10-27"
+- input_cost_per_token: 3.0e-06
+  output_cost_per_token: 1.2e-05
+  region: '*'
+deprecationDate: '2025-10-27'
 features:
-    - function_calling
-    - parallel_function_calling
+- function_calling
+- parallel_function_calling
 isDeprecated: true
 limits:
-    context_window: 128000
-    max_input_tokens: 128000
-    max_output_tokens: 65536
-    max_tokens: 65536
+  context_window: 128000
+  max_input_tokens: 128000
+  max_output_tokens: 65536
+  max_tokens: 65536
 mode: chat
 model: openai/o1-mini-2024-09-12
 sources:
-    - https://openrouter.ai/openai/o1-mini-2024-09-12/api
-    - https://developers.openai.com/docs/deprecations
+- https://openrouter.ai/openai/o1-mini-2024-09-12/api
+- https://developers.openai.com/docs/deprecations
+status: deprecated

--- a/providers/openrouter/openai/o1-mini.yaml
+++ b/providers/openrouter/openai/o1-mini.yaml
@@ -1,14 +1,15 @@
 costs:
-    - input_cost_per_token: 0.000003
-      output_cost_per_token: 0.000012
-      region: "*"
+- input_cost_per_token: 3.0e-06
+  output_cost_per_token: 1.2e-05
+  region: '*'
 features:
-    - function_calling
-    - parallel_function_calling
+- function_calling
+- parallel_function_calling
 isDeprecated: true
 limits:
-    max_input_tokens: 128000
-    max_output_tokens: 65536
-    max_tokens: 65536
+  max_input_tokens: 128000
+  max_output_tokens: 65536
+  max_tokens: 65536
 mode: chat
 model: openai/o1-mini
+status: deprecated

--- a/providers/openrouter/openrouter/healer-alpha.yaml
+++ b/providers/openrouter/openrouter/healer-alpha.yaml
@@ -1,34 +1,35 @@
 costs:
-    - input_cost_per_image: 0
-      input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_image: 0
+  input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
-    - system_messages
+- function_calling
+- tool_choice
+- structured_output
+- system_messages
 isDeprecated: true
 limits:
-    context_window: 262144
-    max_input_tokens: 230144
-    max_output_tokens: 32000
-    max_tokens: 32000
+  context_window: 262144
+  max_input_tokens: 230144
+  max_output_tokens: 32000
+  max_tokens: 32000
 modalities:
-    input:
-        - text
-        - image
-        - audio
-        - video
-    output:
-        - text
+  input:
+  - text
+  - image
+  - audio
+  - video
+  output:
+  - text
 mode: chat
 model: openrouter/healer-alpha
 params:
-    - defaultValue: 1
-      key: temperature
-    - defaultValue: 0.95
-      key: top_p
+- defaultValue: 1
+  key: temperature
+- defaultValue: 0.95
+  key: top_p
 sources:
-    - https://openrouter.ai/api/v1/models
+- https://openrouter.ai/api/v1/models
 thinking: true
+status: deprecated

--- a/providers/openrouter/openrouter/hunter-alpha.yaml
+++ b/providers/openrouter/openrouter/hunter-alpha.yaml
@@ -1,29 +1,30 @@
 costs:
-    - input_cost_per_image: 0
-      input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_image: 0
+  input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - system_messages
+- function_calling
+- tool_choice
+- system_messages
 limits:
-    context_window: 1048576
-    max_output_tokens: 32000
-    max_tokens: 32000
+  context_window: 1048576
+  max_output_tokens: 32000
+  max_tokens: 32000
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: openrouter/hunter-alpha
 params:
-    - defaultValue: 128
-      key: max_tokens
-      maxValue: 32000
-      minValue: 1
+- defaultValue: 128
+  key: max_tokens
+  maxValue: 32000
+  minValue: 1
 sources:
-    - https://openrouter.ai/openrouter/hunter-alpha/api
+- https://openrouter.ai/openrouter/hunter-alpha/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/phi-3-medium-128k-instruct.yaml
+++ b/providers/openrouter/phi-3-medium-128k-instruct.yaml
@@ -1,14 +1,14 @@
 limits:
-    context_window: 128000
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 128000
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: microsoft/phi-3-medium-128k-instruct
 sources:
-    - https://openrouter.ai/microsoft/phi-3-medium-128k-instruct/api
-status: active
+- https://openrouter.ai/microsoft/phi-3-medium-128k-instruct/api
+status: deprecated

--- a/providers/openrouter/phi-3-mini-128k-instruct.yaml
+++ b/providers/openrouter/phi-3-mini-128k-instruct.yaml
@@ -1,12 +1,12 @@
 limits:
-    context_window: 128000
+  context_window: 128000
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: phi-3-mini-128k-instruct
 sources:
-    - https://openrouter.ai/microsoft/phi-3-mini-128k-instruct/api
-status: active
+- https://openrouter.ai/microsoft/phi-3-mini-128k-instruct/api
+status: deprecated

--- a/providers/openrouter/phi-3.5-mini-128k-instruct.yaml
+++ b/providers/openrouter/phi-3.5-mini-128k-instruct.yaml
@@ -1,13 +1,13 @@
 limits:
-    context_window: 128000
+  context_window: 128000
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: microsoft/phi-3.5-mini-128k-instruct
 sources:
-    - https://openrouter.ai/microsoft/phi-3.5-mini-128k-instruct/api
-    - https://openrouter.ai/microsoft/phi-3.5-mini-128k-instruct
-status: active
+- https://openrouter.ai/microsoft/phi-3.5-mini-128k-instruct/api
+- https://openrouter.ai/microsoft/phi-3.5-mini-128k-instruct
+status: deprecated

--- a/providers/openrouter/phi-4-multimodal-instruct.yaml
+++ b/providers/openrouter/phi-4-multimodal-instruct.yaml
@@ -1,18 +1,19 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 limits:
-    context_window: 131072
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 131072
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: microsoft/phi-4-multimodal-instruct
 sources:
-    - https://openrouter.ai/microsoft/phi-4-multimodal-instruct/api
+- https://openrouter.ai/microsoft/phi-4-multimodal-instruct/api
+status: deprecated

--- a/providers/openrouter/phi-4-reasoning-plus.yaml
+++ b/providers/openrouter/phi-4-reasoning-plus.yaml
@@ -1,25 +1,26 @@
 features:
-    - system_messages
+- system_messages
 limits:
-    context_window: 32768
-    max_output_tokens: 32768
-    max_tokens: 32768
+  context_window: 32768
+  max_output_tokens: 32768
+  max_tokens: 32768
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: phi-4-reasoning-plus
 params:
-    - defaultValue: 0.95
-      key: top_p
-    - defaultValue: 32768
-      key: max_tokens
-      maxValue: 32768
-      minValue: 1
+- defaultValue: 0.95
+  key: top_p
+- defaultValue: 32768
+  key: max_tokens
+  maxValue: 32768
+  minValue: 1
 sources:
-    - https://openrouter.ai/microsoft/phi-4-reasoning-plus/api
-    - https://openrouter.ai/microsoft/phi-4-reasoning-plus/providers
-    - https://huggingface.co/microsoft/Phi-4-reasoning-plus
+- https://openrouter.ai/microsoft/phi-4-reasoning-plus/api
+- https://openrouter.ai/microsoft/phi-4-reasoning-plus/providers
+- https://huggingface.co/microsoft/Phi-4-reasoning-plus
 thinking: true
+status: deprecated

--- a/providers/openrouter/phi-4.yaml
+++ b/providers/openrouter/phi-4.yaml
@@ -1,26 +1,27 @@
 costs:
-    - input_cost_per_token: 6.5e-8
-      output_cost_per_token: 1.4e-7
-      region: "*"
+- input_cost_per_token: 6.5e-08
+  output_cost_per_token: 1.4e-07
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
+- function_calling
+- tool_choice
+- structured_output
 limits:
-    context_window: 16384
-    max_output_tokens: 16384
-    max_tokens: 16384
+  context_window: 16384
+  max_output_tokens: 16384
+  max_tokens: 16384
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: phi-4
 params:
-    - defaultValue: 128
-      key: max_tokens
-      maxValue: 16384
-      minValue: 1
+- defaultValue: 128
+  key: max_tokens
+  maxValue: 16384
+  minValue: 1
 sources:
-    - https://openrouter.ai/microsoft/phi-4/api
+- https://openrouter.ai/microsoft/phi-4/api
+status: deprecated

--- a/providers/openrouter/pixtral-12b.yaml
+++ b/providers/openrouter/pixtral-12b.yaml
@@ -1,21 +1,21 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 1.e-7
-      region: "*"
+- input_cost_per_token: 1.0e-07
+  output_cost_per_token: 1.0e-07
+  region: '*'
 features:
-    - function_calling
+- function_calling
 limits:
-    context_window: 32768
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 32768
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: pixtral-12b
 sources:
-    - https://openrouter.ai/mistralai/pixtral-12b/api
-status: active
+- https://openrouter.ai/mistralai/pixtral-12b/api
+status: deprecated

--- a/providers/openrouter/pixtral-large-2411.yaml
+++ b/providers/openrouter/pixtral-large-2411.yaml
@@ -1,23 +1,24 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
-      input_cost_per_token: 0.000002
-      output_cost_per_token: 0.000006
-      region: "*"
+- cache_read_input_token_cost: 2.0e-07
+  input_cost_per_token: 2.0e-06
+  output_cost_per_token: 6.0e-06
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
+- function_calling
+- tool_choice
+- structured_output
 limits:
-    context_window: 131072
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 131072
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: pixtral-large-2411
 sources:
-    - https://openrouter.ai/mistralai/pixtral-large-2411/api
+- https://openrouter.ai/mistralai/pixtral-large-2411/api
+status: deprecated

--- a/providers/openrouter/pygmalionai/mythalion-13b.yaml
+++ b/providers/openrouter/pygmalionai/mythalion-13b.yaml
@@ -1,16 +1,16 @@
 costs:
-    - input_cost_per_token: 0.000001875
-      output_cost_per_token: 0.000001875
-      region: "*"
+- input_cost_per_token: 1.875e-06
+  output_cost_per_token: 1.875e-06
+  region: '*'
 limits:
-    context_window: 8192
+  context_window: 8192
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: pygmalionai/mythalion-13b
 sources:
-    - https://openrouter.ai/pygmalionai/mythalion-13b/api
-status: active
+- https://openrouter.ai/pygmalionai/mythalion-13b/api
+status: deprecated

--- a/providers/openrouter/qwen-2-72b-instruct.yaml
+++ b/providers/openrouter/qwen-2-72b-instruct.yaml
@@ -1,15 +1,16 @@
 limits:
-    context_window: 32768
+  context_window: 32768
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: qwen/qwen-2-72b-instruct
 params:
-    - key: max_tokens
-      maxValue: 4096
+- key: max_tokens
+  maxValue: 4096
 sources:
-    - https://openrouter.ai/qwen/qwen-2-72b-instruct/api
-    - https://openrouter.ai/qwen/qwen-2-72b-instruct
+- https://openrouter.ai/qwen/qwen-2-72b-instruct/api
+- https://openrouter.ai/qwen/qwen-2-72b-instruct
+status: deprecated

--- a/providers/openrouter/qwen-2.5-72b-instruct.yaml
+++ b/providers/openrouter/qwen-2.5-72b-instruct.yaml
@@ -1,21 +1,22 @@
 costs:
-    - input_cost_per_token: 1.2e-7
-      output_cost_per_token: 3.9e-7
-      region: "*"
+- input_cost_per_token: 1.2e-07
+  output_cost_per_token: 3.9e-07
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
+- function_calling
+- tool_choice
+- structured_output
 limits:
-    context_window: 32768
-    max_output_tokens: 8000
-    max_tokens: 8000
+  context_window: 32768
+  max_output_tokens: 8000
+  max_tokens: 8000
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: qwen-2.5-72b-instruct
 sources:
-    - https://openrouter.ai/qwen/qwen-2.5-72b-instruct/api
+- https://openrouter.ai/qwen/qwen-2.5-72b-instruct/api
+status: deprecated

--- a/providers/openrouter/qwen-2.5-72b-instruct:free.yaml
+++ b/providers/openrouter/qwen-2.5-72b-instruct:free.yaml
@@ -1,21 +1,22 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 features:
-    - function_calling
-    - structured_output
-    - json_output
+- function_calling
+- structured_output
+- json_output
 limits:
-    context_window: 131072
-    max_output_tokens: 8000
-    max_tokens: 8000
+  context_window: 131072
+  max_output_tokens: 8000
+  max_tokens: 8000
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: qwen-2.5-72b-instruct:free
 sources:
-    - https://openrouter.ai/qwen/qwen-2.5-72b-instruct:free/api
+- https://openrouter.ai/qwen/qwen-2.5-72b-instruct:free/api
+status: deprecated

--- a/providers/openrouter/qwen-2.5-7b-instruct.yaml
+++ b/providers/openrouter/qwen-2.5-7b-instruct.yaml
@@ -1,22 +1,23 @@
 costs:
-    - input_cost_per_token: 4.e-8
-      output_cost_per_token: 1.e-7
-      region: "*"
+- input_cost_per_token: 4.0e-08
+  output_cost_per_token: 1.0e-07
+  region: '*'
 features:
-    - json_output
+- json_output
 limits:
-    context_window: 32768
-    max_output_tokens: 32768
-    max_tokens: 32768
+  context_window: 32768
+  max_output_tokens: 32768
+  max_tokens: 32768
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: qwen-2.5-7b-instruct
 params:
-    - key: max_tokens
-      maxValue: 32768
+- key: max_tokens
+  maxValue: 32768
 sources:
-    - https://openrouter.ai/qwen/qwen-2.5-7b-instruct/api
+- https://openrouter.ai/qwen/qwen-2.5-7b-instruct/api
+status: deprecated

--- a/providers/openrouter/qwen-2.5-coder-32b-instruct.yaml
+++ b/providers/openrouter/qwen-2.5-coder-32b-instruct.yaml
@@ -1,23 +1,24 @@
 costs:
-    - input_cost_per_token: 6.6e-7
-      output_cost_per_token: 0.000001
-      region: "*"
+- input_cost_per_token: 6.6e-07
+  output_cost_per_token: 1.0e-06
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
+- function_calling
+- tool_choice
 limits:
-    context_window: 32768
-    max_output_tokens: 8192
-    max_tokens: 8192
+  context_window: 32768
+  max_output_tokens: 8192
+  max_tokens: 8192
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: qwen-2.5-coder-32b-instruct
 params:
-    - key: max_tokens
-      maxValue: 8192
+- key: max_tokens
+  maxValue: 8192
 sources:
-    - https://openrouter.ai/qwen/qwen-2.5-coder-32b-instruct/api
+- https://openrouter.ai/qwen/qwen-2.5-coder-32b-instruct/api
+status: deprecated

--- a/providers/openrouter/qwen-2.5-coder-32b-instruct:free.yaml
+++ b/providers/openrouter/qwen-2.5-coder-32b-instruct:free.yaml
@@ -1,17 +1,18 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 limits:
-    context_window: 128000
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 128000
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: qwen/qwen-2.5-coder-32b-instruct:free
 sources:
-    - https://openrouter.ai/qwen/qwen-2.5-coder-32b-instruct:free/api
+- https://openrouter.ai/qwen/qwen-2.5-coder-32b-instruct:free/api
+status: deprecated

--- a/providers/openrouter/qwen-2.5-vl-7b-instruct.yaml
+++ b/providers/openrouter/qwen-2.5-vl-7b-instruct.yaml
@@ -1,18 +1,19 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 2.e-7
-      region: "*"
+- input_cost_per_token: 2.0e-07
+  output_cost_per_token: 2.0e-07
+  region: '*'
 limits:
-    context_window: 32768
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 32768
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: qwen/qwen-2.5-vl-7b-instruct
 sources:
-    - https://openrouter.ai/qwen/qwen-2.5-vl-7b-instruct/api
+- https://openrouter.ai/qwen/qwen-2.5-vl-7b-instruct/api
+status: deprecated

--- a/providers/openrouter/qwen-max.yaml
+++ b/providers/openrouter/qwen-max.yaml
@@ -1,26 +1,27 @@
 costs:
-    - cache_read_input_token_cost: 2.08e-7
-      input_cost_per_token: 0.00000104
-      output_cost_per_token: 0.00000416
-      region: "*"
+- cache_read_input_token_cost: 2.08e-07
+  input_cost_per_token: 1.04e-06
+  output_cost_per_token: 4.16e-06
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
+- function_calling
+- tool_choice
+- structured_output
 limits:
-    context_window: 32768
-    max_input_tokens: 30720
-    max_output_tokens: 8192
-    max_tokens: 8192
+  context_window: 32768
+  max_input_tokens: 30720
+  max_output_tokens: 8192
+  max_tokens: 8192
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: qwen-max
 params:
-    - key: max_tokens
-      maxValue: 8192
+- key: max_tokens
+  maxValue: 8192
 sources:
-    - https://openrouter.ai/qwen/qwen-max/api
+- https://openrouter.ai/qwen/qwen-max/api
+status: deprecated

--- a/providers/openrouter/qwen-plus.yaml
+++ b/providers/openrouter/qwen-plus.yaml
@@ -1,36 +1,37 @@
 costs:
-    - cache_read_input_token_cost: 5.2e-8
-      input_cost_per_token: 2.6e-7
-      output_cost_per_token: 7.8e-7
-      region: "*"
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 2.4e-7
-                from: 256000
-          input:
-              - cost_per_token: 0.0000012
-                from: 256000
-          output:
-              - cost_per_token: 0.0000036
-                from: 256000
-features:
-    - function_calling
-    - tool_choice
-    - structured_output
-limits:
-    context_window: 1000000
-    max_input_tokens: 995904
-    max_output_tokens: 32768
-    max_tokens: 32768
-modalities:
+- cache_read_input_token_cost: 5.2e-08
+  input_cost_per_token: 2.6e-07
+  output_cost_per_token: 7.8e-07
+  region: '*'
+  tiered_pricing:
+    cache_read:
+    - cost_per_token: 2.4e-07
+      from: 256000
     input:
-        - text
+    - cost_per_token: 1.2e-06
+      from: 256000
     output:
-        - text
+    - cost_per_token: 3.6e-06
+      from: 256000
+features:
+- function_calling
+- tool_choice
+- structured_output
+limits:
+  context_window: 1000000
+  max_input_tokens: 995904
+  max_output_tokens: 32768
+  max_tokens: 32768
+modalities:
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: qwen-plus
 params:
-    - key: max_tokens
-      maxValue: 32768
+- key: max_tokens
+  maxValue: 32768
 sources:
-    - https://openrouter.ai/qwen/qwen-plus/api
+- https://openrouter.ai/qwen/qwen-plus/api
+status: deprecated

--- a/providers/openrouter/qwen-turbo.yaml
+++ b/providers/openrouter/qwen-turbo.yaml
@@ -1,21 +1,22 @@
 costs:
-    - cache_read_input_token_cost: 6.5e-9
-      input_cost_per_token: 3.25e-8
-      output_cost_per_token: 1.3e-7
-      region: "*"
+- cache_read_input_token_cost: 6.5e-09
+  input_cost_per_token: 3.25e-08
+  output_cost_per_token: 1.3e-07
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - system_messages
+- function_calling
+- tool_choice
+- system_messages
 limits:
-    context_window: 131072
-    max_input_tokens: 98304
-    max_output_tokens: 8192
-    max_tokens: 8192
+  context_window: 131072
+  max_input_tokens: 98304
+  max_output_tokens: 8192
+  max_tokens: 8192
 mode: chat
 model: qwen-turbo
 params:
-    - key: max_tokens
-      maxValue: 8192
+- key: max_tokens
+  maxValue: 8192
 sources:
-    - https://openrouter.ai/qwen/qwen-turbo/api
+- https://openrouter.ai/qwen/qwen-turbo/api
+status: deprecated

--- a/providers/openrouter/qwen-vl-max.yaml
+++ b/providers/openrouter/qwen-vl-max.yaml
@@ -1,25 +1,26 @@
 costs:
-    - input_cost_per_token: 5.2e-7
-      output_cost_per_token: 0.00000208
-      region: "*"
+- input_cost_per_token: 5.2e-07
+  output_cost_per_token: 2.08e-06
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
+- function_calling
+- tool_choice
 limits:
-    context_window: 131072
-    max_input_tokens: 129024
-    max_output_tokens: 32768
-    max_tokens: 32768
+  context_window: 131072
+  max_input_tokens: 129024
+  max_output_tokens: 32768
+  max_tokens: 32768
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: qwen-vl-max
 params:
-    - key: max_tokens
-      maxValue: 32768
+- key: max_tokens
+  maxValue: 32768
 sources:
-    - https://openrouter.ai/qwen/qwen-vl-max/api
+- https://openrouter.ai/qwen/qwen-vl-max/api
+status: deprecated

--- a/providers/openrouter/qwen-vl-plus.yaml
+++ b/providers/openrouter/qwen-vl-plus.yaml
@@ -1,27 +1,28 @@
 costs:
-    - cache_read_input_token_cost: 2.73e-8
-      input_cost_per_token: 1.365e-7
-      output_cost_per_token: 4.095e-7
-      region: "*"
+- cache_read_input_token_cost: 2.73e-08
+  input_cost_per_token: 1.365e-07
+  output_cost_per_token: 4.095e-07
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
+- function_calling
+- tool_choice
+- structured_output
 limits:
-    context_window: 131072
-    max_input_tokens: 129024
-    max_output_tokens: 8192
-    max_tokens: 8192
+  context_window: 131072
+  max_input_tokens: 129024
+  max_output_tokens: 8192
+  max_tokens: 8192
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: qwen-vl-plus
 params:
-    - key: max_tokens
-      maxValue: 8192
+- key: max_tokens
+  maxValue: 8192
 sources:
-    - https://openrouter.ai/qwen/qwen-vl-plus/api
+- https://openrouter.ai/qwen/qwen-vl-plus/api
+status: deprecated

--- a/providers/openrouter/qwen/qwen-2.5-vl-7b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen-2.5-vl-7b-instruct.yaml
@@ -1,16 +1,17 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 2.e-7
-      region: "*"
+- input_cost_per_token: 2.0e-07
+  output_cost_per_token: 2.0e-07
+  region: '*'
 limits:
-    context_window: 32768
+  context_window: 32768
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: qwen/qwen-2.5-vl-7b-instruct
 sources:
-    - https://openrouter.ai/qwen/qwen-2.5-vl-7b-instruct/api
+- https://openrouter.ai/qwen/qwen-2.5-vl-7b-instruct/api
+status: deprecated

--- a/providers/openrouter/qwen/qwen3-4b:free.yaml
+++ b/providers/openrouter/qwen/qwen3-4b:free.yaml
@@ -1,21 +1,22 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
-    - system_messages
+- function_calling
+- tool_choice
+- structured_output
+- system_messages
 limits:
-    context_window: 128000
+  context_window: 128000
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: qwen/qwen3-4b:free
 sources:
-    - https://openrouter.ai/qwen/qwen3-4b:free/api
+- https://openrouter.ai/qwen/qwen3-4b:free/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/qwen/qwen3-coder:exacto.yaml
+++ b/providers/openrouter/qwen/qwen3-coder:exacto.yaml
@@ -1,21 +1,22 @@
 costs:
-    - cache_read_input_token_cost: 2.2e-8
-      input_cost_per_token: 2.2e-7
-      output_cost_per_token: 0.000001
-      region: "*"
+- cache_read_input_token_cost: 2.2e-08
+  input_cost_per_token: 2.2e-07
+  output_cost_per_token: 1.0e-06
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
-    - json_output
+- function_calling
+- tool_choice
+- structured_output
+- json_output
 limits:
-    context_window: 262144
+  context_window: 262144
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: qwen/qwen3-coder:exacto
 sources:
-    - https://openrouter.ai/qwen/qwen3-coder:exacto/api
+- https://openrouter.ai/qwen/qwen3-coder:exacto/api
+status: deprecated

--- a/providers/openrouter/qwen2.5-vl-32b-instruct.yaml
+++ b/providers/openrouter/qwen2.5-vl-32b-instruct.yaml
@@ -1,21 +1,21 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 6.e-7
-      region: "*"
+- input_cost_per_token: 2.0e-07
+  output_cost_per_token: 6.0e-07
+  region: '*'
 features:
-    - system_messages
-    - json_output
+- system_messages
+- json_output
 limits:
-    context_window: 128000
-    max_tokens: 4096
+  context_window: 128000
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: qwen2.5-vl-32b-instruct
 sources:
-    - https://openrouter.ai/qwen/qwen2.5-vl-32b-instruct/api
-status: active
+- https://openrouter.ai/qwen/qwen2.5-vl-32b-instruct/api
+status: deprecated

--- a/providers/openrouter/qwen2.5-vl-32b-instruct:free.yaml
+++ b/providers/openrouter/qwen2.5-vl-32b-instruct:free.yaml
@@ -1,20 +1,20 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 limits:
-    context_window: 32768
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 32768
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: qwen2.5-vl-32b-instruct:free
 sources:
-    - https://openrouter.ai/qwen/qwen2.5-vl-32b-instruct:free/api
-    - https://openrouter.ai/qwen/qwen2.5-vl-32b-instruct:free
-status: active
+- https://openrouter.ai/qwen/qwen2.5-vl-32b-instruct:free/api
+- https://openrouter.ai/qwen/qwen2.5-vl-32b-instruct:free
+status: deprecated

--- a/providers/openrouter/qwen2.5-vl-72b-instruct.yaml
+++ b/providers/openrouter/qwen2.5-vl-72b-instruct.yaml
@@ -1,18 +1,19 @@
 costs:
-    - input_cost_per_token: 8.e-7
-      output_cost_per_token: 8.e-7
-      region: "*"
+- input_cost_per_token: 8.0e-07
+  output_cost_per_token: 8.0e-07
+  region: '*'
 limits:
-    context_window: 32768
-    max_output_tokens: 32768
-    max_tokens: 32768
+  context_window: 32768
+  max_output_tokens: 32768
+  max_tokens: 32768
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: qwen2.5-vl-72b-instruct
 sources:
-    - https://openrouter.ai/qwen/qwen2.5-vl-72b-instruct/api
+- https://openrouter.ai/qwen/qwen2.5-vl-72b-instruct/api
+status: deprecated

--- a/providers/openrouter/qwen2.5-vl-72b-instruct:free.yaml
+++ b/providers/openrouter/qwen2.5-vl-72b-instruct:free.yaml
@@ -1,17 +1,18 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 limits:
-    context_window: 131072
+  context_window: 131072
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: qwen2.5-vl-72b-instruct:free
 sources:
-    - https://openrouter.ai/qwen/qwen2.5-vl-72b-instruct:free/api
-    - https://openrouter.ai/qwen/qwen2.5-vl-72b-instruct/api
+- https://openrouter.ai/qwen/qwen2.5-vl-72b-instruct:free/api
+- https://openrouter.ai/qwen/qwen2.5-vl-72b-instruct/api
+status: deprecated

--- a/providers/openrouter/qwen3-14b.yaml
+++ b/providers/openrouter/qwen3-14b.yaml
@@ -1,21 +1,22 @@
 costs:
-    - input_cost_per_token: 6.e-8
-      output_cost_per_token: 2.4e-7
-      region: "*"
+- input_cost_per_token: 6.0e-08
+  output_cost_per_token: 2.4e-07
+  region: '*'
 features:
-    - function_calling
-    - structured_output
+- function_calling
+- structured_output
 limits:
-    context_window: 40960
-    max_output_tokens: 40960
-    max_tokens: 40960
+  context_window: 40960
+  max_output_tokens: 40960
+  max_tokens: 40960
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: qwen3-14b
 sources:
-    - https://openrouter.ai/qwen/qwen3-14b/api
+- https://openrouter.ai/qwen/qwen3-14b/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/qwen3-14b:free.yaml
+++ b/providers/openrouter/qwen3-14b:free.yaml
@@ -1,23 +1,24 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
-    - json_output
+- function_calling
+- tool_choice
+- structured_output
+- json_output
 limits:
-    context_window: 40960
-    max_output_tokens: 40960
-    max_tokens: 40960
+  context_window: 40960
+  max_output_tokens: 40960
+  max_tokens: 40960
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: qwen3-14b:free
 sources:
-    - https://openrouter.ai/qwen/qwen3-14b:free/api
+- https://openrouter.ai/qwen/qwen3-14b:free/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/qwen3-235b-a22b-2507.yaml
+++ b/providers/openrouter/qwen3-235b-a22b-2507.yaml
@@ -1,19 +1,20 @@
 costs:
-    - input_cost_per_token: 7.1e-8
-      output_cost_per_token: 1.e-7
-      region: "*"
+- input_cost_per_token: 7.1e-08
+  output_cost_per_token: 1.0e-07
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - json_output
+- function_calling
+- tool_choice
+- json_output
 limits:
-    context_window: 262144
+  context_window: 262144
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: qwen3-235b-a22b-2507
 sources:
-    - https://openrouter.ai/qwen/qwen3-235b-a22b-2507/api
+- https://openrouter.ai/qwen/qwen3-235b-a22b-2507/api
+status: deprecated

--- a/providers/openrouter/qwen3-235b-a22b-thinking-2507.yaml
+++ b/providers/openrouter/qwen3-235b-a22b-thinking-2507.yaml
@@ -1,22 +1,23 @@
 costs:
-    - input_cost_per_token: 1.495e-7
-      output_cost_per_token: 0.000001495
-      region: "*"
+- input_cost_per_token: 1.495e-07
+  output_cost_per_token: 1.495e-06
+  region: '*'
 features:
-    - function_calling
-    - structured_output
-    - prompt_caching
+- function_calling
+- structured_output
+- prompt_caching
 limits:
-    context_window: 131072
-    max_output_tokens: 81920
-    max_tokens: 81920
+  context_window: 131072
+  max_output_tokens: 81920
+  max_tokens: 81920
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: qwen3-235b-a22b-thinking-2507
 sources:
-    - https://openrouter.ai/qwen/qwen3-235b-a22b-thinking-2507/api
+- https://openrouter.ai/qwen/qwen3-235b-a22b-thinking-2507/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/qwen3-235b-a22b.yaml
+++ b/providers/openrouter/qwen3-235b-a22b.yaml
@@ -1,26 +1,27 @@
 costs:
-    - input_cost_per_token: 4.55e-7
-      output_cost_per_token: 0.00000182
-      region: "*"
+- input_cost_per_token: 4.55e-07
+  output_cost_per_token: 1.82e-06
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
+- function_calling
+- tool_choice
+- structured_output
 limits:
-    context_window: 131072
-    max_input_tokens: 98304
-    max_output_tokens: 8192
-    max_tokens: 8192
+  context_window: 131072
+  max_input_tokens: 98304
+  max_output_tokens: 8192
+  max_tokens: 8192
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: qwen3-235b-a22b
 params:
-    - key: max_tokens
-      maxValue: 8192
+- key: max_tokens
+  maxValue: 8192
 sources:
-    - https://openrouter.ai/qwen/qwen3-235b-a22b/api
+- https://openrouter.ai/qwen/qwen3-235b-a22b/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/qwen3-235b-a22b:free.yaml
+++ b/providers/openrouter/qwen3-235b-a22b:free.yaml
@@ -1,23 +1,23 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
+- function_calling
+- tool_choice
 limits:
-    context_window: 131072
-    max_output_tokens: 8192
-    max_tokens: 8192
+  context_window: 131072
+  max_output_tokens: 8192
+  max_tokens: 8192
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: qwen3-235b-a22b:free
 sources:
-    - https://openrouter.ai/qwen/qwen3-235b-a22b:free/api
-    - https://openrouter.ai/qwen/qwen3-235b-a22b/api
-status: active
+- https://openrouter.ai/qwen/qwen3-235b-a22b:free/api
+- https://openrouter.ai/qwen/qwen3-235b-a22b/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/qwen3-30b-a3b-instruct-2507.yaml
+++ b/providers/openrouter/qwen3-30b-a3b-instruct-2507.yaml
@@ -1,24 +1,25 @@
 costs:
-    - input_cost_per_token: 9.e-8
-      output_cost_per_token: 3.e-7
-      region: "*"
+- input_cost_per_token: 9.0e-08
+  output_cost_per_token: 3.0e-07
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
+- function_calling
+- tool_choice
+- structured_output
 limits:
-    context_window: 262144
-    max_output_tokens: 262144
-    max_tokens: 262144
+  context_window: 262144
+  max_output_tokens: 262144
+  max_tokens: 262144
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: qwen3-30b-a3b-instruct-2507
 params:
-    - key: max_tokens
-      maxValue: 262144
+- key: max_tokens
+  maxValue: 262144
 sources:
-    - https://openrouter.ai/qwen/qwen3-30b-a3b-instruct-2507/api
+- https://openrouter.ai/qwen/qwen3-30b-a3b-instruct-2507/api
+status: deprecated

--- a/providers/openrouter/qwen3-30b-a3b.yaml
+++ b/providers/openrouter/qwen3-30b-a3b.yaml
@@ -1,25 +1,26 @@
 costs:
-    - input_cost_per_token: 8.e-8
-      output_cost_per_token: 2.8e-7
-      region: "*"
+- input_cost_per_token: 8.0e-08
+  output_cost_per_token: 2.8e-07
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
+- function_calling
+- tool_choice
+- structured_output
 limits:
-    context_window: 40960
-    max_output_tokens: 40960
-    max_tokens: 40960
+  context_window: 40960
+  max_output_tokens: 40960
+  max_tokens: 40960
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: qwen3-30b-a3b
 params:
-    - key: max_tokens
-      maxValue: 40960
+- key: max_tokens
+  maxValue: 40960
 sources:
-    - https://openrouter.ai/qwen/qwen3-30b-a3b/api
+- https://openrouter.ai/qwen/qwen3-30b-a3b/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/qwen3-30b-a3b:free.yaml
+++ b/providers/openrouter/qwen3-30b-a3b:free.yaml
@@ -1,22 +1,22 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
+- function_calling
+- tool_choice
 limits:
-    context_window: 131072
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 131072
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: qwen3-30b-a3b:free
 sources:
-    - https://openrouter.ai/qwen/qwen3-30b-a3b:free/api
-status: active
+- https://openrouter.ai/qwen/qwen3-30b-a3b:free/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/qwen3-32b.yaml
+++ b/providers/openrouter/qwen3-32b.yaml
@@ -1,23 +1,24 @@
 costs:
-    - cache_read_input_token_cost: 4.e-8
-      input_cost_per_token: 8.e-8
-      output_cost_per_token: 2.4e-7
-      region: "*"
+- cache_read_input_token_cost: 4.0e-08
+  input_cost_per_token: 8.0e-08
+  output_cost_per_token: 2.4e-07
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
+- function_calling
+- tool_choice
+- structured_output
 limits:
-    context_window: 40960
-    max_output_tokens: 40960
-    max_tokens: 40960
+  context_window: 40960
+  max_output_tokens: 40960
+  max_tokens: 40960
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: qwen3-32b
 sources:
-    - https://openrouter.ai/qwen/qwen3-32b/api
+- https://openrouter.ai/qwen/qwen3-32b/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/qwen3-4b:free.yaml
+++ b/providers/openrouter/qwen3-4b:free.yaml
@@ -1,21 +1,22 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
-    - json_output
+- function_calling
+- tool_choice
+- structured_output
+- json_output
 limits:
-    context_window: 40960
+  context_window: 40960
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: qwen3-4b:free
 sources:
-    - https://openrouter.ai/qwen/qwen3-4b:free/api
+- https://openrouter.ai/qwen/qwen3-4b:free/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/qwen3-8b.yaml
+++ b/providers/openrouter/qwen3-8b.yaml
@@ -1,25 +1,25 @@
 costs:
-    - input_cost_per_token: 5.e-8
-      output_cost_per_token: 4.e-7
-      region: "*"
+- input_cost_per_token: 5.0e-08
+  output_cost_per_token: 4.0e-07
+  region: '*'
 features:
-    - function_calling
-    - structured_output
+- function_calling
+- structured_output
 limits:
-    context_window: 40960
-    max_output_tokens: 8192
-    max_tokens: 8192
+  context_window: 40960
+  max_output_tokens: 8192
+  max_tokens: 8192
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: qwen3-8b
 params:
-    - key: max_tokens
-      maxValue: 8192
+- key: max_tokens
+  maxValue: 8192
 sources:
-    - https://openrouter.ai/qwen/qwen3-8b/api
-status: active
+- https://openrouter.ai/qwen/qwen3-8b/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/qwen3-8b:free.yaml
+++ b/providers/openrouter/qwen3-8b:free.yaml
@@ -1,26 +1,27 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
+- function_calling
+- tool_choice
+- structured_output
 limits:
-    context_window: 40960
-    max_input_tokens: 40960
-    max_output_tokens: 8192
-    max_tokens: 8192
+  context_window: 40960
+  max_input_tokens: 40960
+  max_output_tokens: 8192
+  max_tokens: 8192
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: qwen3-8b:free
 params:
-    - key: max_tokens
-      maxValue: 8192
+- key: max_tokens
+  maxValue: 8192
 sources:
-    - https://openrouter.ai/qwen/qwen3-8b:free/api
+- https://openrouter.ai/qwen/qwen3-8b:free/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/qwen3-coder.yaml
+++ b/providers/openrouter/qwen3-coder.yaml
@@ -1,20 +1,21 @@
 costs:
-    - cache_read_input_token_cost: 2.2e-8
-      input_cost_per_token: 2.2e-7
-      output_cost_per_token: 0.000001
-      region: "*"
+- cache_read_input_token_cost: 2.2e-08
+  input_cost_per_token: 2.2e-07
+  output_cost_per_token: 1.0e-06
+  region: '*'
 features:
-    - function_calling
-    - structured_output
-    - tool_choice
+- function_calling
+- structured_output
+- tool_choice
 limits:
-    context_window: 262144
+  context_window: 262144
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: qwen3-coder
 sources:
-    - https://openrouter.ai/qwen/qwen3-coder/api
+- https://openrouter.ai/qwen/qwen3-coder/api
+status: deprecated

--- a/providers/openrouter/qwen3-coder:free.yaml
+++ b/providers/openrouter/qwen3-coder:free.yaml
@@ -1,23 +1,24 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
-    - json_output
+- function_calling
+- tool_choice
+- structured_output
+- json_output
 limits:
-    context_window: 262144
-    max_output_tokens: 262144
-    max_tokens: 262144
+  context_window: 262144
+  max_output_tokens: 262144
+  max_tokens: 262144
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: qwen3-coder:free
 sources:
-    - https://openrouter.ai/qwen/qwen3-coder:free/api
-    - https://openrouter.ai/qwen/qwen3-coder/api
+- https://openrouter.ai/qwen/qwen3-coder:free/api
+- https://openrouter.ai/qwen/qwen3-coder/api
+status: deprecated

--- a/providers/openrouter/qwerky-72b:free.yaml
+++ b/providers/openrouter/qwerky-72b:free.yaml
@@ -1,11 +1,12 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 mode: chat
 model: qwerky-72b:free
 params:
-    - key: max_tokens
-      maxValue: 4096
+- key: max_tokens
+  maxValue: 4096
 sources:
-    - https://openrouter.ai/qwen/qwerky-72b:free/api
+- https://openrouter.ai/qwen/qwerky-72b:free/api
+status: deprecated

--- a/providers/openrouter/qwq-32b-arliai-rpr-v1.yaml
+++ b/providers/openrouter/qwq-32b-arliai-rpr-v1.yaml
@@ -1,14 +1,14 @@
 limits:
-    context_window: 32768
+  context_window: 32768
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: qwq-32b-arliai-rpr-v1
 sources:
-    - https://openrouter.ai/arliai/qwq-32b-arliai-rpr-v1/api
-    - https://openrouter.ai/arliai/qwq-32b-arliai-rpr-v1
-status: active
+- https://openrouter.ai/arliai/qwq-32b-arliai-rpr-v1/api
+- https://openrouter.ai/arliai/qwq-32b-arliai-rpr-v1
+status: deprecated
 thinking: true

--- a/providers/openrouter/qwq-32b-arliai-rpr-v1:free.yaml
+++ b/providers/openrouter/qwq-32b-arliai-rpr-v1:free.yaml
@@ -1,19 +1,19 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 limits:
-    context_window: 32768
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 32768
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: qwq-32b-arliai-rpr-v1:free
 sources:
-    - https://openrouter.ai/arliai/qwq-32b-arliai-rpr-v1:free/api
-status: active
+- https://openrouter.ai/arliai/qwq-32b-arliai-rpr-v1:free/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/qwq-32b.yaml
+++ b/providers/openrouter/qwq-32b.yaml
@@ -1,21 +1,22 @@
 costs:
-    - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 5.8e-7
-      region: "*"
+- input_cost_per_token: 1.5e-07
+  output_cost_per_token: 5.8e-07
+  region: '*'
 features:
-    - function_calling
-    - structured_output
+- function_calling
+- structured_output
 limits:
-    context_window: 131072
-    max_output_tokens: 131072
-    max_tokens: 131072
+  context_window: 131072
+  max_output_tokens: 131072
+  max_tokens: 131072
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: qwq-32b
 sources:
-    - https://openrouter.ai/qwen/qwq-32b/api
+- https://openrouter.ai/qwen/qwq-32b/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/qwq-32b:free.yaml
+++ b/providers/openrouter/qwq-32b:free.yaml
@@ -1,21 +1,22 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 features:
-    - function_calling
+- function_calling
 limits:
-    context_window: 131072
-    max_output_tokens: 131072
-    max_tokens: 131072
+  context_window: 131072
+  max_output_tokens: 131072
+  max_tokens: 131072
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: qwq-32b:free
 sources:
-    - https://openrouter.ai/qwen/qwq-32b:free/api
-    - https://openrouter.ai/qwen/qwq-32b/api
+- https://openrouter.ai/qwen/qwq-32b:free/api
+- https://openrouter.ai/qwen/qwq-32b/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/r1-1776.yaml
+++ b/providers/openrouter/r1-1776.yaml
@@ -1,15 +1,15 @@
 limits:
-    context_window: 128000
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 128000
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: r1-1776
 sources:
-    - https://openrouter.ai/perplexity/r1-1776/api
-status: active
+- https://openrouter.ai/perplexity/r1-1776/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/raifle/sorcererlm-8x22b.yaml
+++ b/providers/openrouter/raifle/sorcererlm-8x22b.yaml
@@ -1,12 +1,12 @@
 limits:
-    context_window: 16000
+  context_window: 16000
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: raifle/sorcererlm-8x22b
 sources:
-    - https://openrouter.ai/raifle/sorcererlm-8x22b/api
-status: active
+- https://openrouter.ai/raifle/sorcererlm-8x22b/api
+status: deprecated

--- a/providers/openrouter/reka-flash-3.yaml
+++ b/providers/openrouter/reka-flash-3.yaml
@@ -1,40 +1,41 @@
 costs:
-    - input_cost_per_image: 0.01
-      input_cost_per_token: 8.e-7
-      output_cost_per_token: 0.000002
-      region: "*"
+- input_cost_per_image: 0.01
+  input_cost_per_token: 8.0e-07
+  output_cost_per_token: 2.0e-06
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
+- function_calling
+- tool_choice
 limits:
-    max_output_tokens: 4096
-    max_tokens: 4096
+  max_output_tokens: 4096
+  max_tokens: 4096
 messages:
-    options:
-        - user
-        - assistant
+  options:
+  - user
+  - assistant
 modalities:
-    input:
-        - text
-        - image
-        - audio
-        - video
-        - pdf
-    output:
-        - text
+  input:
+  - text
+  - image
+  - audio
+  - video
+  - pdf
+  output:
+  - text
 mode: chat
 model: reka-flash-3
 params:
-    - defaultValue: 0.4
-      key: temperature
-      maxValue: 2
-      minValue: 0
-    - defaultValue: 0.95
-      key: top_p
-    - defaultValue: 1024
-      key: top_k
+- defaultValue: 0.4
+  key: temperature
+  maxValue: 2
+  minValue: 0
+- defaultValue: 0.95
+  key: top_p
+- defaultValue: 1024
+  key: top_k
 sources:
-    - https://openrouter.ai/reka-ai/reka-flash-3/api
-    - https://docs.reka.ai/pricing
-    - https://docs.reka.ai/chat/models
-    - https://docs.reka.ai/chat/api-reference/create
+- https://openrouter.ai/reka-ai/reka-flash-3/api
+- https://docs.reka.ai/pricing
+- https://docs.reka.ai/chat/models
+- https://docs.reka.ai/chat/api-reference/create
+status: deprecated

--- a/providers/openrouter/reka-flash-3:free.yaml
+++ b/providers/openrouter/reka-flash-3:free.yaml
@@ -1,26 +1,27 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 features:
-    - function_calling
-    - system_messages
+- function_calling
+- system_messages
 limits:
-    max_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-        - image
-        - audio
-        - video
-        - pdf
-    output:
-        - text
+  input:
+  - text
+  - image
+  - audio
+  - video
+  - pdf
+  output:
+  - text
 mode: chat
 model: reka-flash-3:free
 sources:
-    - https://openrouter.ai/reka/reka-flash-3:free/api
-    - https://docs.reka.ai/pricing
-    - https://docs.reka.ai/chat/models
-    - https://docs.reka.ai/chat/function-calling
-    - https://docs.reka.ai/chat/chat-with-image-video-and-audio
+- https://openrouter.ai/reka/reka-flash-3:free/api
+- https://docs.reka.ai/pricing
+- https://docs.reka.ai/chat/models
+- https://docs.reka.ai/chat/function-calling
+- https://docs.reka.ai/chat/chat-with-image-video-and-audio
+status: deprecated

--- a/providers/openrouter/reka/reka-edge.yaml
+++ b/providers/openrouter/reka/reka-edge.yaml
@@ -1,23 +1,24 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 1.e-7
-      region: "*"
+- input_cost_per_token: 1.0e-07
+  output_cost_per_token: 1.0e-07
+  region: '*'
 features:
-    - function_calling
-    - structured_output
-    - tool_choice
+- function_calling
+- structured_output
+- tool_choice
 limits:
-    context_window: 16384
-    max_output_tokens: 16384
-    max_tokens: 16384
+  context_window: 16384
+  max_output_tokens: 16384
+  max_tokens: 16384
 modalities:
-    input:
-        - image
-        - text
-        - video
-    output:
-        - text
+  input:
+  - image
+  - text
+  - video
+  output:
+  - text
 mode: chat
 model: reka/reka-edge
 sources:
-    - https://openrouter.ai/reka/reka-edge/api
+- https://openrouter.ai/reka/reka-edge/api
+status: deprecated

--- a/providers/openrouter/remm-slerp-l2-13b.yaml
+++ b/providers/openrouter/remm-slerp-l2-13b.yaml
@@ -1,19 +1,20 @@
 costs:
-    - input_cost_per_token: 4.5e-7
-      output_cost_per_token: 6.5e-7
-      region: "*"
+- input_cost_per_token: 4.5e-07
+  output_cost_per_token: 6.5e-07
+  region: '*'
 features:
-    - structured_output
+- structured_output
 limits:
-    context_window: 6144
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 6144
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: remm-slerp-l2-13b
 sources:
-    - https://openrouter.ai/undi95/remm-slerp-l2-13b/api
+- https://openrouter.ai/undi95/remm-slerp-l2-13b/api
+status: deprecated

--- a/providers/openrouter/rocinante-12b.yaml
+++ b/providers/openrouter/rocinante-12b.yaml
@@ -1,21 +1,22 @@
 costs:
-    - input_cost_per_token: 1.7e-7
-      output_cost_per_token: 4.3e-7
-      region: "*"
+- input_cost_per_token: 1.7e-07
+  output_cost_per_token: 4.3e-07
+  region: '*'
 features:
-    - tool_choice
-    - function_calling
-    - structured_output
+- tool_choice
+- function_calling
+- structured_output
 limits:
-    context_window: 32768
-    max_output_tokens: 32768
-    max_tokens: 32768
+  context_window: 32768
+  max_output_tokens: 32768
+  max_tokens: 32768
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: rocinante-12b
 sources:
-    - https://openrouter.ai/thedrummer/rocinante-12b/api
+- https://openrouter.ai/thedrummer/rocinante-12b/api
+status: deprecated

--- a/providers/openrouter/router.yaml
+++ b/providers/openrouter/router.yaml
@@ -1,19 +1,19 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 limits:
-    context_window: 2000000
+  context_window: 2000000
 modalities:
-    input:
-        - audio
-        - image
-        - text
-    output:
-        - text
+  input:
+  - audio
+  - image
+  - text
+  output:
+  - text
 mode: chat
 model: router
 sources:
-    - https://openrouter.ai/openrouter/auto/api
-    - https://openrouter.ai/docs/guides/routing/routers/auto-router
-status: active
+- https://openrouter.ai/openrouter/auto/api
+- https://openrouter.ai/docs/guides/routing/routers/auto-router
+status: deprecated

--- a/providers/openrouter/sarvam-m.yaml
+++ b/providers/openrouter/sarvam-m.yaml
@@ -1,13 +1,13 @@
 limits:
-    context_window: 32768
+  context_window: 32768
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: sarvam-m
 sources:
-    - https://openrouter.ai/sarvamai/sarvam-m/api
-status: active
+- https://openrouter.ai/sarvamai/sarvam-m/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/sarvam-m:free.yaml
+++ b/providers/openrouter/sarvam-m:free.yaml
@@ -1,17 +1,17 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 limits:
-    context_window: 32768
+  context_window: 32768
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: sarvam-m:free
 sources:
-    - https://openrouter.ai/sarvamai/sarvam-m:free/api
-status: active
+- https://openrouter.ai/sarvamai/sarvam-m:free/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/shisa-v2-llama3.3-70b.yaml
+++ b/providers/openrouter/shisa-v2-llama3.3-70b.yaml
@@ -1,5 +1,6 @@
 isDeprecated: true
 limits:
-    max_tokens: 4096
+  max_tokens: 4096
 mode: chat
 model: shisa-v2-llama3.3-70b
+status: deprecated

--- a/providers/openrouter/shisa-v2-llama3.3-70b:free.yaml
+++ b/providers/openrouter/shisa-v2-llama3.3-70b:free.yaml
@@ -1,5 +1,6 @@
 isDeprecated: true
 limits:
-    max_tokens: 4096
+  max_tokens: 4096
 mode: chat
 model: shisa-v2-llama3.3-70b:free
+status: deprecated

--- a/providers/openrouter/skyfall-36b-v2.yaml
+++ b/providers/openrouter/skyfall-36b-v2.yaml
@@ -1,7 +1,8 @@
 limits:
-    max_output_tokens: 4096
-    max_tokens: 4096
+  max_output_tokens: 4096
+  max_tokens: 4096
 mode: chat
 model: skyfall-36b-v2
 sources:
-    - https://openrouter.ai/skyfall-36b-v2/api
+- https://openrouter.ai/skyfall-36b-v2/api
+status: deprecated

--- a/providers/openrouter/sonar-deep-research.yaml
+++ b/providers/openrouter/sonar-deep-research.yaml
@@ -1,17 +1,18 @@
 costs:
-    - input_cost_per_query: 0.005
-      input_cost_per_token: 0.000002
-      output_cost_per_token: 0.000008
-      region: "*"
+- input_cost_per_query: 0.005
+  input_cost_per_token: 2.0e-06
+  output_cost_per_token: 8.0e-06
+  region: '*'
 limits:
-    context_window: 128000
+  context_window: 128000
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: sonar-deep-research
 sources:
-    - https://openrouter.ai/perplexity/sonar-deep-research/api
+- https://openrouter.ai/perplexity/sonar-deep-research/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/sonar-pro.yaml
+++ b/providers/openrouter/sonar-pro.yaml
@@ -1,25 +1,26 @@
 costs:
-    - input_cost_per_query: 0.005
-      input_cost_per_token: 0.000003
-      output_cost_per_token: 0.000015
-      region: "*"
+- input_cost_per_query: 0.005
+  input_cost_per_token: 3.0e-06
+  output_cost_per_token: 1.5e-05
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
+- function_calling
+- tool_choice
 limits:
-    context_window: 200000
-    max_output_tokens: 8000
-    max_tokens: 8000
+  context_window: 200000
+  max_output_tokens: 8000
+  max_tokens: 8000
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: perplexity/sonar-pro
 params:
-    - key: max_tokens
-      maxValue: 8000
+- key: max_tokens
+  maxValue: 8000
 sources:
-    - https://openrouter.ai/perplexity/sonar-pro/api
+- https://openrouter.ai/perplexity/sonar-pro/api
+status: deprecated

--- a/providers/openrouter/sonar-reasoning-pro.yaml
+++ b/providers/openrouter/sonar-reasoning-pro.yaml
@@ -1,21 +1,22 @@
 costs:
-    - input_cost_per_query: 0.005
-      input_cost_per_token: 0.000002
-      output_cost_per_token: 0.000008
-      region: "*"
+- input_cost_per_query: 0.005
+  input_cost_per_token: 2.0e-06
+  output_cost_per_token: 8.0e-06
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
+- function_calling
+- tool_choice
 limits:
-    context_window: 128000
+  context_window: 128000
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: sonar-reasoning-pro
 sources:
-    - https://openrouter.ai/perplexity/sonar-reasoning-pro/api
+- https://openrouter.ai/perplexity/sonar-reasoning-pro/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/sonar-reasoning.yaml
+++ b/providers/openrouter/sonar-reasoning.yaml
@@ -1,20 +1,20 @@
 costs:
-    - input_cost_per_token: 0.000002
-      output_cost_per_token: 0.000008
-      region: "*"
+- input_cost_per_token: 2.0e-06
+  output_cost_per_token: 8.0e-06
+  region: '*'
 limits:
-    context_window: 127000
+  context_window: 127000
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: sonar-reasoning
 sources:
-    - https://openrouter.ai/perplexity/sonar-reasoning/api
-    - https://docs.perplexity.ai/guides/pricing
-    - https://docs.perplexity.ai/guides/model-cards
-    - https://docs.perplexity.ai/docs/sonar/models/sonar-reasoning-pro
-status: active
+- https://openrouter.ai/perplexity/sonar-reasoning/api
+- https://docs.perplexity.ai/guides/pricing
+- https://docs.perplexity.ai/guides/model-cards
+- https://docs.perplexity.ai/docs/sonar/models/sonar-reasoning-pro
+status: deprecated
 thinking: true

--- a/providers/openrouter/sonar.yaml
+++ b/providers/openrouter/sonar.yaml
@@ -1,20 +1,21 @@
 costs:
-    - input_cost_per_query: 0.005
-      input_cost_per_token: 0.000001
-      output_cost_per_token: 0.000001
-      region: "*"
+- input_cost_per_query: 0.005
+  input_cost_per_token: 1.0e-06
+  output_cost_per_token: 1.0e-06
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
+- function_calling
+- tool_choice
 limits:
-    context_window: 127072
+  context_window: 127072
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: sonar
 sources:
-    - https://openrouter.ai/perplexity/sonar/api
+- https://openrouter.ai/perplexity/sonar/api
+status: deprecated

--- a/providers/openrouter/sorcererlm-8x22b.yaml
+++ b/providers/openrouter/sorcererlm-8x22b.yaml
@@ -1,14 +1,14 @@
 limits:
-    context_window: 16000
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 16000
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: sorcererlm-8x22b
 sources:
-    - https://openrouter.ai/raifle/sorcererlm-8x22b/api
-status: active
+- https://openrouter.ai/raifle/sorcererlm-8x22b/api
+status: deprecated

--- a/providers/openrouter/spotlight.yaml
+++ b/providers/openrouter/spotlight.yaml
@@ -1,13 +1,14 @@
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: spotlight
 params:
-    - key: max_tokens
-      maxValue: 65537
+- key: max_tokens
+  maxValue: 65537
 sources:
-    - https://openrouter.ai/spotlight/api
+- https://openrouter.ai/spotlight/api
+status: deprecated

--- a/providers/openrouter/toppy-m-7b.yaml
+++ b/providers/openrouter/toppy-m-7b.yaml
@@ -1,16 +1,17 @@
 limits:
-    context_window: 4096
-    max_output_tokens: 4096
-    max_tokens: 4096
+  context_window: 4096
+  max_output_tokens: 4096
+  max_tokens: 4096
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: toppy-m-7b
 params:
-    - key: max_tokens
-      maxValue: 4096
+- key: max_tokens
+  maxValue: 4096
 sources:
-    - https://openrouter.ai/undi95/toppy-m-7b/api
+- https://openrouter.ai/undi95/toppy-m-7b/api
+status: deprecated

--- a/providers/openrouter/ui-tars-1.5-7b.yaml
+++ b/providers/openrouter/ui-tars-1.5-7b.yaml
@@ -1,21 +1,22 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 2.e-7
-      region: "*"
+- input_cost_per_token: 1.0e-07
+  output_cost_per_token: 2.0e-07
+  region: '*'
 limits:
-    context_window: 128000
-    max_output_tokens: 2048
-    max_tokens: 2048
+  context_window: 128000
+  max_output_tokens: 2048
+  max_tokens: 2048
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: ui-tars-1.5-7b
 params:
-    - key: max_tokens
-      maxValue: 2048
+- key: max_tokens
+  maxValue: 2048
 sources:
-    - https://openrouter.ai/bytedance/ui-tars-1.5-7b/api
+- https://openrouter.ai/bytedance/ui-tars-1.5-7b/api
+status: deprecated

--- a/providers/openrouter/unslopnemo-12b.yaml
+++ b/providers/openrouter/unslopnemo-12b.yaml
@@ -1,20 +1,21 @@
 costs:
-    - input_cost_per_token: 4.e-7
-      output_cost_per_token: 4.e-7
-      region: "*"
+- input_cost_per_token: 4.0e-07
+  output_cost_per_token: 4.0e-07
+  region: '*'
 features:
-    - function_calling
-    - structured_output
+- function_calling
+- structured_output
 limits:
-    context_window: 32768
-    max_output_tokens: 32768
-    max_tokens: 32768
+  context_window: 32768
+  max_output_tokens: 32768
+  max_tokens: 32768
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: unslopnemo-12b
 sources:
-    - https://openrouter.ai/thedrummer/unslopnemo-12b/api
+- https://openrouter.ai/thedrummer/unslopnemo-12b/api
+status: deprecated

--- a/providers/openrouter/valkyrie-49b-v1.yaml
+++ b/providers/openrouter/valkyrie-49b-v1.yaml
@@ -1,12 +1,13 @@
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: valkyrie-49b-v1
 params:
-    - key: max_tokens
-      maxValue: 131072
+- key: max_tokens
+  maxValue: 131072
 sources:
-    - https://openrouter.ai/valkyrie-49b-v1/api
+- https://openrouter.ai/valkyrie-49b-v1/api
+status: deprecated

--- a/providers/openrouter/virtuoso-large.yaml
+++ b/providers/openrouter/virtuoso-large.yaml
@@ -1,24 +1,25 @@
 costs:
-    - input_cost_per_token: 7.5e-7
-      output_cost_per_token: 0.0000012
-      region: "*"
+- input_cost_per_token: 7.5e-07
+  output_cost_per_token: 1.2e-06
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
+- function_calling
+- tool_choice
+- structured_output
 limits:
-    context_window: 131072
-    max_output_tokens: 64000
-    max_tokens: 64000
+  context_window: 131072
+  max_output_tokens: 64000
+  max_tokens: 64000
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: virtuoso-large
 params:
-    - key: max_tokens
-      maxValue: 64000
+- key: max_tokens
+  maxValue: 64000
 sources:
-    - https://openrouter.ai/arcee-ai/virtuoso-large/api
+- https://openrouter.ai/arcee-ai/virtuoso-large/api
+status: deprecated

--- a/providers/openrouter/weaver.yaml
+++ b/providers/openrouter/weaver.yaml
@@ -1,7 +1,8 @@
 mode: chat
 model: weaver
 params:
-    - key: max_tokens
-      maxValue: 1000
+- key: max_tokens
+  maxValue: 1000
 sources:
-    - https://openrouter.ai/weaver/api
+- https://openrouter.ai/weaver/api
+status: deprecated

--- a/providers/openrouter/wizardlm-2-8x22b.yaml
+++ b/providers/openrouter/wizardlm-2-8x22b.yaml
@@ -1,24 +1,25 @@
 costs:
-    - input_cost_per_token: 6.2e-7
-      output_cost_per_token: 6.2e-7
-      region: "*"
+- input_cost_per_token: 6.2e-07
+  output_cost_per_token: 6.2e-07
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
+- function_calling
+- tool_choice
 limits:
-    context_window: 65535
-    max_input_tokens: 57535
-    max_output_tokens: 8000
-    max_tokens: 8000
+  context_window: 65535
+  max_input_tokens: 57535
+  max_output_tokens: 8000
+  max_tokens: 8000
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: wizardlm-2-8x22b
 params:
-    - key: max_tokens
-      maxValue: 8000
+- key: max_tokens
+  maxValue: 8000
 sources:
-    - https://openrouter.ai/microsoft/wizardlm-2-8x22b/api
+- https://openrouter.ai/microsoft/wizardlm-2-8x22b/api
+status: deprecated

--- a/providers/openrouter/x-ai/grok-4-fast:free.yaml
+++ b/providers/openrouter/x-ai/grok-4-fast:free.yaml
@@ -1,26 +1,27 @@
 costs:
-    - input_cost_per_token: 0
-      output_cost_per_token: 0
-      region: "*"
+- input_cost_per_token: 0
+  output_cost_per_token: 0
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
+- function_calling
+- tool_choice
+- structured_output
 limits:
-    context_window: 2000000
-    max_input_tokens: 2000000
-    max_output_tokens: 30000
-    max_tokens: 30000
+  context_window: 2000000
+  max_input_tokens: 2000000
+  max_output_tokens: 30000
+  max_tokens: 30000
 modalities:
-    input:
-        - text
-        - image
-    output:
-        - text
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: x-ai/grok-4-fast:free
 sources:
-    - https://openrouter.ai/x-ai/grok-4-fast:free/api
-    - https://docs.x.ai/developers/models#models-and-pricing
-    - https://openrouter.ai/x-ai/grok-4-fast/api
+- https://openrouter.ai/x-ai/grok-4-fast:free/api
+- https://docs.x.ai/developers/models#models-and-pricing
+- https://openrouter.ai/x-ai/grok-4-fast/api
 thinking: true
+status: deprecated

--- a/providers/openrouter/x-ai/grok-4.20-beta.yaml
+++ b/providers/openrouter/x-ai/grok-4.20-beta.yaml
@@ -1,30 +1,31 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
-      input_cost_per_token: 0.000002
-      output_cost_per_token: 0.000006
-      region: "*"
-      tiered_pricing:
-          input:
-              - cost_per_token: 0.000004
-                from: 200000
-          output:
-              - cost_per_token: 0.000012
-                from: 200000
-features:
-    - function_calling
-    - tool_choice
-    - structured_output
-limits:
-    context_window: 2000000
-modalities:
+- cache_read_input_token_cost: 2.0e-07
+  input_cost_per_token: 2.0e-06
+  output_cost_per_token: 6.0e-06
+  region: '*'
+  tiered_pricing:
     input:
-        - text
-        - image
+    - cost_per_token: 4.0e-06
+      from: 200000
     output:
-        - text
+    - cost_per_token: 1.2e-05
+      from: 200000
+features:
+- function_calling
+- tool_choice
+- structured_output
+limits:
+  context_window: 2000000
+modalities:
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: x-ai/grok-4.20-beta
 sources:
-    - https://openrouter.ai/x-ai/grok-4.20-beta/api
-    - https://docs.x.ai/developers/models#models-and-pricing
+- https://openrouter.ai/x-ai/grok-4.20-beta/api
+- https://docs.x.ai/developers/models#models-and-pricing
 thinking: true
+status: deprecated

--- a/providers/openrouter/x-ai/grok-4.20-multi-agent-beta.yaml
+++ b/providers/openrouter/x-ai/grok-4.20-multi-agent-beta.yaml
@@ -1,30 +1,31 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
-      input_cost_per_token: 0.000002
-      output_cost_per_token: 0.000006
-      region: "*"
-      tiered_pricing:
-          input:
-              - cost_per_token: 0.000004
-                from: 200000
-          output:
-              - cost_per_token: 0.000012
-                from: 200000
-features:
-    - function_calling
-    - tool_choice
-    - structured_output
-limits:
-    context_window: 2000000
-modalities:
+- cache_read_input_token_cost: 2.0e-07
+  input_cost_per_token: 2.0e-06
+  output_cost_per_token: 6.0e-06
+  region: '*'
+  tiered_pricing:
     input:
-        - text
-        - image
+    - cost_per_token: 4.0e-06
+      from: 200000
     output:
-        - text
+    - cost_per_token: 1.2e-05
+      from: 200000
+features:
+- function_calling
+- tool_choice
+- structured_output
+limits:
+  context_window: 2000000
+modalities:
+  input:
+  - text
+  - image
+  output:
+  - text
 mode: chat
 model: x-ai/grok-4.20-multi-agent-beta
 sources:
-    - https://openrouter.ai/x-ai/grok-4.20-multi-agent-beta/api
-    - https://docs.x.ai/developers/models#models-and-pricing
+- https://openrouter.ai/x-ai/grok-4.20-multi-agent-beta/api
+- https://docs.x.ai/developers/models#models-and-pricing
 thinking: true
+status: deprecated

--- a/providers/openrouter/z-ai/glm-4.6:exacto.yaml
+++ b/providers/openrouter/z-ai/glm-4.6:exacto.yaml
@@ -1,22 +1,23 @@
 costs:
-    - input_cost_per_token: 3.9e-7
-      output_cost_per_token: 0.0000019
-      region: "*"
+- input_cost_per_token: 3.9e-07
+  output_cost_per_token: 1.9e-06
+  region: '*'
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
+- function_calling
+- tool_choice
+- structured_output
 limits:
-    context_window: 204800
-    max_output_tokens: 204800
-    max_tokens: 204800
+  context_window: 204800
+  max_output_tokens: 204800
+  max_tokens: 204800
 modalities:
-    input:
-        - text
-    output:
-        - text
+  input:
+  - text
+  output:
+  - text
 mode: chat
 model: z-ai/glm-4.6:exacto
 sources:
-    - https://openrouter.ai/z-ai/glm-4.6:exacto/api
+- https://openrouter.ai/z-ai/glm-4.6:exacto/api
 thinking: true
+status: deprecated


### PR DESCRIPTION
Auto-generated by model-deprecation script for provider `openrouter`.

Sets `status: deprecated` on model YAML files whose `model` ID no longer appears in the OpenRouter API response.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Bulk updates provider model metadata; incorrect deprecation flags or formatting changes could cause clients to hide or mis-handle models when parsing these YAML definitions.
> 
> **Overview**
> Marks a large set of `providers/openrouter/*.yaml` model definitions as **deprecated** by adding `status: deprecated` (and in a few cases replacing existing `status: active/preview`).
> 
> Also normalizes YAML structure/formatting across these files (flattening list nesting in `costs`, `features`, `modalities`, `params`, and `sources`, plus consistent numeric/quoting and top-level `deprecationDate` placement), without changing the underlying model IDs or limits values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 118c84ad7172e3cbadc31f3e8c233da794a2c6fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->