### PR TITLE
feat(deepinfra): update model YAMLs [bot]

### DIFF
--- a/providers/deepinfra/Bria/fibo.yaml
+++ b/providers/deepinfra/Bria/fibo.yaml
@@ -11,3 +11,4 @@ mode: image
 model: Bria/fibo
 sources:
     - https://deepinfra.com/Bria/fibo/api
+status: active

--- a/providers/deepinfra/Bria/remove_background.yaml
+++ b/providers/deepinfra/Bria/remove_background.yaml
@@ -10,3 +10,4 @@ mode: image
 model: Bria/remove_background
 sources:
     - https://deepinfra.com/Bria/remove_background/api
+status: active

--- a/providers/deepinfra/ByteDance/Seed-1.8.yaml
+++ b/providers/deepinfra/ByteDance/Seed-1.8.yaml
@@ -31,3 +31,4 @@ mode: chat
 model: ByteDance/Seed-1.8
 sources:
     - https://deepinfra.com/ByteDance/Seed-1.8/api
+thinking: true

--- a/providers/deepinfra/ByteDance/Seed-2.0-mini.yaml
+++ b/providers/deepinfra/ByteDance/Seed-2.0-mini.yaml
@@ -15,6 +15,7 @@ costs:
                 from: 128000
 features:
     - function_calling
+    - json_output
     - prompt_caching
     - structured_output
 limits:

--- a/providers/deepinfra/MiniMaxAI/MiniMax-M2.1.yaml
+++ b/providers/deepinfra/MiniMaxAI/MiniMax-M2.1.yaml
@@ -7,10 +7,16 @@ features:
     - prompt_caching
     - function_calling
     - structured_output
+    - json_output
 limits:
     context_window: 196608
     max_output_tokens: 131072
     max_tokens: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: MiniMaxAI/MiniMax-M2.1
 sources:

--- a/providers/deepinfra/PaddlePaddle/PaddleOCR-VL-0.9B.yaml
+++ b/providers/deepinfra/PaddlePaddle/PaddleOCR-VL-0.9B.yaml
@@ -4,6 +4,8 @@ costs:
       region: "*"
 features:
     - structured_output
+    - json_output
+    - prompt_caching
 limits:
     context_window: 16384
     max_output_tokens: 8192

--- a/providers/deepinfra/black-forest-labs/FLUX-1-dev.yaml
+++ b/providers/deepinfra/black-forest-labs/FLUX-1-dev.yaml
@@ -10,3 +10,4 @@ mode: image
 model: black-forest-labs/FLUX-1-dev
 sources:
     - https://api.deepinfra.com/models/black-forest-labs/FLUX-1-dev
+status: active

--- a/providers/deepinfra/black-forest-labs/FLUX-1-schnell.yaml
+++ b/providers/deepinfra/black-forest-labs/FLUX-1-schnell.yaml
@@ -10,3 +10,4 @@ mode: image
 model: black-forest-labs/FLUX-1-schnell
 sources:
     - https://deepinfra.com/black-forest-labs/FLUX-1-schnell/api
+status: active

--- a/providers/deepinfra/black-forest-labs/FLUX-2-klein-9b.yaml
+++ b/providers/deepinfra/black-forest-labs/FLUX-2-klein-9b.yaml
@@ -3,6 +3,8 @@ costs:
       region: "*"
 modalities:
     input:
+        - text
+    output:
         - image
 mode: image
 model: black-forest-labs/FLUX-2-klein-9b

--- a/providers/deepinfra/black-forest-labs/FLUX-2-max.yaml
+++ b/providers/deepinfra/black-forest-labs/FLUX-2-max.yaml
@@ -1,5 +1,6 @@
 costs:
-    - output_cost_per_image: 0.07
+    - input_cost_per_image: 0.03 
+      output_cost_per_image: 0.07
       region: "*"
 modalities:
     input:

--- a/providers/deepinfra/black-forest-labs/FLUX-2-max.yaml
+++ b/providers/deepinfra/black-forest-labs/FLUX-2-max.yaml
@@ -1,6 +1,5 @@
 costs:
-    - input_cost_per_image: 0.03
-      output_cost_per_image: 0.07
+    - output_cost_per_image: 0.07
       region: "*"
 modalities:
     input:
@@ -12,3 +11,4 @@ mode: image
 model: black-forest-labs/FLUX-2-max
 sources:
     - https://deepinfra.com/black-forest-labs/FLUX-2-max/api
+status: active

--- a/providers/deepinfra/moonshotai/Kimi-K2.5-Turbo.yaml
+++ b/providers/deepinfra/moonshotai/Kimi-K2.5-Turbo.yaml
@@ -7,9 +7,12 @@ features:
     - prompt_caching
     - function_calling
     - structured_output
+    - json_output
 limits:
     context_window: 262144
     max_input_tokens: 262144
+    max_output_tokens: 64000
+    max_tokens: 64000
 modalities:
     input:
         - text

--- a/providers/deepinfra/sentence-transformers/multi-qa-mpnet-base-dot-v1.yaml
+++ b/providers/deepinfra/sentence-transformers/multi-qa-mpnet-base-dot-v1.yaml
@@ -14,3 +14,4 @@ model: sentence-transformers/multi-qa-mpnet-base-dot-v1
 sources:
     - https://deepinfra.com/sentence-transformers/multi-qa-mpnet-base-dot-v1/api
     - https://huggingface.co/sentence-transformers/multi-qa-mpnet-base-dot-v1
+status: active

--- a/providers/deepinfra/sentence-transformers/paraphrase-MiniLM-L6-v2.yaml
+++ b/providers/deepinfra/sentence-transformers/paraphrase-MiniLM-L6-v2.yaml
@@ -13,3 +13,4 @@ mode: embedding
 model: sentence-transformers/paraphrase-MiniLM-L6-v2
 sources:
     - https://deepinfra.com/sentence-transformers/paraphrase-MiniLM-L6-v2/api
+status: active

--- a/providers/deepinfra/zai-org/GLM-4.7.yaml
+++ b/providers/deepinfra/zai-org/GLM-4.7.yaml
@@ -7,6 +7,7 @@ features:
     - prompt_caching
     - function_calling
     - structured_output
+    - json_output
 limits:
     context_window: 202752
     max_input_tokens: 202752


### PR DESCRIPTION
Auto-generated by poc-agent for provider `deepinfra`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only changes updating model capability metadata and limits; primary risk is misconfigured flags (e.g., `json_output`, `thinking`, modalities/limits) affecting model selection or validation.
> 
> **Overview**
> Updates several DeepInfra provider model YAMLs to reflect current capabilities and availability.
> 
> Marks multiple models as **active**, adds/expands declared capabilities (notably `json_output` and `thinking`), and adjusts metadata such as modalities and token limits (e.g., adds missing `modalities` for `MiniMax-M2.1`, sets max output/tokens for `Kimi-K2.5-Turbo`, and fixes `FLUX-2-klein-9b` input/output modality declaration).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63047cf22a529f0f56ce8a8593bff227f9341ee5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->