### PR TITLE
[Community] Update model: ai21/jamba-large-1.7

### DIFF
--- a/providers/ai21/jamba-large-1.7.yaml
+++ b/providers/ai21/jamba-large-1.7.yaml
@@ -9,15 +9,13 @@ features:
     - json_output
 limits:
     context_window: 256000
-    max_input_tokens: 256000
     max_output_tokens: 4096
-    max_tokens: 4096
 modalities:
     input:
         - text
     output:
         - text
-mode: chat
+mode: completion
 model: jamba-large-1.7
 params:
     - defaultValue: 4096
@@ -29,7 +27,7 @@ params:
       maxValue: 2
       minValue: 0
     - defaultValue: 1
-      key: "n"
+      key: n
       maxValue: 16
       minValue: 1
 removeParams:


### PR DESCRIPTION
This PR updates the model `ai21/jamba-large-1.7` in the catalog.

Submitted via the TrueFoundry Model Catalog UI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Switches `ai21/jamba-large-1.7` from `chat` to `completion` mode and adjusts token limit fields, which could affect how clients route requests and validate token counts for this model.
> 
> **Overview**
> Updates the `ai21/jamba-large-1.7` catalog definition to use **`mode: completion`** instead of chat.
> 
> Cleans up token limit metadata by dropping `max_input_tokens`/`max_tokens` in `limits` (leaving `context_window` and `max_output_tokens`) and normalizes the `n` param key formatting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 11b53ad94353cfdb8fbcef9f2b9b11891c62a631. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->