### PR TITLE
feat(google-vertex): update model YAMLs [bot]

### DIFF
--- a/providers/google-vertex/gemini-2.5-flash-lite.yaml
+++ b/providers/google-vertex/gemini-2.5-flash-lite.yaml
@@ -119,7 +119,7 @@ costs:
       output_cost_per_token: 4.e-7
       output_cost_per_token_batches: 2.e-7
       region: europe-central2
-deprecationDate: "2026-07-22"
+deprecationDate: "2026-10-16"
 features:
     - function_calling
     - parallel_function_calling

--- a/providers/google-vertex/gemini-3-pro-image-preview.yaml
+++ b/providers/google-vertex/gemini-3-pro-image-preview.yaml
@@ -220,7 +220,6 @@ modalities:
     input:
         - text
         - image
-        - pdf
     output:
         - text
         - image

--- a/providers/google-vertex/meta/llama-3.1-8b-instruct-maas.yaml
+++ b/providers/google-vertex/meta/llama-3.1-8b-instruct-maas.yaml
@@ -5,6 +5,7 @@ costs:
 features:
     - function_calling
     - tool_choice
+isDeprecated: true
 limits:
     context_window: 128000
     max_input_tokens: 128000


### PR DESCRIPTION
Auto-generated by poc-agent for provider `google-vertex`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: YAML metadata updates only (deprecation flag/date and supported modalities) with no code-path or runtime logic changes.
> 
> **Overview**
> Updates Google Vertex model manifests.
> 
> `gemini-2.5-flash-lite` has its `deprecationDate` pushed out to `2026-10-16`. `gemini-3-pro-image-preview` removes `pdf` from supported input modalities, and `meta/llama-3.1-8b-instruct-maas` is now marked `isDeprecated: true`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01d6420e7a74386f3009e2ecf48a172bb9db6659. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->