### PR TITLE
feat(anthropic): update model YAMLs [bot]

### DIFF
--- a/providers/anthropic/claude-4-opus-20250514.yaml
+++ b/providers/anthropic/claude-4-opus-20250514.yaml
@@ -38,4 +38,5 @@ params:
 removeParams:
     - temperature
     - top_p
+status: active
 thinking: true

--- a/providers/anthropic/claude-haiku-4-5.yaml
+++ b/providers/anthropic/claude-haiku-4-5.yaml
@@ -33,4 +33,5 @@ params:
       key: max_tokens
       maxValue: 64000
       minValue: 1
+status: active
 thinking: true

--- a/providers/anthropic/claude-sonnet-4-20250514.yaml
+++ b/providers/anthropic/claude-sonnet-4-20250514.yaml
@@ -6,29 +6,17 @@ costs:
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: "*"
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 6.e-7
-                from: 200000
-          cache_write:
-              - cost_per_token: 0.0000075
-                from: 200000
-          input:
-              - cost_per_token: 0.000006
-                from: 200000
-          output:
-              - cost_per_token: 0.0000225
-                from: 200000
 features:
     - function_calling
     - tool_choice
+    - cache_control
     - prompt_caching
     - structured_output
     - assistant_prefill
     - system_messages
 limits:
-    context_window: 1000000
-    max_input_tokens: 1000000
+    context_window: 200000
+    max_input_tokens: 200000
     max_output_tokens: 64000
     max_tokens: 64000
     tool_use_system_prompt_tokens: 346

--- a/providers/anthropic/claude-sonnet-4-20250514.yaml
+++ b/providers/anthropic/claude-sonnet-4-20250514.yaml
@@ -15,8 +15,8 @@ features:
     - assistant_prefill
     - system_messages
 limits:
-    context_window: 200000
-    max_input_tokens: 200000
+    context_window: 1000000
+    max_input_tokens: 1000000
     max_output_tokens: 64000
     max_tokens: 64000
     tool_use_system_prompt_tokens: 346

--- a/providers/anthropic/claude-sonnet-4-5.yaml
+++ b/providers/anthropic/claude-sonnet-4-5.yaml
@@ -6,19 +6,6 @@ costs:
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: "*"
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 6.e-7
-                from: 200000
-          cache_write:
-              - cost_per_token: 0.0000075
-                from: 200000
-          input:
-              - cost_per_token: 0.000006
-                from: 200000
-          output:
-              - cost_per_token: 0.0000225
-                from: 200000
 features:
     - function_calling
     - tool_choice


### PR DESCRIPTION
Auto-generated by poc-agent for provider `anthropic`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change: updates model capability flags and pricing metadata in provider YAMLs without touching runtime code paths.
> 
> **Overview**
> Updates Anthropic model YAMLs by marking `claude-4-opus-20250514` and `claude-haiku-4-5` as **active**.
> 
> Adjusts Claude Sonnet configs by **removing `tiered_pricing` blocks** from `claude-sonnet-4-20250514` and `claude-sonnet-4-5`, and **adding `cache_control`** to the Sonnet 4 (20250514) feature list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 087beda07d9268dc4a071429f2a6db9da52bb85e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->