### PR TITLE
feat(google-gemini): add new models [bot]

### DIFF
--- a/providers/google-gemini/gemma-4-26b-a4b-it.yaml
+++ b/providers/google-gemini/gemma-4-26b-a4b-it.yaml
@@ -1,0 +1,14 @@
+limits:
+    max_input_tokens: 262144
+    max_output_tokens: 32768
+mode: unknown
+model: gemma-4-26b-a4b-it
+params:
+    - defaultValue: 1
+      key: temperature
+      maxValue: 2
+    - defaultValue: 0.95
+      key: top_p
+    - defaultValue: 64
+      key: top_k
+thinking: true

--- a/providers/google-gemini/gemma-4-31b-it.yaml
+++ b/providers/google-gemini/gemma-4-31b-it.yaml
@@ -1,0 +1,14 @@
+limits:
+    max_input_tokens: 262144
+    max_output_tokens: 32768
+mode: unknown
+model: gemma-4-31b-it
+params:
+    - defaultValue: 1
+      key: temperature
+      maxValue: 2
+    - defaultValue: 0.95
+      key: top_p
+    - defaultValue: 64
+      key: top_k
+thinking: true


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `google-gemini`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds two new provider model YAMLs only; no runtime logic changes, so risk is limited to potential misconfiguration of model metadata/limits.
> 
> **Overview**
> Adds two new Google Gemini model definition files, `gemma-4-26b-a4b-it` and `gemma-4-31b-it`, including token limits, supported sampling params (`temperature`, `top_p`, `top_k`), and enabling `thinking`.
> 
> Both models are introduced with `mode: unknown` and a max input/output of 262,144/32,768 tokens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38499ecc233074f93f8854985cf6a97cf2ff8571. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->