### PR TITLE
feat(groq): update model YAMLs [bot]

### DIFF
--- a/providers/groq/allam-2-7b.yaml
+++ b/providers/groq/allam-2-7b.yaml
@@ -1,5 +1,6 @@
 features:
     - structured_output
+    - json_output
 limits:
     context_window: 4096
     max_output_tokens: 4096

--- a/providers/groq/moonshotai/kimi-k2-instruct-0905.yaml
+++ b/providers/groq/moonshotai/kimi-k2-instruct-0905.yaml
@@ -6,6 +6,7 @@ costs:
 deprecationDate: "2026-04-15"
 features:
     - prompt_caching
+isDeprecated: true
 limits:
     context_window: 256000
 modalities:

--- a/providers/groq/openai/gpt-oss-safeguard-20b.yaml
+++ b/providers/groq/openai/gpt-oss-safeguard-20b.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 3.75e-8
+    - cache_read_input_token_cost: 3.7e-8
       input_cost_per_token: 7.5e-8
       output_cost_per_token: 3.e-7
       region: "*"

--- a/providers/groq/qwen/qwen3-32b.yaml
+++ b/providers/groq/qwen/qwen3-32b.yaml
@@ -5,7 +5,6 @@ costs:
 features:
     - function_calling
     - parallel_function_calling
-    - tool_choice
     - structured_output
     - json_output
 limits:

--- a/providers/groq/whisper-large-v3.yaml
+++ b/providers/groq/whisper-large-v3.yaml
@@ -26,3 +26,5 @@ removeParams:
 sources:
     - https://console.groq.com/docs/speech-to-text
 status: active
+supportedModes:
+    - audio_translation


### PR DESCRIPTION
Auto-generated by poc-agent for provider `groq`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: config-only updates to Groq model capability/metadata flags and pricing, with no code-path changes.
> 
> **Overview**
> Updates Groq provider model YAMLs to reflect refreshed capabilities and lifecycle metadata.
> 
> `allam-2-7b` now advertises **`json_output`** support; `kimi-k2-instruct-0905` is marked **deprecated** via `isDeprecated: true`; `gpt-oss-safeguard-20b` pricing is tweaked; `qwen3-32b` drops the `tool_choice` feature flag; and `whisper-large-v3` adds `supportedModes: [audio_translation]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7654e6fa7dfd4196aad4b4f1fa3df3e6440756f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->