### PR TITLE
feat(google-vertex): add new models [bot]

### DIFF
--- a/providers/google-vertex/advimman/lama.yaml
+++ b/providers/google-vertex/advimman/lama.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: advimman/lama

--- a/providers/google-vertex/ai21/jamba-large-1.6.yaml
+++ b/providers/google-vertex/ai21/jamba-large-1.6.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: ai21/jamba-large-1.6

--- a/providers/google-vertex/aisingapore/gemma-sea-lion-v4.yaml
+++ b/providers/google-vertex/aisingapore/gemma-sea-lion-v4.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: aisingapore/gemma-sea-lion-v4

--- a/providers/google-vertex/anthropic/claude-haiku-4-5.yaml
+++ b/providers/google-vertex/anthropic/claude-haiku-4-5.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: anthropic/claude-haiku-4-5

--- a/providers/google-vertex/autogluon-ai/autogluon.yaml
+++ b/providers/google-vertex/autogluon-ai/autogluon.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: autogluon-ai/autogluon

--- a/providers/google-vertex/baai/bge.yaml
+++ b/providers/google-vertex/baai/bge.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: baai/bge

--- a/providers/google-vertex/black-forest-labs/flux-2-klein-4b.yaml
+++ b/providers/google-vertex/black-forest-labs/flux-2-klein-4b.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: black-forest-labs/flux-2-klein-4b

--- a/providers/google-vertex/black-forest-labs/flux1-schnell.yaml
+++ b/providers/google-vertex/black-forest-labs/flux1-schnell.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: black-forest-labs/flux1-schnell

--- a/providers/google-vertex/bytedance/stable-diffusion-xl-lightning.yaml
+++ b/providers/google-vertex/bytedance/stable-diffusion-xl-lightning.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: bytedance/stable-diffusion-xl-lightning

--- a/providers/google-vertex/cambai/mars7.yaml
+++ b/providers/google-vertex/cambai/mars7.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: cambai/mars7

--- a/providers/google-vertex/cambai/mars8.yaml
+++ b/providers/google-vertex/cambai/mars8.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: cambai/mars8

--- a/providers/google-vertex/contextualai/rerank-v2-instruct.yaml
+++ b/providers/google-vertex/contextualai/rerank-v2-instruct.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: contextualai/rerank-v2-instruct

--- a/providers/google-vertex/csm/cube.yaml
+++ b/providers/google-vertex/csm/cube.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: csm/cube

--- a/providers/google-vertex/dandelin/vilt-b32-finetuned-vqa.yaml
+++ b/providers/google-vertex/dandelin/vilt-b32-finetuned-vqa.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: dandelin/vilt-b32-finetuned-vqa

--- a/providers/google-vertex/deepseek-ai/deepseek-ocr-2.yaml
+++ b/providers/google-vertex/deepseek-ai/deepseek-ocr-2.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: deepseek-ai/deepseek-ocr-2

--- a/providers/google-vertex/deepseek-ai/deepseek-ocr.yaml
+++ b/providers/google-vertex/deepseek-ai/deepseek-ocr.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: deepseek-ai/deepseek-ocr

--- a/providers/google-vertex/deepseek-ai/deepseek-r1.yaml
+++ b/providers/google-vertex/deepseek-ai/deepseek-r1.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: deepseek-ai/deepseek-r1

--- a/providers/google-vertex/deepseek-ai/deepseek-v3-1.yaml
+++ b/providers/google-vertex/deepseek-ai/deepseek-v3-1.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: deepseek-ai/deepseek-v3-1

--- a/providers/google-vertex/deepseek-ai/deepseek-v3-2.yaml
+++ b/providers/google-vertex/deepseek-ai/deepseek-v3-2.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: deepseek-ai/deepseek-v3-2

--- a/providers/google-vertex/deepseek-ai/deepseek-v3.yaml
+++ b/providers/google-vertex/deepseek-ai/deepseek-v3.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: deepseek-ai/deepseek-v3

--- a/providers/google-vertex/elevenlabs/elevenlabs-tts-v2-5.yaml
+++ b/providers/google-vertex/elevenlabs/elevenlabs-tts-v2-5.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: elevenlabs/elevenlabs-tts-v2-5

--- a/providers/google-vertex/google/automl-e2e.yaml
+++ b/providers/google-vertex/google/automl-e2e.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/automl-e2e

--- a/providers/google-vertex/google/automl-vision-image-classification.yaml
+++ b/providers/google-vertex/google/automl-vision-image-classification.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/automl-vision-image-classification

--- a/providers/google-vertex/google/automl-vision-image-object-detection.yaml
+++ b/providers/google-vertex/google/automl-vision-image-object-detection.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/automl-vision-image-object-detection

--- a/providers/google-vertex/google/bart-large-cnn.yaml
+++ b/providers/google-vertex/google/bart-large-cnn.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/bart-large-cnn

--- a/providers/google-vertex/google/bert-base-uncased.yaml
+++ b/providers/google-vertex/google/bert-base-uncased.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/bert-base-uncased

--- a/providers/google-vertex/google/bert-base.yaml
+++ b/providers/google-vertex/google/bert-base.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/bert-base

--- a/providers/google-vertex/google/chirp-2.yaml
+++ b/providers/google-vertex/google/chirp-2.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/chirp-2

--- a/providers/google-vertex/google/chirp-3.yaml
+++ b/providers/google-vertex/google/chirp-3.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/chirp-3

--- a/providers/google-vertex/google/cloudnerf-pytorch-zipnerf.yaml
+++ b/providers/google-vertex/google/cloudnerf-pytorch-zipnerf.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/cloudnerf-pytorch-zipnerf

--- a/providers/google-vertex/google/codegemma.yaml
+++ b/providers/google-vertex/google/codegemma.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/codegemma

--- a/providers/google-vertex/google/content-moderation.yaml
+++ b/providers/google-vertex/google/content-moderation.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/content-moderation

--- a/providers/google-vertex/google/cxr-foundation.yaml
+++ b/providers/google-vertex/google/cxr-foundation.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/cxr-foundation

--- a/providers/google-vertex/google/derm-foundation.yaml
+++ b/providers/google-vertex/google/derm-foundation.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/derm-foundation

--- a/providers/google-vertex/google/dito.yaml
+++ b/providers/google-vertex/google/dito.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/dito

--- a/providers/google-vertex/google/earth-ai-imagery-mammut-eap-10-2025.yaml
+++ b/providers/google-vertex/google/earth-ai-imagery-mammut-eap-10-2025.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/earth-ai-imagery-mammut-eap-10-2025

--- a/providers/google-vertex/google/earth-ai-imagery-owlvit-eap-10-2025.yaml
+++ b/providers/google-vertex/google/earth-ai-imagery-owlvit-eap-10-2025.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/earth-ai-imagery-owlvit-eap-10-2025

--- a/providers/google-vertex/google/embeddinggemma.yaml
+++ b/providers/google-vertex/google/embeddinggemma.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/embeddinggemma

--- a/providers/google-vertex/google/f-vlm-jax.yaml
+++ b/providers/google-vertex/google/f-vlm-jax.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/f-vlm-jax

--- a/providers/google-vertex/google/face-detector.yaml
+++ b/providers/google-vertex/google/face-detector.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/face-detector

--- a/providers/google-vertex/google/functiongemma.yaml
+++ b/providers/google-vertex/google/functiongemma.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/functiongemma

--- a/providers/google-vertex/google/gemini-2.0-flash-001.yaml
+++ b/providers/google-vertex/google/gemini-2.0-flash-001.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/gemini-2.0-flash-001

--- a/providers/google-vertex/google/gemini-2.0-flash-lite-001.yaml
+++ b/providers/google-vertex/google/gemini-2.0-flash-lite-001.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/gemini-2.0-flash-lite-001

--- a/providers/google-vertex/google/gemini-2.5-computer-use-preview-10-2025.yaml
+++ b/providers/google-vertex/google/gemini-2.5-computer-use-preview-10-2025.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/gemini-2.5-computer-use-preview-10-2025

--- a/providers/google-vertex/google/gemini-2.5-flash-image.yaml
+++ b/providers/google-vertex/google/gemini-2.5-flash-image.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/gemini-2.5-flash-image

--- a/providers/google-vertex/google/gemini-2.5-flash-lite-preview-09-2025.yaml
+++ b/providers/google-vertex/google/gemini-2.5-flash-lite-preview-09-2025.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/gemini-2.5-flash-lite-preview-09-2025

--- a/providers/google-vertex/google/gemini-2.5-flash-lite.yaml
+++ b/providers/google-vertex/google/gemini-2.5-flash-lite.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/gemini-2.5-flash-lite

--- a/providers/google-vertex/google/gemini-2.5-flash-preview-09-2025.yaml
+++ b/providers/google-vertex/google/gemini-2.5-flash-preview-09-2025.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/gemini-2.5-flash-preview-09-2025

--- a/providers/google-vertex/google/gemini-2.5-flash-tts.yaml
+++ b/providers/google-vertex/google/gemini-2.5-flash-tts.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/gemini-2.5-flash-tts

--- a/providers/google-vertex/google/gemini-2.5-flash.yaml
+++ b/providers/google-vertex/google/gemini-2.5-flash.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/gemini-2.5-flash

--- a/providers/google-vertex/google/gemini-2.5-pro-tts.yaml
+++ b/providers/google-vertex/google/gemini-2.5-pro-tts.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/gemini-2.5-pro-tts

--- a/providers/google-vertex/google/gemini-2.5-pro.yaml
+++ b/providers/google-vertex/google/gemini-2.5-pro.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/gemini-2.5-pro

--- a/providers/google-vertex/google/gemini-3-flash-preview.yaml
+++ b/providers/google-vertex/google/gemini-3-flash-preview.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/gemini-3-flash-preview

--- a/providers/google-vertex/google/gemini-3-pro-image-preview.yaml
+++ b/providers/google-vertex/google/gemini-3-pro-image-preview.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/gemini-3-pro-image-preview

--- a/providers/google-vertex/google/gemini-3-pro-preview.yaml
+++ b/providers/google-vertex/google/gemini-3-pro-preview.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/gemini-3-pro-preview

--- a/providers/google-vertex/google/gemini-3.1-flash-image-preview.yaml
+++ b/providers/google-vertex/google/gemini-3.1-flash-image-preview.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/gemini-3.1-flash-image-preview

--- a/providers/google-vertex/google/gemini-3.1-flash-lite-preview.yaml
+++ b/providers/google-vertex/google/gemini-3.1-flash-lite-preview.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/gemini-3.1-flash-lite-preview

--- a/providers/google-vertex/google/gemini-3.1-pro-preview.yaml
+++ b/providers/google-vertex/google/gemini-3.1-pro-preview.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/gemini-3.1-pro-preview

--- a/providers/google-vertex/google/gemini-embedding-001.yaml
+++ b/providers/google-vertex/google/gemini-embedding-001.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/gemini-embedding-001

--- a/providers/google-vertex/google/gemini-embedding-2-preview.yaml
+++ b/providers/google-vertex/google/gemini-embedding-2-preview.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/gemini-embedding-2-preview

--- a/providers/google-vertex/google/gemini-live-2.5-flash-native-audio.yaml
+++ b/providers/google-vertex/google/gemini-live-2.5-flash-native-audio.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/gemini-live-2.5-flash-native-audio

--- a/providers/google-vertex/google/gemma.yaml
+++ b/providers/google-vertex/google/gemma.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/gemma

--- a/providers/google-vertex/google/gemma2.yaml
+++ b/providers/google-vertex/google/gemma2.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/gemma2

--- a/providers/google-vertex/google/gemma3.yaml
+++ b/providers/google-vertex/google/gemma3.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/gemma3

--- a/providers/google-vertex/google/gemma3n.yaml
+++ b/providers/google-vertex/google/gemma3n.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/gemma3n

--- a/providers/google-vertex/google/gemma4.yaml
+++ b/providers/google-vertex/google/gemma4.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/gemma4

--- a/providers/google-vertex/google/hear.yaml
+++ b/providers/google-vertex/google/hear.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/hear

--- a/providers/google-vertex/google/image-segmentation-001.yaml
+++ b/providers/google-vertex/google/image-segmentation-001.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/image-segmentation-001

--- a/providers/google-vertex/google/imageclassification-efficientnet.yaml
+++ b/providers/google-vertex/google/imageclassification-efficientnet.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/imageclassification-efficientnet

--- a/providers/google-vertex/google/imageclassification-proprietary-efficientnet.yaml
+++ b/providers/google-vertex/google/imageclassification-proprietary-efficientnet.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/imageclassification-proprietary-efficientnet

--- a/providers/google-vertex/google/imageclassification-proprietary-maxvit.yaml
+++ b/providers/google-vertex/google/imageclassification-proprietary-maxvit.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/imageclassification-proprietary-maxvit

--- a/providers/google-vertex/google/imageclassification-proprietary-vit.yaml
+++ b/providers/google-vertex/google/imageclassification-proprietary-vit.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/imageclassification-proprietary-vit

--- a/providers/google-vertex/google/imageclassification-vit.yaml
+++ b/providers/google-vertex/google/imageclassification-vit.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/imageclassification-vit

--- a/providers/google-vertex/google/imagegeneration.yaml
+++ b/providers/google-vertex/google/imagegeneration.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/imagegeneration

--- a/providers/google-vertex/google/imagen-3.0-capability-001.yaml
+++ b/providers/google-vertex/google/imagen-3.0-capability-001.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/imagen-3.0-capability-001

--- a/providers/google-vertex/google/imagen-3.0-capability-002.yaml
+++ b/providers/google-vertex/google/imagen-3.0-capability-002.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/imagen-3.0-capability-002

--- a/providers/google-vertex/google/imagen-3.0-generate-002.yaml
+++ b/providers/google-vertex/google/imagen-3.0-generate-002.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/imagen-3.0-generate-002

--- a/providers/google-vertex/google/imagen-4.0-fast-generate-001.yaml
+++ b/providers/google-vertex/google/imagen-4.0-fast-generate-001.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/imagen-4.0-fast-generate-001

--- a/providers/google-vertex/google/imagen-4.0-generate-001.yaml
+++ b/providers/google-vertex/google/imagen-4.0-generate-001.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/imagen-4.0-generate-001

--- a/providers/google-vertex/google/imagen-4.0-ultra-generate-001.yaml
+++ b/providers/google-vertex/google/imagen-4.0-ultra-generate-001.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/imagen-4.0-ultra-generate-001

--- a/providers/google-vertex/google/imageobjectdetection-proprietary-spinenet.yaml
+++ b/providers/google-vertex/google/imageobjectdetection-proprietary-spinenet.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/imageobjectdetection-proprietary-spinenet

--- a/providers/google-vertex/google/imageobjectdetection-proprietary-yolo.yaml
+++ b/providers/google-vertex/google/imageobjectdetection-proprietary-yolo.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/imageobjectdetection-proprietary-yolo

--- a/providers/google-vertex/google/imageobjectdetection-yolo.yaml
+++ b/providers/google-vertex/google/imageobjectdetection-yolo.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/imageobjectdetection-yolo

--- a/providers/google-vertex/google/imagesegmentation-deeplabv3.yaml
+++ b/providers/google-vertex/google/imagesegmentation-deeplabv3.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/imagesegmentation-deeplabv3

--- a/providers/google-vertex/google/imagetext.yaml
+++ b/providers/google-vertex/google/imagetext.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/imagetext

--- a/providers/google-vertex/google/imagewatermarkdetector.yaml
+++ b/providers/google-vertex/google/imagewatermarkdetector.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/imagewatermarkdetector

--- a/providers/google-vertex/google/jax-owl-vit-v2.yaml
+++ b/providers/google-vertex/google/jax-owl-vit-v2.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/jax-owl-vit-v2

--- a/providers/google-vertex/google/keras-yolov8.yaml
+++ b/providers/google-vertex/google/keras-yolov8.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/keras-yolov8

--- a/providers/google-vertex/google/label-detector-pali-001.yaml
+++ b/providers/google-vertex/google/label-detector-pali-001.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/label-detector-pali-001

--- a/providers/google-vertex/google/language-v1-analyze-entity-sentiment.yaml
+++ b/providers/google-vertex/google/language-v1-analyze-entity-sentiment.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/language-v1-analyze-entity-sentiment

--- a/providers/google-vertex/google/language-v1-analyze-sentiment.yaml
+++ b/providers/google-vertex/google/language-v1-analyze-sentiment.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/language-v1-analyze-sentiment

--- a/providers/google-vertex/google/language-v1-analyze-syntax.yaml
+++ b/providers/google-vertex/google/language-v1-analyze-syntax.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/language-v1-analyze-syntax

--- a/providers/google-vertex/google/language-v1-classify-text-v1.yaml
+++ b/providers/google-vertex/google/language-v1-classify-text-v1.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/language-v1-classify-text-v1

--- a/providers/google-vertex/google/language-v1-moderate-text.yaml
+++ b/providers/google-vertex/google/language-v1-moderate-text.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/language-v1-moderate-text

--- a/providers/google-vertex/google/lyria-002.yaml
+++ b/providers/google-vertex/google/lyria-002.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/lyria-002

--- a/providers/google-vertex/google/lyria-3-clip-preview.yaml
+++ b/providers/google-vertex/google/lyria-3-clip-preview.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/lyria-3-clip-preview

--- a/providers/google-vertex/google/lyria-3-pro-preview.yaml
+++ b/providers/google-vertex/google/lyria-3-pro-preview.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/lyria-3-pro-preview

--- a/providers/google-vertex/google/mammut.yaml
+++ b/providers/google-vertex/google/mammut.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/mammut

--- a/providers/google-vertex/google/medasr.yaml
+++ b/providers/google-vertex/google/medasr.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/medasr

--- a/providers/google-vertex/google/medgemma.yaml
+++ b/providers/google-vertex/google/medgemma.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/medgemma

--- a/providers/google-vertex/google/medsiglip.yaml
+++ b/providers/google-vertex/google/medsiglip.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/medsiglip

--- a/providers/google-vertex/google/multimodalembedding.yaml
+++ b/providers/google-vertex/google/multimodalembedding.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/multimodalembedding

--- a/providers/google-vertex/google/object-detector.yaml
+++ b/providers/google-vertex/google/object-detector.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/object-detector

--- a/providers/google-vertex/google/occupancy-analytics.yaml
+++ b/providers/google-vertex/google/occupancy-analytics.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/occupancy-analytics

--- a/providers/google-vertex/google/owlvit-base-patch32.yaml
+++ b/providers/google-vertex/google/owlvit-base-patch32.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/owlvit-base-patch32

--- a/providers/google-vertex/google/paligemma.yaml
+++ b/providers/google-vertex/google/paligemma.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/paligemma

--- a/providers/google-vertex/google/path-foundation.yaml
+++ b/providers/google-vertex/google/path-foundation.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/path-foundation

--- a/providers/google-vertex/google/people-blur.yaml
+++ b/providers/google-vertex/google/people-blur.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/people-blur

--- a/providers/google-vertex/google/pic2word.yaml
+++ b/providers/google-vertex/google/pic2word.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/pic2word

--- a/providers/google-vertex/google/ppe-detector.yaml
+++ b/providers/google-vertex/google/ppe-detector.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/ppe-detector

--- a/providers/google-vertex/google/pretrained-form-parser.yaml
+++ b/providers/google-vertex/google/pretrained-form-parser.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/pretrained-form-parser

--- a/providers/google-vertex/google/pretrained-ocr.yaml
+++ b/providers/google-vertex/google/pretrained-ocr.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/pretrained-ocr

--- a/providers/google-vertex/google/product-recognizer.yaml
+++ b/providers/google-vertex/google/product-recognizer.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/product-recognizer

--- a/providers/google-vertex/google/pt-test.yaml
+++ b/providers/google-vertex/google/pt-test.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/pt-test

--- a/providers/google-vertex/google/resnet50.yaml
+++ b/providers/google-vertex/google/resnet50.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/resnet50

--- a/providers/google-vertex/google/shieldgemma2.yaml
+++ b/providers/google-vertex/google/shieldgemma2.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/shieldgemma2

--- a/providers/google-vertex/google/t5-1.1.yaml
+++ b/providers/google-vertex/google/t5-1.1.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/t5-1.1

--- a/providers/google-vertex/google/t5-flan.yaml
+++ b/providers/google-vertex/google/t5-flan.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/t5-flan

--- a/providers/google-vertex/google/t5gemma.yaml
+++ b/providers/google-vertex/google/t5gemma.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/t5gemma

--- a/providers/google-vertex/google/tab-net.yaml
+++ b/providers/google-vertex/google/tab-net.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/tab-net

--- a/providers/google-vertex/google/tag-recognizer.yaml
+++ b/providers/google-vertex/google/tag-recognizer.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/tag-recognizer

--- a/providers/google-vertex/google/text-detector.yaml
+++ b/providers/google-vertex/google/text-detector.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/text-detector

--- a/providers/google-vertex/google/text-embedding-005.yaml
+++ b/providers/google-vertex/google/text-embedding-005.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/text-embedding-005

--- a/providers/google-vertex/google/text-embedding-large-exp-03-07.yaml
+++ b/providers/google-vertex/google/text-embedding-large-exp-03-07.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/text-embedding-large-exp-03-07

--- a/providers/google-vertex/google/text-multilingual-embedding-002.yaml
+++ b/providers/google-vertex/google/text-multilingual-embedding-002.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/text-multilingual-embedding-002

--- a/providers/google-vertex/google/text-translation.yaml
+++ b/providers/google-vertex/google/text-translation.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/text-translation

--- a/providers/google-vertex/google/textembedding-gecko.yaml
+++ b/providers/google-vertex/google/textembedding-gecko.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/textembedding-gecko

--- a/providers/google-vertex/google/tfvision-movinet-var.yaml
+++ b/providers/google-vertex/google/tfvision-movinet-var.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/tfvision-movinet-var

--- a/providers/google-vertex/google/tfvision-movinet-vcn.yaml
+++ b/providers/google-vertex/google/tfvision-movinet-vcn.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/tfvision-movinet-vcn

--- a/providers/google-vertex/google/tfvision-yolov7.yaml
+++ b/providers/google-vertex/google/tfvision-yolov7.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/tfvision-yolov7

--- a/providers/google-vertex/google/timesfm.yaml
+++ b/providers/google-vertex/google/timesfm.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/timesfm

--- a/providers/google-vertex/google/translate-llm.yaml
+++ b/providers/google-vertex/google/translate-llm.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/translate-llm

--- a/providers/google-vertex/google/translategemma.yaml
+++ b/providers/google-vertex/google/translategemma.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/translategemma

--- a/providers/google-vertex/google/txgemma.yaml
+++ b/providers/google-vertex/google/txgemma.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/txgemma

--- a/providers/google-vertex/google/vehicle-detector.yaml
+++ b/providers/google-vertex/google/vehicle-detector.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/vehicle-detector

--- a/providers/google-vertex/google/veo-2.0-generate-001.yaml
+++ b/providers/google-vertex/google/veo-2.0-generate-001.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/veo-2.0-generate-001

--- a/providers/google-vertex/google/veo-3.0-fast-generate-001.yaml
+++ b/providers/google-vertex/google/veo-3.0-fast-generate-001.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/veo-3.0-fast-generate-001

--- a/providers/google-vertex/google/veo-3.0-generate-001.yaml
+++ b/providers/google-vertex/google/veo-3.0-generate-001.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/veo-3.0-generate-001

--- a/providers/google-vertex/google/veo-3.1-fast-generate-001.yaml
+++ b/providers/google-vertex/google/veo-3.1-fast-generate-001.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/veo-3.1-fast-generate-001

--- a/providers/google-vertex/google/veo-3.1-generate-001.yaml
+++ b/providers/google-vertex/google/veo-3.1-generate-001.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/veo-3.1-generate-001

--- a/providers/google-vertex/google/veo-3.1-lite-generate-001.yaml
+++ b/providers/google-vertex/google/veo-3.1-lite-generate-001.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/veo-3.1-lite-generate-001

--- a/providers/google-vertex/google/video-speech-transcription.yaml
+++ b/providers/google-vertex/google/video-speech-transcription.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/video-speech-transcription

--- a/providers/google-vertex/google/video-text-detection.yaml
+++ b/providers/google-vertex/google/video-text-detection.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/video-text-detection

--- a/providers/google-vertex/google/virtual-try-on-001.yaml
+++ b/providers/google-vertex/google/virtual-try-on-001.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/virtual-try-on-001

--- a/providers/google-vertex/google/vit-jax.yaml
+++ b/providers/google-vertex/google/vit-jax.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/vit-jax

--- a/providers/google-vertex/google/weather-next-v2.yaml
+++ b/providers/google-vertex/google/weather-next-v2.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/weather-next-v2

--- a/providers/google-vertex/google/weathernext.yaml
+++ b/providers/google-vertex/google/weathernext.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: google/weathernext

--- a/providers/google-vertex/hidream-ai/hidream-i1.yaml
+++ b/providers/google-vertex/hidream-ai/hidream-i1.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: hidream-ai/hidream-i1

--- a/providers/google-vertex/ifzhang/bytetrack-multi-object-tracking.yaml
+++ b/providers/google-vertex/ifzhang/bytetrack-multi-object-tracking.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: ifzhang/bytetrack-multi-object-tracking

--- a/providers/google-vertex/impira/layoutlm-document-qa.yaml
+++ b/providers/google-vertex/impira/layoutlm-document-qa.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: impira/layoutlm-document-qa

--- a/providers/google-vertex/instantx/instant-id.yaml
+++ b/providers/google-vertex/instantx/instant-id.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: instantx/instant-id

--- a/providers/google-vertex/intfloat/e5.yaml
+++ b/providers/google-vertex/intfloat/e5.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: intfloat/e5

--- a/providers/google-vertex/intfloat/multilingual-e5-large-instruct-maas.yaml
+++ b/providers/google-vertex/intfloat/multilingual-e5-large-instruct-maas.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: intfloat/multilingual-e5-large-instruct-maas

--- a/providers/google-vertex/jinaai/jina-embeddings-v3.yaml
+++ b/providers/google-vertex/jinaai/jina-embeddings-v3.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: jinaai/jina-embeddings-v3

--- a/providers/google-vertex/liuhaotian/pytorch-llava.yaml
+++ b/providers/google-vertex/liuhaotian/pytorch-llava.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: liuhaotian/pytorch-llava

--- a/providers/google-vertex/lllyasviel/control-net.yaml
+++ b/providers/google-vertex/lllyasviel/control-net.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: lllyasviel/control-net

--- a/providers/google-vertex/lmsys/lmsys-vicuna-7b.yaml
+++ b/providers/google-vertex/lmsys/lmsys-vicuna-7b.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: lmsys/lmsys-vicuna-7b

--- a/providers/google-vertex/meta/codellama-7b-hf.yaml
+++ b/providers/google-vertex/meta/codellama-7b-hf.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: meta/codellama-7b-hf

--- a/providers/google-vertex/meta/faster-r-cnn.yaml
+++ b/providers/google-vertex/meta/faster-r-cnn.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: meta/faster-r-cnn

--- a/providers/google-vertex/meta/imagebind.yaml
+++ b/providers/google-vertex/meta/imagebind.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: meta/imagebind

--- a/providers/google-vertex/meta/llama-2-quantized.yaml
+++ b/providers/google-vertex/meta/llama-2-quantized.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: meta/llama-2-quantized

--- a/providers/google-vertex/meta/llama-guard.yaml
+++ b/providers/google-vertex/meta/llama-guard.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: meta/llama-guard

--- a/providers/google-vertex/meta/llama2.yaml
+++ b/providers/google-vertex/meta/llama2.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: meta/llama2

--- a/providers/google-vertex/meta/llama3-2.yaml
+++ b/providers/google-vertex/meta/llama3-2.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: meta/llama3-2

--- a/providers/google-vertex/meta/llama3-3.yaml
+++ b/providers/google-vertex/meta/llama3-3.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: meta/llama3-3

--- a/providers/google-vertex/meta/llama3.yaml
+++ b/providers/google-vertex/meta/llama3.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: meta/llama3

--- a/providers/google-vertex/meta/llama3_1.yaml
+++ b/providers/google-vertex/meta/llama3_1.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: meta/llama3_1

--- a/providers/google-vertex/meta/llama4.yaml
+++ b/providers/google-vertex/meta/llama4.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: meta/llama4

--- a/providers/google-vertex/meta/mask-r-cnn.yaml
+++ b/providers/google-vertex/meta/mask-r-cnn.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: meta/mask-r-cnn

--- a/providers/google-vertex/meta/nllb.yaml
+++ b/providers/google-vertex/meta/nllb.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: meta/nllb

--- a/providers/google-vertex/meta/prompt-guard.yaml
+++ b/providers/google-vertex/meta/prompt-guard.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: meta/prompt-guard

--- a/providers/google-vertex/meta/retinanet.yaml
+++ b/providers/google-vertex/meta/retinanet.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: meta/retinanet

--- a/providers/google-vertex/meta/roberta-large.yaml
+++ b/providers/google-vertex/meta/roberta-large.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: meta/roberta-large

--- a/providers/google-vertex/meta/sam3.yaml
+++ b/providers/google-vertex/meta/sam3.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: meta/sam3

--- a/providers/google-vertex/meta/segment-anything.yaml
+++ b/providers/google-vertex/meta/segment-anything.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: meta/segment-anything

--- a/providers/google-vertex/meta/xlm-roberta-large.yaml
+++ b/providers/google-vertex/meta/xlm-roberta-large.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: meta/xlm-roberta-large

--- a/providers/google-vertex/microsoft/bio-gpt.yaml
+++ b/providers/google-vertex/microsoft/bio-gpt.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: microsoft/bio-gpt

--- a/providers/google-vertex/microsoft/microsoft-biomedclip.yaml
+++ b/providers/google-vertex/microsoft/microsoft-biomedclip.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: microsoft/microsoft-biomedclip

--- a/providers/google-vertex/microsoft/phi3.yaml
+++ b/providers/google-vertex/microsoft/phi3.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: microsoft/phi3

--- a/providers/google-vertex/microsoft/phi4.yaml
+++ b/providers/google-vertex/microsoft/phi4.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: microsoft/phi4

--- a/providers/google-vertex/minimaxai/minimax-m2.yaml
+++ b/providers/google-vertex/minimaxai/minimax-m2.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: minimaxai/minimax-m2

--- a/providers/google-vertex/mistral-ai/mistral.yaml
+++ b/providers/google-vertex/mistral-ai/mistral.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: mistral-ai/mistral

--- a/providers/google-vertex/mistral-ai/mixtral.yaml
+++ b/providers/google-vertex/mistral-ai/mixtral.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: mistral-ai/mixtral

--- a/providers/google-vertex/mistralai/codestral-2501-self-deploy.yaml
+++ b/providers/google-vertex/mistralai/codestral-2501-self-deploy.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: mistralai/codestral-2501-self-deploy

--- a/providers/google-vertex/mistralai/ministral-3.yaml
+++ b/providers/google-vertex/mistralai/ministral-3.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: mistralai/ministral-3

--- a/providers/google-vertex/mistralai/mistral-large-3.yaml
+++ b/providers/google-vertex/mistralai/mistral-large-3.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: mistralai/mistral-large-3

--- a/providers/google-vertex/mongodb/voyage-3.5-lite.yaml
+++ b/providers/google-vertex/mongodb/voyage-3.5-lite.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: mongodb/voyage-3.5-lite

--- a/providers/google-vertex/mongodb/voyage-4-large.yaml
+++ b/providers/google-vertex/mongodb/voyage-4-large.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: mongodb/voyage-4-large

--- a/providers/google-vertex/mongodb/voyage-4-lite.yaml
+++ b/providers/google-vertex/mongodb/voyage-4-lite.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: mongodb/voyage-4-lite

--- a/providers/google-vertex/mongodb/voyage-4.yaml
+++ b/providers/google-vertex/mongodb/voyage-4.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: mongodb/voyage-4

--- a/providers/google-vertex/mongodb/voyage-multimodal-3.5.yaml
+++ b/providers/google-vertex/mongodb/voyage-multimodal-3.5.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: mongodb/voyage-multimodal-3.5

--- a/providers/google-vertex/moonshotai/kimi-k2-5.yaml
+++ b/providers/google-vertex/moonshotai/kimi-k2-5.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: moonshotai/kimi-k2-5

--- a/providers/google-vertex/moonshotai/kimi-k2.yaml
+++ b/providers/google-vertex/moonshotai/kimi-k2.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: moonshotai/kimi-k2

--- a/providers/google-vertex/nari-labs/dia-1.6b.yaml
+++ b/providers/google-vertex/nari-labs/dia-1.6b.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: nari-labs/dia-1.6b

--- a/providers/google-vertex/nvidia/cosmos.yaml
+++ b/providers/google-vertex/nvidia/cosmos.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: nvidia/cosmos

--- a/providers/google-vertex/nvidia/llama-nemotron-super.yaml
+++ b/providers/google-vertex/nvidia/llama-nemotron-super.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: nvidia/llama-nemotron-super

--- a/providers/google-vertex/nvidia/nemotron-3-super.yaml
+++ b/providers/google-vertex/nvidia/nemotron-3-super.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: nvidia/nemotron-3-super

--- a/providers/google-vertex/nvidia/nemotron-nano-12b-v2-vl.yaml
+++ b/providers/google-vertex/nvidia/nemotron-nano-12b-v2-vl.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: nvidia/nemotron-nano-12b-v2-vl

--- a/providers/google-vertex/nvidia/nemotron-v3-super-120b.yaml
+++ b/providers/google-vertex/nvidia/nemotron-v3-super-120b.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: nvidia/nemotron-v3-super-120b

--- a/providers/google-vertex/nvidia/nemotron-v3.yaml
+++ b/providers/google-vertex/nvidia/nemotron-v3.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: nvidia/nemotron-v3

--- a/providers/google-vertex/openai/clip-vit-base-patch32.yaml
+++ b/providers/google-vertex/openai/clip-vit-base-patch32.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: openai/clip-vit-base-patch32

--- a/providers/google-vertex/openai/gpt-oss.yaml
+++ b/providers/google-vertex/openai/gpt-oss.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: openai/gpt-oss

--- a/providers/google-vertex/openai/openclip.yaml
+++ b/providers/google-vertex/openai/openclip.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: openai/openclip

--- a/providers/google-vertex/openai/whisper-large.yaml
+++ b/providers/google-vertex/openai/whisper-large.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: openai/whisper-large

--- a/providers/google-vertex/openlm-research/openllama.yaml
+++ b/providers/google-vertex/openlm-research/openllama.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: openlm-research/openllama

--- a/providers/google-vertex/qodo/qodo-embed-1-7b-v1.yaml
+++ b/providers/google-vertex/qodo/qodo-embed-1-7b-v1.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: qodo/qodo-embed-1-7b-v1

--- a/providers/google-vertex/qwen/qwen-image.yaml
+++ b/providers/google-vertex/qwen/qwen-image.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: qwen/qwen-image

--- a/providers/google-vertex/qwen/qwen2.yaml
+++ b/providers/google-vertex/qwen/qwen2.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: qwen/qwen2

--- a/providers/google-vertex/qwen/qwen3-5.yaml
+++ b/providers/google-vertex/qwen/qwen3-5.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: qwen/qwen3-5

--- a/providers/google-vertex/qwen/qwen3-coder-next.yaml
+++ b/providers/google-vertex/qwen/qwen3-coder-next.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: qwen/qwen3-coder-next

--- a/providers/google-vertex/qwen/qwen3-coder.yaml
+++ b/providers/google-vertex/qwen/qwen3-coder.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: qwen/qwen3-coder

--- a/providers/google-vertex/qwen/qwen3-embedding.yaml
+++ b/providers/google-vertex/qwen/qwen3-embedding.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: qwen/qwen3-embedding

--- a/providers/google-vertex/qwen/qwen3-next.yaml
+++ b/providers/google-vertex/qwen/qwen3-next.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: qwen/qwen3-next

--- a/providers/google-vertex/qwen/qwen3-vl.yaml
+++ b/providers/google-vertex/qwen/qwen3-vl.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: qwen/qwen3-vl

--- a/providers/google-vertex/qwen/qwen3.yaml
+++ b/providers/google-vertex/qwen/qwen3.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: qwen/qwen3

--- a/providers/google-vertex/qwen/qwq.yaml
+++ b/providers/google-vertex/qwen/qwq.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: qwen/qwq

--- a/providers/google-vertex/runwayml/stable-diffusion-inpainting.yaml
+++ b/providers/google-vertex/runwayml/stable-diffusion-inpainting.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: runwayml/stable-diffusion-inpainting

--- a/providers/google-vertex/salesforce/blip-image-captioning-base.yaml
+++ b/providers/google-vertex/salesforce/blip-image-captioning-base.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: salesforce/blip-image-captioning-base

--- a/providers/google-vertex/salesforce/blip-vqa-base.yaml
+++ b/providers/google-vertex/salesforce/blip-vqa-base.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: salesforce/blip-vqa-base

--- a/providers/google-vertex/salesforce/blip2-opt-2.7-b.yaml
+++ b/providers/google-vertex/salesforce/blip2-opt-2.7-b.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: salesforce/blip2-opt-2.7-b

--- a/providers/google-vertex/sesame/csm.yaml
+++ b/providers/google-vertex/sesame/csm.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: sesame/csm

--- a/providers/google-vertex/stability-ai/stable-diffusion-2-1.yaml
+++ b/providers/google-vertex/stability-ai/stable-diffusion-2-1.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: stability-ai/stable-diffusion-2-1

--- a/providers/google-vertex/stability-ai/stable-diffusion-4x-upscaler.yaml
+++ b/providers/google-vertex/stability-ai/stable-diffusion-4x-upscaler.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: stability-ai/stable-diffusion-4x-upscaler

--- a/providers/google-vertex/stability-ai/stable-diffusion-xl-base.yaml
+++ b/providers/google-vertex/stability-ai/stable-diffusion-xl-base.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: stability-ai/stable-diffusion-xl-base

--- a/providers/google-vertex/stability-ai/stable-diffusion-xl-lcm.yaml
+++ b/providers/google-vertex/stability-ai/stable-diffusion-xl-lcm.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: stability-ai/stable-diffusion-xl-lcm

--- a/providers/google-vertex/thudm/cogvideox.yaml
+++ b/providers/google-vertex/thudm/cogvideox.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: thudm/cogvideox

--- a/providers/google-vertex/tiiuae/falcon-instruct-7b-peft.yaml
+++ b/providers/google-vertex/tiiuae/falcon-instruct-7b-peft.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: tiiuae/falcon-instruct-7b-peft

--- a/providers/google-vertex/timbrooks/instruct-pix2pix.yaml
+++ b/providers/google-vertex/timbrooks/instruct-pix2pix.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: timbrooks/instruct-pix2pix

--- a/providers/google-vertex/virtueai/virtueguard-text-lite.yaml
+++ b/providers/google-vertex/virtueai/virtueguard-text-lite.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: virtueai/virtueguard-text-lite

--- a/providers/google-vertex/wan-ai/wan2-1.yaml
+++ b/providers/google-vertex/wan-ai/wan2-1.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: wan-ai/wan2-1

--- a/providers/google-vertex/wan-ai/wan2-2.yaml
+++ b/providers/google-vertex/wan-ai/wan2-2.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: wan-ai/wan2-2

--- a/providers/google-vertex/writer/palmyra-x4.yaml
+++ b/providers/google-vertex/writer/palmyra-x4.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: writer/palmyra-x4

--- a/providers/google-vertex/zai-org/glm-4.5.yaml
+++ b/providers/google-vertex/zai-org/glm-4.5.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: zai-org/glm-4.5

--- a/providers/google-vertex/zai-org/glm-4.7.yaml
+++ b/providers/google-vertex/zai-org/glm-4.7.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: zai-org/glm-4.7

--- a/providers/google-vertex/zai-org/glm-5.yaml
+++ b/providers/google-vertex/zai-org/glm-5.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: zai-org/glm-5

--- a/providers/google-vertex/zai-org/glm-image.yaml
+++ b/providers/google-vertex/zai-org/glm-image.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: zai-org/glm-image

--- a/providers/google-vertex/zai-org/glm-ocr.yaml
+++ b/providers/google-vertex/zai-org/glm-ocr.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: zai-org/glm-ocr


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `google-vertex`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly additive config, but it introduces many new model entries with `mode: unknown`, which could impact model discovery/validation or route selection if consumers assume a known mode.
> 
> **Overview**
> **Adds many new model registry entries for the `google-vertex` provider.** This PR introduces a large set of new `providers/google-vertex/**.yaml` files that each declare a `model` identifier (spanning Gemini, Imagen/Veo, Anthropic, Meta, Mistral, Qwen, etc.) and currently mark `mode: unknown`.
> 
> No runtime code changes are included; the change is purely expanding the provider’s model catalog/configuration surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c16b0678b7b9cd4bd0972c78b67d026c048b78c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->