### PR TITLE
fix: change mode for mistral models

### DIFF
--- a/providers/aws-bedrock/amazon.nova-2-sonic-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.nova-2-sonic-v1:0.yaml
@@ -33,7 +33,7 @@ modalities:
     output:
         - text
         - audio
-mode: chat
+mode: text_to_speech
 model: amazon.nova-2-sonic-v1:0
 params:
     - defaultValue: 65536

--- a/providers/aws-bedrock/amazon.nova-2-sonic-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.nova-2-sonic-v1:0.yaml
@@ -33,7 +33,7 @@ modalities:
     output:
         - text
         - audio
-mode: text_to_speech
+mode: audio_transcription
 model: amazon.nova-2-sonic-v1:0
 params:
     - defaultValue: 65536

--- a/providers/deepinfra/allenai/olmOCR-2-7B-1025.yaml
+++ b/providers/deepinfra/allenai/olmOCR-2-7B-1025.yaml
@@ -4,8 +4,6 @@ costs:
       region: "*"
 limits:
     context_window: 16384
-    max_output_tokens: 16384
-    max_tokens: 16384
 modalities:
     input:
         - text

--- a/providers/deepinfra/black-forest-labs/FLUX-2-max.yaml
+++ b/providers/deepinfra/black-forest-labs/FLUX-2-max.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_image: 0.03 
+    - input_cost_per_image: 0.03
       output_cost_per_image: 0.07
       region: "*"
 modalities:

--- a/providers/mistral-ai/codestral-2508.yaml
+++ b/providers/mistral-ai/codestral-2508.yaml
@@ -6,7 +6,7 @@ features:
     - function_calling
 limits:
     context_window: 256000
-mode: completion
+mode: chat
 model: codestral-2508
 params:
     - defaultValue: 0.3

--- a/providers/mistral-ai/codestral-latest.yaml
+++ b/providers/mistral-ai/codestral-latest.yaml
@@ -6,7 +6,7 @@ features:
     - function_calling
 limits:
     context_window: 256000
-mode: completion
+mode: chat
 model: codestral-latest
 params:
     - defaultValue: 0.3


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Provider metadata changes alter how requests are routed/formatted (e.g., `completion` vs `chat` vs `audio_transcription`), which could break clients expecting the previous mode for these models.
> 
> **Overview**
> Updates provider model YAML metadata to better match actual model capabilities.
> 
> Switches Mistral `codestral-2508` and `codestral-latest` default `mode` from `completion` to `chat` while keeping both in `supportedModes`, changes AWS Bedrock `amazon.nova-2-sonic-v1:0` from `chat` to `audio_transcription`, and removes `max_tokens`/`max_output_tokens` limits from DeepInfra `allenai/olmOCR-2-7B-1025`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ed7f6e086e3e342959fd41ad805aa47c0c0e20d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->