### PR TITLE
feat(google-gemini): add new models [bot]

### DIFF
--- a/providers/google-gemini/gemma-4-26b-a4b-it.yaml
+++ b/providers/google-gemini/gemma-4-26b-a4b-it.yaml
@@ -1,0 +1,14 @@
+limits:
+    max_input_tokens: 262144
+    max_output_tokens: 32768
+mode: unknown
+model: gemma-4-26b-a4b-it
+params:
+    - defaultValue: 1
+      key: temperature
+      maxValue: 2
+    - defaultValue: 0.95
+      key: top_p
+    - defaultValue: 64
+      key: top_k
+thinking: true

--- a/providers/google-gemini/gemma-4-31b-it.yaml
+++ b/providers/google-gemini/gemma-4-31b-it.yaml
@@ -1,0 +1,14 @@
+limits:
+    max_input_tokens: 262144
+    max_output_tokens: 32768
+mode: unknown
+model: gemma-4-31b-it
+params:
+    - defaultValue: 1
+      key: temperature
+      maxValue: 2
+    - defaultValue: 0.95
+      key: top_p
+    - defaultValue: 64
+      key: top_k
+thinking: true


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `google-gemini`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds two new `google-gemini` model definition YAMLs without changing any existing runtime logic. Primary risk is misconfiguration (e.g., `mode: unknown` or token limits) affecting model selection/validation.
> 
> **Overview**
> Adds configuration entries for two new Google Gemini models, `gemma-4-26b-a4b-it` and `gemma-4-31b-it`.
> 
> Each model definition sets large token limits (262k input / 32k output), exposes `temperature`/`top_p`/`top_k` parameters, and enables `thinking`, with `mode` currently set to `unknown`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 197087b8ca005c8b22b15ffb4621fb836e6a3e91. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->