### PR TITLE
feat(together-ai): update model YAMLs [bot]

### DIFF
--- a/providers/together-ai/LiquidAI/LFM2-24B-A2B.yaml
+++ b/providers/together-ai/LiquidAI/LFM2-24B-A2B.yaml
@@ -3,6 +3,7 @@ costs:
       output_cost_per_token: 1.2e-7
       region: "*"
 features:
+    - function_calling
     - system_messages
 limits:
     context_window: 32768

--- a/providers/together-ai/MiniMaxAI/MiniMax-M1-40k.yaml
+++ b/providers/together-ai/MiniMaxAI/MiniMax-M1-40k.yaml
@@ -4,6 +4,8 @@ features:
     - system_messages
 limits:
     context_window: 1000000
+    max_output_tokens: 40000
+    max_tokens: 40000
 modalities:
     input:
         - text

--- a/providers/together-ai/MiniMaxAI/MiniMax-M2.yaml
+++ b/providers/together-ai/MiniMaxAI/MiniMax-M2.yaml
@@ -6,6 +6,7 @@ costs:
 features:
     - function_calling
     - structured_output
+    - json_output
 limits:
     context_window: 228700
 modalities:

--- a/providers/together-ai/Qwen/Qwen-Image.yaml
+++ b/providers/together-ai/Qwen/Qwen-Image.yaml
@@ -8,5 +8,6 @@ modalities:
         - image
 mode: image
 model: Qwen/Qwen-Image
+status: active
 supportedModes:
     - image

--- a/providers/together-ai/Qwen/Qwen2-7B.yaml
+++ b/providers/together-ai/Qwen/Qwen2-7B.yaml
@@ -5,3 +5,4 @@ modalities:
         - text
 mode: completion
 model: Qwen/Qwen2-7B
+status: active

--- a/providers/together-ai/Qwen/Qwen2.5-32B.yaml
+++ b/providers/together-ai/Qwen/Qwen2.5-32B.yaml
@@ -1,3 +1,7 @@
+limits:
+    context_window: 131072
+    max_output_tokens: 8000
+    max_tokens: 8000
 modalities:
     input:
         - text
@@ -5,3 +9,6 @@ modalities:
         - text
 mode: completion
 model: Qwen/Qwen2.5-32B
+sources:
+    - https://huggingface.co/Qwen/Qwen2.5-32B
+status: active

--- a/providers/together-ai/Qwen/Qwen2.5-7B.yaml
+++ b/providers/together-ai/Qwen/Qwen2.5-7B.yaml
@@ -5,3 +5,6 @@ modalities:
         - text
 mode: completion
 model: Qwen/Qwen2.5-7B
+sources:
+    - https://www.together.ai/pricing
+status: active

--- a/providers/together-ai/Qwen/Qwen3-14B.yaml
+++ b/providers/together-ai/Qwen/Qwen3-14B.yaml
@@ -1,3 +1,6 @@
+features:
+    - function_calling
+    - system_messages
 limits:
     context_window: 32768
     max_output_tokens: 32768
@@ -10,9 +13,5 @@ modalities:
 mode: completion
 model: Qwen/Qwen3-14B
 sources:
-    - https://together.ai/models
-    - https://docs.together.ai/docs/serverless-models
-    - https://docs.together.ai/docs/deprecations
-    - https://docs.together.ai/docs/changelog
     - https://huggingface.co/Qwen/Qwen3-14B
 thinking: true

--- a/providers/together-ai/Qwen/Qwen3-30B-A3B-Base.yaml
+++ b/providers/together-ai/Qwen/Qwen3-30B-A3B-Base.yaml
@@ -1,3 +1,7 @@
+limits:
+    context_window: 32768
+    max_output_tokens: 32768
+    max_tokens: 32768
 modalities:
     input:
         - text

--- a/providers/together-ai/Qwen/Qwen3-30B-A3B.yaml
+++ b/providers/together-ai/Qwen/Qwen3-30B-A3B.yaml
@@ -17,4 +17,5 @@ mode: chat
 model: Qwen/Qwen3-30B-A3B
 sources:
     - https://huggingface.co/Qwen/Qwen3-30B-A3B
+status: active
 thinking: true

--- a/providers/together-ai/Qwen/Qwen3-32B.yaml
+++ b/providers/together-ai/Qwen/Qwen3-32B.yaml
@@ -1,6 +1,10 @@
 features:
     - function_calling
     - system_messages
+limits:
+    context_window: 32768
+    max_output_tokens: 32768
+    max_tokens: 32768
 modalities:
     input:
         - text

--- a/providers/together-ai/Qwen/Qwen3-VL-8B-Instruct.yaml
+++ b/providers/together-ai/Qwen/Qwen3-VL-8B-Instruct.yaml
@@ -2,6 +2,8 @@ costs:
     - input_cost_per_token: 1.8e-7
       output_cost_per_token: 6.8e-7
       region: "*"
+deprecationDate: "2026-04-16"
+isDeprecated: true
 limits:
     context_window: 262144
 modalities:

--- a/providers/together-ai/ServiceNow-AI/Apriel-1.5-15b-Thinker.yaml
+++ b/providers/together-ai/ServiceNow-AI/Apriel-1.5-15b-Thinker.yaml
@@ -2,11 +2,15 @@ costs:
     - input_cost_per_token: 0
       output_cost_per_token: 0
       region: "*"
+features:
+    - function_calling
+    - system_messages
 limits:
     context_window: 131072
 modalities:
     input:
         - text
+        - image
     output:
         - text
 mode: chat

--- a/providers/together-ai/ServiceNow-AI/Apriel-1.6-15b-Thinker.yaml
+++ b/providers/together-ai/ServiceNow-AI/Apriel-1.6-15b-Thinker.yaml
@@ -2,12 +2,22 @@ costs:
     - input_cost_per_token: 0
       output_cost_per_token: 0
       region: "*"
+features:
+    - function_calling
+    - system_messages
 limits:
     context_window: 131072
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
 mode: chat
 model: ServiceNow-AI/Apriel-1.6-15b-Thinker
 sources:
     - https://www.together.ai/pricing
+    - https://huggingface.co/ServiceNow-AI/Apriel-1.6-15b-Thinker
 status: active
 supportedModes:
     - chat


### PR DESCRIPTION
Auto-generated by poc-agent for provider `together-ai`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates Together.ai model YAML metadata (features/limits/status/deprecation) with no runtime code changes, though incorrect limits/capabilities could affect downstream routing/validation.
> 
> **Overview**
> Updates Together.ai provider model YAMLs to reflect **new/adjusted capabilities and limits**: adds `function_calling`/`system_messages` (e.g., `LiquidAI/LFM2-24B-A2B`, `ServiceNow-AI/Apriel-*`) and introduces `json_output` for `MiniMax-M2`.
> 
> Expands/normalizes **token limits and metadata** (e.g., `MiniMax-M1-40k` `max_tokens`/`max_output_tokens`, `Qwen2.5-32B` and several `Qwen3*` models `limits`), sets `status: active` for multiple Qwen entries, adds/updates `sources`, and marks `Qwen3-VL-8B-Instruct` as deprecated with a `deprecationDate`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 714dc1113c274b3badfab21311164e9f23c398e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->