### PR TITLE
feat(openrouter): add new models [bot]

### DIFF
--- a/providers/openrouter/arcee-ai/trinity-large-thinking.yaml
+++ b/providers/openrouter/arcee-ai/trinity-large-thinking.yaml
@@ -1,0 +1,19 @@
+costs:
+    - input_cost_per_token: 2.2e-7
+      output_cost_per_token: 8.5e-7
+      region: "*"
+limits:
+    context_window: 262144
+    max_output_tokens: 262144
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: chat
+model: arcee-ai/trinity-large-thinking
+params:
+    - defaultValue: 0.3
+      key: temperature
+    - defaultValue: 0.8
+      key: top_p

--- a/providers/openrouter/google/gemma-4-26b-a4b-it.yaml
+++ b/providers/openrouter/google/gemma-4-26b-a4b-it.yaml
@@ -1,0 +1,23 @@
+costs:
+    - input_cost_per_token: 1.3e-7
+      output_cost_per_token: 4.e-7
+      region: "*"
+limits:
+    context_window: 262144
+    max_output_tokens: 262144
+modalities:
+    input:
+        - image
+        - text
+        - video
+    output:
+        - text
+mode: chat
+model: google/gemma-4-26b-a4b-it
+params:
+    - defaultValue: 1
+      key: temperature
+    - defaultValue: 0.95
+      key: top_p
+    - defaultValue: 64
+      key: top_k

--- a/providers/openrouter/google/gemma-4-31b-it.yaml
+++ b/providers/openrouter/google/gemma-4-31b-it.yaml
@@ -1,0 +1,23 @@
+costs:
+    - input_cost_per_token: 1.4e-7
+      output_cost_per_token: 4.e-7
+      region: "*"
+limits:
+    context_window: 262144
+    max_output_tokens: 131072
+modalities:
+    input:
+        - image
+        - text
+        - video
+    output:
+        - text
+mode: chat
+model: google/gemma-4-31b-it
+params:
+    - defaultValue: 1
+      key: temperature
+    - defaultValue: 0.95
+      key: top_p
+    - defaultValue: 64
+      key: top_k

--- a/providers/openrouter/qwen/qwen3.6-plus:free.yaml
+++ b/providers/openrouter/qwen/qwen3.6-plus:free.yaml
@@ -1,0 +1,16 @@
+costs:
+    - input_cost_per_token: 0
+      output_cost_per_token: 0
+      region: "*"
+limits:
+    context_window: 1000000
+    max_output_tokens: 65536
+modalities:
+    input:
+        - text
+        - image
+        - video
+    output:
+        - text
+mode: chat
+model: qwen/qwen3.6-plus:free

--- a/providers/openrouter/rekaai/reka-edge.yaml
+++ b/providers/openrouter/rekaai/reka-edge.yaml
@@ -1,0 +1,16 @@
+costs:
+    - input_cost_per_token: 1.e-7
+      output_cost_per_token: 1.e-7
+      region: "*"
+limits:
+    context_window: 16384
+    max_output_tokens: 16384
+modalities:
+    input:
+        - image
+        - text
+        - video
+    output:
+        - text
+mode: chat
+model: rekaai/reka-edge

--- a/providers/openrouter/z-ai/glm-5v-turbo.yaml
+++ b/providers/openrouter/z-ai/glm-5v-turbo.yaml
@@ -1,0 +1,22 @@
+costs:
+    - cache_read_input_token_cost: 2.4e-7
+      input_cost_per_token: 0.0000012
+      output_cost_per_token: 0.000004
+      region: "*"
+limits:
+    context_window: 202752
+    max_output_tokens: 131072
+modalities:
+    input:
+        - image
+        - text
+        - video
+    output:
+        - text
+mode: chat
+model: z-ai/glm-5v-turbo
+params:
+    - defaultValue: 1
+      key: temperature
+    - defaultValue: 0.95
+      key: top_p


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `openrouter`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that adds new OpenRouter model YAMLs; main impact is enabling selection of these models and using the specified token limits/pricing (including a free tier).
> 
> **Overview**
> Adds six new OpenRouter model configuration files, defining **pricing**, **context/output token limits**, and **supported modalities** for `arcee-ai/trinity-large-thinking`, `google/gemma-4-26b-a4b-it`, `google/gemma-4-31b-it`, `qwen/qwen3.6-plus:free`, `rekaai/reka-edge`, and `z-ai/glm-5v-turbo`.
> 
> Some models include default sampling parameters (`temperature`, `top_p`, `top_k`) and `glm-5v-turbo` adds a `cache_read_input_token_cost` entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 620f7794cb9d07e1a06db189ce4fd825bd65494b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->