### PR TITLE
feat(deepinfra): add new models [bot]

### DIFF
--- a/providers/deepinfra/ByteDance/Seed-2.0-pro.yaml
+++ b/providers/deepinfra/ByteDance/Seed-2.0-pro.yaml
@@ -1,0 +1,15 @@
+costs:
+    - cache_read_input_token_cost: 1.e-7
+      input_cost_per_token: 5.e-7
+      output_cost_per_token: 0.000003
+      region: "*"
+features:
+    - prompt_caching
+limits:
+    context_window: 256000
+    max_tokens: 256000
+modalities:
+    input:
+        - image
+mode: unknown
+model: ByteDance/Seed-2.0-pro

--- a/providers/deepinfra/Wan-AI/Wan2.7-Image-Edit.yaml
+++ b/providers/deepinfra/Wan-AI/Wan2.7-Image-Edit.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: Wan-AI/Wan2.7-Image-Edit


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `deepinfra`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds new DeepInfra model metadata YAMLs (no executable code changes). Main risk is incorrect pricing/limits or incomplete metadata (e.g., `mode: unknown`) affecting model selection or billing display.
> 
> **Overview**
> Adds two new DeepInfra model definition files: `ByteDance/Seed-2.0-pro` (with token pricing, `prompt_caching`, 256k context/max tokens, and image input modality) and `Wan-AI/Wan2.7-Image-Edit` (basic stub metadata with `mode: unknown`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6932856ad930af98f963b004d7b1767d87fb822d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->