### PR TITLE
feat(google-gemini): update model YAMLs [bot]

### DIFF
--- a/providers/google-gemini/aqa.yaml
+++ b/providers/google-gemini/aqa.yaml
@@ -8,5 +8,5 @@ modalities:
         - text
     output:
         - text
-mode: unknown
+mode: chat
 model: aqa

--- a/providers/google-gemini/gemini-2.5-flash-native-audio-preview-12-2025.yaml
+++ b/providers/google-gemini/gemini-2.5-flash-native-audio-preview-12-2025.yaml
@@ -1,7 +1,6 @@
 costs:
     - input_cost_per_audio_token: 0.000003
       input_cost_per_token: 5.e-7
-      input_cost_per_video_token: 0.000003
       output_cost_per_audio_token: 0.000012
       output_cost_per_token: 0.000002
       region: "*"

--- a/providers/google-gemini/gemini-2.5-flash-native-audio-preview-12-2025.yaml
+++ b/providers/google-gemini/gemini-2.5-flash-native-audio-preview-12-2025.yaml
@@ -1,6 +1,7 @@
 costs:
     - input_cost_per_audio_token: 0.000003
       input_cost_per_token: 5.e-7
+      input_cost_per_video_token: 0.000003
       output_cost_per_audio_token: 0.000012
       output_cost_per_token: 0.000002
       region: "*"

--- a/providers/google-gemini/lyria-3-pro-preview.yaml
+++ b/providers/google-gemini/lyria-3-pro-preview.yaml
@@ -8,7 +8,7 @@ modalities:
     output:
         - audio
         - text
-mode: unknown
+mode: text_to_speech
 model: lyria-3-pro-preview
 params:
     - defaultValue: 1
@@ -20,6 +20,8 @@ params:
       key: top_k
 removeParams:
     - max_tokens
+    - stop
+    - tool_choice
 sources:
     - https://ai.google.dev/gemini-api/docs/music-generation
 status: preview


### PR DESCRIPTION
Auto-generated by poc-agent for provider `google-gemini`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only changes adjusting model metadata (`mode`) and filtering of unsupported parameters; main impact is on request shaping for affected models.
> 
> **Overview**
> Updates the Google Gemini model YAMLs to use explicit `mode` values: `aqa` is now marked as `chat`, and `lyria-3-pro-preview` as `text_to_speech`.
> 
> For `lyria-3-pro-preview`, expands `removeParams` to also drop `stop` and `tool_choice`, further constraining which request fields are forwarded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92ddd6960f9a9c2c13f8b1f953f37bb2f664beb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->