### PR TITLE
feat(cohere): update model YAMLs [bot]

### DIFF
--- a/providers/cohere/embed-multilingual-v3.0-image.yaml
+++ b/providers/cohere/embed-multilingual-v3.0-image.yaml
@@ -6,6 +6,8 @@ messages:
 modalities:
     input:
         - image
+    output:
+        - embedding
 mode: embedding
 model: embed-multilingual-v3.0-image
 removeParams:

--- a/providers/cohere/rerank-multilingual-v3.0.yaml
+++ b/providers/cohere/rerank-multilingual-v3.0.yaml
@@ -5,6 +5,9 @@ costs:
       region: "*"
 limits:
     context_window: 4096
+modalities:
+    input:
+        - text
 mode: rerank
 model: rerank-multilingual-v3.0
 removeParams:

--- a/providers/cohere/tiny-aya-water.yaml
+++ b/providers/cohere/tiny-aya-water.yaml
@@ -2,6 +2,11 @@ features:
     - structured_output
 limits:
     context_window: 8000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: completion
 model: tiny-aya-water
 status: active


### PR DESCRIPTION
Auto-generated by poc-agent for provider `cohere`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk metadata-only YAML changes that just declare input/output modalities; no runtime logic is modified.
> 
> **Overview**
> Adds explicit `modalities` declarations to several Cohere model YAMLs: `embed-multilingual-v3.0-image` now declares *embedding* output, `rerank-multilingual-v3.0` declares *text* input, and `tiny-aya-water` declares *text* input/output to match its completion/chat usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a8626586d713ee89b23f138fe1a31d85e23d9a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->