### PR TITLE
chore(openrouter): deprecate stale models [bot]

### DIFF
--- a/providers/openrouter/aion-1.0-mini.yaml
+++ b/providers/openrouter/aion-1.0-mini.yaml
@@ -21,4 +21,5 @@ params:
       maxValue: 32768
 sources:
     - https://openrouter.ai/aion-labs/aion-1.0-mini/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/aion-1.0.yaml
+++ b/providers/openrouter/aion-1.0.yaml
@@ -21,4 +21,5 @@ params:
       maxValue: 32768
 sources:
     - https://openrouter.ai/aion-labs/aion-1.0/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/aion-rp-llama-3.1-8b.yaml
+++ b/providers/openrouter/aion-rp-llama-3.1-8b.yaml
@@ -21,3 +21,4 @@ params:
       maxValue: 32768
 sources:
     - https://openrouter.ai/aion-labs/aion-rp-llama-3.1-8b/api
+status: deprecated

--- a/providers/openrouter/allenai/olmo-3.1-32b-think.yaml
+++ b/providers/openrouter/allenai/olmo-3.1-32b-think.yaml
@@ -19,4 +19,5 @@ mode: chat
 model: allenai/olmo-3.1-32b-think
 sources:
     - https://openrouter.ai/allenai/olmo-3.1-32b-think/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/anthropic/claude-2.yaml
+++ b/providers/openrouter/anthropic/claude-2.yaml
@@ -19,3 +19,4 @@ mode: chat
 model: anthropic/claude-2
 sources:
     - https://openrouter.ai/anthropic/claude-2/api
+status: deprecated

--- a/providers/openrouter/anthropic/claude-3-5-haiku-20241022.yaml
+++ b/providers/openrouter/anthropic/claude-3-5-haiku-20241022.yaml
@@ -28,3 +28,4 @@ sources:
     - https://openrouter.ai/anthropic/claude-3-5-haiku-20241022/api
     - https://platform.claude.com/docs/en/docs/about-claude/models
     - https://platform.claude.com/docs/en/about-claude/pricing
+status: deprecated

--- a/providers/openrouter/anthropic/claude-3-5-haiku.yaml
+++ b/providers/openrouter/anthropic/claude-3-5-haiku.yaml
@@ -22,3 +22,4 @@ mode: chat
 model: anthropic/claude-3-5-haiku
 sources:
     - https://openrouter.ai/anthropic/claude-3-5-haiku/api
+status: deprecated

--- a/providers/openrouter/anthropic/claude-3-haiku-20240307.yaml
+++ b/providers/openrouter/anthropic/claude-3-haiku-20240307.yaml
@@ -15,3 +15,4 @@ modalities:
         - image
 mode: chat
 model: anthropic/claude-3-haiku-20240307
+status: deprecated

--- a/providers/openrouter/anthropic/claude-3-opus.yaml
+++ b/providers/openrouter/anthropic/claude-3-opus.yaml
@@ -15,3 +15,4 @@ modalities:
         - image
 mode: chat
 model: anthropic/claude-3-opus
+status: deprecated

--- a/providers/openrouter/anthropic/claude-3-sonnet.yaml
+++ b/providers/openrouter/anthropic/claude-3-sonnet.yaml
@@ -17,3 +17,4 @@ model: anthropic/claude-3-sonnet
 sources:
     - https://openrouter.ai/anthropic/claude-3-sonnet/api
     - https://platform.claude.com/docs/en/docs/about-claude/models
+status: deprecated

--- a/providers/openrouter/anthropic/claude-3.5-sonnet:beta.yaml
+++ b/providers/openrouter/anthropic/claude-3.5-sonnet:beta.yaml
@@ -24,3 +24,4 @@ mode: chat
 model: anthropic/claude-3.5-sonnet:beta
 sources:
     - https://openrouter.ai/anthropic/claude-3.5-sonnet:beta/api
+status: deprecated

--- a/providers/openrouter/anthropic/claude-3.7-sonnet.yaml
+++ b/providers/openrouter/anthropic/claude-3.7-sonnet.yaml
@@ -32,4 +32,5 @@ params:
       minValue: 1
 sources:
     - https://openrouter.ai/anthropic/claude-3.7-sonnet/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/anthropic/claude-3.7-sonnet:beta.yaml
+++ b/providers/openrouter/anthropic/claude-3.7-sonnet:beta.yaml
@@ -16,3 +16,4 @@ modalities:
         - image
 mode: chat
 model: anthropic/claude-3.7-sonnet:beta
+status: deprecated

--- a/providers/openrouter/anthropic/claude-instant-v1.yaml
+++ b/providers/openrouter/anthropic/claude-instant-v1.yaml
@@ -8,3 +8,4 @@ limits:
     max_tokens: 8191
 mode: chat
 model: anthropic/claude-instant-v1
+status: deprecated

--- a/providers/openrouter/anubis-70b-v1.1.yaml
+++ b/providers/openrouter/anubis-70b-v1.1.yaml
@@ -10,3 +10,4 @@ mode: chat
 model: anubis-70b-v1.1
 sources:
     - https://openrouter.ai/anubis-70b-v1.1/api
+status: deprecated

--- a/providers/openrouter/anubis-pro-105b-v1.yaml
+++ b/providers/openrouter/anubis-pro-105b-v1.yaml
@@ -10,3 +10,4 @@ params:
       maxValue: 131072
 sources:
     - https://openrouter.ai/anubis-pro-105b-v1/api
+status: deprecated

--- a/providers/openrouter/arcee-ai/trinity-large-preview:free.yaml
+++ b/providers/openrouter/arcee-ai/trinity-large-preview:free.yaml
@@ -20,4 +20,4 @@ model: arcee-ai/trinity-large-preview:free
 sources:
     - https://openrouter.ai/arcee-ai/trinity-large-preview:free/api
     - https://openrouter.ai/arcee-ai/trinity-large-preview/api
-status: preview
+status: deprecated

--- a/providers/openrouter/auto.yaml
+++ b/providers/openrouter/auto.yaml
@@ -8,3 +8,4 @@ mode: chat
 model: auto
 sources:
     - https://openrouter.ai/openrouter/auto/api
+status: deprecated

--- a/providers/openrouter/chatgpt-4o-latest.yaml
+++ b/providers/openrouter/chatgpt-4o-latest.yaml
@@ -7,3 +7,4 @@ model: chatgpt-4o-latest
 params:
     - key: max_tokens
       maxValue: 16384
+status: deprecated

--- a/providers/openrouter/claude-3-haiku.yaml
+++ b/providers/openrouter/claude-3-haiku.yaml
@@ -22,3 +22,4 @@ mode: chat
 model: claude-3-haiku
 sources:
     - https://openrouter.ai/anthropic/claude-3-haiku/api
+status: deprecated

--- a/providers/openrouter/claude-3-haiku:beta.yaml
+++ b/providers/openrouter/claude-3-haiku:beta.yaml
@@ -28,3 +28,4 @@ params:
       maxValue: 4096
 sources:
     - https://openrouter.ai/anthropic/claude-3-haiku:beta/api
+status: deprecated

--- a/providers/openrouter/claude-3-opus.yaml
+++ b/providers/openrouter/claude-3-opus.yaml
@@ -9,3 +9,4 @@ model: claude-3-opus
 params:
     - key: max_tokens
       maxValue: 4096
+status: deprecated

--- a/providers/openrouter/claude-3-opus:beta.yaml
+++ b/providers/openrouter/claude-3-opus:beta.yaml
@@ -22,3 +22,4 @@ mode: chat
 model: claude-3-opus:beta
 sources:
     - https://openrouter.ai/anthropic/claude-3-opus:beta/api
+status: deprecated

--- a/providers/openrouter/claude-3-sonnet.yaml
+++ b/providers/openrouter/claude-3-sonnet.yaml
@@ -22,3 +22,4 @@ params:
       maxValue: 4096
 sources:
     - https://openrouter.ai/anthropic/claude-3-sonnet/api
+status: deprecated

--- a/providers/openrouter/claude-3.5-haiku-20241022.yaml
+++ b/providers/openrouter/claude-3.5-haiku-20241022.yaml
@@ -28,3 +28,4 @@ params:
 sources:
     - https://openrouter.ai/anthropic/claude-3.5-haiku
     - https://openrouter.ai/anthropic/claude-3.5-haiku/api
+status: deprecated

--- a/providers/openrouter/claude-3.5-haiku.yaml
+++ b/providers/openrouter/claude-3.5-haiku.yaml
@@ -25,3 +25,4 @@ params:
       maxValue: 8192
 sources:
     - https://openrouter.ai/anthropic/claude-3.5-haiku/api
+status: deprecated

--- a/providers/openrouter/claude-3.5-haiku:beta.yaml
+++ b/providers/openrouter/claude-3.5-haiku:beta.yaml
@@ -26,3 +26,4 @@ params:
       maxValue: 8192
 sources:
     - https://openrouter.ai/anthropic/claude-3.5-haiku:beta/api
+status: deprecated

--- a/providers/openrouter/claude-3.5-sonnet-20240620.yaml
+++ b/providers/openrouter/claude-3.5-sonnet-20240620.yaml
@@ -21,3 +21,4 @@ params:
       maxValue: 8192
 sources:
     - https://openrouter.ai/anthropic/claude-3.5-sonnet-20240620/api
+status: deprecated

--- a/providers/openrouter/claude-3.5-sonnet-20240620:beta.yaml
+++ b/providers/openrouter/claude-3.5-sonnet-20240620:beta.yaml
@@ -9,3 +9,4 @@ model: claude-3.5-sonnet-20240620:beta
 params:
     - key: max_tokens
       maxValue: 8192
+status: deprecated

--- a/providers/openrouter/claude-3.5-sonnet.yaml
+++ b/providers/openrouter/claude-3.5-sonnet.yaml
@@ -25,3 +25,4 @@ params:
       maxValue: 8192
 sources:
     - https://openrouter.ai/anthropic/claude-3.5-sonnet/api
+status: deprecated

--- a/providers/openrouter/claude-3.5-sonnet:beta.yaml
+++ b/providers/openrouter/claude-3.5-sonnet:beta.yaml
@@ -25,3 +25,4 @@ params:
       maxValue: 8192
 sources:
     - https://openrouter.ai/anthropic/claude-3.5-sonnet:beta/api
+status: deprecated

--- a/providers/openrouter/claude-3.7-sonnet.yaml
+++ b/providers/openrouter/claude-3.7-sonnet.yaml
@@ -9,3 +9,4 @@ model: claude-3.7-sonnet
 params:
     - key: max_tokens
       maxValue: 64000
+status: deprecated

--- a/providers/openrouter/claude-3.7-sonnet:beta.yaml
+++ b/providers/openrouter/claude-3.7-sonnet:beta.yaml
@@ -27,4 +27,5 @@ params:
       maxValue: 128000
 sources:
     - https://openrouter.ai/anthropic/claude-3.7-sonnet:beta/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/claude-3.7-sonnet:thinking.yaml
+++ b/providers/openrouter/claude-3.7-sonnet:thinking.yaml
@@ -27,4 +27,5 @@ params:
       maxValue: 64000
 sources:
     - https://openrouter.ai/anthropic/claude-3.7-sonnet:thinking/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/claude-opus-4.yaml
+++ b/providers/openrouter/claude-opus-4.yaml
@@ -27,4 +27,5 @@ params:
       maxValue: 32000
 sources:
     - https://openrouter.ai/anthropic/claude-opus-4/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/claude-sonnet-4.yaml
+++ b/providers/openrouter/claude-sonnet-4.yaml
@@ -42,5 +42,5 @@ params:
       maxValue: 64000
 sources:
     - https://openrouter.ai/anthropic/claude-sonnet-4/api
-status: active
+status: deprecated
 thinking: true

--- a/providers/openrouter/codellama-7b-instruct-solidity.yaml
+++ b/providers/openrouter/codellama-7b-instruct-solidity.yaml
@@ -4,3 +4,4 @@ model: codellama-7b-instruct-solidity
 params:
     - key: max_tokens
       maxValue: 4096
+status: deprecated

--- a/providers/openrouter/coder-large.yaml
+++ b/providers/openrouter/coder-large.yaml
@@ -6,3 +6,4 @@ model: coder-large
 sources:
     - https://openrouter.ai/coder-large/api
     - https://openrouter.ai/api/v1/models
+status: deprecated

--- a/providers/openrouter/codestral-2501.yaml
+++ b/providers/openrouter/codestral-2501.yaml
@@ -5,3 +5,4 @@ limits:
     max_tokens: 4096
 mode: chat
 model: codestral-2501
+status: deprecated

--- a/providers/openrouter/codex-mini.yaml
+++ b/providers/openrouter/codex-mini.yaml
@@ -20,4 +20,5 @@ params:
 sources:
     - https://openrouter.ai/openai/codex-mini/api
     - https://developers.openai.com/docs/deprecations
+status: deprecated
 thinking: true

--- a/providers/openrouter/cognitivecomputations/dolphin-mixtral-8x7b.yaml
+++ b/providers/openrouter/cognitivecomputations/dolphin-mixtral-8x7b.yaml
@@ -15,3 +15,4 @@ mode: chat
 model: cognitivecomputations/dolphin-mixtral-8x7b
 sources:
     - https://openrouter.ai/cognitivecomputations/dolphin-mixtral-8x7b/api
+status: deprecated

--- a/providers/openrouter/cohere/command-r-plus.yaml
+++ b/providers/openrouter/cohere/command-r-plus.yaml
@@ -24,3 +24,4 @@ params:
 sources:
     - https://openrouter.ai/cohere/command-r-plus/api
     - https://docs.cohere.com/docs/command-r-plus
+status: deprecated

--- a/providers/openrouter/command-a.yaml
+++ b/providers/openrouter/command-a.yaml
@@ -26,3 +26,4 @@ params:
 sources:
     - https://openrouter.ai/cohere/command-a/api
     - https://docs.cohere.com/docs/command-a
+status: deprecated

--- a/providers/openrouter/command-r-03-2024.yaml
+++ b/providers/openrouter/command-r-03-2024.yaml
@@ -22,4 +22,4 @@ sources:
     - https://openrouter.ai/cohere/command-r-03-2024/api
     - https://docs.cohere.com/docs/command-r
     - https://cohere.com/pricing
-status: active
+status: deprecated

--- a/providers/openrouter/command-r-08-2024.yaml
+++ b/providers/openrouter/command-r-08-2024.yaml
@@ -23,4 +23,4 @@ params:
 sources:
     - https://openrouter.ai/cohere/command-r-08-2024/api
     - https://docs.cohere.com/docs/command-r
-status: active
+status: deprecated

--- a/providers/openrouter/command-r-plus-04-2024.yaml
+++ b/providers/openrouter/command-r-plus-04-2024.yaml
@@ -24,3 +24,4 @@ sources:
     - https://openrouter.ai/cohere/command-r-plus-04-2024/api
     - https://docs.cohere.com/docs/command-r-plus
     - https://cohere.com/pricing
+status: deprecated

--- a/providers/openrouter/command-r-plus-08-2024.yaml
+++ b/providers/openrouter/command-r-plus-08-2024.yaml
@@ -23,3 +23,4 @@ params:
 sources:
     - https://openrouter.ai/cohere/command-r-plus-08-2024/api
     - https://docs.cohere.com/docs/command-r-plus
+status: deprecated

--- a/providers/openrouter/command-r-plus.yaml
+++ b/providers/openrouter/command-r-plus.yaml
@@ -24,3 +24,4 @@ params:
 sources:
     - https://openrouter.ai/cohere/command-r-plus/api
     - https://docs.cohere.com/docs/command-r-plus
+status: deprecated

--- a/providers/openrouter/command-r.yaml
+++ b/providers/openrouter/command-r.yaml
@@ -17,3 +17,4 @@ params:
       maxValue: 4000
 sources:
     - https://openrouter.ai/cohere/command-r/api
+status: deprecated

--- a/providers/openrouter/command-r7b-12-2024.yaml
+++ b/providers/openrouter/command-r7b-12-2024.yaml
@@ -23,3 +23,4 @@ params:
       maxValue: 4000
 sources:
     - https://openrouter.ai/cohere/command-r7b-12-2024/api
+status: deprecated

--- a/providers/openrouter/command.yaml
+++ b/providers/openrouter/command.yaml
@@ -12,3 +12,4 @@ params:
 sources:
     - https://openrouter.ai/cohere/command/api
     - https://docs.cohere.com/docs/models
+status: deprecated

--- a/providers/openrouter/databricks/dbrx-instruct.yaml
+++ b/providers/openrouter/databricks/dbrx-instruct.yaml
@@ -15,3 +15,4 @@ mode: chat
 model: databricks/dbrx-instruct
 sources:
     - https://openrouter.ai/databricks/dbrx-instruct/api
+status: deprecated

--- a/providers/openrouter/deepseek-chat-v3-0324.yaml
+++ b/providers/openrouter/deepseek-chat-v3-0324.yaml
@@ -20,3 +20,4 @@ params:
       maxValue: 163840
 sources:
     - https://openrouter.ai/deepseek/deepseek-chat-v3-0324/api
+status: deprecated

--- a/providers/openrouter/deepseek-chat-v3-0324:free.yaml
+++ b/providers/openrouter/deepseek-chat-v3-0324:free.yaml
@@ -21,3 +21,4 @@ params:
       maxValue: 16384
 sources:
     - https://openrouter.ai/deepseek/deepseek-chat-v3-0324:free
+status: deprecated

--- a/providers/openrouter/deepseek-chat.yaml
+++ b/providers/openrouter/deepseek-chat.yaml
@@ -17,3 +17,4 @@ mode: chat
 model: deepseek-chat
 sources:
     - https://openrouter.ai/deepseek/deepseek-chat/api
+status: deprecated

--- a/providers/openrouter/deepseek-prover-v2.yaml
+++ b/providers/openrouter/deepseek-prover-v2.yaml
@@ -9,3 +9,4 @@ mode: chat
 model: deepseek-prover-v2
 sources:
     - https://openrouter.ai/deepseek/deepseek-prover-v2/api
+status: deprecated

--- a/providers/openrouter/deepseek-r1-0528-qwen3-8b.yaml
+++ b/providers/openrouter/deepseek-r1-0528-qwen3-8b.yaml
@@ -9,4 +9,5 @@ mode: chat
 model: deepseek-r1-0528-qwen3-8b
 sources:
     - https://openrouter.ai/deepseek/deepseek-r1-0528-qwen3-8b/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/deepseek-r1-0528-qwen3-8b:free.yaml
+++ b/providers/openrouter/deepseek-r1-0528-qwen3-8b:free.yaml
@@ -16,5 +16,5 @@ model: deepseek-r1-0528-qwen3-8b:free
 sources:
     - https://openrouter.ai/deepseek/deepseek-r1-0528-qwen3-8b:free
     - https://openrouter.ai/deepseek/deepseek-r1-0528-qwen3-8b:free/api
-status: active
+status: deprecated
 thinking: true

--- a/providers/openrouter/deepseek-r1-0528.yaml
+++ b/providers/openrouter/deepseek-r1-0528.yaml
@@ -22,4 +22,5 @@ params:
       maxValue: 65536
 sources:
     - https://openrouter.ai/deepseek/deepseek-r1-0528/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/deepseek-r1-0528:free.yaml
+++ b/providers/openrouter/deepseek-r1-0528:free.yaml
@@ -21,4 +21,5 @@ model: deepseek-r1-0528:free
 sources:
     - https://openrouter.ai/deepseek/deepseek-r1-0528:free/api
     - https://openrouter.ai/deepseek/deepseek-r1-0528:free
+status: deprecated
 thinking: true

--- a/providers/openrouter/deepseek-r1-distill-llama-70b.yaml
+++ b/providers/openrouter/deepseek-r1-distill-llama-70b.yaml
@@ -19,4 +19,5 @@ mode: chat
 model: deepseek-r1-distill-llama-70b
 sources:
     - https://openrouter.ai/deepseek/deepseek-r1-distill-llama-70b/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/deepseek-r1-distill-llama-70b:free.yaml
+++ b/providers/openrouter/deepseek-r1-distill-llama-70b:free.yaml
@@ -20,4 +20,5 @@ params:
       maxValue: 16384
 sources:
     - https://openrouter.ai/deepseek/deepseek-r1-distill-llama-70b:free/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/deepseek-r1-distill-llama-8b.yaml
+++ b/providers/openrouter/deepseek-r1-distill-llama-8b.yaml
@@ -10,4 +10,5 @@ params:
       maxValue: 32000
 sources:
     - https://openrouter.ai/deepseek/deepseek-r1-distill-llama-8b/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/deepseek-r1-distill-qwen-1.5b.yaml
+++ b/providers/openrouter/deepseek-r1-distill-qwen-1.5b.yaml
@@ -12,4 +12,5 @@ params:
       maxValue: 32768
 sources:
     - https://openrouter.ai/deepseek/deepseek-r1-distill-qwen-1.5b/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/deepseek-r1-distill-qwen-14b.yaml
+++ b/providers/openrouter/deepseek-r1-distill-qwen-14b.yaml
@@ -12,4 +12,5 @@ params:
       maxValue: 32000
 sources:
     - https://openrouter.ai/deepseek/deepseek-r1-distill-qwen-14b/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/deepseek-r1-distill-qwen-14b:free.yaml
+++ b/providers/openrouter/deepseek-r1-distill-qwen-14b:free.yaml
@@ -13,5 +13,5 @@ mode: chat
 model: deepseek-r1-distill-qwen-14b:free
 sources:
     - https://openrouter.ai/deepseek/deepseek-r1-distill-qwen-14b:free/api
-status: active
+status: deprecated
 thinking: true

--- a/providers/openrouter/deepseek-r1-distill-qwen-32b.yaml
+++ b/providers/openrouter/deepseek-r1-distill-qwen-32b.yaml
@@ -22,4 +22,5 @@ params:
       maxValue: 32768
 sources:
     - https://openrouter.ai/deepseek/deepseek-r1-distill-qwen-32b/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/deepseek-r1-distill-qwen-7b.yaml
+++ b/providers/openrouter/deepseek-r1-distill-qwen-7b.yaml
@@ -9,4 +9,5 @@ mode: chat
 model: deepseek/deepseek-r1-distill-qwen-7b
 sources:
     - https://openrouter.ai/deepseek/deepseek-r1-distill-qwen-7b/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/deepseek-r1.yaml
+++ b/providers/openrouter/deepseek-r1.yaml
@@ -21,4 +21,5 @@ params:
       maxValue: 16000
 sources:
     - https://openrouter.ai/deepseek/deepseek-r1/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/deepseek-r1:free.yaml
+++ b/providers/openrouter/deepseek-r1:free.yaml
@@ -15,4 +15,5 @@ mode: chat
 model: deepseek-r1:free
 sources:
     - https://openrouter.ai/deepseek/deepseek-r1:free/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/deepseek-r1t-chimera:free.yaml
+++ b/providers/openrouter/deepseek-r1t-chimera:free.yaml
@@ -15,4 +15,5 @@ mode: chat
 model: deepseek-r1t-chimera:free
 sources:
     - https://openrouter.ai/tngtech/deepseek-r1t-chimera:free/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/deepseek-r1t2-chimera.yaml
+++ b/providers/openrouter/deepseek-r1t2-chimera.yaml
@@ -20,4 +20,5 @@ mode: chat
 model: deepseek-r1t2-chimera
 sources:
     - https://openrouter.ai/tngtech/deepseek-r1t2-chimera/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/deepseek-r1t2-chimera:free.yaml
+++ b/providers/openrouter/deepseek-r1t2-chimera:free.yaml
@@ -22,5 +22,5 @@ model: deepseek-r1t2-chimera:free
 sources:
     - https://openrouter.ai/tngtech/deepseek-r1t2-chimera/api
     - https://openrouter.ai/tngtech/deepseek-r1t2-chimera:free/api
-status: active
+status: deprecated
 thinking: true

--- a/providers/openrouter/deepseek-v3-base.yaml
+++ b/providers/openrouter/deepseek-v3-base.yaml
@@ -13,3 +13,4 @@ mode: chat
 model: deepseek-v3-base
 sources:
     - https://openrouter.ai/deepseek/deepseek-v3-base/api
+status: deprecated

--- a/providers/openrouter/deepseek/deepseek-coder.yaml
+++ b/providers/openrouter/deepseek/deepseek-coder.yaml
@@ -9,3 +9,4 @@ limits:
     max_tokens: 4096
 mode: chat
 model: deepseek/deepseek-coder
+status: deprecated

--- a/providers/openrouter/deepseek/deepseek-v3.1-terminus:exacto.yaml
+++ b/providers/openrouter/deepseek/deepseek-v3.1-terminus:exacto.yaml
@@ -17,4 +17,5 @@ mode: chat
 model: deepseek/deepseek-v3.1-terminus:exacto
 sources:
     - https://openrouter.ai/deepseek/deepseek-v3.1-terminus:exacto/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/devstral-medium.yaml
+++ b/providers/openrouter/devstral-medium.yaml
@@ -20,3 +20,4 @@ model: devstral-medium
 sources:
     - https://openrouter.ai/mistralai/devstral-medium
     - https://openrouter.ai/mistralai/devstral-medium/api
+status: deprecated

--- a/providers/openrouter/devstral-small-2505.yaml
+++ b/providers/openrouter/devstral-small-2505.yaml
@@ -5,3 +5,4 @@ limits:
     max_tokens: 4096
 mode: chat
 model: devstral-small-2505
+status: deprecated

--- a/providers/openrouter/devstral-small-2505:free.yaml
+++ b/providers/openrouter/devstral-small-2505:free.yaml
@@ -15,3 +15,4 @@ sources:
     - https://openrouter.ai/mistralai/devstral-small-2505:free/api
     - https://openrouter.ai/mistralai/devstral-small-2505/api
     - https://docs.mistral.ai/getting-started/models/
+status: deprecated

--- a/providers/openrouter/devstral-small.yaml
+++ b/providers/openrouter/devstral-small.yaml
@@ -20,3 +20,4 @@ mode: chat
 model: devstral-small
 sources:
     - https://openrouter.ai/mistralai/devstral-small/api
+status: deprecated

--- a/providers/openrouter/dolphin-mistral-24b-venice-edition:free.yaml
+++ b/providers/openrouter/dolphin-mistral-24b-venice-edition:free.yaml
@@ -17,4 +17,4 @@ mode: chat
 model: dolphin-mistral-24b-venice-edition:free
 sources:
     - https://openrouter.ai/cognitivecomputations/dolphin-mistral-24b-venice-edition:free/api
-status: active
+status: deprecated

--- a/providers/openrouter/dolphin-mixtral-8x22b.yaml
+++ b/providers/openrouter/dolphin-mixtral-8x22b.yaml
@@ -12,3 +12,4 @@ params:
       maxValue: 8192
 sources:
     - https://openrouter.ai/cognitivecomputations/dolphin-mixtral-8x22b/api
+status: deprecated

--- a/providers/openrouter/dolphin3.0-mistral-24b:free.yaml
+++ b/providers/openrouter/dolphin3.0-mistral-24b:free.yaml
@@ -17,3 +17,4 @@ mode: chat
 model: dolphin3.0-mistral-24b:free
 sources:
     - https://openrouter.ai/cognitivecomputations/dolphin3.0-mistral-24b:free/api
+status: deprecated

--- a/providers/openrouter/dolphin3.0-r1-mistral-24b.yaml
+++ b/providers/openrouter/dolphin3.0-r1-mistral-24b.yaml
@@ -13,4 +13,5 @@ mode: chat
 model: dolphin3.0-r1-mistral-24b
 sources:
     - https://openrouter.ai/cognitivecomputations/dolphin3.0-r1-mistral-24b/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/dolphin3.0-r1-mistral-24b:free.yaml
+++ b/providers/openrouter/dolphin3.0-r1-mistral-24b:free.yaml
@@ -15,4 +15,5 @@ mode: chat
 model: dolphin3.0-r1-mistral-24b:free
 sources:
     - https://openrouter.ai/cognitivecomputations/dolphin3.0-r1-mistral-24b:free/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/ernie-4.5-300b-a47b.yaml
+++ b/providers/openrouter/ernie-4.5-300b-a47b.yaml
@@ -20,3 +20,4 @@ params:
       maxValue: 12000
 sources:
     - https://openrouter.ai/baidu/ernie-4.5-300b-a47b/api
+status: deprecated

--- a/providers/openrouter/fimbulvetr-11b-v2.yaml
+++ b/providers/openrouter/fimbulvetr-11b-v2.yaml
@@ -12,3 +12,4 @@ params:
       maxValue: 4096
 sources:
     - https://openrouter.ai/sao10k/fimbulvetr-11b-v2/api
+status: deprecated

--- a/providers/openrouter/fireworks/firellava-13b.yaml
+++ b/providers/openrouter/fireworks/firellava-13b.yaml
@@ -15,3 +15,4 @@ mode: chat
 model: fireworks/firellava-13b
 sources:
     - https://openrouter.ai/fireworks/firellava-13b/api
+status: deprecated

--- a/providers/openrouter/gemini-2.0-flash-001.yaml
+++ b/providers/openrouter/gemini-2.0-flash-001.yaml
@@ -9,3 +9,4 @@ model: gemini-2.0-flash-001
 params:
     - key: max_tokens
       maxValue: 8192
+status: deprecated

--- a/providers/openrouter/gemini-2.0-flash-lite-001.yaml
+++ b/providers/openrouter/gemini-2.0-flash-lite-001.yaml
@@ -9,3 +9,4 @@ model: gemini-2.0-flash-lite-001
 params:
     - key: max_tokens
       maxValue: 8192
+status: deprecated

--- a/providers/openrouter/gemini-2.5-flash-lite.yaml
+++ b/providers/openrouter/gemini-2.5-flash-lite.yaml
@@ -33,4 +33,5 @@ params:
 sources:
     - https://openrouter.ai/google/gemini-2.5-flash-lite/api
     - https://ai.google.dev/gemini-api/docs/pricing
+status: deprecated
 thinking: true

--- a/providers/openrouter/gemini-2.5-flash.yaml
+++ b/providers/openrouter/gemini-2.5-flash.yaml
@@ -33,4 +33,5 @@ params:
       maxValue: 65535
 sources:
     - https://openrouter.ai/google/gemini-2.5-flash/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/gemini-2.5-pro.yaml
+++ b/providers/openrouter/gemini-2.5-pro.yaml
@@ -44,4 +44,5 @@ params:
       maxValue: 65536
 sources:
     - https://openrouter.ai/google/gemini-2.5-pro/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/gemini-flash-1.5-8b.yaml
+++ b/providers/openrouter/gemini-flash-1.5-8b.yaml
@@ -22,3 +22,4 @@ params:
       maxValue: 8192
 sources:
     - https://openrouter.ai/google/gemini-flash-1.5-8b/api
+status: deprecated

--- a/providers/openrouter/gemini-flash-1.5.yaml
+++ b/providers/openrouter/gemini-flash-1.5.yaml
@@ -17,3 +17,4 @@ params:
       maxValue: 8192
 sources:
     - https://openrouter.ai/google/gemini-flash-1.5/api
+status: deprecated

--- a/providers/openrouter/gemini-pro-1.5.yaml
+++ b/providers/openrouter/gemini-pro-1.5.yaml
@@ -22,3 +22,4 @@ params:
       maxValue: 8192
 sources:
     - https://openrouter.ai/google/gemini-pro-1.5/api
+status: deprecated

--- a/providers/openrouter/gemma-2-27b-it.yaml
+++ b/providers/openrouter/gemma-2-27b-it.yaml
@@ -19,3 +19,4 @@ mode: chat
 model: gemma-2-27b-it
 sources:
     - https://openrouter.ai/google/gemma-2-27b-it/api
+status: deprecated

--- a/providers/openrouter/gemma-2-9b-it.yaml
+++ b/providers/openrouter/gemma-2-9b-it.yaml
@@ -22,3 +22,4 @@ params:
       maxValue: 8192
 sources:
     - https://openrouter.ai/google/gemma-2-9b-it/api
+status: deprecated

--- a/providers/openrouter/gemma-2-9b-it:free.yaml
+++ b/providers/openrouter/gemma-2-9b-it:free.yaml
@@ -18,3 +18,4 @@ params:
       maxValue: 8192
 sources:
     - https://openrouter.ai/google/gemma-2-9b-it:free/api
+status: deprecated

--- a/providers/openrouter/gemma-3-12b-it.yaml
+++ b/providers/openrouter/gemma-3-12b-it.yaml
@@ -21,3 +21,4 @@ params:
       maxValue: 8192
 sources:
     - https://openrouter.ai/google/gemma-3-12b-it/api
+status: deprecated

--- a/providers/openrouter/gemma-3-12b-it:free.yaml
+++ b/providers/openrouter/gemma-3-12b-it:free.yaml
@@ -21,3 +21,4 @@ params:
       maxValue: 8192
 sources:
     - https://openrouter.ai/google/gemma-3-12b-it:free/api
+status: deprecated

--- a/providers/openrouter/gemma-3-27b-it.yaml
+++ b/providers/openrouter/gemma-3-27b-it.yaml
@@ -24,3 +24,4 @@ params:
       maxValue: 16384
 sources:
     - https://openrouter.ai/google/gemma-3-27b-it/api
+status: deprecated

--- a/providers/openrouter/gemma-3-27b-it:free.yaml
+++ b/providers/openrouter/gemma-3-27b-it:free.yaml
@@ -21,3 +21,4 @@ params:
       maxValue: 8192
 sources:
     - https://openrouter.ai/google/gemma-3-27b-it:free/api
+status: deprecated

--- a/providers/openrouter/gemma-3-4b-it.yaml
+++ b/providers/openrouter/gemma-3-4b-it.yaml
@@ -21,3 +21,4 @@ mode: chat
 model: gemma-3-4b-it
 sources:
     - https://openrouter.ai/google/gemma-3-4b-it/api
+status: deprecated

--- a/providers/openrouter/gemma-3-4b-it:free.yaml
+++ b/providers/openrouter/gemma-3-4b-it:free.yaml
@@ -22,3 +22,4 @@ params:
       maxValue: 8192
 sources:
     - https://openrouter.ai/google/gemma-3-4b-it:free/api
+status: deprecated

--- a/providers/openrouter/gemma-3n-e2b-it:free.yaml
+++ b/providers/openrouter/gemma-3n-e2b-it:free.yaml
@@ -18,4 +18,4 @@ params:
       maxValue: 2048
 sources:
     - https://openrouter.ai/google/gemma-3n-e2b-it:free/api
-status: active
+status: deprecated

--- a/providers/openrouter/gemma-3n-e4b-it.yaml
+++ b/providers/openrouter/gemma-3n-e4b-it.yaml
@@ -15,3 +15,4 @@ mode: chat
 model: gemma-3n-e4b-it
 sources:
     - https://openrouter.ai/google/gemma-3n-e4b-it/api
+status: deprecated

--- a/providers/openrouter/gemma-3n-e4b-it:free.yaml
+++ b/providers/openrouter/gemma-3n-e4b-it:free.yaml
@@ -18,3 +18,4 @@ params:
       maxValue: 2048
 sources:
     - https://openrouter.ai/google/gemma-3n-e4b-it:free/api
+status: deprecated

--- a/providers/openrouter/glm-4-32b.yaml
+++ b/providers/openrouter/glm-4-32b.yaml
@@ -19,3 +19,4 @@ params:
       maxValue: 32000
 sources:
     - https://openrouter.ai/z-ai/glm-4-32b/api
+status: deprecated

--- a/providers/openrouter/glm-4-32b:free.yaml
+++ b/providers/openrouter/glm-4-32b:free.yaml
@@ -3,3 +3,4 @@ limits:
     max_tokens: 4096
 mode: chat
 model: glm-4-32b:free
+status: deprecated

--- a/providers/openrouter/glm-4.1v-9b-thinking.yaml
+++ b/providers/openrouter/glm-4.1v-9b-thinking.yaml
@@ -13,4 +13,5 @@ params:
       maxValue: 8000
 sources:
     - https://openrouter.ai/THUDM/glm-4.1v-9b-thinking/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/glm-4.5-air.yaml
+++ b/providers/openrouter/glm-4.5-air.yaml
@@ -6,3 +6,4 @@ model: glm-4.5-air
 params:
     - key: max_tokens
       maxValue: 96000
+status: deprecated

--- a/providers/openrouter/glm-4.5-air:free.yaml
+++ b/providers/openrouter/glm-4.5-air:free.yaml
@@ -19,4 +19,5 @@ mode: chat
 model: glm-4.5-air:free
 sources:
     - https://openrouter.ai/z-ai/glm-4.5-air:free/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/glm-4.5.yaml
+++ b/providers/openrouter/glm-4.5.yaml
@@ -22,4 +22,5 @@ params:
     - key: reasoning
 sources:
     - https://openrouter.ai/z-ai/glm-4.5/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/glm-z1-32b.yaml
+++ b/providers/openrouter/glm-z1-32b.yaml
@@ -14,4 +14,5 @@ mode: chat
 model: glm-z1-32b
 sources:
     - https://openrouter.ai/thudm/glm-z1-32b/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/glm-z1-32b:free.yaml
+++ b/providers/openrouter/glm-z1-32b:free.yaml
@@ -18,4 +18,5 @@ model: glm-z1-32b:free
 sources:
     - https://openrouter.ai/thudm/glm-z1-32b:free/api
     - https://openrouter.ai/thudm/glm-z1-32b/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/goliath-120b.yaml
+++ b/providers/openrouter/goliath-120b.yaml
@@ -15,4 +15,4 @@ mode: chat
 model: goliath-120b
 sources:
     - https://openrouter.ai/alpindale/goliath-120b/api
-status: active
+status: deprecated

--- a/providers/openrouter/google/gemini-2.0-flash-001.yaml
+++ b/providers/openrouter/google/gemini-2.0-flash-001.yaml
@@ -32,3 +32,4 @@ mode: chat
 model: google/gemini-2.0-flash-001
 sources:
     - https://openrouter.ai/google/gemini-2.0-flash-001/api
+status: deprecated

--- a/providers/openrouter/google/gemini-pro-1.5.yaml
+++ b/providers/openrouter/google/gemini-pro-1.5.yaml
@@ -20,3 +20,4 @@ mode: chat
 model: google/gemini-pro-1.5
 sources:
     - https://openrouter.ai/google/gemini-pro-1.5/api
+status: deprecated

--- a/providers/openrouter/google/gemini-pro-vision.yaml
+++ b/providers/openrouter/google/gemini-pro-vision.yaml
@@ -13,3 +13,4 @@ modalities:
         - image
 mode: chat
 model: google/gemini-pro-vision
+status: deprecated

--- a/providers/openrouter/google/palm-2-chat-bison.yaml
+++ b/providers/openrouter/google/palm-2-chat-bison.yaml
@@ -13,3 +13,4 @@ mode: chat
 model: google/palm-2-chat-bison
 sources:
     - https://openrouter.ai/google/palm-2-chat-bison/api
+status: deprecated

--- a/providers/openrouter/google/palm-2-codechat-bison.yaml
+++ b/providers/openrouter/google/palm-2-codechat-bison.yaml
@@ -15,3 +15,4 @@ mode: chat
 model: google/palm-2-codechat-bison
 sources:
     - https://openrouter.ai/google/palm-2-codechat-bison/api
+status: deprecated

--- a/providers/openrouter/gpt-3.5-turbo-0613.yaml
+++ b/providers/openrouter/gpt-3.5-turbo-0613.yaml
@@ -22,3 +22,4 @@ params:
       maxValue: 4096
 sources:
     - https://openrouter.ai/openai/gpt-3.5-turbo-0613/api
+status: deprecated

--- a/providers/openrouter/gpt-3.5-turbo-16k.yaml
+++ b/providers/openrouter/gpt-3.5-turbo-16k.yaml
@@ -22,3 +22,4 @@ params:
       maxValue: 4096
 sources:
     - https://openrouter.ai/openai/gpt-3.5-turbo-16k/api
+status: deprecated

--- a/providers/openrouter/gpt-3.5-turbo-instruct.yaml
+++ b/providers/openrouter/gpt-3.5-turbo-instruct.yaml
@@ -18,3 +18,4 @@ mode: chat
 model: gpt-3.5-turbo-instruct
 sources:
     - https://openrouter.ai/openai/gpt-3.5-turbo-instruct/api
+status: deprecated

--- a/providers/openrouter/gpt-3.5-turbo.yaml
+++ b/providers/openrouter/gpt-3.5-turbo.yaml
@@ -23,3 +23,4 @@ params:
       maxValue: 4096
 sources:
     - https://openrouter.ai/openai/gpt-3.5-turbo/api
+status: deprecated

--- a/providers/openrouter/gpt-4-0314.yaml
+++ b/providers/openrouter/gpt-4-0314.yaml
@@ -6,3 +6,4 @@ model: gpt-4-0314
 params:
     - key: max_tokens
       maxValue: 4096
+status: deprecated

--- a/providers/openrouter/gpt-4-turbo.yaml
+++ b/providers/openrouter/gpt-4-turbo.yaml
@@ -25,3 +25,4 @@ params:
       maxValue: 4096
 sources:
     - https://openrouter.ai/openai/gpt-4-turbo/api
+status: deprecated

--- a/providers/openrouter/gpt-4.1-mini.yaml
+++ b/providers/openrouter/gpt-4.1-mini.yaml
@@ -24,3 +24,4 @@ params:
       maxValue: 32768
 sources:
     - https://openrouter.ai/openai/gpt-4.1-mini/api
+status: deprecated

--- a/providers/openrouter/gpt-4.1-nano.yaml
+++ b/providers/openrouter/gpt-4.1-nano.yaml
@@ -26,3 +26,4 @@ params:
       maxValue: 32768
 sources:
     - https://openrouter.ai/openai/gpt-4.1-nano/api
+status: deprecated

--- a/providers/openrouter/gpt-4.1.yaml
+++ b/providers/openrouter/gpt-4.1.yaml
@@ -27,3 +27,4 @@ params:
       maxValue: 32768
 sources:
     - https://openrouter.ai/openai/gpt-4.1/api
+status: deprecated

--- a/providers/openrouter/gpt-4.yaml
+++ b/providers/openrouter/gpt-4.yaml
@@ -21,3 +21,4 @@ mode: chat
 model: gpt-4
 sources:
     - https://openrouter.ai/openai/gpt-4/api
+status: deprecated

--- a/providers/openrouter/gpt-4o-2024-05-13.yaml
+++ b/providers/openrouter/gpt-4o-2024-05-13.yaml
@@ -24,3 +24,4 @@ params:
       maxValue: 4096
 sources:
     - https://openrouter.ai/openai/gpt-4o-2024-05-13/api
+status: deprecated

--- a/providers/openrouter/gpt-4o-2024-08-06.yaml
+++ b/providers/openrouter/gpt-4o-2024-08-06.yaml
@@ -26,3 +26,4 @@ params:
       maxValue: 16384
 sources:
     - https://openrouter.ai/openai/gpt-4o-2024-08-06/api
+status: deprecated

--- a/providers/openrouter/gpt-4o-2024-11-20.yaml
+++ b/providers/openrouter/gpt-4o-2024-11-20.yaml
@@ -24,3 +24,4 @@ params:
       maxValue: 16384
 sources:
     - https://openrouter.ai/openai/gpt-4o-2024-11-20/api
+status: deprecated

--- a/providers/openrouter/gpt-4o-mini-2024-07-18.yaml
+++ b/providers/openrouter/gpt-4o-mini-2024-07-18.yaml
@@ -25,3 +25,4 @@ params:
       maxValue: 16384
 sources:
     - https://openrouter.ai/openai/gpt-4o-mini-2024-07-18/api
+status: deprecated

--- a/providers/openrouter/gpt-4o-mini.yaml
+++ b/providers/openrouter/gpt-4o-mini.yaml
@@ -24,3 +24,4 @@ params:
       maxValue: 16384
 sources:
     - https://openrouter.ai/openai/gpt-4o-mini/api
+status: deprecated

--- a/providers/openrouter/gpt-4o.yaml
+++ b/providers/openrouter/gpt-4o.yaml
@@ -26,3 +26,4 @@ params:
       maxValue: 16384
 sources:
     - https://openrouter.ai/openai/gpt-4o/api
+status: deprecated

--- a/providers/openrouter/gpt-4o:extended.yaml
+++ b/providers/openrouter/gpt-4o:extended.yaml
@@ -25,3 +25,4 @@ params:
       maxValue: 64000
 sources:
     - https://openrouter.ai/openai/gpt-4o:extended/api
+status: deprecated

--- a/providers/openrouter/gpt-oss-120b.yaml
+++ b/providers/openrouter/gpt-oss-120b.yaml
@@ -24,4 +24,5 @@ removeParams:
     - stream
 sources:
     - https://openrouter.ai/openai/gpt-oss-120b/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/gpt-oss-20b.yaml
+++ b/providers/openrouter/gpt-oss-20b.yaml
@@ -27,4 +27,5 @@ removeParams:
     - stream
 sources:
     - https://openrouter.ai/openai/gpt-oss-20b/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/grok-2-1212.yaml
+++ b/providers/openrouter/grok-2-1212.yaml
@@ -5,3 +5,4 @@ limits:
     max_tokens: 4096
 mode: chat
 model: grok-2-1212
+status: deprecated

--- a/providers/openrouter/grok-2-vision-1212.yaml
+++ b/providers/openrouter/grok-2-vision-1212.yaml
@@ -11,3 +11,4 @@ model: grok-2-vision-1212
 sources:
     - https://openrouter.ai/x-ai/grok-2-vision-1212/api
     - https://docs.x.ai/developers/models#models-and-pricing
+status: deprecated

--- a/providers/openrouter/grok-3-beta.yaml
+++ b/providers/openrouter/grok-3-beta.yaml
@@ -20,3 +20,4 @@ model: grok-3-beta
 sources:
     - https://openrouter.ai/x-ai/grok-3-beta/api
     - https://docs.x.ai/developers/models#models-and-pricing
+status: deprecated

--- a/providers/openrouter/grok-3-mini-beta.yaml
+++ b/providers/openrouter/grok-3-mini-beta.yaml
@@ -20,4 +20,5 @@ model: grok-3-mini-beta
 sources:
     - https://openrouter.ai/x-ai/grok-3-mini-beta/api
     - https://docs.x.ai/developers/models#models-and-pricing
+status: deprecated
 thinking: true

--- a/providers/openrouter/grok-3-mini.yaml
+++ b/providers/openrouter/grok-3-mini.yaml
@@ -21,4 +21,5 @@ params:
 sources:
     - https://openrouter.ai/x-ai/grok-3-mini/api
     - https://docs.x.ai/developers/models#models-and-pricing
+status: deprecated
 thinking: true

--- a/providers/openrouter/grok-3.yaml
+++ b/providers/openrouter/grok-3.yaml
@@ -20,3 +20,4 @@ model: grok-3
 sources:
     - https://openrouter.ai/x-ai/grok-3/api
     - https://docs.x.ai/developers/models#models-and-pricing
+status: deprecated

--- a/providers/openrouter/grok-4.yaml
+++ b/providers/openrouter/grok-4.yaml
@@ -30,4 +30,5 @@ model: grok-4
 sources:
     - https://openrouter.ai/x-ai/grok-4/api
     - https://docs.x.ai/developers/models#models-and-pricing
+status: deprecated
 thinking: true

--- a/providers/openrouter/grok-vision-beta.yaml
+++ b/providers/openrouter/grok-vision-beta.yaml
@@ -10,3 +10,4 @@ mode: chat
 model: grok-vision-beta
 sources:
     - https://openrouter.ai/x-ai/grok-vision-beta/api
+status: deprecated

--- a/providers/openrouter/hermes-2-pro-llama-3-8b.yaml
+++ b/providers/openrouter/hermes-2-pro-llama-3-8b.yaml
@@ -22,3 +22,4 @@ params:
       maxValue: 8192
 sources:
     - https://openrouter.ai/nousresearch/hermes-2-pro-llama-3-8b/api
+status: deprecated

--- a/providers/openrouter/hermes-3-llama-3.1-405b.yaml
+++ b/providers/openrouter/hermes-3-llama-3.1-405b.yaml
@@ -21,3 +21,4 @@ params:
       maxValue: 16384
 sources:
     - https://openrouter.ai/nousresearch/hermes-3-llama-3.1-405b/api
+status: deprecated

--- a/providers/openrouter/hermes-3-llama-3.1-70b.yaml
+++ b/providers/openrouter/hermes-3-llama-3.1-70b.yaml
@@ -15,4 +15,4 @@ mode: chat
 model: hermes-3-llama-3.1-70b
 sources:
     - https://openrouter.ai/nousresearch/hermes-3-llama-3.1-70b/api
-status: active
+status: deprecated

--- a/providers/openrouter/horizon-alpha.yaml
+++ b/providers/openrouter/horizon-alpha.yaml
@@ -13,3 +13,4 @@ params:
       maxValue: 128000
 sources:
     - https://openrouter.ai/horizon-alpha/api
+status: deprecated

--- a/providers/openrouter/hunyuan-a13b-instruct.yaml
+++ b/providers/openrouter/hunyuan-a13b-instruct.yaml
@@ -19,4 +19,5 @@ mode: chat
 model: hunyuan-a13b-instruct
 sources:
     - https://openrouter.ai/tencent/hunyuan-a13b-instruct/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/hunyuan-a13b-instruct:free.yaml
+++ b/providers/openrouter/hunyuan-a13b-instruct:free.yaml
@@ -18,4 +18,5 @@ model: hunyuan-a13b-instruct:free
 sources:
     - https://openrouter.ai/tencent/hunyuan-a13b-instruct:free/api
     - https://openrouter.ai/tencent/hunyuan-a13b-instruct/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/inception/mercury-coder.yaml
+++ b/providers/openrouter/inception/mercury-coder.yaml
@@ -20,4 +20,4 @@ mode: chat
 model: inception/mercury-coder
 sources:
     - https://openrouter.ai/inception/mercury-coder/api
-status: active
+status: deprecated

--- a/providers/openrouter/inception/mercury.yaml
+++ b/providers/openrouter/inception/mercury.yaml
@@ -1,3 +1,4 @@
 isDeprecated: true
 mode: unknown
 model: inception/mercury
+status: deprecated

--- a/providers/openrouter/inflection-3-pi.yaml
+++ b/providers/openrouter/inflection-3-pi.yaml
@@ -20,3 +20,4 @@ params:
       maxValue: 1024
 sources:
     - https://openrouter.ai/inflection/inflection-3-pi/api
+status: deprecated

--- a/providers/openrouter/inflection-3-productivity.yaml
+++ b/providers/openrouter/inflection-3-productivity.yaml
@@ -21,3 +21,4 @@ params:
       maxValue: 1024
 sources:
     - https://openrouter.ai/inflection/inflection-3-productivity/api
+status: deprecated

--- a/providers/openrouter/internvl3-14b.yaml
+++ b/providers/openrouter/internvl3-14b.yaml
@@ -10,3 +10,4 @@ mode: chat
 model: internvl3-14b
 sources:
     - https://openrouter.ai/opengvlab/internvl3-14b/api
+status: deprecated

--- a/providers/openrouter/jamba-1.6-large.yaml
+++ b/providers/openrouter/jamba-1.6-large.yaml
@@ -23,3 +23,4 @@ sources:
     - https://docs.ai21.com/reference/jamba-1-6-api-ref
     - https://docs.ai21.com/docs/jamba-foundation-models
     - https://www.ai21.com/pricing
+status: deprecated

--- a/providers/openrouter/jamba-1.6-mini.yaml
+++ b/providers/openrouter/jamba-1.6-mini.yaml
@@ -18,3 +18,4 @@ params:
       maxValue: 4096
 sources:
     - https://openrouter.ai/ai21/jamba-1.6-mini/api
+status: deprecated

--- a/providers/openrouter/jondurbin/airoboros-l2-70b-2.1.yaml
+++ b/providers/openrouter/jondurbin/airoboros-l2-70b-2.1.yaml
@@ -7,3 +7,4 @@ limits:
     max_tokens: 4096
 mode: chat
 model: jondurbin/airoboros-l2-70b-2.1
+status: deprecated

--- a/providers/openrouter/kimi-dev-72b:free.yaml
+++ b/providers/openrouter/kimi-dev-72b:free.yaml
@@ -13,5 +13,5 @@ mode: chat
 model: kimi-dev-72b:free
 sources:
     - https://openrouter.ai/moonshotai/kimi-dev-72b:free/api
-status: active
+status: deprecated
 thinking: true

--- a/providers/openrouter/kimi-k2.yaml
+++ b/providers/openrouter/kimi-k2.yaml
@@ -18,3 +18,4 @@ mode: chat
 model: kimi-k2
 sources:
     - https://openrouter.ai/moonshotai/kimi-k2/api
+status: deprecated

--- a/providers/openrouter/kimi-k2:free.yaml
+++ b/providers/openrouter/kimi-k2:free.yaml
@@ -19,3 +19,4 @@ model: kimi-k2:free
 sources:
     - https://openrouter.ai/moonshotai/kimi-k2:free/api
     - https://openrouter.ai/moonshotai/kimi-k2/api
+status: deprecated

--- a/providers/openrouter/kimi-vl-a3b-thinking.yaml
+++ b/providers/openrouter/kimi-vl-a3b-thinking.yaml
@@ -10,4 +10,5 @@ mode: chat
 model: kimi-vl-a3b-thinking
 sources:
     - https://openrouter.ai/moonshotai/kimi-vl-a3b-thinking/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/kimi-vl-a3b-thinking:free.yaml
+++ b/providers/openrouter/kimi-vl-a3b-thinking:free.yaml
@@ -16,4 +16,5 @@ model: kimi-vl-a3b-thinking:free
 sources:
     - https://openrouter.ai/moonshotai/kimi-vl-a3b-thinking:free/api
     - https://openrouter.ai/moonshotai/kimi-vl-a3b-thinking:free
+status: deprecated
 thinking: true

--- a/providers/openrouter/kwaipilot/kat-coder-pro.yaml
+++ b/providers/openrouter/kwaipilot/kat-coder-pro.yaml
@@ -21,3 +21,4 @@ mode: chat
 model: kwaipilot/kat-coder-pro
 sources:
     - https://openrouter.ai/kwaipilot/kat-coder-pro/api
+status: deprecated

--- a/providers/openrouter/l3-euryale-70b.yaml
+++ b/providers/openrouter/l3-euryale-70b.yaml
@@ -21,3 +21,4 @@ params:
       maxValue: 8192
 sources:
     - https://openrouter.ai/sao10k/l3-euryale-70b/api
+status: deprecated

--- a/providers/openrouter/l3-lunaris-8b.yaml
+++ b/providers/openrouter/l3-lunaris-8b.yaml
@@ -3,3 +3,4 @@ limits:
     max_tokens: 4096
 mode: chat
 model: l3-lunaris-8b
+status: deprecated

--- a/providers/openrouter/l3.1-euryale-70b.yaml
+++ b/providers/openrouter/l3.1-euryale-70b.yaml
@@ -22,4 +22,4 @@ params:
       maxValue: 16384
 sources:
     - https://openrouter.ai/sao10k/l3.1-euryale-70b/api
-status: active
+status: deprecated

--- a/providers/openrouter/l3.3-euryale-70b.yaml
+++ b/providers/openrouter/l3.3-euryale-70b.yaml
@@ -19,3 +19,4 @@ mode: chat
 model: l3.3-euryale-70b
 sources:
     - https://openrouter.ai/sao10k/l3.3-euryale-70b/api
+status: deprecated

--- a/providers/openrouter/lfm-3b.yaml
+++ b/providers/openrouter/lfm-3b.yaml
@@ -10,3 +10,4 @@ model: lfm-3b
 sources:
     - https://openrouter.ai/liquid/lfm-3b/api
     - https://openrouter.ai/liquid/lfm-3b
+status: deprecated

--- a/providers/openrouter/lfm-40b.yaml
+++ b/providers/openrouter/lfm-40b.yaml
@@ -12,4 +12,4 @@ params:
       maxValue: 65536
 sources:
     - https://openrouter.ai/liquid/lfm-40b/api
-status: active
+status: deprecated

--- a/providers/openrouter/lfm-7b.yaml
+++ b/providers/openrouter/lfm-7b.yaml
@@ -15,4 +15,4 @@ mode: chat
 model: liquid/lfm-7b
 sources:
     - https://openrouter.ai/liquid/lfm-7b/api
-status: active
+status: deprecated

--- a/providers/openrouter/llama-3-70b-instruct.yaml
+++ b/providers/openrouter/llama-3-70b-instruct.yaml
@@ -22,3 +22,4 @@ params:
       maxValue: 8000
 sources:
     - https://openrouter.ai/meta-llama/llama-3-70b-instruct/api
+status: deprecated

--- a/providers/openrouter/llama-3-8b-instruct.yaml
+++ b/providers/openrouter/llama-3-8b-instruct.yaml
@@ -24,3 +24,4 @@ params:
       maxValue: 16384
 sources:
     - https://openrouter.ai/meta-llama/llama-3-8b-instruct/api
+status: deprecated

--- a/providers/openrouter/llama-3-lumimaid-70b.yaml
+++ b/providers/openrouter/llama-3-lumimaid-70b.yaml
@@ -10,3 +10,4 @@ model: llama-3-lumimaid-70b
 sources:
     - https://openrouter.ai/neversleep/llama-3-lumimaid-70b/api
     - https://openrouter.ai/neversleep/llama-3-lumimaid-70b
+status: deprecated

--- a/providers/openrouter/llama-3.1-405b-instruct.yaml
+++ b/providers/openrouter/llama-3.1-405b-instruct.yaml
@@ -20,4 +20,4 @@ params:
       maxValue: 16384
 sources:
     - https://openrouter.ai/meta-llama/llama-3.1-405b-instruct/api
-status: active
+status: deprecated

--- a/providers/openrouter/llama-3.1-405b-instruct:free.yaml
+++ b/providers/openrouter/llama-3.1-405b-instruct:free.yaml
@@ -17,3 +17,4 @@ mode: chat
 model: llama-3.1-405b-instruct:free
 sources:
     - https://openrouter.ai/meta-llama/llama-3.1-405b-instruct:free/api
+status: deprecated

--- a/providers/openrouter/llama-3.1-405b.yaml
+++ b/providers/openrouter/llama-3.1-405b.yaml
@@ -15,3 +15,4 @@ mode: completion
 model: llama-3.1-405b
 sources:
     - https://openrouter.ai/meta-llama/llama-3.1-405b/api
+status: deprecated

--- a/providers/openrouter/llama-3.1-70b-instruct.yaml
+++ b/providers/openrouter/llama-3.1-70b-instruct.yaml
@@ -19,3 +19,4 @@ params:
       maxValue: 16384
 sources:
     - https://openrouter.ai/meta-llama/llama-3.1-70b-instruct/api
+status: deprecated

--- a/providers/openrouter/llama-3.1-8b-instruct.yaml
+++ b/providers/openrouter/llama-3.1-8b-instruct.yaml
@@ -21,4 +21,4 @@ params:
       maxValue: 16384
 sources:
     - https://openrouter.ai/meta-llama/llama-3.1-8b-instruct/api
-status: active
+status: deprecated

--- a/providers/openrouter/llama-3.1-lumimaid-8b.yaml
+++ b/providers/openrouter/llama-3.1-lumimaid-8b.yaml
@@ -9,3 +9,4 @@ mode: chat
 model: llama-3.1-lumimaid-8b
 sources:
     - https://openrouter.ai/neversleep/llama-3.1-lumimaid-8b/api
+status: deprecated

--- a/providers/openrouter/llama-3.1-nemotron-70b-instruct.yaml
+++ b/providers/openrouter/llama-3.1-nemotron-70b-instruct.yaml
@@ -23,4 +23,4 @@ params:
       maxValue: 16384
 sources:
     - https://openrouter.ai/nvidia/llama-3.1-nemotron-70b-instruct/api
-status: active
+status: deprecated

--- a/providers/openrouter/llama-3.1-nemotron-ultra-253b-v1.yaml
+++ b/providers/openrouter/llama-3.1-nemotron-ultra-253b-v1.yaml
@@ -18,4 +18,5 @@ mode: chat
 model: llama-3.1-nemotron-ultra-253b-v1
 sources:
     - https://openrouter.ai/nvidia/llama-3.1-nemotron-ultra-253b-v1/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/llama-3.1-nemotron-ultra-253b-v1:free.yaml
+++ b/providers/openrouter/llama-3.1-nemotron-ultra-253b-v1:free.yaml
@@ -18,5 +18,5 @@ model: llama-3.1-nemotron-ultra-253b-v1:free
 sources:
     - https://openrouter.ai/nvidia/llama-3.1-nemotron-ultra-253b-v1:free/api
     - https://openrouter.ai/nvidia/llama-3.1-nemotron-ultra-253b-v1/api
-status: active
+status: deprecated
 thinking: true

--- a/providers/openrouter/llama-3.2-11b-vision-instruct.yaml
+++ b/providers/openrouter/llama-3.2-11b-vision-instruct.yaml
@@ -22,4 +22,4 @@ params:
       maxValue: 16384
 sources:
     - https://openrouter.ai/meta-llama/llama-3.2-11b-vision-instruct/api
-status: active
+status: deprecated

--- a/providers/openrouter/llama-3.2-11b-vision-instruct:free.yaml
+++ b/providers/openrouter/llama-3.2-11b-vision-instruct:free.yaml
@@ -19,4 +19,4 @@ params:
       maxValue: 2048
 sources:
     - https://openrouter.ai/meta-llama/llama-3.2-11b-vision-instruct:free/api
-status: active
+status: deprecated

--- a/providers/openrouter/llama-3.2-1b-instruct.yaml
+++ b/providers/openrouter/llama-3.2-1b-instruct.yaml
@@ -16,3 +16,4 @@ params:
       maxValue: 16384
 sources:
     - https://openrouter.ai/meta-llama/llama-3.2-1b-instruct/api
+status: deprecated

--- a/providers/openrouter/llama-3.2-3b-instruct.yaml
+++ b/providers/openrouter/llama-3.2-3b-instruct.yaml
@@ -19,3 +19,4 @@ params:
       maxValue: 20000
 sources:
     - https://openrouter.ai/meta-llama/llama-3.2-3b-instruct/api
+status: deprecated

--- a/providers/openrouter/llama-3.2-3b-instruct:free.yaml
+++ b/providers/openrouter/llama-3.2-3b-instruct:free.yaml
@@ -13,3 +13,4 @@ mode: chat
 model: llama-3.2-3b-instruct:free
 sources:
     - https://openrouter.ai/meta-llama/llama-3.2-3b-instruct:free/api
+status: deprecated

--- a/providers/openrouter/llama-3.2-90b-vision-instruct.yaml
+++ b/providers/openrouter/llama-3.2-90b-vision-instruct.yaml
@@ -14,3 +14,4 @@ params:
 sources:
     - https://openrouter.ai/meta-llama/llama-3.2-90b-vision-instruct/api
     - https://openrouter.ai/meta-llama/llama-3.2-90b-vision-instruct
+status: deprecated

--- a/providers/openrouter/llama-3.3-70b-instruct.yaml
+++ b/providers/openrouter/llama-3.3-70b-instruct.yaml
@@ -23,3 +23,4 @@ params:
       maxValue: 16384
 sources:
     - https://openrouter.ai/meta-llama/llama-3.3-70b-instruct/api
+status: deprecated

--- a/providers/openrouter/llama-3.3-70b-instruct:free.yaml
+++ b/providers/openrouter/llama-3.3-70b-instruct:free.yaml
@@ -19,3 +19,4 @@ removeParams:
     - response_format
 sources:
     - https://openrouter.ai/meta-llama/llama-3.3-70b-instruct:free/api
+status: deprecated

--- a/providers/openrouter/llama-3.3-nemotron-super-49b-v1.yaml
+++ b/providers/openrouter/llama-3.3-nemotron-super-49b-v1.yaml
@@ -12,4 +12,5 @@ mode: chat
 model: llama-3.3-nemotron-super-49b-v1
 sources:
     - https://openrouter.ai/nvidia/llama-3.3-nemotron-super-49b-v1/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/llama-4-maverick.yaml
+++ b/providers/openrouter/llama-4-maverick.yaml
@@ -23,3 +23,4 @@ params:
       maxValue: 16384
 sources:
     - https://openrouter.ai/meta-llama/llama-4-maverick/api
+status: deprecated

--- a/providers/openrouter/llama-4-scout.yaml
+++ b/providers/openrouter/llama-4-scout.yaml
@@ -22,3 +22,4 @@ params:
       maxValue: 16384
 sources:
     - https://openrouter.ai/meta-llama/llama-4-scout/api
+status: deprecated

--- a/providers/openrouter/llama-guard-2-8b.yaml
+++ b/providers/openrouter/llama-guard-2-8b.yaml
@@ -16,3 +16,4 @@ model: meta-llama/llama-guard-2-8b
 sources:
     - https://openrouter.ai/meta-llama/llama-guard-2-8b/api
     - https://openrouter.ai/meta-llama/llama-guard-2-8b
+status: deprecated

--- a/providers/openrouter/llama-guard-3-8b.yaml
+++ b/providers/openrouter/llama-guard-3-8b.yaml
@@ -15,3 +15,4 @@ mode: chat
 model: llama-guard-3-8b
 sources:
     - https://openrouter.ai/meta-llama/llama-guard-3-8b/api
+status: deprecated

--- a/providers/openrouter/llama-guard-4-12b.yaml
+++ b/providers/openrouter/llama-guard-4-12b.yaml
@@ -14,3 +14,4 @@ mode: chat
 model: llama-guard-4-12b
 sources:
     - https://openrouter.ai/meta-llama/llama-guard-4-12b/api
+status: deprecated

--- a/providers/openrouter/llama3.1-typhoon2-70b-instruct.yaml
+++ b/providers/openrouter/llama3.1-typhoon2-70b-instruct.yaml
@@ -11,4 +11,4 @@ mode: chat
 model: scb10x/llama3.1-typhoon2-70b-instruct
 sources:
     - https://openrouter.ai/scb10x/llama3.1-typhoon2-70b-instruct/api
-status: active
+status: deprecated

--- a/providers/openrouter/llemma_7b.yaml
+++ b/providers/openrouter/llemma_7b.yaml
@@ -15,4 +15,4 @@ mode: chat
 model: llemma_7b
 sources:
     - https://openrouter.ai/eleutherai/llemma_7b/api
-status: active
+status: deprecated

--- a/providers/openrouter/maestro-reasoning.yaml
+++ b/providers/openrouter/maestro-reasoning.yaml
@@ -21,3 +21,4 @@ params:
       maxValue: 32000
 sources:
     - https://openrouter.ai/arcee-ai/maestro-reasoning/api
+status: deprecated

--- a/providers/openrouter/magistral-medium-2506.yaml
+++ b/providers/openrouter/magistral-medium-2506.yaml
@@ -6,3 +6,4 @@ model: magistral-medium-2506
 params:
     - key: max_tokens
       maxValue: 40000
+status: deprecated

--- a/providers/openrouter/magistral-medium-2506:thinking.yaml
+++ b/providers/openrouter/magistral-medium-2506:thinking.yaml
@@ -16,4 +16,5 @@ params:
 sources:
     - https://openrouter.ai/mistralai/magistral-medium-2506:thinking/api
     - https://docs.mistral.ai/getting-started/models/
+status: deprecated
 thinking: true

--- a/providers/openrouter/magistral-small-2506.yaml
+++ b/providers/openrouter/magistral-small-2506.yaml
@@ -16,4 +16,5 @@ params:
 sources:
     - https://openrouter.ai/mistralai/magistral-small-2506
     - https://docs.mistral.ai/getting-started/models/
+status: deprecated
 thinking: true

--- a/providers/openrouter/magnum-v2-72b.yaml
+++ b/providers/openrouter/magnum-v2-72b.yaml
@@ -5,3 +5,4 @@ mode: chat
 model: magnum-v2-72b
 sources:
     - https://openrouter.ai/alpindale/magnum-v2-72b/api
+status: deprecated

--- a/providers/openrouter/magnum-v4-72b.yaml
+++ b/providers/openrouter/magnum-v4-72b.yaml
@@ -18,4 +18,4 @@ params:
       maxValue: 2048
 sources:
     - https://openrouter.ai/anthracite-org/magnum-v4-72b/api
-status: active
+status: deprecated

--- a/providers/openrouter/mai-ds-r1.yaml
+++ b/providers/openrouter/mai-ds-r1.yaml
@@ -14,4 +14,5 @@ model: mai-ds-r1
 sources:
     - https://openrouter.ai/microsoft/mai-ds-r1/api
     - https://openrouter.ai/microsoft/mai-ds-r1
+status: deprecated
 thinking: true

--- a/providers/openrouter/mai-ds-r1:free.yaml
+++ b/providers/openrouter/mai-ds-r1:free.yaml
@@ -15,4 +15,5 @@ mode: chat
 model: mai-ds-r1:free
 sources:
     - https://openrouter.ai/microsoft/mai-ds-r1:free/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/mercury-coder.yaml
+++ b/providers/openrouter/mercury-coder.yaml
@@ -21,3 +21,4 @@ mode: chat
 model: mercury-coder
 sources:
     - https://openrouter.ai/inception/mercury-coder/api
+status: deprecated

--- a/providers/openrouter/mercury.yaml
+++ b/providers/openrouter/mercury.yaml
@@ -4,3 +4,4 @@ model: mercury
 params:
     - key: max_tokens
       maxValue: 16000
+status: deprecated

--- a/providers/openrouter/meta-llama/codellama-34b-instruct.yaml
+++ b/providers/openrouter/meta-llama/codellama-34b-instruct.yaml
@@ -14,3 +14,4 @@ mode: chat
 model: meta-llama/codellama-34b-instruct
 sources:
     - https://openrouter.ai/meta-llama/codellama-34b-instruct/api
+status: deprecated

--- a/providers/openrouter/meta-llama/llama-2-13b-chat.yaml
+++ b/providers/openrouter/meta-llama/llama-2-13b-chat.yaml
@@ -15,3 +15,4 @@ mode: chat
 model: meta-llama/llama-2-13b-chat
 sources:
     - https://openrouter.ai/meta-llama/llama-2-13b-chat/api
+status: deprecated

--- a/providers/openrouter/meta-llama/llama-2-70b-chat.yaml
+++ b/providers/openrouter/meta-llama/llama-2-70b-chat.yaml
@@ -16,3 +16,4 @@ mode: chat
 model: meta-llama/llama-2-70b-chat
 sources:
     - https://openrouter.ai/meta-llama/llama-2-70b-chat/api
+status: deprecated

--- a/providers/openrouter/meta-llama/llama-3-70b-instruct:nitro.yaml
+++ b/providers/openrouter/meta-llama/llama-3-70b-instruct:nitro.yaml
@@ -19,3 +19,4 @@ mode: chat
 model: meta-llama/llama-3-70b-instruct:nitro
 sources:
     - https://openrouter.ai/meta-llama/llama-3-70b-instruct:nitro/api
+status: deprecated

--- a/providers/openrouter/meta-llama/llama-3-8b-instruct:extended.yaml
+++ b/providers/openrouter/meta-llama/llama-3-8b-instruct:extended.yaml
@@ -18,3 +18,4 @@ mode: chat
 model: meta-llama/llama-3-8b-instruct:extended
 sources:
     - https://openrouter.ai/meta-llama/llama-3-8b-instruct:extended/api
+status: deprecated

--- a/providers/openrouter/meta-llama/llama-3-8b-instruct:free.yaml
+++ b/providers/openrouter/meta-llama/llama-3-8b-instruct:free.yaml
@@ -17,3 +17,4 @@ mode: chat
 model: meta-llama/llama-3-8b-instruct:free
 sources:
     - https://openrouter.ai/meta-llama/llama-3-8b-instruct:free/api
+status: deprecated

--- a/providers/openrouter/meta-llama/llama-3.1-405b-instruct.yaml
+++ b/providers/openrouter/meta-llama/llama-3.1-405b-instruct.yaml
@@ -15,3 +15,4 @@ mode: chat
 model: meta-llama/llama-3.1-405b-instruct
 sources:
     - https://openrouter.ai/meta-llama/llama-3.1-405b-instruct/api
+status: deprecated

--- a/providers/openrouter/meta-llama/llama-3.1-405b.yaml
+++ b/providers/openrouter/meta-llama/llama-3.1-405b.yaml
@@ -13,4 +13,4 @@ mode: chat
 model: meta-llama/llama-3.1-405b
 sources:
     - https://openrouter.ai/meta-llama/llama-3.1-405b/api
-status: active
+status: deprecated

--- a/providers/openrouter/microsoft/wizardlm-2-8x22b:nitro.yaml
+++ b/providers/openrouter/microsoft/wizardlm-2-8x22b:nitro.yaml
@@ -18,3 +18,4 @@ mode: chat
 model: microsoft/wizardlm-2-8x22b:nitro
 sources:
     - https://openrouter.ai/microsoft/wizardlm-2-8x22b:nitro/api
+status: deprecated

--- a/providers/openrouter/midnight-rose-70b.yaml
+++ b/providers/openrouter/midnight-rose-70b.yaml
@@ -14,3 +14,4 @@ params:
       maxValue: 2048
 sources:
     - https://openrouter.ai/sophosympatheia/midnight-rose-70b/api
+status: deprecated

--- a/providers/openrouter/minimax-01.yaml
+++ b/providers/openrouter/minimax-01.yaml
@@ -22,4 +22,4 @@ params:
       maxValue: 1000192
 sources:
     - https://openrouter.ai/minimax/minimax-01/api
-status: active
+status: deprecated

--- a/providers/openrouter/minimax-m1.yaml
+++ b/providers/openrouter/minimax-m1.yaml
@@ -25,4 +25,5 @@ params:
       maxValue: 40000
 sources:
     - https://openrouter.ai/minimax/minimax-m1/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/ministral-3b.yaml
+++ b/providers/openrouter/ministral-3b.yaml
@@ -5,3 +5,4 @@ limits:
     max_tokens: 4096
 mode: chat
 model: ministral-3b
+status: deprecated

--- a/providers/openrouter/ministral-8b.yaml
+++ b/providers/openrouter/ministral-8b.yaml
@@ -5,3 +5,4 @@ limits:
     max_tokens: 4096
 mode: chat
 model: ministral-8b
+status: deprecated

--- a/providers/openrouter/mistral-7b-instruct-v0.1.yaml
+++ b/providers/openrouter/mistral-7b-instruct-v0.1.yaml
@@ -13,3 +13,4 @@ mode: chat
 model: mistral-7b-instruct-v0.1
 sources:
     - https://openrouter.ai/mistralai/mistral-7b-instruct-v0.1/api
+status: deprecated

--- a/providers/openrouter/mistral-7b-instruct-v0.2.yaml
+++ b/providers/openrouter/mistral-7b-instruct-v0.2.yaml
@@ -9,3 +9,4 @@ mode: chat
 model: mistral-7b-instruct-v0.2
 sources:
     - https://openrouter.ai/mistralai/mistral-7b-instruct-v0.2/api
+status: deprecated

--- a/providers/openrouter/mistral-7b-instruct-v0.3.yaml
+++ b/providers/openrouter/mistral-7b-instruct-v0.3.yaml
@@ -14,3 +14,4 @@ params:
       maxValue: 16384
 sources:
     - https://openrouter.ai/mistralai/mistral-7b-instruct-v0.3/api
+status: deprecated

--- a/providers/openrouter/mistral-7b-instruct.yaml
+++ b/providers/openrouter/mistral-7b-instruct.yaml
@@ -18,4 +18,4 @@ params:
       maxValue: 16384
 sources:
     - https://openrouter.ai/mistralai/mistral-7b-instruct/api
-status: active
+status: deprecated

--- a/providers/openrouter/mistral-7b-instruct:free.yaml
+++ b/providers/openrouter/mistral-7b-instruct:free.yaml
@@ -18,4 +18,4 @@ params:
       maxValue: 16384
 sources:
     - https://openrouter.ai/mistralai/mistral-7b-instruct:free/api
-status: active
+status: deprecated

--- a/providers/openrouter/mistral-large-2407.yaml
+++ b/providers/openrouter/mistral-large-2407.yaml
@@ -21,3 +21,4 @@ mode: chat
 model: mistral-large-2407
 sources:
     - https://openrouter.ai/mistralai/mistral-large-2407/api
+status: deprecated

--- a/providers/openrouter/mistral-large-2411.yaml
+++ b/providers/openrouter/mistral-large-2411.yaml
@@ -23,3 +23,4 @@ mode: chat
 model: mistral-large-2411
 sources:
     - https://openrouter.ai/mistralai/mistral-large-2411/api
+status: deprecated

--- a/providers/openrouter/mistral-large.yaml
+++ b/providers/openrouter/mistral-large.yaml
@@ -19,3 +19,4 @@ mode: chat
 model: mistral-large
 sources:
     - https://openrouter.ai/mistralai/mistral-large/api
+status: deprecated

--- a/providers/openrouter/mistral-medium-3.yaml
+++ b/providers/openrouter/mistral-medium-3.yaml
@@ -21,4 +21,4 @@ model: mistral-medium-3
 sources:
     - https://openrouter.ai/mistralai/mistral-medium-3/api
     - https://docs.mistral.ai/models/mistral-medium-3-25-05
-status: active
+status: deprecated

--- a/providers/openrouter/mistral-nemo.yaml
+++ b/providers/openrouter/mistral-nemo.yaml
@@ -23,3 +23,4 @@ params:
       maxValue: 16384
 sources:
     - https://openrouter.ai/mistralai/mistral-nemo/api
+status: deprecated

--- a/providers/openrouter/mistral-nemo:free.yaml
+++ b/providers/openrouter/mistral-nemo:free.yaml
@@ -23,4 +23,4 @@ params:
       maxValue: 128000
 sources:
     - https://openrouter.ai/mistralai/mistral-nemo:free/api
-status: active
+status: deprecated

--- a/providers/openrouter/mistral-saba.yaml
+++ b/providers/openrouter/mistral-saba.yaml
@@ -20,3 +20,4 @@ mode: chat
 model: mistral-saba
 sources:
     - https://openrouter.ai/mistralai/mistral-saba/api
+status: deprecated

--- a/providers/openrouter/mistral-small-24b-instruct-2501.yaml
+++ b/providers/openrouter/mistral-small-24b-instruct-2501.yaml
@@ -16,4 +16,4 @@ mode: chat
 model: mistralai/mistral-small-24b-instruct-2501
 sources:
     - https://openrouter.ai/mistralai/mistral-small-24b-instruct-2501/api
-status: active
+status: deprecated

--- a/providers/openrouter/mistral-small-24b-instruct-2501:free.yaml
+++ b/providers/openrouter/mistral-small-24b-instruct-2501:free.yaml
@@ -19,4 +19,4 @@ model: mistral-small-24b-instruct-2501:free
 sources:
     - https://openrouter.ai/mistralai/mistral-small-24b-instruct-2501:free
     - https://openrouter.ai/api/v1/models
-status: active
+status: deprecated

--- a/providers/openrouter/mistral-small-3.1-24b-instruct.yaml
+++ b/providers/openrouter/mistral-small-3.1-24b-instruct.yaml
@@ -24,3 +24,4 @@ params:
       maxValue: 131072
 sources:
     - https://openrouter.ai/mistralai/mistral-small-3.1-24b-instruct/api
+status: deprecated

--- a/providers/openrouter/mistral-small-3.1-24b-instruct:free.yaml
+++ b/providers/openrouter/mistral-small-3.1-24b-instruct:free.yaml
@@ -19,3 +19,4 @@ mode: chat
 model: mistral-small-3.1-24b-instruct:free
 sources:
     - https://openrouter.ai/mistralai/mistral-small-3.1-24b-instruct:free/api
+status: deprecated

--- a/providers/openrouter/mistral-small-3.2-24b-instruct.yaml
+++ b/providers/openrouter/mistral-small-3.2-24b-instruct.yaml
@@ -17,3 +17,4 @@ mode: chat
 model: mistral-small-3.2-24b-instruct
 sources:
     - https://openrouter.ai/mistralai/mistral-small-3.2-24b-instruct/api
+status: deprecated

--- a/providers/openrouter/mistral-small-3.2-24b-instruct:free.yaml
+++ b/providers/openrouter/mistral-small-3.2-24b-instruct:free.yaml
@@ -19,3 +19,4 @@ mode: chat
 model: mistral-small-3.2-24b-instruct:free
 sources:
     - https://openrouter.ai/mistralai/mistral-small-3.2-24b-instruct:free/api
+status: deprecated

--- a/providers/openrouter/mistral-small.yaml
+++ b/providers/openrouter/mistral-small.yaml
@@ -19,3 +19,4 @@ model: mistral-small
 sources:
     - https://openrouter.ai/mistralai/mistral-small/api
     - https://docs.mistral.ai/getting-started/models/
+status: deprecated

--- a/providers/openrouter/mistral-tiny.yaml
+++ b/providers/openrouter/mistral-tiny.yaml
@@ -5,3 +5,4 @@ limits:
     max_tokens: 4096
 mode: chat
 model: mistral-tiny
+status: deprecated

--- a/providers/openrouter/mistralai/devstral-2512:free.yaml
+++ b/providers/openrouter/mistralai/devstral-2512:free.yaml
@@ -12,3 +12,4 @@ limits:
     max_tokens: 262144
 mode: chat
 model: mistralai/devstral-2512:free
+status: deprecated

--- a/providers/openrouter/mistralai/mistral-7b-instruct.yaml
+++ b/providers/openrouter/mistralai/mistral-7b-instruct.yaml
@@ -17,3 +17,4 @@ mode: chat
 model: mistralai/mistral-7b-instruct
 sources:
     - https://openrouter.ai/mistralai/mistral-7b-instruct/api
+status: deprecated

--- a/providers/openrouter/mistralai/mistral-7b-instruct:free.yaml
+++ b/providers/openrouter/mistralai/mistral-7b-instruct:free.yaml
@@ -15,4 +15,4 @@ mode: chat
 model: mistralai/mistral-7b-instruct:free
 sources:
     - https://openrouter.ai/mistralai/mistral-7b-instruct:free/api
-status: active
+status: deprecated

--- a/providers/openrouter/mistralai/mistral-small-3.1-24b-instruct:free.yaml
+++ b/providers/openrouter/mistralai/mistral-small-3.1-24b-instruct:free.yaml
@@ -19,3 +19,4 @@ mode: chat
 model: mistralai/mistral-small-3.1-24b-instruct:free
 sources:
     - https://openrouter.ai/mistralai/mistral-small-3.1-24b-instruct:free/api
+status: deprecated

--- a/providers/openrouter/mistralai/mistral-small-creative.yaml
+++ b/providers/openrouter/mistralai/mistral-small-creative.yaml
@@ -19,3 +19,4 @@ mode: chat
 model: mistralai/mistral-small-creative
 sources:
     - https://openrouter.ai/mistralai/mistral-small-creative/api
+status: deprecated

--- a/providers/openrouter/mistralai/pixtral-12b.yaml
+++ b/providers/openrouter/mistralai/pixtral-12b.yaml
@@ -20,3 +20,4 @@ params:
       key: temperature
 sources:
     - https://openrouter.ai/mistralai/pixtral-12b/api
+status: deprecated

--- a/providers/openrouter/mixtral-8x22b-instruct.yaml
+++ b/providers/openrouter/mixtral-8x22b-instruct.yaml
@@ -19,3 +19,4 @@ mode: chat
 model: mixtral-8x22b-instruct
 sources:
     - https://openrouter.ai/mistralai/mixtral-8x22b-instruct/api
+status: deprecated

--- a/providers/openrouter/mixtral-8x7b-instruct.yaml
+++ b/providers/openrouter/mixtral-8x7b-instruct.yaml
@@ -23,4 +23,4 @@ params:
       maxValue: 16384
 sources:
     - https://openrouter.ai/mistralai/mixtral-8x7b-instruct/api
-status: active
+status: deprecated

--- a/providers/openrouter/mn-celeste-12b.yaml
+++ b/providers/openrouter/mn-celeste-12b.yaml
@@ -9,4 +9,4 @@ mode: chat
 model: mn-celeste-12b
 sources:
     - https://openrouter.ai/nothingiisreal/mn-celeste-12b/api
-status: active
+status: deprecated

--- a/providers/openrouter/mn-inferor-12b.yaml
+++ b/providers/openrouter/mn-inferor-12b.yaml
@@ -6,3 +6,4 @@ params:
       maxValue: 4096
 sources:
     - https://openrouter.ai/mn-inferor-12b/api
+status: deprecated

--- a/providers/openrouter/moonshotai/kimi-k2-0905:exacto.yaml
+++ b/providers/openrouter/moonshotai/kimi-k2-0905:exacto.yaml
@@ -20,4 +20,4 @@ params:
       key: temperature
 sources:
     - https://openrouter.ai/moonshotai/kimi-k2-0905:exacto/api
-status: active
+status: deprecated

--- a/providers/openrouter/morph-v2.yaml
+++ b/providers/openrouter/morph-v2.yaml
@@ -17,3 +17,4 @@ removeParams:
 sources:
     - https://openrouter.ai/morph/morph-v2/api
     - https://docs.morphllm.com/
+status: deprecated

--- a/providers/openrouter/morph-v3-fast.yaml
+++ b/providers/openrouter/morph-v3-fast.yaml
@@ -24,4 +24,4 @@ removeParams:
 sources:
     - https://openrouter.ai/morph/morph-v3-fast/api
     - https://docs.morphllm.com/quickstart
-status: active
+status: deprecated

--- a/providers/openrouter/morph-v3-large.yaml
+++ b/providers/openrouter/morph-v3-large.yaml
@@ -18,4 +18,4 @@ params:
       maxValue: 131072
 sources:
     - https://openrouter.ai/morph/morph-v3-large/api
-status: active
+status: deprecated

--- a/providers/openrouter/mythalion-13b.yaml
+++ b/providers/openrouter/mythalion-13b.yaml
@@ -14,3 +14,4 @@ params:
       maxValue: 4096
 sources:
     - https://openrouter.ai/pygmalionai/mythalion-13b/api
+status: deprecated

--- a/providers/openrouter/mythomax-l2-13b.yaml
+++ b/providers/openrouter/mythomax-l2-13b.yaml
@@ -18,3 +18,4 @@ mode: chat
 model: mythomax-l2-13b
 sources:
     - https://openrouter.ai/gryphe/mythomax-l2-13b/api
+status: deprecated

--- a/providers/openrouter/neversleep/llama-3.1-lumimaid-8b.yaml
+++ b/providers/openrouter/neversleep/llama-3.1-lumimaid-8b.yaml
@@ -9,3 +9,4 @@ mode: chat
 model: neversleep/llama-3.1-lumimaid-8b
 sources:
     - https://openrouter.ai/neversleep/llama-3.1-lumimaid-8b/api
+status: deprecated

--- a/providers/openrouter/neversleep/noromaid-20b.yaml
+++ b/providers/openrouter/neversleep/noromaid-20b.yaml
@@ -11,3 +11,4 @@ mode: chat
 model: neversleep/noromaid-20b
 sources:
     - https://openrouter.ai/neversleep/noromaid-20b/api
+status: deprecated

--- a/providers/openrouter/noromaid-20b.yaml
+++ b/providers/openrouter/noromaid-20b.yaml
@@ -11,3 +11,4 @@ mode: chat
 model: noromaid-20b
 sources:
     - https://openrouter.ai/neversleep/noromaid-20b/api
+status: deprecated

--- a/providers/openrouter/nous-hermes-2-mixtral-8x7b-dpo.yaml
+++ b/providers/openrouter/nous-hermes-2-mixtral-8x7b-dpo.yaml
@@ -12,3 +12,4 @@ params:
       maxValue: 2048
 sources:
     - https://openrouter.ai/nousresearch/nous-hermes-2-mixtral-8x7b-dpo/api
+status: deprecated

--- a/providers/openrouter/nousresearch/nous-hermes-llama2-13b.yaml
+++ b/providers/openrouter/nousresearch/nous-hermes-llama2-13b.yaml
@@ -14,3 +14,4 @@ mode: chat
 model: nousresearch/nous-hermes-llama2-13b
 sources:
     - https://openrouter.ai/nousresearch/nous-hermes-llama2-13b/api
+status: deprecated

--- a/providers/openrouter/nova-lite-v1.yaml
+++ b/providers/openrouter/nova-lite-v1.yaml
@@ -22,3 +22,4 @@ params:
       maxValue: 5120
 sources:
     - https://openrouter.ai/amazon/nova-lite-v1/api
+status: deprecated

--- a/providers/openrouter/nova-micro-v1.yaml
+++ b/providers/openrouter/nova-micro-v1.yaml
@@ -21,3 +21,4 @@ params:
       maxValue: 5120
 sources:
     - https://openrouter.ai/amazon/nova-micro-v1/api
+status: deprecated

--- a/providers/openrouter/nova-pro-v1.yaml
+++ b/providers/openrouter/nova-pro-v1.yaml
@@ -23,3 +23,4 @@ params:
       maxValue: 5120
 sources:
     - https://openrouter.ai/amazon/nova-pro-v1/api
+status: deprecated

--- a/providers/openrouter/o1-mini-2024-09-12.yaml
+++ b/providers/openrouter/o1-mini-2024-09-12.yaml
@@ -4,3 +4,4 @@ model: o1-mini-2024-09-12
 params:
     - key: max_tokens
       maxValue: 65536
+status: deprecated

--- a/providers/openrouter/o1-mini.yaml
+++ b/providers/openrouter/o1-mini.yaml
@@ -4,3 +4,4 @@ model: o1-mini
 params:
     - key: max_tokens
       maxValue: 65536
+status: deprecated

--- a/providers/openrouter/o1-pro.yaml
+++ b/providers/openrouter/o1-pro.yaml
@@ -27,4 +27,5 @@ removeParams:
     - "n"
 sources:
     - https://openrouter.ai/openai/o1-pro/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/o1.yaml
+++ b/providers/openrouter/o1.yaml
@@ -24,4 +24,5 @@ params:
       maxValue: 100000
 sources:
     - https://openrouter.ai/openai/o1/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/o3-mini-high.yaml
+++ b/providers/openrouter/o3-mini-high.yaml
@@ -23,4 +23,5 @@ params:
       maxValue: 100000
 sources:
     - https://openrouter.ai/openai/o3-mini-high/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/o3-mini.yaml
+++ b/providers/openrouter/o3-mini.yaml
@@ -29,4 +29,5 @@ params:
       type: string
 sources:
     - https://openrouter.ai/openai/o3-mini/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/o3-pro.yaml
+++ b/providers/openrouter/o3-pro.yaml
@@ -23,4 +23,5 @@ params:
       maxValue: 100000
 sources:
     - https://openrouter.ai/openai/o3-pro/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/o3.yaml
+++ b/providers/openrouter/o3.yaml
@@ -24,4 +24,5 @@ params:
       maxValue: 100000
 sources:
     - https://openrouter.ai/openai/o3/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/o4-mini-high.yaml
+++ b/providers/openrouter/o4-mini-high.yaml
@@ -24,4 +24,5 @@ params:
       maxValue: 100000
 sources:
     - https://openrouter.ai/openai/o4-mini-high/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/o4-mini.yaml
+++ b/providers/openrouter/o4-mini.yaml
@@ -25,5 +25,5 @@ params:
       maxValue: 100000
 sources:
     - https://openrouter.ai/openai/o4-mini/api
-status: active
+status: deprecated
 thinking: true

--- a/providers/openrouter/openai/gpt-4.1-2025-04-14.yaml
+++ b/providers/openrouter/openai/gpt-4.1-2025-04-14.yaml
@@ -26,3 +26,4 @@ params:
       maxValue: 32768
 sources:
     - https://openrouter.ai/openai/gpt-4.1-2025-04-14/api
+status: deprecated

--- a/providers/openrouter/openai/gpt-4.1-mini-2025-04-14.yaml
+++ b/providers/openrouter/openai/gpt-4.1-mini-2025-04-14.yaml
@@ -23,4 +23,4 @@ mode: chat
 model: openai/gpt-4.1-mini-2025-04-14
 sources:
     - https://openrouter.ai/openai/gpt-4.1-mini-2025-04-14/api
-status: active
+status: deprecated

--- a/providers/openrouter/openai/gpt-4.1-nano-2025-04-14.yaml
+++ b/providers/openrouter/openai/gpt-4.1-nano-2025-04-14.yaml
@@ -23,3 +23,4 @@ mode: chat
 model: openai/gpt-4.1-nano-2025-04-14
 sources:
     - https://openrouter.ai/openai/gpt-4.1-nano-2025-04-14/api
+status: deprecated

--- a/providers/openrouter/openai/gpt-oss-120b:exacto.yaml
+++ b/providers/openrouter/openai/gpt-oss-120b:exacto.yaml
@@ -22,4 +22,5 @@ params:
       type: string
 sources:
     - https://openrouter.ai/openai/gpt-oss-120b:exacto/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/openai/o1-mini-2024-09-12.yaml
+++ b/providers/openrouter/openai/o1-mini-2024-09-12.yaml
@@ -17,3 +17,4 @@ model: openai/o1-mini-2024-09-12
 sources:
     - https://openrouter.ai/openai/o1-mini-2024-09-12/api
     - https://developers.openai.com/docs/deprecations
+status: deprecated

--- a/providers/openrouter/openai/o1-mini.yaml
+++ b/providers/openrouter/openai/o1-mini.yaml
@@ -12,3 +12,4 @@ limits:
     max_tokens: 65536
 mode: chat
 model: openai/o1-mini
+status: deprecated

--- a/providers/openrouter/openrouter/healer-alpha.yaml
+++ b/providers/openrouter/openrouter/healer-alpha.yaml
@@ -31,4 +31,5 @@ params:
       key: top_p
 sources:
     - https://openrouter.ai/api/v1/models
+status: deprecated
 thinking: true

--- a/providers/openrouter/openrouter/hunter-alpha.yaml
+++ b/providers/openrouter/openrouter/hunter-alpha.yaml
@@ -26,4 +26,5 @@ params:
       minValue: 1
 sources:
     - https://openrouter.ai/openrouter/hunter-alpha/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/phi-3-medium-128k-instruct.yaml
+++ b/providers/openrouter/phi-3-medium-128k-instruct.yaml
@@ -11,4 +11,4 @@ mode: chat
 model: microsoft/phi-3-medium-128k-instruct
 sources:
     - https://openrouter.ai/microsoft/phi-3-medium-128k-instruct/api
-status: active
+status: deprecated

--- a/providers/openrouter/phi-3-mini-128k-instruct.yaml
+++ b/providers/openrouter/phi-3-mini-128k-instruct.yaml
@@ -9,4 +9,4 @@ mode: chat
 model: phi-3-mini-128k-instruct
 sources:
     - https://openrouter.ai/microsoft/phi-3-mini-128k-instruct/api
-status: active
+status: deprecated

--- a/providers/openrouter/phi-3.5-mini-128k-instruct.yaml
+++ b/providers/openrouter/phi-3.5-mini-128k-instruct.yaml
@@ -10,4 +10,4 @@ model: microsoft/phi-3.5-mini-128k-instruct
 sources:
     - https://openrouter.ai/microsoft/phi-3.5-mini-128k-instruct/api
     - https://openrouter.ai/microsoft/phi-3.5-mini-128k-instruct
-status: active
+status: deprecated

--- a/providers/openrouter/phi-4-multimodal-instruct.yaml
+++ b/providers/openrouter/phi-4-multimodal-instruct.yaml
@@ -16,3 +16,4 @@ mode: chat
 model: microsoft/phi-4-multimodal-instruct
 sources:
     - https://openrouter.ai/microsoft/phi-4-multimodal-instruct/api
+status: deprecated

--- a/providers/openrouter/phi-4-reasoning-plus.yaml
+++ b/providers/openrouter/phi-4-reasoning-plus.yaml
@@ -22,4 +22,5 @@ sources:
     - https://openrouter.ai/microsoft/phi-4-reasoning-plus/api
     - https://openrouter.ai/microsoft/phi-4-reasoning-plus/providers
     - https://huggingface.co/microsoft/Phi-4-reasoning-plus
+status: deprecated
 thinking: true

--- a/providers/openrouter/phi-4.yaml
+++ b/providers/openrouter/phi-4.yaml
@@ -24,3 +24,4 @@ params:
       minValue: 1
 sources:
     - https://openrouter.ai/microsoft/phi-4/api
+status: deprecated

--- a/providers/openrouter/pixtral-12b.yaml
+++ b/providers/openrouter/pixtral-12b.yaml
@@ -18,4 +18,4 @@ mode: chat
 model: pixtral-12b
 sources:
     - https://openrouter.ai/mistralai/pixtral-12b/api
-status: active
+status: deprecated

--- a/providers/openrouter/pixtral-large-2411.yaml
+++ b/providers/openrouter/pixtral-large-2411.yaml
@@ -21,3 +21,4 @@ mode: chat
 model: pixtral-large-2411
 sources:
     - https://openrouter.ai/mistralai/pixtral-large-2411/api
+status: deprecated

--- a/providers/openrouter/pygmalionai/mythalion-13b.yaml
+++ b/providers/openrouter/pygmalionai/mythalion-13b.yaml
@@ -13,4 +13,4 @@ mode: chat
 model: pygmalionai/mythalion-13b
 sources:
     - https://openrouter.ai/pygmalionai/mythalion-13b/api
-status: active
+status: deprecated

--- a/providers/openrouter/qwen-2-72b-instruct.yaml
+++ b/providers/openrouter/qwen-2-72b-instruct.yaml
@@ -13,3 +13,4 @@ params:
 sources:
     - https://openrouter.ai/qwen/qwen-2-72b-instruct/api
     - https://openrouter.ai/qwen/qwen-2-72b-instruct
+status: deprecated

--- a/providers/openrouter/qwen-2.5-72b-instruct.yaml
+++ b/providers/openrouter/qwen-2.5-72b-instruct.yaml
@@ -19,3 +19,4 @@ mode: chat
 model: qwen-2.5-72b-instruct
 sources:
     - https://openrouter.ai/qwen/qwen-2.5-72b-instruct/api
+status: deprecated

--- a/providers/openrouter/qwen-2.5-72b-instruct:free.yaml
+++ b/providers/openrouter/qwen-2.5-72b-instruct:free.yaml
@@ -19,3 +19,4 @@ mode: chat
 model: qwen-2.5-72b-instruct:free
 sources:
     - https://openrouter.ai/qwen/qwen-2.5-72b-instruct:free/api
+status: deprecated

--- a/providers/openrouter/qwen-2.5-7b-instruct.yaml
+++ b/providers/openrouter/qwen-2.5-7b-instruct.yaml
@@ -20,3 +20,4 @@ params:
       maxValue: 32768
 sources:
     - https://openrouter.ai/qwen/qwen-2.5-7b-instruct/api
+status: deprecated

--- a/providers/openrouter/qwen-2.5-coder-32b-instruct.yaml
+++ b/providers/openrouter/qwen-2.5-coder-32b-instruct.yaml
@@ -21,3 +21,4 @@ params:
       maxValue: 8192
 sources:
     - https://openrouter.ai/qwen/qwen-2.5-coder-32b-instruct/api
+status: deprecated

--- a/providers/openrouter/qwen-2.5-coder-32b-instruct:free.yaml
+++ b/providers/openrouter/qwen-2.5-coder-32b-instruct:free.yaml
@@ -15,3 +15,4 @@ mode: chat
 model: qwen/qwen-2.5-coder-32b-instruct:free
 sources:
     - https://openrouter.ai/qwen/qwen-2.5-coder-32b-instruct:free/api
+status: deprecated

--- a/providers/openrouter/qwen-2.5-vl-7b-instruct.yaml
+++ b/providers/openrouter/qwen-2.5-vl-7b-instruct.yaml
@@ -16,3 +16,4 @@ mode: chat
 model: qwen/qwen-2.5-vl-7b-instruct
 sources:
     - https://openrouter.ai/qwen/qwen-2.5-vl-7b-instruct/api
+status: deprecated

--- a/providers/openrouter/qwen-max.yaml
+++ b/providers/openrouter/qwen-max.yaml
@@ -24,3 +24,4 @@ params:
       maxValue: 8192
 sources:
     - https://openrouter.ai/qwen/qwen-max/api
+status: deprecated

--- a/providers/openrouter/qwen-plus.yaml
+++ b/providers/openrouter/qwen-plus.yaml
@@ -34,3 +34,4 @@ params:
       maxValue: 32768
 sources:
     - https://openrouter.ai/qwen/qwen-plus/api
+status: deprecated

--- a/providers/openrouter/qwen-turbo.yaml
+++ b/providers/openrouter/qwen-turbo.yaml
@@ -19,3 +19,4 @@ params:
       maxValue: 8192
 sources:
     - https://openrouter.ai/qwen/qwen-turbo/api
+status: deprecated

--- a/providers/openrouter/qwen-vl-max.yaml
+++ b/providers/openrouter/qwen-vl-max.yaml
@@ -23,3 +23,4 @@ params:
       maxValue: 32768
 sources:
     - https://openrouter.ai/qwen/qwen-vl-max/api
+status: deprecated

--- a/providers/openrouter/qwen-vl-plus.yaml
+++ b/providers/openrouter/qwen-vl-plus.yaml
@@ -25,3 +25,4 @@ params:
       maxValue: 8192
 sources:
     - https://openrouter.ai/qwen/qwen-vl-plus/api
+status: deprecated

--- a/providers/openrouter/qwen/qwen-2.5-vl-7b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen-2.5-vl-7b-instruct.yaml
@@ -14,3 +14,4 @@ mode: chat
 model: qwen/qwen-2.5-vl-7b-instruct
 sources:
     - https://openrouter.ai/qwen/qwen-2.5-vl-7b-instruct/api
+status: deprecated

--- a/providers/openrouter/qwen/qwen3-4b:free.yaml
+++ b/providers/openrouter/qwen/qwen3-4b:free.yaml
@@ -18,4 +18,5 @@ mode: chat
 model: qwen/qwen3-4b:free
 sources:
     - https://openrouter.ai/qwen/qwen3-4b:free/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/qwen/qwen3-coder:exacto.yaml
+++ b/providers/openrouter/qwen/qwen3-coder:exacto.yaml
@@ -19,3 +19,4 @@ mode: chat
 model: qwen/qwen3-coder:exacto
 sources:
     - https://openrouter.ai/qwen/qwen3-coder:exacto/api
+status: deprecated

--- a/providers/openrouter/qwen2.5-vl-32b-instruct.yaml
+++ b/providers/openrouter/qwen2.5-vl-32b-instruct.yaml
@@ -18,4 +18,4 @@ mode: chat
 model: qwen2.5-vl-32b-instruct
 sources:
     - https://openrouter.ai/qwen/qwen2.5-vl-32b-instruct/api
-status: active
+status: deprecated

--- a/providers/openrouter/qwen2.5-vl-32b-instruct:free.yaml
+++ b/providers/openrouter/qwen2.5-vl-32b-instruct:free.yaml
@@ -17,4 +17,4 @@ model: qwen2.5-vl-32b-instruct:free
 sources:
     - https://openrouter.ai/qwen/qwen2.5-vl-32b-instruct:free/api
     - https://openrouter.ai/qwen/qwen2.5-vl-32b-instruct:free
-status: active
+status: deprecated

--- a/providers/openrouter/qwen2.5-vl-72b-instruct.yaml
+++ b/providers/openrouter/qwen2.5-vl-72b-instruct.yaml
@@ -16,3 +16,4 @@ mode: chat
 model: qwen2.5-vl-72b-instruct
 sources:
     - https://openrouter.ai/qwen/qwen2.5-vl-72b-instruct/api
+status: deprecated

--- a/providers/openrouter/qwen2.5-vl-72b-instruct:free.yaml
+++ b/providers/openrouter/qwen2.5-vl-72b-instruct:free.yaml
@@ -15,3 +15,4 @@ model: qwen2.5-vl-72b-instruct:free
 sources:
     - https://openrouter.ai/qwen/qwen2.5-vl-72b-instruct:free/api
     - https://openrouter.ai/qwen/qwen2.5-vl-72b-instruct/api
+status: deprecated

--- a/providers/openrouter/qwen3-14b.yaml
+++ b/providers/openrouter/qwen3-14b.yaml
@@ -18,4 +18,5 @@ mode: chat
 model: qwen3-14b
 sources:
     - https://openrouter.ai/qwen/qwen3-14b/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/qwen3-14b:free.yaml
+++ b/providers/openrouter/qwen3-14b:free.yaml
@@ -20,4 +20,5 @@ mode: chat
 model: qwen3-14b:free
 sources:
     - https://openrouter.ai/qwen/qwen3-14b:free/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/qwen3-235b-a22b-2507.yaml
+++ b/providers/openrouter/qwen3-235b-a22b-2507.yaml
@@ -17,3 +17,4 @@ mode: chat
 model: qwen3-235b-a22b-2507
 sources:
     - https://openrouter.ai/qwen/qwen3-235b-a22b-2507/api
+status: deprecated

--- a/providers/openrouter/qwen3-235b-a22b-thinking-2507.yaml
+++ b/providers/openrouter/qwen3-235b-a22b-thinking-2507.yaml
@@ -19,4 +19,5 @@ mode: chat
 model: qwen3-235b-a22b-thinking-2507
 sources:
     - https://openrouter.ai/qwen/qwen3-235b-a22b-thinking-2507/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/qwen3-235b-a22b.yaml
+++ b/providers/openrouter/qwen3-235b-a22b.yaml
@@ -23,4 +23,5 @@ params:
       maxValue: 8192
 sources:
     - https://openrouter.ai/qwen/qwen3-235b-a22b/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/qwen3-235b-a22b:free.yaml
+++ b/providers/openrouter/qwen3-235b-a22b:free.yaml
@@ -19,5 +19,5 @@ model: qwen3-235b-a22b:free
 sources:
     - https://openrouter.ai/qwen/qwen3-235b-a22b:free/api
     - https://openrouter.ai/qwen/qwen3-235b-a22b/api
-status: active
+status: deprecated
 thinking: true

--- a/providers/openrouter/qwen3-30b-a3b-instruct-2507.yaml
+++ b/providers/openrouter/qwen3-30b-a3b-instruct-2507.yaml
@@ -22,3 +22,4 @@ params:
       maxValue: 262144
 sources:
     - https://openrouter.ai/qwen/qwen3-30b-a3b-instruct-2507/api
+status: deprecated

--- a/providers/openrouter/qwen3-30b-a3b.yaml
+++ b/providers/openrouter/qwen3-30b-a3b.yaml
@@ -22,4 +22,5 @@ params:
       maxValue: 40960
 sources:
     - https://openrouter.ai/qwen/qwen3-30b-a3b/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/qwen3-30b-a3b:free.yaml
+++ b/providers/openrouter/qwen3-30b-a3b:free.yaml
@@ -18,5 +18,5 @@ mode: chat
 model: qwen3-30b-a3b:free
 sources:
     - https://openrouter.ai/qwen/qwen3-30b-a3b:free/api
-status: active
+status: deprecated
 thinking: true

--- a/providers/openrouter/qwen3-32b.yaml
+++ b/providers/openrouter/qwen3-32b.yaml
@@ -20,4 +20,5 @@ mode: chat
 model: qwen3-32b
 sources:
     - https://openrouter.ai/qwen/qwen3-32b/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/qwen3-4b:free.yaml
+++ b/providers/openrouter/qwen3-4b:free.yaml
@@ -18,4 +18,5 @@ mode: chat
 model: qwen3-4b:free
 sources:
     - https://openrouter.ai/qwen/qwen3-4b:free/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/qwen3-8b.yaml
+++ b/providers/openrouter/qwen3-8b.yaml
@@ -21,5 +21,5 @@ params:
       maxValue: 8192
 sources:
     - https://openrouter.ai/qwen/qwen3-8b/api
-status: active
+status: deprecated
 thinking: true

--- a/providers/openrouter/qwen3-8b:free.yaml
+++ b/providers/openrouter/qwen3-8b:free.yaml
@@ -23,4 +23,5 @@ params:
       maxValue: 8192
 sources:
     - https://openrouter.ai/qwen/qwen3-8b:free/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/qwen3-coder.yaml
+++ b/providers/openrouter/qwen3-coder.yaml
@@ -18,3 +18,4 @@ mode: chat
 model: qwen3-coder
 sources:
     - https://openrouter.ai/qwen/qwen3-coder/api
+status: deprecated

--- a/providers/openrouter/qwen3-coder:free.yaml
+++ b/providers/openrouter/qwen3-coder:free.yaml
@@ -21,3 +21,4 @@ model: qwen3-coder:free
 sources:
     - https://openrouter.ai/qwen/qwen3-coder:free/api
     - https://openrouter.ai/qwen/qwen3-coder/api
+status: deprecated

--- a/providers/openrouter/qwerky-72b:free.yaml
+++ b/providers/openrouter/qwerky-72b:free.yaml
@@ -9,3 +9,4 @@ params:
       maxValue: 4096
 sources:
     - https://openrouter.ai/qwen/qwerky-72b:free/api
+status: deprecated

--- a/providers/openrouter/qwq-32b-arliai-rpr-v1.yaml
+++ b/providers/openrouter/qwq-32b-arliai-rpr-v1.yaml
@@ -10,5 +10,5 @@ model: qwq-32b-arliai-rpr-v1
 sources:
     - https://openrouter.ai/arliai/qwq-32b-arliai-rpr-v1/api
     - https://openrouter.ai/arliai/qwq-32b-arliai-rpr-v1
-status: active
+status: deprecated
 thinking: true

--- a/providers/openrouter/qwq-32b-arliai-rpr-v1:free.yaml
+++ b/providers/openrouter/qwq-32b-arliai-rpr-v1:free.yaml
@@ -15,5 +15,5 @@ mode: chat
 model: qwq-32b-arliai-rpr-v1:free
 sources:
     - https://openrouter.ai/arliai/qwq-32b-arliai-rpr-v1:free/api
-status: active
+status: deprecated
 thinking: true

--- a/providers/openrouter/qwq-32b.yaml
+++ b/providers/openrouter/qwq-32b.yaml
@@ -18,4 +18,5 @@ mode: chat
 model: qwq-32b
 sources:
     - https://openrouter.ai/qwen/qwq-32b/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/qwq-32b:free.yaml
+++ b/providers/openrouter/qwq-32b:free.yaml
@@ -18,4 +18,5 @@ model: qwq-32b:free
 sources:
     - https://openrouter.ai/qwen/qwq-32b:free/api
     - https://openrouter.ai/qwen/qwq-32b/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/r1-1776.yaml
+++ b/providers/openrouter/r1-1776.yaml
@@ -11,5 +11,5 @@ mode: chat
 model: r1-1776
 sources:
     - https://openrouter.ai/perplexity/r1-1776/api
-status: active
+status: deprecated
 thinking: true

--- a/providers/openrouter/raifle/sorcererlm-8x22b.yaml
+++ b/providers/openrouter/raifle/sorcererlm-8x22b.yaml
@@ -9,4 +9,4 @@ mode: chat
 model: raifle/sorcererlm-8x22b
 sources:
     - https://openrouter.ai/raifle/sorcererlm-8x22b/api
-status: active
+status: deprecated

--- a/providers/openrouter/reka-flash-3.yaml
+++ b/providers/openrouter/reka-flash-3.yaml
@@ -38,3 +38,4 @@ sources:
     - https://docs.reka.ai/pricing
     - https://docs.reka.ai/chat/models
     - https://docs.reka.ai/chat/api-reference/create
+status: deprecated

--- a/providers/openrouter/reka-flash-3:free.yaml
+++ b/providers/openrouter/reka-flash-3:free.yaml
@@ -24,3 +24,4 @@ sources:
     - https://docs.reka.ai/chat/models
     - https://docs.reka.ai/chat/function-calling
     - https://docs.reka.ai/chat/chat-with-image-video-and-audio
+status: deprecated

--- a/providers/openrouter/reka/reka-edge.yaml
+++ b/providers/openrouter/reka/reka-edge.yaml
@@ -21,3 +21,4 @@ mode: chat
 model: reka/reka-edge
 sources:
     - https://openrouter.ai/reka/reka-edge/api
+status: deprecated

--- a/providers/openrouter/remm-slerp-l2-13b.yaml
+++ b/providers/openrouter/remm-slerp-l2-13b.yaml
@@ -17,3 +17,4 @@ mode: chat
 model: remm-slerp-l2-13b
 sources:
     - https://openrouter.ai/undi95/remm-slerp-l2-13b/api
+status: deprecated

--- a/providers/openrouter/rocinante-12b.yaml
+++ b/providers/openrouter/rocinante-12b.yaml
@@ -19,3 +19,4 @@ mode: chat
 model: rocinante-12b
 sources:
     - https://openrouter.ai/thedrummer/rocinante-12b/api
+status: deprecated

--- a/providers/openrouter/router.yaml
+++ b/providers/openrouter/router.yaml
@@ -16,4 +16,4 @@ model: router
 sources:
     - https://openrouter.ai/openrouter/auto/api
     - https://openrouter.ai/docs/guides/routing/routers/auto-router
-status: active
+status: deprecated

--- a/providers/openrouter/sarvam-m.yaml
+++ b/providers/openrouter/sarvam-m.yaml
@@ -9,5 +9,5 @@ mode: chat
 model: sarvam-m
 sources:
     - https://openrouter.ai/sarvamai/sarvam-m/api
-status: active
+status: deprecated
 thinking: true

--- a/providers/openrouter/sarvam-m:free.yaml
+++ b/providers/openrouter/sarvam-m:free.yaml
@@ -13,5 +13,5 @@ mode: chat
 model: sarvam-m:free
 sources:
     - https://openrouter.ai/sarvamai/sarvam-m:free/api
-status: active
+status: deprecated
 thinking: true

--- a/providers/openrouter/shisa-v2-llama3.3-70b.yaml
+++ b/providers/openrouter/shisa-v2-llama3.3-70b.yaml
@@ -3,3 +3,4 @@ limits:
     max_tokens: 4096
 mode: chat
 model: shisa-v2-llama3.3-70b
+status: deprecated

--- a/providers/openrouter/shisa-v2-llama3.3-70b:free.yaml
+++ b/providers/openrouter/shisa-v2-llama3.3-70b:free.yaml
@@ -3,3 +3,4 @@ limits:
     max_tokens: 4096
 mode: chat
 model: shisa-v2-llama3.3-70b:free
+status: deprecated

--- a/providers/openrouter/skyfall-36b-v2.yaml
+++ b/providers/openrouter/skyfall-36b-v2.yaml
@@ -5,3 +5,4 @@ mode: chat
 model: skyfall-36b-v2
 sources:
     - https://openrouter.ai/skyfall-36b-v2/api
+status: deprecated

--- a/providers/openrouter/sonar-deep-research.yaml
+++ b/providers/openrouter/sonar-deep-research.yaml
@@ -14,4 +14,5 @@ mode: chat
 model: sonar-deep-research
 sources:
     - https://openrouter.ai/perplexity/sonar-deep-research/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/sonar-pro.yaml
+++ b/providers/openrouter/sonar-pro.yaml
@@ -23,3 +23,4 @@ params:
       maxValue: 8000
 sources:
     - https://openrouter.ai/perplexity/sonar-pro/api
+status: deprecated

--- a/providers/openrouter/sonar-reasoning-pro.yaml
+++ b/providers/openrouter/sonar-reasoning-pro.yaml
@@ -18,4 +18,5 @@ mode: chat
 model: sonar-reasoning-pro
 sources:
     - https://openrouter.ai/perplexity/sonar-reasoning-pro/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/sonar-reasoning.yaml
+++ b/providers/openrouter/sonar-reasoning.yaml
@@ -16,5 +16,5 @@ sources:
     - https://docs.perplexity.ai/guides/pricing
     - https://docs.perplexity.ai/guides/model-cards
     - https://docs.perplexity.ai/docs/sonar/models/sonar-reasoning-pro
-status: active
+status: deprecated
 thinking: true

--- a/providers/openrouter/sonar.yaml
+++ b/providers/openrouter/sonar.yaml
@@ -18,3 +18,4 @@ mode: chat
 model: sonar
 sources:
     - https://openrouter.ai/perplexity/sonar/api
+status: deprecated

--- a/providers/openrouter/sorcererlm-8x22b.yaml
+++ b/providers/openrouter/sorcererlm-8x22b.yaml
@@ -11,4 +11,4 @@ mode: chat
 model: sorcererlm-8x22b
 sources:
     - https://openrouter.ai/raifle/sorcererlm-8x22b/api
-status: active
+status: deprecated

--- a/providers/openrouter/spotlight.yaml
+++ b/providers/openrouter/spotlight.yaml
@@ -11,3 +11,4 @@ params:
       maxValue: 65537
 sources:
     - https://openrouter.ai/spotlight/api
+status: deprecated

--- a/providers/openrouter/toppy-m-7b.yaml
+++ b/providers/openrouter/toppy-m-7b.yaml
@@ -14,3 +14,4 @@ params:
       maxValue: 4096
 sources:
     - https://openrouter.ai/undi95/toppy-m-7b/api
+status: deprecated

--- a/providers/openrouter/ui-tars-1.5-7b.yaml
+++ b/providers/openrouter/ui-tars-1.5-7b.yaml
@@ -19,3 +19,4 @@ params:
       maxValue: 2048
 sources:
     - https://openrouter.ai/bytedance/ui-tars-1.5-7b/api
+status: deprecated

--- a/providers/openrouter/unslopnemo-12b.yaml
+++ b/providers/openrouter/unslopnemo-12b.yaml
@@ -18,3 +18,4 @@ mode: chat
 model: unslopnemo-12b
 sources:
     - https://openrouter.ai/thedrummer/unslopnemo-12b/api
+status: deprecated

--- a/providers/openrouter/valkyrie-49b-v1.yaml
+++ b/providers/openrouter/valkyrie-49b-v1.yaml
@@ -10,3 +10,4 @@ params:
       maxValue: 131072
 sources:
     - https://openrouter.ai/valkyrie-49b-v1/api
+status: deprecated

--- a/providers/openrouter/virtuoso-large.yaml
+++ b/providers/openrouter/virtuoso-large.yaml
@@ -22,3 +22,4 @@ params:
       maxValue: 64000
 sources:
     - https://openrouter.ai/arcee-ai/virtuoso-large/api
+status: deprecated

--- a/providers/openrouter/weaver.yaml
+++ b/providers/openrouter/weaver.yaml
@@ -5,3 +5,4 @@ params:
       maxValue: 1000
 sources:
     - https://openrouter.ai/weaver/api
+status: deprecated

--- a/providers/openrouter/wizardlm-2-8x22b.yaml
+++ b/providers/openrouter/wizardlm-2-8x22b.yaml
@@ -22,3 +22,4 @@ params:
       maxValue: 8000
 sources:
     - https://openrouter.ai/microsoft/wizardlm-2-8x22b/api
+status: deprecated

--- a/providers/openrouter/x-ai/grok-4-fast:free.yaml
+++ b/providers/openrouter/x-ai/grok-4-fast:free.yaml
@@ -23,4 +23,5 @@ sources:
     - https://openrouter.ai/x-ai/grok-4-fast:free/api
     - https://docs.x.ai/developers/models#models-and-pricing
     - https://openrouter.ai/x-ai/grok-4-fast/api
+status: deprecated
 thinking: true

--- a/providers/openrouter/x-ai/grok-4.20-beta.yaml
+++ b/providers/openrouter/x-ai/grok-4.20-beta.yaml
@@ -27,4 +27,5 @@ model: x-ai/grok-4.20-beta
 sources:
     - https://openrouter.ai/x-ai/grok-4.20-beta/api
     - https://docs.x.ai/developers/models#models-and-pricing
+status: deprecated
 thinking: true

--- a/providers/openrouter/x-ai/grok-4.20-multi-agent-beta.yaml
+++ b/providers/openrouter/x-ai/grok-4.20-multi-agent-beta.yaml
@@ -27,4 +27,5 @@ model: x-ai/grok-4.20-multi-agent-beta
 sources:
     - https://openrouter.ai/x-ai/grok-4.20-multi-agent-beta/api
     - https://docs.x.ai/developers/models#models-and-pricing
+status: deprecated
 thinking: true

--- a/providers/openrouter/z-ai/glm-4.6:exacto.yaml
+++ b/providers/openrouter/z-ai/glm-4.6:exacto.yaml
@@ -19,4 +19,5 @@ mode: chat
 model: z-ai/glm-4.6:exacto
 sources:
     - https://openrouter.ai/z-ai/glm-4.6:exacto/api
+status: deprecated
 thinking: true


### PR DESCRIPTION
Auto-generated by model-deprecation script for provider `openrouter`.

Sets `status: deprecated` on model YAML files whose `model` ID no longer appears in the OpenRouter API response.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk metadata-only change, but it may affect any tooling/UI that filters or routes models based on the new `status: deprecated` flag (including models previously marked `active`/`preview`).
> 
> **Overview**
> Marks a large set of OpenRouter model definition YAMLs as **deprecated** by adding `status: deprecated` (and, where present, overriding prior `status: active`/`preview`).
> 
> No runtime logic changes; this is a catalog/metadata update intended to flag models that no longer appear in the OpenRouter API response.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit febd016c72ca6dc836b0bbb7b2a5c99d9af2a7d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->