### PR TITLE
feat(openrouter): update model YAMLs [bot]

### DIFF
--- a/providers/openrouter/deepseek/deepseek-v3.2-speciale.yaml
+++ b/providers/openrouter/deepseek/deepseek-v3.2-speciale.yaml
@@ -1,6 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
-      input_cost_per_token: 4.e-7
+    - input_cost_per_token: 4.e-7
       output_cost_per_token: 0.0000012
       region: "*"
 features:

--- a/providers/openrouter/openai/gpt-5.4-mini.yaml
+++ b/providers/openrouter/openai/gpt-5.4-mini.yaml
@@ -5,6 +5,7 @@ costs:
       region: "*"
 features:
     - function_calling
+    - json_output
     - structured_output
     - system_messages
     - tool_choice

--- a/providers/openrouter/qwen/qwen3-max.yaml
+++ b/providers/openrouter/qwen/qwen3-max.yaml
@@ -4,20 +4,15 @@ costs:
       output_cost_per_token: 0.0000039
       region: "*"
       tiered_pricing:
-          cache_read:
-              - cost_per_token: 4.8e-7
-                from: 32000
-              - cost_per_token: 6.e-7
-                from: 128000
           input:
-              - cost_per_token: 0.0000024
+              - cost_per_token: 0.00000156
                 from: 32000
-              - cost_per_token: 0.000003
+              - cost_per_token: 0.00000195
                 from: 128000
           output:
-              - cost_per_token: 0.000012
+              - cost_per_token: 0.0000078
                 from: 32000
-              - cost_per_token: 0.000015
+              - cost_per_token: 0.00000975
                 from: 128000
 features:
     - function_calling

--- a/providers/openrouter/qwen/qwen3.5-9b.yaml
+++ b/providers/openrouter/qwen/qwen3.5-9b.yaml
@@ -8,8 +8,8 @@ features:
     - structured_output
 limits:
     context_window: 256000
-    max_output_tokens: 65536
-    max_tokens: 65536
+    max_output_tokens: 32768
+    max_tokens: 32768
 modalities:
     input:
         - text


### PR DESCRIPTION
Auto-generated by poc-agent for provider `openrouter`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates model pricing and token limits in OpenRouter YAMLs, which can affect billing estimates and request sizing. Changes are config-only but impact runtime constraints and cost calculations.
> 
> **Overview**
> Updates OpenRouter model YAML metadata.
> 
> Adjusts pricing fields (removes `cache_read_input_token_cost` for `deepseek-v3.2-speciale` and revises `qwen3-max` tiered `input`/`output` token rates), adds `json_output` capability to `gpt-5.4-mini`, and reduces `qwen3.5-9b` `max_tokens`/`max_output_tokens` from 65,536 to 32,768.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 451510e9653e07c3bb2946298e5ae1fc6a21dd76. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->