### PR TITLE
fix: retire removed model

### DIFF
--- a/providers/sambanova/DeepSeek-R1-Distill-Llama-70B.yaml
+++ b/providers/sambanova/DeepSeek-R1-Distill-Llama-70B.yaml
@@ -13,5 +13,5 @@ mode: chat
 model: DeepSeek-R1-Distill-Llama-70B
 sources:
     - https://docs.sambanova.ai/docs/en/features/function-calling
-status: active
+status: retired
 thinking: true

--- a/providers/sambanova/DeepSeek-R1-Distill-Llama-70B.yaml
+++ b/providers/sambanova/DeepSeek-R1-Distill-Llama-70B.yaml
@@ -2,6 +2,7 @@ costs:
     - input_cost_per_token: 7.e-7
       output_cost_per_token: 0.0000014
       region: "*"
+isDeprecated: true
 limits:
     context_window: 128000
 modalities:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk config-only change that deprecates a single model entry; potential impact is limited to model discovery/availability if any consumers still reference it.
> 
> **Overview**
> Marks the SambaNova `DeepSeek-R1-Distill-Llama-70B` model as no longer available by setting `isDeprecated: true` and changing its `status` from `active` to `retired` in the provider YAML.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b451b514dc6e8c70073d928c6c151b5b2a24e295. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->