### PR TITLE
feat(openrouter): update model YAMLs [bot]

### DIFF
--- a/providers/openrouter/liquid/lfm-2-24b-a2b.yaml
+++ b/providers/openrouter/liquid/lfm-2-24b-a2b.yaml
@@ -2,9 +2,6 @@ costs:
     - input_cost_per_token: 3.e-8
       output_cost_per_token: 1.2e-7
       region: "*"
-features:
-    - function_calling
-    - tool_choice
 limits:
     context_window: 32768
 modalities:

--- a/providers/openrouter/liquid/lfm-2.5-1.2b-instruct:free.yaml
+++ b/providers/openrouter/liquid/lfm-2.5-1.2b-instruct:free.yaml
@@ -3,7 +3,6 @@ costs:
       output_cost_per_token: 0
       region: "*"
 features:
-    - function_calling
     - tool_choice
 limits:
     context_window: 32768

--- a/providers/openrouter/liquid/lfm-2.5-1.2b-thinking:free.yaml
+++ b/providers/openrouter/liquid/lfm-2.5-1.2b-thinking:free.yaml
@@ -4,6 +4,7 @@ costs:
       region: "*"
 features:
     - system_messages
+    - function_calling
 limits:
     context_window: 32768
 modalities:

--- a/providers/openrouter/liquid/lfm2-8b-a1b.yaml
+++ b/providers/openrouter/liquid/lfm2-8b-a1b.yaml
@@ -2,13 +2,8 @@ costs:
     - input_cost_per_token: 1.e-8
       output_cost_per_token: 2.e-8
       region: "*"
-features:
-    - function_calling
-    - tool_choice
 limits:
-    context_window: 32768
-    max_output_tokens: 32768
-    max_tokens: 32768
+    context_window: 8192
 modalities:
     input:
         - text

--- a/providers/openrouter/meituan/longcat-flash-chat.yaml
+++ b/providers/openrouter/meituan/longcat-flash-chat.yaml
@@ -5,7 +5,6 @@ costs:
 features:
     - function_calling
     - tool_choice
-    - structured_output
 limits:
     context_window: 131072
     max_output_tokens: 131072

--- a/providers/openrouter/meta-llama/llama-3-70b-instruct.yaml
+++ b/providers/openrouter/meta-llama/llama-3-70b-instruct.yaml
@@ -5,7 +5,6 @@ costs:
 features:
     - function_calling
     - tool_choice
-    - structured_output
 limits:
     context_window: 8192
     max_output_tokens: 8000

--- a/providers/openrouter/minimax/minimax-01.yaml
+++ b/providers/openrouter/minimax/minimax-01.yaml
@@ -2,6 +2,9 @@ costs:
     - input_cost_per_token: 2.e-7
       output_cost_per_token: 0.0000011
       region: "*"
+features:
+    - function_calling
+    - tool_choice
 limits:
     context_window: 1000192
     max_output_tokens: 1000192

--- a/providers/openrouter/minimax/minimax-m2.5.yaml
+++ b/providers/openrouter/minimax/minimax-m2.5.yaml
@@ -1,12 +1,7 @@
 costs:
-    - cache_read_input_token_cost: 9.5e-8
-      input_cost_per_token: 1.9e-7
-      output_cost_per_token: 0.00000115
+    - input_cost_per_token: 1.18e-7
+      output_cost_per_token: 9.9e-7
       region: "*"
-features:
-    - function_calling
-    - tool_choice
-    - structured_output
 limits:
     context_window: 196608
     max_output_tokens: 65536
@@ -18,6 +13,14 @@ modalities:
         - text
 mode: chat
 model: minimax/minimax-m2.5
+params:
+    - defaultValue: 128
+      key: max_tokens
+      maxValue: 65536
+      minValue: 1
+    - defaultValue: true
+      key: reasoning
+      type: boolean
 sources:
     - https://openrouter.ai/minimax/minimax-m2.5/api
 thinking: true

--- a/providers/openrouter/mistralai/devstral-2512.yaml
+++ b/providers/openrouter/mistralai/devstral-2512.yaml
@@ -5,8 +5,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
     - structured_output
+    - tool_choice
 limits:
     context_window: 262144
     max_input_tokens: 262144

--- a/providers/openrouter/mistralai/ministral-8b-2512.yaml
+++ b/providers/openrouter/mistralai/ministral-8b-2512.yaml
@@ -7,6 +7,7 @@ features:
     - function_calling
     - tool_choice
     - structured_output
+    - json_output
 limits:
     context_window: 262144
     max_input_tokens: 262144

--- a/providers/openrouter/moonshotai/kimi-k2-0905.yaml
+++ b/providers/openrouter/moonshotai/kimi-k2-0905.yaml
@@ -8,6 +8,7 @@ features:
     - tool_choice
     - structured_output
     - system_messages
+    - json_output
 limits:
     context_window: 131072
 modalities:

--- a/providers/openrouter/moonshotai/kimi-k2.5.yaml
+++ b/providers/openrouter/moonshotai/kimi-k2.5.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_token_cost: 2.1e-7
-      input_cost_per_token: 4.2e-7
-      output_cost_per_token: 0.0000022
+    - cache_read_input_token_cost: 1.935e-7
+      input_cost_per_token: 3.827e-7
+      output_cost_per_token: 0.00000172
       region: "*"
 features:
     - function_calling
@@ -9,8 +9,8 @@ features:
     - structured_output
 limits:
     context_window: 262144
-    max_output_tokens: 65535
-    max_tokens: 65535
+    max_output_tokens: 262144
+    max_tokens: 262144
 modalities:
     input:
         - text

--- a/providers/openrouter/nousresearch/hermes-4-70b.yaml
+++ b/providers/openrouter/nousresearch/hermes-4-70b.yaml
@@ -16,6 +16,9 @@ modalities:
         - text
 mode: chat
 model: nousresearch/hermes-4-70b
+params:
+    - key: reasoning
+      type: json
 sources:
     - https://openrouter.ai/nousresearch/hermes-4-70b/api
 thinking: true

--- a/providers/openrouter/openai/gpt-4.1-mini.yaml
+++ b/providers/openrouter/openai/gpt-4.1-mini.yaml
@@ -12,7 +12,6 @@ features:
     - structured_output
 limits:
     context_window: 1047576
-    max_input_tokens: 1047576
     max_output_tokens: 32768
     max_tokens: 32768
 modalities:

--- a/providers/openrouter/openai/gpt-5-codex.yaml
+++ b/providers/openrouter/openai/gpt-5-codex.yaml
@@ -8,6 +8,8 @@ features:
     - tool_choice
     - structured_output
     - prompt_caching
+    - json_output
+    - system_messages
 limits:
     context_window: 400000
     max_input_tokens: 272000

--- a/providers/openrouter/openai/gpt-5.2-chat.yaml
+++ b/providers/openrouter/openai/gpt-5.2-chat.yaml
@@ -17,6 +17,7 @@ modalities:
     input:
         - text
         - image
+        - pdf
     output:
         - text
 mode: chat

--- a/providers/openrouter/openai/gpt-5.4-pro.yaml
+++ b/providers/openrouter/openai/gpt-5.4-pro.yaml
@@ -23,7 +23,6 @@ modalities:
     input:
         - text
         - image
-        - pdf
     output:
         - text
 mode: chat

--- a/providers/openrouter/openai/gpt-5.4.yaml
+++ b/providers/openrouter/openai/gpt-5.4.yaml
@@ -1,18 +1,7 @@
 costs:
-    - cache_read_input_token_cost: 2.5e-7
-      input_cost_per_token: 0.0000025
+    - input_cost_per_token: 0.0000025
       output_cost_per_token: 0.000015
       region: "*"
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 5.e-7
-                from: 272000
-          input:
-              - cost_per_token: 0.000005
-                from: 272000
-          output:
-              - cost_per_token: 0.0000225
-                from: 272000
 features:
     - function_calling
     - tool_choice
@@ -27,7 +16,6 @@ modalities:
     input:
         - text
         - image
-        - pdf
     output:
         - text
 mode: chat

--- a/providers/openrouter/openai/gpt-audio.yaml
+++ b/providers/openrouter/openai/gpt-audio.yaml
@@ -5,8 +5,11 @@ costs:
       output_cost_per_token: 0.00001
       region: "*"
 features:
+    - function_calling
     - structured_output
     - system_messages
+    - tool_choice
+    - json_output
 limits:
     context_window: 128000
     max_output_tokens: 16384

--- a/providers/openrouter/openai/o1.yaml
+++ b/providers/openrouter/openai/o1.yaml
@@ -5,7 +5,6 @@ costs:
       region: "*"
 features:
     - function_calling
-    - parallel_function_calling
     - system_messages
     - tool_choice
     - prompt_caching
@@ -19,7 +18,6 @@ modalities:
     input:
         - text
         - image
-        - pdf
     output:
         - text
 mode: chat

--- a/providers/openrouter/openai/o3-pro.yaml
+++ b/providers/openrouter/openai/o3-pro.yaml
@@ -13,7 +13,6 @@ limits:
 modalities:
     input:
         - text
-        - pdf
         - image
     output:
         - text

--- a/providers/openrouter/openai/o3.yaml
+++ b/providers/openrouter/openai/o3.yaml
@@ -14,8 +14,8 @@ limits:
     max_tokens: 100000
 modalities:
     input:
-        - image
         - text
+        - image
         - pdf
     output:
         - text

--- a/providers/openrouter/openai/o4-mini-deep-research.yaml
+++ b/providers/openrouter/openai/o4-mini-deep-research.yaml
@@ -21,6 +21,11 @@ modalities:
         - text
 mode: chat
 model: openai/o4-mini-deep-research
+params:
+    - defaultValue: 100000
+      key: max_tokens
+      maxValue: 100000
+      minValue: 1
 sources:
     - https://openrouter.ai/openai/o4-mini-deep-research/api
 thinking: true

--- a/providers/openrouter/openai/o4-mini.yaml
+++ b/providers/openrouter/openai/o4-mini.yaml
@@ -8,6 +8,7 @@ features:
     - structured_output
     - tool_choice
     - system_messages
+    - prompt_caching
 limits:
     context_window: 200000
     max_output_tokens: 100000

--- a/providers/openrouter/perplexity/sonar-deep-research.yaml
+++ b/providers/openrouter/perplexity/sonar-deep-research.yaml
@@ -1,10 +1,10 @@
 costs:
-    - input_cost_per_token: 0.000002
+    - input_cost_per_query: 0.005
+      input_cost_per_token: 0.000002
       output_cost_per_token: 0.000008
       region: "*"
 features:
     - system_messages
-    - tool_choice
 limits:
     context_window: 128000
 modalities:

--- a/providers/openrouter/qwen/qwen-max.yaml
+++ b/providers/openrouter/qwen/qwen-max.yaml
@@ -7,6 +7,7 @@ features:
     - function_calling
     - tool_choice
     - structured_output
+    - json_output
 limits:
     context_window: 32768
     max_input_tokens: 30720

--- a/providers/openrouter/qwen/qwen-plus-2025-07-28.yaml
+++ b/providers/openrouter/qwen/qwen-plus-2025-07-28.yaml
@@ -4,10 +4,10 @@ costs:
       region: "*"
       tiered_pricing:
           input:
-              - cost_per_token: 0.0000012
+              - cost_per_token: 7.8e-7
                 from: 256000
           output:
-              - cost_per_token: 0.0000036
+              - cost_per_token: 0.00000234
                 from: 256000
 features:
     - function_calling

--- a/providers/openrouter/qwen/qwen-plus.yaml
+++ b/providers/openrouter/qwen/qwen-plus.yaml
@@ -5,13 +5,13 @@ costs:
       region: "*"
       tiered_pricing:
           cache_read:
-              - cost_per_token: 2.4e-7
+              - cost_per_token: 1.56e-7
                 from: 256000
           input:
-              - cost_per_token: 0.0000012
+              - cost_per_token: 7.8e-7
                 from: 256000
           output:
-              - cost_per_token: 0.0000036
+              - cost_per_token: 0.00000234
                 from: 256000
 features:
     - function_calling

--- a/providers/openrouter/qwen/qwen-vl-plus.yaml
+++ b/providers/openrouter/qwen/qwen-vl-plus.yaml
@@ -4,8 +4,9 @@ costs:
       output_cost_per_token: 4.095e-7
       region: "*"
 features:
+    - function_calling
     - tool_choice
-    - structured_output
+    - json_output
 limits:
     context_window: 131072
     max_input_tokens: 129024

--- a/providers/openrouter/qwen/qwen2.5-coder-7b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen2.5-coder-7b-instruct.yaml
@@ -4,6 +4,8 @@ costs:
       region: "*"
 features:
     - structured_output
+    - function_calling
+    - tool_choice
 limits:
     context_window: 32768
 modalities:

--- a/providers/openrouter/qwen/qwen2.5-vl-32b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen2.5-vl-32b-instruct.yaml
@@ -2,6 +2,8 @@ costs:
     - input_cost_per_token: 2.e-7
       output_cost_per_token: 6.e-7
       region: "*"
+features:
+    - json_output
 limits:
     context_window: 128000
 modalities:

--- a/providers/openrouter/qwen/qwen2.5-vl-72b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen2.5-vl-72b-instruct.yaml
@@ -2,6 +2,10 @@ costs:
     - input_cost_per_token: 8.e-7
       output_cost_per_token: 8.e-7
       region: "*"
+features:
+    - function_calling
+    - structured_output
+    - json_output
 limits:
     context_window: 32768
     max_output_tokens: 32768
@@ -14,5 +18,11 @@ modalities:
         - text
 mode: chat
 model: qwen/qwen2.5-vl-72b-instruct
+params:
+    - key: top_k
+      minValue: 0
+    - key: seed
+      type: number
 sources:
     - https://openrouter.ai/qwen/qwen2.5-vl-72b-instruct/api
+status: active

--- a/providers/openrouter/qwen/qwen3-235b-a22b-2507.yaml
+++ b/providers/openrouter/qwen/qwen3-235b-a22b-2507.yaml
@@ -6,11 +6,10 @@ features:
     - function_calling
     - tool_choice
     - structured_output
+    - json_output
 limits:
     context_window: 262144
     max_input_tokens: 262144
-    max_output_tokens: 262144
-    max_tokens: 262144
 modalities:
     input:
         - text

--- a/providers/openrouter/qwen/qwen3-235b-a22b.yaml
+++ b/providers/openrouter/qwen/qwen3-235b-a22b.yaml
@@ -25,4 +25,5 @@ params:
       minValue: 1
 sources:
     - https://openrouter.ai/qwen/qwen3-235b-a22b/api
+status: active
 thinking: true

--- a/providers/openrouter/qwen/qwen3-coder-flash.yaml
+++ b/providers/openrouter/qwen/qwen3-coder-flash.yaml
@@ -7,9 +7,13 @@ costs:
           input:
               - cost_per_token: 3.25e-7
                 from: 32000
+              - cost_per_token: 5.2e-7
+                from: 128000
           output:
               - cost_per_token: 0.000001625
                 from: 32000
+              - cost_per_token: 0.0000026
+                from: 128000
 features:
     - function_calling
     - tool_choice

--- a/providers/openrouter/qwen/qwen3-coder-plus.yaml
+++ b/providers/openrouter/qwen/qwen3-coder-plus.yaml
@@ -5,14 +5,20 @@ costs:
       region: "*"
       tiered_pricing:
           cache_read:
-              - cost_per_token: 3.6e-7
+              - cost_per_token: 2.34e-7
                 from: 32000
+              - cost_per_token: 3.9e-7
+                from: 128000
           input:
-              - cost_per_token: 0.0000018
+              - cost_per_token: 0.00000117
                 from: 32000
+              - cost_per_token: 0.00000195
+                from: 128000
           output:
-              - cost_per_token: 0.000009
+              - cost_per_token: 0.00000585
                 from: 32000
+              - cost_per_token: 0.00000975
+                from: 128000
 features:
     - function_calling
     - tool_choice

--- a/providers/openrouter/qwen/qwen3-coder.yaml
+++ b/providers/openrouter/qwen/qwen3-coder.yaml
@@ -7,11 +7,10 @@ features:
     - function_calling
     - tool_choice
     - structured_output
+    - json_output
 limits:
     context_window: 262144
     max_input_tokens: 262144
-    max_output_tokens: 262144
-    max_tokens: 262144
 modalities:
     input:
         - text
@@ -21,3 +20,4 @@ mode: chat
 model: qwen/qwen3-coder
 sources:
     - https://openrouter.ai/qwen/qwen3-coder/api
+status: active

--- a/providers/openrouter/qwen/qwen3-max-thinking.yaml
+++ b/providers/openrouter/qwen/qwen3-max-thinking.yaml
@@ -6,9 +6,13 @@ costs:
           input:
               - cost_per_token: 0.00000156
                 from: 32000
+              - cost_per_token: 0.00000195
+                from: 128000
           output:
               - cost_per_token: 0.0000078
                 from: 32000
+              - cost_per_token: 0.00000975
+                from: 128000
 features:
     - function_calling
     - tool_choice

--- a/providers/openrouter/qwen/qwen3-vl-235b-a22b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen3-vl-235b-a22b-instruct.yaml
@@ -1,6 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 1.1e-7
-      input_cost_per_token: 2.e-7
+    - input_cost_per_token: 2.e-7
       output_cost_per_token: 8.8e-7
       region: "*"
 features:

--- a/providers/openrouter/qwen/qwen3-vl-235b-a22b-thinking.yaml
+++ b/providers/openrouter/qwen/qwen3-vl-235b-a22b-thinking.yaml
@@ -13,6 +13,7 @@ modalities:
     input:
         - text
         - image
+        - video
     output:
         - text
 mode: chat

--- a/providers/openrouter/stepfun/step-3.5-flash.yaml
+++ b/providers/openrouter/stepfun/step-3.5-flash.yaml
@@ -1,6 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-8
-      input_cost_per_token: 1.e-7
+    - input_cost_per_token: 1.e-7
       output_cost_per_token: 3.e-7
       region: "*"
 features:
@@ -9,6 +8,8 @@ features:
     - system_messages
 limits:
     context_window: 262144
+    max_output_tokens: 65536
+    max_tokens: 65536
 modalities:
     input:
         - text

--- a/providers/openrouter/undi95/remm-slerp-l2-13b.yaml
+++ b/providers/openrouter/undi95/remm-slerp-l2-13b.yaml
@@ -4,7 +4,6 @@ costs:
       region: "*"
 features:
     - structured_output
-    - function_calling
     - json_output
 limits:
     context_window: 6144

--- a/providers/openrouter/x-ai/grok-3-mini-beta.yaml
+++ b/providers/openrouter/x-ai/grok-3-mini-beta.yaml
@@ -7,6 +7,8 @@ features:
     - function_calling
     - tool_choice
     - structured_output
+    - json_output
+    - prompt_caching
 limits:
     context_window: 131072
 modalities:

--- a/providers/openrouter/x-ai/grok-code-fast-1.yaml
+++ b/providers/openrouter/x-ai/grok-code-fast-1.yaml
@@ -8,6 +8,7 @@ features:
     - tool_choice
     - structured_output
     - system_messages
+    - prompt_caching
 limits:
     context_window: 256000
     max_output_tokens: 10000

--- a/providers/openrouter/z-ai/glm-4.5-air:free.yaml
+++ b/providers/openrouter/z-ai/glm-4.5-air:free.yaml
@@ -17,6 +17,11 @@ modalities:
         - text
 mode: chat
 model: z-ai/glm-4.5-air:free
+params:
+    - defaultValue: 96000
+      key: max_tokens
+      maxValue: 96000
+      minValue: 1
 sources:
     - https://openrouter.ai/z-ai/glm-4.5-air:free/api
 thinking: true

--- a/providers/openrouter/z-ai/glm-4.5.yaml
+++ b/providers/openrouter/z-ai/glm-4.5.yaml
@@ -7,6 +7,8 @@ features:
     - function_calling
     - tool_choice
     - system_messages
+    - structured_output
+    - json_output
 limits:
     context_window: 131072
     max_output_tokens: 98304

--- a/providers/openrouter/z-ai/glm-4.7-flash.yaml
+++ b/providers/openrouter/z-ai/glm-4.7-flash.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 1.00000002e-8
+    - cache_read_input_token_cost: 1.e-8
       input_cost_per_token: 6.e-8
       output_cost_per_token: 4.e-7
       region: "*"
@@ -7,12 +7,12 @@ features:
     - function_calling
     - tool_choice
     - structured_output
+    - json_output
 limits:
     context_window: 202752
 modalities:
     input:
         - text
-        - image
     output:
         - text
 mode: chat


### PR DESCRIPTION
Auto-generated by poc-agent for provider `openrouter`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates model metadata (features, limits, pricing, and params) across many OpenRouter YAMLs, which can change routing, UI capability flags, and cost calculations. Risk is moderate due to wide config surface area, but changes are data-only with no code modifications.
> 
> **Overview**
> **Updates OpenRouter model YAML metadata** across Liquid, Meituan, Minimax, Mistral, Moonshot, Nous, OpenAI, Perplexity, Qwen, Stepfun, Undi95, X-AI, and Z-AI.
> 
> This refresh adjusts advertised **features** (e.g., add/remove `function_calling`, `tool_choice`, `structured_output`, `json_output`, `prompt_caching`, `system_messages`), updates **limits/modalities** (e.g., context windows, max token settings, adds/removes `pdf`/`video` inputs), and revises **pricing** (including tiered pricing and per-query cost). Several models also gain/modify **`params`** (e.g., `max_tokens`, `reasoning`, `reasoning_effort`, `top_k`, `seed`) and some `status`/`thinking` flags are updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b4124f1dacc30f75787d0029243aab28e581c1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->