### PR TITLE
feat(cerebras): update model YAMLs [bot]

### DIFF
--- a/providers/cerebras/qwen-3-235b-a22b-instruct-2507.yaml
+++ b/providers/cerebras/qwen-3-235b-a22b-instruct-2507.yaml
@@ -11,10 +11,16 @@ features:
     - system_messages
     - json_output
 limits:
-    context_window: 131072
-    max_input_tokens: 131072
-    max_output_tokens: 40960
-    max_tokens: 40960
+    context_window: 131000
+    max_input_tokens: 131000
+    max_output_tokens: 40000
+    max_tokens: 40000
+messages:
+    options:
+        - system
+        - user
+        - assistant
+        - developer
 modalities:
     input:
         - text
@@ -24,9 +30,7 @@ mode: chat
 model: qwen-3-235b-a22b-instruct-2507
 params:
     - key: max_tokens
-      maxValue: 40960
-    - key: temperature
-      maxValue: 1.5
+      maxValue: 40000
     - key: seed
       type: number
 sources:


### PR DESCRIPTION
Auto-generated by poc-agent for provider `cerebras`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that tweaks token limits and allowed message roles for a single Cerebras model YAML. Main risk is mismatched limits vs provider capabilities causing request validation/usage differences.
> 
> **Overview**
> Updates the Cerebras `qwen-3-235b-a22b-instruct-2507` model spec by lowering advertised token limits (`context_window`, input/output, and `max_tokens`) and aligning the `max_tokens` param cap accordingly.
> 
> Adds a `messages.options` section to explicitly allow `system`, `user`, `assistant`, and `developer` roles in chat inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7d2407fa2c959611266f05f86200a8c173b67fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->