### PR TITLE
feat(google-vertex): update model YAMLs [bot]

### DIFF
--- a/providers/google-vertex/google/cloudnerf-pytorch-zipnerf.yaml
+++ b/providers/google-vertex/google/cloudnerf-pytorch-zipnerf.yaml
@@ -1,2 +1,9 @@
+modalities:
+    input:
+        - image
+    output:
+        - image
 mode: unknown
 model: cloudnerf-pytorch-zipnerf
+sources:
+    - https://console.cloud.google.com/vertex-ai/publishers/google/model-garden/cloudnerf-pytorch-zipnerf

--- a/providers/google-vertex/google/gemini-2.5-flash-lite-preview-09-2025.yaml
+++ b/providers/google-vertex/google/gemini-2.5-flash-lite-preview-09-2025.yaml
@@ -27,6 +27,7 @@ modalities:
         - image
         - audio
         - video
+        - pdf
     output:
         - text
 mode: chat

--- a/providers/google-vertex/google/gemini-2.5-flash-preview-09-2025.yaml
+++ b/providers/google-vertex/google/gemini-2.5-flash-preview-09-2025.yaml
@@ -24,6 +24,7 @@ modalities:
         - image
         - audio
         - video
+        - pdf
     output:
         - text
 mode: chat

--- a/providers/google-vertex/google/gemini-2.5-pro-tts.yaml
+++ b/providers/google-vertex/google/gemini-2.5-pro-tts.yaml
@@ -1,3 +1,154 @@
+costs:
+    - input_cost_per_token: 0.000001
+      input_cost_per_token_batches: 5.e-7
+      output_cost_per_audio_token: 0.00002
+      output_cost_per_token_batches: 0.00001
+      region: us-west4
+    - input_cost_per_token: 0.000001
+      input_cost_per_token_batches: 5.e-7
+      output_cost_per_audio_token: 0.00002
+      output_cost_per_token_batches: 0.00001
+      region: us-west1
+    - input_cost_per_token: 0.000001
+      input_cost_per_token_batches: 5.e-7
+      output_cost_per_audio_token: 0.00002
+      output_cost_per_token_batches: 0.00001
+      region: us-south1
+    - input_cost_per_token: 0.000001
+      input_cost_per_token_batches: 5.e-7
+      output_cost_per_audio_token: 0.00002
+      output_cost_per_token_batches: 0.00001
+      region: us-east5
+    - input_cost_per_token: 0.000001
+      input_cost_per_token_batches: 5.e-7
+      output_cost_per_audio_token: 0.00002
+      output_cost_per_token_batches: 0.00001
+      region: us-east4
+    - input_cost_per_token: 0.000001
+      input_cost_per_token_batches: 5.e-7
+      output_cost_per_audio_token: 0.00002
+      output_cost_per_token_batches: 0.00001
+      region: us-east1
+    - input_cost_per_token: 0.000001
+      input_cost_per_token_batches: 5.e-7
+      output_cost_per_audio_token: 0.00002
+      output_cost_per_token_batches: 0.00001
+      region: us-central1
+    - input_cost_per_token: 0.000001
+      input_cost_per_token_batches: 5.e-7
+      output_cost_per_audio_token: 0.00002
+      output_cost_per_token_batches: 0.00001
+      region: southamerica-east1
+    - input_cost_per_token: 0.000001
+      input_cost_per_token_batches: 5.e-7
+      output_cost_per_audio_token: 0.00002
+      output_cost_per_token_batches: 0.00001
+      region: northamerica-northeast1
+    - input_cost_per_token: 0.000001
+      input_cost_per_token_batches: 5.e-7
+      output_cost_per_audio_token: 0.00002
+      output_cost_per_token_batches: 0.00001
+      region: me-west1
+    - input_cost_per_token: 0.000001
+      input_cost_per_token_batches: 5.e-7
+      output_cost_per_audio_token: 0.00002
+      output_cost_per_token_batches: 0.00001
+      region: me-central2
+    - input_cost_per_token: 0.000001
+      input_cost_per_token_batches: 5.e-7
+      output_cost_per_audio_token: 0.00002
+      output_cost_per_token_batches: 0.00001
+      region: me-central1
+    - input_cost_per_token: 0.000001
+      input_cost_per_token_batches: 5.e-7
+      output_cost_per_audio_token: 0.00002
+      output_cost_per_token_batches: 0.00001
+      region: global
+    - input_cost_per_token: 0.000001
+      input_cost_per_token_batches: 5.e-7
+      output_cost_per_audio_token: 0.00002
+      output_cost_per_token_batches: 0.00001
+      region: europe-west9
+    - input_cost_per_token: 0.000001
+      input_cost_per_token_batches: 5.e-7
+      output_cost_per_audio_token: 0.00002
+      output_cost_per_token_batches: 0.00001
+      region: europe-west8
+    - input_cost_per_token: 0.000001
+      input_cost_per_token_batches: 5.e-7
+      output_cost_per_audio_token: 0.00002
+      output_cost_per_token_batches: 0.00001
+      region: europe-west6
+    - input_cost_per_token: 0.000001
+      input_cost_per_token_batches: 5.e-7
+      output_cost_per_audio_token: 0.00002
+      output_cost_per_token_batches: 0.00001
+      region: europe-west4
+    - input_cost_per_token: 0.000001
+      input_cost_per_token_batches: 5.e-7
+      output_cost_per_audio_token: 0.00002
+      output_cost_per_token_batches: 0.00001
+      region: europe-west3
+    - input_cost_per_token: 0.000001
+      input_cost_per_token_batches: 5.e-7
+      output_cost_per_audio_token: 0.00002
+      output_cost_per_token_batches: 0.00001
+      region: europe-west2
+    - input_cost_per_token: 0.000001
+      input_cost_per_token_batches: 5.e-7
+      output_cost_per_audio_token: 0.00002
+      output_cost_per_token_batches: 0.00001
+      region: europe-west1
+    - input_cost_per_token: 0.000001
+      input_cost_per_token_batches: 5.e-7
+      output_cost_per_audio_token: 0.00002
+      output_cost_per_token_batches: 0.00001
+      region: europe-southwest1
+    - input_cost_per_token: 0.000001
+      input_cost_per_token_batches: 5.e-7
+      output_cost_per_audio_token: 0.00002
+      output_cost_per_token_batches: 0.00001
+      region: europe-north1
+    - input_cost_per_token: 0.000001
+      input_cost_per_token_batches: 5.e-7
+      output_cost_per_audio_token: 0.00002
+      output_cost_per_token_batches: 0.00001
+      region: europe-central2
+    - input_cost_per_token: 0.000001
+      input_cost_per_token_batches: 5.e-7
+      output_cost_per_audio_token: 0.00002
+      output_cost_per_token_batches: 0.00001
+      region: australia-southeast1
+    - input_cost_per_token: 0.000001
+      input_cost_per_token_batches: 5.e-7
+      output_cost_per_audio_token: 0.00002
+      output_cost_per_token_batches: 0.00001
+      region: asia-southeast1
+    - input_cost_per_token: 0.000001
+      input_cost_per_token_batches: 5.e-7
+      output_cost_per_audio_token: 0.00002
+      output_cost_per_token_batches: 0.00001
+      region: asia-south1
+    - input_cost_per_token: 0.000001
+      input_cost_per_token_batches: 5.e-7
+      output_cost_per_audio_token: 0.00002
+      output_cost_per_token_batches: 0.00001
+      region: asia-northeast3
+    - input_cost_per_token: 0.000001
+      input_cost_per_token_batches: 5.e-7
+      output_cost_per_audio_token: 0.00002
+      output_cost_per_token_batches: 0.00001
+      region: asia-northeast1
+    - input_cost_per_token: 0.000001
+      input_cost_per_token_batches: 5.e-7
+      output_cost_per_audio_token: 0.00002
+      output_cost_per_token_batches: 0.00001
+      region: asia-east2
+    - input_cost_per_token: 0.000001
+      input_cost_per_token_batches: 5.e-7
+      output_cost_per_audio_token: 0.00002
+      output_cost_per_token_batches: 0.00001
+      region: asia-east1
 limits:
     context_window: 32000
 modalities:
@@ -15,4 +166,5 @@ sources:
     - https://ai.google.dev/gemini-api/docs/speech-generation
     - https://ai.google.dev/gemini-api/docs/models#gemini-2.5-pro-preview-tts
     - https://ai.google.dev/gemini-api/docs/pricing
+    - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/locations
 status: preview

--- a/providers/google-vertex/google/gemini-3.1-flash-image-preview.yaml
+++ b/providers/google-vertex/google/gemini-3.1-flash-image-preview.yaml
@@ -190,11 +190,17 @@ modalities:
     input:
         - text
         - image
+        - pdf
     output:
         - text
         - image
 mode: chat
 model: gemini-3.1-flash-image-preview
+params:
+    - defaultValue: 1
+      key: temperature
+    - defaultValue: 0.95
+      key: top_p
 removeParams:
     - tool_choice
 sources:

--- a/providers/google-vertex/google/language-v1-analyze-sentiment.yaml
+++ b/providers/google-vertex/google/language-v1-analyze-sentiment.yaml
@@ -20,3 +20,4 @@ sources:
     - https://cloud.google.com/natural-language/pricing
     - https://docs.cloud.google.com/natural-language/docs/reference/rest/v1/documents/analyzeSentiment
     - https://docs.cloud.google.com/natural-language/docs/basics
+status: active

--- a/providers/google-vertex/google/language-v1-classify-text-v1.yaml
+++ b/providers/google-vertex/google/language-v1-classify-text-v1.yaml
@@ -20,3 +20,4 @@ sources:
     - https://cloud.google.com/natural-language/pricing
     - https://docs.cloud.google.com/natural-language/docs/classifying-text
     - https://docs.cloud.google.com/natural-language/docs/reference/rest/v1/documents/classifyText
+status: active

--- a/providers/google-vertex/google/language-v1-moderate-text.yaml
+++ b/providers/google-vertex/google/language-v1-moderate-text.yaml
@@ -19,3 +19,4 @@ removeParams:
 sources:
     - https://cloud.google.com/natural-language/pricing
     - https://docs.cloud.google.com/natural-language/docs/moderating-text
+status: active

--- a/providers/google-vertex/google/pretrained-ocr.yaml
+++ b/providers/google-vertex/google/pretrained-ocr.yaml
@@ -1,14 +1,10 @@
 costs:
     - input_cost_per_page: 0.0015
-      region: us-central1
-    - input_cost_per_page: 0.0015
       region: northamerica-northeast1
     - input_cost_per_page: 0.0015
       region: europe-west3
     - input_cost_per_page: 0.0015
       region: europe-west2
-    - input_cost_per_page: 0.0015
-      region: europe-west1
     - input_cost_per_page: 0.0015
       region: australia-southeast1
     - input_cost_per_page: 0.0015

--- a/providers/google-vertex/google/tab-net.yaml
+++ b/providers/google-vertex/google/tab-net.yaml
@@ -1,2 +1,6 @@
 mode: unknown
 model: tab-net
+sources:
+    - https://docs.cloud.google.com/vertex-ai/docs/tabular-data/tabular-workflows/tabnet
+    - https://docs.cloud.google.com/vertex-ai/docs/tabular-data/tabular-workflows/pricing
+status: preview

--- a/providers/google-vertex/google/vehicle-detector.yaml
+++ b/providers/google-vertex/google/vehicle-detector.yaml
@@ -5,3 +5,11 @@ modalities:
         - text
 mode: image
 model: vehicle-detector
+removeParams:
+    - max_tokens
+    - temperature
+    - top_p
+    - "n"
+    - stop
+    - stream
+    - tool_choice

--- a/providers/google-vertex/google/veo-3.0-generate-001.yaml
+++ b/providers/google-vertex/google/veo-3.0-generate-001.yaml
@@ -24,6 +24,8 @@ costs:
     - output_cost_per_second: 0.5
       region: me-central1
     - output_cost_per_second: 0.5
+      region: global
+    - output_cost_per_second: 0.5
       region: europe-west9
     - output_cost_per_second: 0.5
       region: europe-west8

--- a/providers/google-vertex/google/veo-3.1-fast-generate-001.yaml
+++ b/providers/google-vertex/google/veo-3.1-fast-generate-001.yaml
@@ -1,3 +1,91 @@
+costs:
+    - output_cost_per_second: 0.15
+      output_cost_per_second_4k: 0.35
+      region: us-west4
+    - output_cost_per_second: 0.15
+      output_cost_per_second_4k: 0.35
+      region: us-west1
+    - output_cost_per_second: 0.15
+      output_cost_per_second_4k: 0.35
+      region: us-south1
+    - output_cost_per_second: 0.15
+      output_cost_per_second_4k: 0.35
+      region: us-east5
+    - output_cost_per_second: 0.15
+      output_cost_per_second_4k: 0.35
+      region: us-east4
+    - output_cost_per_second: 0.15
+      output_cost_per_second_4k: 0.35
+      region: us-east1
+    - output_cost_per_second: 0.15
+      output_cost_per_second_4k: 0.35
+      region: us-central1
+    - output_cost_per_second: 0.15
+      output_cost_per_second_4k: 0.35
+      region: southamerica-east1
+    - output_cost_per_second: 0.15
+      output_cost_per_second_4k: 0.35
+      region: northamerica-northeast1
+    - output_cost_per_second: 0.15
+      output_cost_per_second_4k: 0.35
+      region: me-west1
+    - output_cost_per_second: 0.15
+      output_cost_per_second_4k: 0.35
+      region: me-central2
+    - output_cost_per_second: 0.15
+      output_cost_per_second_4k: 0.35
+      region: me-central1
+    - output_cost_per_second: 0.15
+      output_cost_per_second_4k: 0.35
+      region: europe-west9
+    - output_cost_per_second: 0.15
+      output_cost_per_second_4k: 0.35
+      region: europe-west8
+    - output_cost_per_second: 0.15
+      output_cost_per_second_4k: 0.35
+      region: europe-west6
+    - output_cost_per_second: 0.15
+      output_cost_per_second_4k: 0.35
+      region: europe-west4
+    - output_cost_per_second: 0.15
+      output_cost_per_second_4k: 0.35
+      region: europe-west3
+    - output_cost_per_second: 0.15
+      output_cost_per_second_4k: 0.35
+      region: europe-west2
+    - output_cost_per_second: 0.15
+      output_cost_per_second_4k: 0.35
+      region: europe-west1
+    - output_cost_per_second: 0.15
+      output_cost_per_second_4k: 0.35
+      region: europe-southwest1
+    - output_cost_per_second: 0.15
+      output_cost_per_second_4k: 0.35
+      region: europe-north1
+    - output_cost_per_second: 0.15
+      output_cost_per_second_4k: 0.35
+      region: europe-central2
+    - output_cost_per_second: 0.15
+      output_cost_per_second_4k: 0.35
+      region: australia-southeast1
+    - output_cost_per_second: 0.15
+      output_cost_per_second_4k: 0.35
+      region: asia-southeast1
+    - output_cost_per_second: 0.15
+      output_cost_per_second_4k: 0.35
+      region: asia-south1
+    - output_cost_per_second: 0.15
+      output_cost_per_second_4k: 0.35
+      region: asia-northeast3
+    - output_cost_per_second: 0.15
+      output_cost_per_second_4k: 0.35
+      region: asia-northeast1
+    - output_cost_per_second: 0.15
+      output_cost_per_second_4k: 0.35
+      region: asia-east2
+    - output_cost_per_second: 0.15
+      output_cost_per_second_4k: 0.35
+      region: asia-east1
 messages:
     options:
         - user

--- a/providers/google-vertex/google/weather-next-v2.yaml
+++ b/providers/google-vertex/google/weather-next-v2.yaml
@@ -10,3 +10,6 @@ removeParams:
     - tool_choice
 sources:
     - https://console.cloud.google.com/vertex-ai/publishers/google/model-garden/weather-next-v2
+    - https://developers.google.com/weathernext
+    - https://developers.google.com/weathernext/guides/access-vmg
+status: preview


### PR DESCRIPTION
Auto-generated by poc-agent for provider `google-vertex`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates model capability/cost metadata (modalities, per-region pricing, and parameter filtering), which can affect request validation and billing if consumed by runtime logic.
> 
> **Overview**
> Refreshes several Google Vertex model YAMLs by **expanding/clarifying model metadata**.
> 
> Adds `pdf` as an accepted input modality for `gemini-2.5-flash(-lite)-preview-09-2025` and `gemini-3.1-flash-image-preview` (also adding default `temperature`/`top_p` params for the latter). Extends regional pricing coverage for `gemini-2.5-pro-tts` and adds `global` pricing for `veo-3.0-generate-001`, while introducing full cost metadata for `veo-3.1-fast-generate-001`.
> 
> Marks Natural Language models (`language-v1-*`) as `active`, adds/normalizes `sources` and `status` for `tab-net`, `weather-next-v2`, and `cloudnerf-pytorch-zipnerf`, adjusts `pretrained-ocr` cost entries, and adds `removeParams` to `vehicle-detector` to strip unsupported generation parameters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 602790e4ac5f8e58e40c01b6f7bd04fae109d3e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->