### PR TITLE
feat(google-gemini): add new models [bot]

### DIFF
--- a/providers/google-gemini/gemma-4-26b-a4b-it.yaml
+++ b/providers/google-gemini/gemma-4-26b-a4b-it.yaml
@@ -1,0 +1,14 @@
+limits:
+    max_input_tokens: 262144
+    max_output_tokens: 32768
+mode: unknown
+model: gemma-4-26b-a4b-it
+params:
+    - defaultValue: 1
+      key: temperature
+      maxValue: 2
+    - defaultValue: 0.95
+      key: top_p
+    - defaultValue: 64
+      key: top_k
+thinking: true

--- a/providers/google-gemini/gemma-4-31b-it.yaml
+++ b/providers/google-gemini/gemma-4-31b-it.yaml
@@ -1,0 +1,14 @@
+limits:
+    max_input_tokens: 262144
+    max_output_tokens: 32768
+mode: unknown
+model: gemma-4-31b-it
+params:
+    - defaultValue: 1
+      key: temperature
+      maxValue: 2
+    - defaultValue: 0.95
+      key: top_p
+    - defaultValue: 64
+      key: top_k
+thinking: true


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `google-gemini`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds two new static model definition YAML files; no runtime logic changes, so risk is limited to potential misconfiguration of model metadata/limits.
> 
> **Overview**
> Registers two new Google Gemini model configs: `gemma-4-26b-a4b-it` and `gemma-4-31b-it`.
> 
> Each model definition sets token limits (262k input/32k output), exposes sampling params (`temperature`, `top_p`, `top_k`), and enables `thinking` with `mode: unknown`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08b20168f2dd826a1edaa030f8d1f04147d92b80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->