### PR TITLE
feat(aws-bedrock): update model YAMLs [bot]

### DIFF
--- a/providers/aws-bedrock/amazon.titan-tg1-large.yaml
+++ b/providers/aws-bedrock/amazon.titan-tg1-large.yaml
@@ -10,6 +10,10 @@ limits:
     max_input_tokens: 8000
     max_output_tokens: 8000
     max_tokens: 8000
+messages:
+    options:
+        - user
+        - assistant
 modalities:
     input:
         - text
@@ -24,6 +28,8 @@ params:
       minValue: 1
     - defaultValue: 0.7
       key: temperature
+removeParams:
+    - "n"
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-titan-text.html
     - https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference-supported-models-features.html

--- a/providers/aws-bedrock/anthropic.claude-opus-4-6-v1.yaml
+++ b/providers/aws-bedrock/anthropic.claude-opus-4-6-v1.yaml
@@ -191,4 +191,5 @@ removeParams:
 sources:
     - https://platform.claude.com/docs/en/docs/about-claude/models
     - https://platform.claude.com/docs/en/docs/about-claude/pricing
+status: active
 thinking: true

--- a/providers/aws-bedrock/anthropic.claude-sonnet-4-6.yaml
+++ b/providers/aws-bedrock/anthropic.claude-sonnet-4-6.yaml
@@ -224,8 +224,11 @@ costs:
       output_cost_per_token_batches: 0.0000075
       region: af-south-1
 features:
+    - assistant_prefill
+    - cache_control
     - function_calling
     - prompt_caching
+    - tool_choice
 limits:
     context_window: 1000000
     max_input_tokens: 1000000

--- a/providers/aws-bedrock/meta.llama3-1-8b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/meta.llama3-1-8b-instruct-v1:0.yaml
@@ -24,6 +24,7 @@ limits:
 modalities:
     input:
         - text
+        - pdf
     output:
         - text
 mode: chat

--- a/providers/aws-bedrock/minimax.minimax-m2.5.yaml
+++ b/providers/aws-bedrock/minimax.minimax-m2.5.yaml
@@ -8,14 +8,71 @@ costs:
       cache_read_input_token_cost: 3.e-8
       input_cost_per_token: 3.e-7
       output_cost_per_token: 0.0000012
+      region: us-east-2
+    - cache_creation_input_token_cost: 3.75e-7
+      cache_read_input_token_cost: 3.e-8
+      input_cost_per_token: 3.e-7
+      output_cost_per_token: 0.0000012
       region: us-east-1
+    - cache_creation_input_token_cost: 3.75e-7
+      cache_read_input_token_cost: 3.e-8
+      input_cost_per_token: 3.e-7
+      output_cost_per_token: 0.0000012
+      region: sa-east-1
+    - cache_creation_input_token_cost: 3.75e-7
+      cache_read_input_token_cost: 3.e-8
+      input_cost_per_token: 3.e-7
+      output_cost_per_token: 0.0000012
+      region: eu-west-2
+    - cache_creation_input_token_cost: 3.75e-7
+      cache_read_input_token_cost: 3.e-8
+      input_cost_per_token: 3.e-7
+      output_cost_per_token: 0.0000012
+      region: eu-west-1
+    - cache_creation_input_token_cost: 3.75e-7
+      cache_read_input_token_cost: 3.e-8
+      input_cost_per_token: 3.e-7
+      output_cost_per_token: 0.0000012
+      region: eu-south-1
+    - cache_creation_input_token_cost: 3.75e-7
+      cache_read_input_token_cost: 3.e-8
+      input_cost_per_token: 3.e-7
+      output_cost_per_token: 0.0000012
+      region: eu-north-1
+    - cache_creation_input_token_cost: 3.75e-7
+      cache_read_input_token_cost: 3.e-8
+      input_cost_per_token: 3.e-7
+      output_cost_per_token: 0.0000012
+      region: eu-central-1
+    - cache_creation_input_token_cost: 3.75e-7
+      cache_read_input_token_cost: 3.e-8
+      input_cost_per_token: 3.e-7
+      output_cost_per_token: 0.0000012
+      region: ap-southeast-3
+    - cache_creation_input_token_cost: 3.75e-7
+      cache_read_input_token_cost: 3.e-8
+      input_cost_per_token: 3.e-7
+      output_cost_per_token: 0.0000012
+      region: ap-southeast-2
+    - cache_creation_input_token_cost: 3.75e-7
+      cache_read_input_token_cost: 3.e-8
+      input_cost_per_token: 3.e-7
+      output_cost_per_token: 0.0000012
+      region: ap-south-1
+    - cache_creation_input_token_cost: 3.75e-7
+      cache_read_input_token_cost: 3.e-8
+      input_cost_per_token: 3.e-7
+      output_cost_per_token: 0.0000012
+      region: ap-northeast-1
 features:
     - function_calling
     - system_messages
     - tool_choice
     - prompt_caching
 limits:
-    context_window: 204800
+    context_window: 1000000
+    max_output_tokens: 8000
+    max_tokens: 8000
 modalities:
     input:
         - text
@@ -23,12 +80,14 @@ modalities:
         - text
 mode: chat
 model: minimax.minimax-m2.5
+params:
+    - key: max_tokens
+      maxValue: 8000
 removeParams:
     - "n"
     - stop
 sources:
-    - https://aws.amazon.com/about-aws/whats-new/2026/03/amazon-bedrock-minimax-glm/
-    - https://platform.minimax.io/docs/api-reference/api-overview
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-minimax-minimax-m2-5.html
     - https://platform.minimax.io/docs/guides/pricing-paygo
     - https://platform.minimax.io/docs/api-reference/text-anthropic-api
     - https://www.minimax.io/news/minimax-m25

--- a/providers/aws-bedrock/mistral.devstral-2-123b.yaml
+++ b/providers/aws-bedrock/mistral.devstral-2-123b.yaml
@@ -42,7 +42,7 @@ features:
     - function_calling
     - structured_output
 limits:
-    context_window: 128000
+    context_window: 256000
     max_output_tokens: 32000
     max_tokens: 32000
 modalities:

--- a/providers/aws-bedrock/nvidia.nemotron-super-3-120b.yaml
+++ b/providers/aws-bedrock/nvidia.nemotron-super-3-120b.yaml
@@ -44,6 +44,8 @@ features:
     - system_messages
     - structured_output
 limits:
+    context_window: 262144
+    max_input_tokens: 262144
     max_output_tokens: 32768
     max_tokens: 32768
 modalities:
@@ -59,7 +61,7 @@ params:
 removeParams:
     - "n"
 sources:
-    - https://build.nvidia.com/nvidia/nemotron-3-super-120b-a12b/modelcard
+    - https://build.nvidia.com/nvidia/nemotron-3-super-120b/modelcard
     - https://aws.amazon.com/marketplace/pp/prodview-pb4o36dbo6dzi
     - https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16
 thinking: true


### PR DESCRIPTION
Auto-generated by poc-agent for provider `aws-bedrock`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only updates to Bedrock model metadata (limits, features, regions, params) with no runtime logic changes; primary risk is misconfigured values impacting model selection/validation at runtime.
> 
> **Overview**
> Updates several `aws-bedrock` model YAMLs to reflect current Bedrock capabilities and constraints.
> 
> Adds/adjusts model metadata including supported `messages` roles (Titan), expanded feature flags (Claude Sonnet), new input modality support (`pdf` for Llama 3.1), updated regional pricing entries (MiniMax), and revised token limits/context windows (MiniMax, Mistral Devstral, NVIDIA Nemotron). Also standardizes `removeParams` (e.g., drop unsupported `n`) and marks Opus as `status: active` with updated sources.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b8578e1e564dec014fbe6d562ae9bb85a8c62d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->