### PR TITLE
feat(mistral-ai): update model YAMLs [bot]

### DIFF
--- a/providers/mistral-ai/codestral-2508.yaml
+++ b/providers/mistral-ai/codestral-2508.yaml
@@ -4,6 +4,8 @@ costs:
       region: "*"
 features:
     - function_calling
+    - structured_output
+    - json_output
 limits:
     context_window: 256000
 mode: completion

--- a/providers/mistral-ai/codestral-embed-2505.yaml
+++ b/providers/mistral-ai/codestral-embed-2505.yaml
@@ -4,7 +4,13 @@ costs:
       region: "*"
 limits:
     context_window: 8192
-mode: unknown
+modalities:
+    input:
+        - text
+        - code
+    output:
+        - embedding
+mode: embedding
 model: codestral-embed-2505
 removeParams:
     - max_tokens

--- a/providers/mistral-ai/codestral-embed.yaml
+++ b/providers/mistral-ai/codestral-embed.yaml
@@ -4,7 +4,13 @@ costs:
       region: "*"
 limits:
     context_window: 8192
-mode: unknown
+modalities:
+    input:
+        - text
+        - code
+    output:
+        - embedding
+mode: embedding
 model: codestral-embed
 removeParams:
     - max_tokens

--- a/providers/mistral-ai/codestral-latest.yaml
+++ b/providers/mistral-ai/codestral-latest.yaml
@@ -4,6 +4,8 @@ costs:
       region: "*"
 features:
     - function_calling
+    - structured_output
+    - json_output
 limits:
     context_window: 256000
 mode: completion

--- a/providers/mistral-ai/devstral-2512.yaml
+++ b/providers/mistral-ai/devstral-2512.yaml
@@ -4,8 +4,15 @@ costs:
       region: "*"
 features:
     - function_calling
+    - structured_output
 limits:
     context_window: 262144
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
 mode: chat
 model: devstral-2512
 params:

--- a/providers/mistral-ai/devstral-latest.yaml
+++ b/providers/mistral-ai/devstral-latest.yaml
@@ -4,6 +4,8 @@ costs:
       region: "*"
 features:
     - function_calling
+    - json_output
+    - structured_output
 limits:
     context_window: 262144
 mode: chat

--- a/providers/mistral-ai/devstral-medium-latest.yaml
+++ b/providers/mistral-ai/devstral-medium-latest.yaml
@@ -4,6 +4,7 @@ costs:
       region: "*"
 features:
     - function_calling
+isDeprecated: true
 limits:
     context_window: 262144
 mode: chat

--- a/providers/mistral-ai/devstral-small-latest.yaml
+++ b/providers/mistral-ai/devstral-small-latest.yaml
@@ -8,6 +8,7 @@ features:
     - tool_choice
     - structured_output
     - assistant_prefill
+isDeprecated: true
 limits:
     context_window: 256000
 modalities:

--- a/providers/mistral-ai/labs-devstral-small-2512.yaml
+++ b/providers/mistral-ai/labs-devstral-small-2512.yaml
@@ -7,6 +7,7 @@ features:
     - tool_choice
     - structured_output
     - assistant_prefill
+isDeprecated: true
 limits:
     context_window: 256000
     max_input_tokens: 256000

--- a/providers/mistral-ai/labs-mistral-small-creative.yaml
+++ b/providers/mistral-ai/labs-mistral-small-creative.yaml
@@ -5,6 +5,7 @@ costs:
 deprecationDate: "2026-04-30"
 features:
     - function_calling
+isDeprecated: true
 limits:
     context_window: 32768
 mode: chat

--- a/providers/mistral-ai/magistral-medium-2509.yaml
+++ b/providers/mistral-ai/magistral-medium-2509.yaml
@@ -4,11 +4,19 @@ costs:
       region: "*"
 features:
     - function_calling
+    - structured_output
+    - json_output
 limits:
     context_window: 131072
 modalities:
     input:
         - image
+        - text
+        - audio
+        - pdf
+    output:
+        - text
+        - audio
 mode: chat
 model: magistral-medium-2509
 params:

--- a/providers/mistral-ai/magistral-small-2509.yaml
+++ b/providers/mistral-ai/magistral-small-2509.yaml
@@ -4,11 +4,17 @@ costs:
       region: "*"
 features:
     - function_calling
+    - structured_output
+    - json_output
 limits:
     context_window: 131072
 modalities:
     input:
         - image
+        - text
+        - pdf
+    output:
+        - text
 mode: chat
 model: magistral-small-2509
 params:

--- a/providers/mistral-ai/magistral-small-latest.yaml
+++ b/providers/mistral-ai/magistral-small-latest.yaml
@@ -4,11 +4,17 @@ costs:
       region: "*"
 features:
     - function_calling
+    - structured_output
+    - json_output
+    - tool_choice
 limits:
     context_window: 131072
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: magistral-small-latest
 params:

--- a/providers/mistral-ai/ministral-14b-2512.yaml
+++ b/providers/mistral-ai/ministral-14b-2512.yaml
@@ -4,11 +4,16 @@ costs:
       region: "*"
 features:
     - function_calling
+    - json_output
+    - structured_output
 limits:
     context_window: 262144
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: ministral-14b-2512
 params:

--- a/providers/mistral-ai/ministral-3b-2512.yaml
+++ b/providers/mistral-ai/ministral-3b-2512.yaml
@@ -4,11 +4,16 @@ costs:
       region: "*"
 features:
     - function_calling
+    - structured_output
+    - json_output
 limits:
     context_window: 131072
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: ministral-3b-2512
 params:
@@ -18,6 +23,7 @@ sources:
     - https://docs.mistral.ai/models/ministral-3-3b-25-12
     - https://docs.mistral.ai/capabilities/vision/
     - https://docs.mistral.ai/capabilities/function_calling/
+    - https://docs.mistral.ai/capabilities/structured_output/
 status: active
 supportedModes:
     - chat

--- a/providers/mistral-ai/ministral-3b-latest.yaml
+++ b/providers/mistral-ai/ministral-3b-latest.yaml
@@ -4,11 +4,16 @@ costs:
       region: "*"
 features:
     - function_calling
+    - structured_output
+    - json_output
 limits:
     context_window: 131072
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: ministral-3b-latest
 params:

--- a/providers/mistral-ai/ministral-8b-2512.yaml
+++ b/providers/mistral-ai/ministral-8b-2512.yaml
@@ -4,11 +4,17 @@ costs:
       region: "*"
 features:
     - function_calling
+    - structured_output
+    - json_output
 limits:
     context_window: 262144
 modalities:
     input:
+        - text
         - image
+        - pdf
+    output:
+        - text
 mode: chat
 model: ministral-8b-2512
 params:

--- a/providers/mistral-ai/mistral-large-2512.yaml
+++ b/providers/mistral-ai/mistral-large-2512.yaml
@@ -4,11 +4,18 @@ costs:
       region: "*"
 features:
     - function_calling
+    - parallel_function_calling
+    - structured_output
+    - json_output
+    - tool_choice
 limits:
     context_window: 262144
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: mistral-large-2512
 params:

--- a/providers/mistral-ai/mistral-large-latest.yaml
+++ b/providers/mistral-ai/mistral-large-latest.yaml
@@ -4,11 +4,20 @@ costs:
       region: "*"
 features:
     - function_calling
+    - structured_output
+    - json_output
 limits:
     context_window: 262144
 modalities:
     input:
+        - text
         - image
+        - audio
+        - pdf
+        - doc
+    output:
+        - text
+        - audio
 mode: chat
 model: mistral-large-latest
 params:

--- a/providers/mistral-ai/mistral-medium-2508.yaml
+++ b/providers/mistral-ai/mistral-medium-2508.yaml
@@ -4,11 +4,17 @@ costs:
       region: "*"
 features:
     - function_calling
+    - json_output
+    - structured_output
+    - tool_choice
 limits:
     context_window: 131072
 modalities:
     input:
         - image
+        - text
+    output:
+        - text
 mode: chat
 model: mistral-medium-2508
 params:

--- a/providers/mistral-ai/mistral-medium-latest.yaml
+++ b/providers/mistral-ai/mistral-medium-latest.yaml
@@ -4,11 +4,19 @@ costs:
       region: "*"
 features:
     - function_calling
+    - structured_output
+    - json_output
+    - tool_choice
 limits:
     context_window: 131072
 modalities:
     input:
+        - text
         - image
+        - audio
+        - pdf
+    output:
+        - text
 mode: chat
 model: mistral-medium-latest
 params:

--- a/providers/mistral-ai/mistral-moderation-2411.yaml
+++ b/providers/mistral-ai/mistral-moderation-2411.yaml
@@ -3,6 +3,7 @@ costs:
       output_cost_per_token: 1.e-7
       region: "*"
 deprecationDate: "2026-06-30"
+isDeprecated: true
 limits:
     context_window: 8192
 mode: moderation

--- a/providers/mistral-ai/mistral-moderation-latest.yaml
+++ b/providers/mistral-ai/mistral-moderation-latest.yaml
@@ -1,3 +1,7 @@
+costs:
+    - input_cost_per_token: 0
+      output_cost_per_token: 0
+      region: "*"
 deprecationDate: "2026-06-30"
 limits:
     context_window: 8192
@@ -12,6 +16,7 @@ removeParams:
     - stream
 sources:
     - https://docs.mistral.ai/capabilities/guardrailing/
+    - https://docs.mistral.ai/models/mistral-moderation-26-03
 status: active
 supportedModes:
     - moderation

--- a/providers/mistral-ai/mistral-ocr-2512.yaml
+++ b/providers/mistral-ai/mistral-ocr-2512.yaml
@@ -4,12 +4,17 @@ costs:
       region: "*"
 features:
     - function_calling
+    - structured_output
+    - json_output
 limits:
     context_window: 16384
 modalities:
     input:
         - image
         - pdf
+        - doc
+    output:
+        - text
 mode: unknown
 model: mistral-ocr-2512
 params:

--- a/providers/mistral-ai/mistral-ocr-latest.yaml
+++ b/providers/mistral-ai/mistral-ocr-latest.yaml
@@ -4,12 +4,16 @@ costs:
       region: "*"
 features:
     - function_calling
+    - structured_output
 limits:
     context_window: 16384
 modalities:
     input:
         - image
         - pdf
+        - doc
+    output:
+        - text
 mode: unknown
 model: mistral-ocr-latest
 params:

--- a/providers/mistral-ai/mistral-small-2506.yaml
+++ b/providers/mistral-ai/mistral-small-2506.yaml
@@ -4,11 +4,16 @@ costs:
       region: "*"
 features:
     - function_calling
+    - structured_output
+    - json_output
 limits:
     context_window: 131072
 modalities:
     input:
         - image
+        - text
+    output:
+        - text
 mode: chat
 model: mistral-small-2506
 params:

--- a/providers/mistral-ai/mistral-small-latest.yaml
+++ b/providers/mistral-ai/mistral-small-latest.yaml
@@ -4,11 +4,20 @@ costs:
       region: "*"
 features:
     - function_calling
+    - structured_output
+    - json_output
 limits:
     context_window: 262144
 modalities:
     input:
+        - text
         - image
+        - audio
+        - pdf
+        - doc
+    output:
+        - text
+        - audio
 mode: chat
 model: mistral-small-latest
 params:
@@ -19,6 +28,7 @@ sources:
     - https://docs.mistral.ai/capabilities/vision/
     - https://docs.mistral.ai/capabilities/function_calling/
     - https://docs.mistral.ai/capabilities/reasoning/
+    - https://docs.mistral.ai/capabilities/structured_output/
 status: active
 supportedModes:
     - chat

--- a/providers/mistral-ai/mistral-small.yaml
+++ b/providers/mistral-ai/mistral-small.yaml
@@ -9,6 +9,7 @@ features:
     - structured_output
     - assistant_prefill
     - json_output
+    - system_messages
 limits:
     context_window: 128000
 modalities:

--- a/providers/mistral-ai/mistral-vibe-cli-with-tools.yaml
+++ b/providers/mistral-ai/mistral-vibe-cli-with-tools.yaml
@@ -4,11 +4,15 @@ costs:
       region: "*"
 features:
     - function_calling
+    - structured_output
 limits:
     context_window: 131072
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: mistral-vibe-cli-with-tools
 params:

--- a/providers/mistral-ai/pixtral-large-2411.yaml
+++ b/providers/mistral-ai/pixtral-large-2411.yaml
@@ -5,6 +5,7 @@ costs:
 deprecationDate: "2026-05-31"
 features:
     - function_calling
+isDeprecated: true
 limits:
     context_window: 131072
 modalities:

--- a/providers/mistral-ai/voxtral-mini-2507.yaml
+++ b/providers/mistral-ai/voxtral-mini-2507.yaml
@@ -4,6 +4,7 @@ costs:
       output_cost_per_token: 4.e-8
       region: "*"
 deprecationDate: "2026-05-31"
+isDeprecated: true
 limits:
     context_window: 16384
 mode: audio_transcription

--- a/providers/mistral-ai/voxtral-mini-latest.yaml
+++ b/providers/mistral-ai/voxtral-mini-latest.yaml
@@ -3,6 +3,7 @@ costs:
       input_cost_per_token: 4.e-8
       output_cost_per_token: 4.e-8
       region: "*"
+isDeprecated: true
 limits:
     context_window: 16384
 mode: audio_transcription

--- a/providers/mistral-ai/voxtral-mini-transcribe-2507.yaml
+++ b/providers/mistral-ai/voxtral-mini-transcribe-2507.yaml
@@ -2,6 +2,7 @@ costs:
     - input_cost_per_second: 0.0000333333
       region: "*"
 deprecationDate: "2026-05-31"
+isDeprecated: true
 limits:
     context_window: 16384
 mode: audio_transcription

--- a/providers/mistral-ai/voxtral-small-2507.yaml
+++ b/providers/mistral-ai/voxtral-small-2507.yaml
@@ -5,6 +5,7 @@ costs:
       region: "*"
 features:
     - function_calling
+isDeprecated: true
 limits:
     context_window: 32768
 modalities:

--- a/providers/mistral-ai/voxtral-small-latest.yaml
+++ b/providers/mistral-ai/voxtral-small-latest.yaml
@@ -5,11 +5,15 @@ costs:
       region: "*"
 features:
     - function_calling
+    - structured_output
 limits:
     context_window: 32768
 modalities:
     input:
         - audio
+        - text
+    output:
+        - text
 mode: chat
 model: voxtral-small-latest
 params:


### PR DESCRIPTION
Auto-generated by poc-agent for provider `mistral-ai`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes model capability flags (e.g., `structured_output`, `json_output`, `tool_choice`) and modalities/modes, which can affect model selection and request validation at runtime.
> 
> **Overview**
> Updates Mistral AI model YAML metadata to reflect newer capabilities and I/O support, including adding `structured_output`/`json_output` (and in a few cases `tool_choice`, `parallel_function_calling`, `system_messages`) across multiple chat and completion models.
> 
> Normalizes model descriptors by expanding `modalities` (e.g., adding `text`, `audio`, `pdf`, `doc`, and explicit outputs), correcting embedding models to `mode: embedding`, setting `mistral-moderation-latest` costs to `0`, and marking several older/soon-to-be-retired models with `isDeprecated: true`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fdc4b025d2fd8eef51b8e92283a522e9ba24be8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->