### PR TITLE
feat(deepinfra): update model YAMLs [bot]

### DIFF
--- a/providers/deepinfra/Qwen/Qwen3.5-27B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3.5-27B.yaml
@@ -7,10 +7,11 @@ features:
     - system_messages
     - tool_choice
     - structured_output
+    - json_output
 limits:
     context_window: 262144
-    max_output_tokens: 262144
-    max_tokens: 262144
+    max_output_tokens: 81920
+    max_tokens: 81920
 modalities:
     input:
         - text

--- a/providers/deepinfra/Qwen/Qwen3.5-2B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3.5-2B.yaml
@@ -9,6 +9,8 @@ features:
     - tool_choice
 limits:
     context_window: 262144
+    max_output_tokens: 81920
+    max_tokens: 81920
 modalities:
     input:
         - text

--- a/providers/deepinfra/Qwen/Qwen3.5-35B-A3B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3.5-35B-A3B.yaml
@@ -5,6 +5,7 @@ costs:
 features:
     - function_calling
     - structured_output
+    - json_output
     - system_messages
 limits:
     context_window: 262144

--- a/providers/deepinfra/Qwen/Qwen3.5-4B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3.5-4B.yaml
@@ -4,6 +4,7 @@ costs:
       region: "*"
 features:
     - function_calling
+    - json_output
     - structured_output
     - system_messages
     - tool_choice


### PR DESCRIPTION
Auto-generated by poc-agent for provider `deepinfra`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only updates to provider model metadata; main impact is on request validation/routing based on advertised features and max token limits.
> 
> **Overview**
> Updates DeepInfra Qwen3.5 model YAMLs to better reflect provider capabilities and constraints.
> 
> Adds `json_output` as a supported feature for `Qwen3.5-27B`, `Qwen3.5-35B-A3B`, and `Qwen3.5-4B`, and adjusts token limits by capping `Qwen3.5-27B` `max_output_tokens`/`max_tokens` to `81920` (from `262144`) while also defining `max_output_tokens`/`max_tokens` for `Qwen3.5-2B` at `81920`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17910cfbc991f2a7192dd18d0e2c194d581abefe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->