### PR TITLE
feat(deepinfra): add new models [bot]

### DIFF
--- a/providers/deepinfra/ByteDance/Seed-2.0-pro.yaml
+++ b/providers/deepinfra/ByteDance/Seed-2.0-pro.yaml
@@ -1,0 +1,15 @@
+costs:
+    - cache_read_input_token_cost: 1.e-7
+      input_cost_per_token: 5.e-7
+      output_cost_per_token: 0.000003
+      region: "*"
+features:
+    - prompt_caching
+limits:
+    context_window: 256000
+    max_tokens: 256000
+modalities:
+    input:
+        - image
+mode: unknown
+model: ByteDance/Seed-2.0-pro

--- a/providers/deepinfra/Wan-AI/Wan2.7-Image-Edit.yaml
+++ b/providers/deepinfra/Wan-AI/Wan2.7-Image-Edit.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: Wan-AI/Wan2.7-Image-Edit


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `deepinfra`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only introduces new provider model YAML metadata (pricing/limits/features) with no runtime logic changes.
> 
> **Overview**
> Registers two new `deepinfra` model definition YAMLs.
> 
> Adds `ByteDance/Seed-2.0-pro` with token pricing, `prompt_caching`, a 256k context/token limit, and image input modality, and adds a minimal entry for `Wan-AI/Wan2.7-Image-Edit` (model id + mode).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40741532233f7d53f9701c7103e69f39dc152928. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->