### PR TITLE
fix: openai params

### DIFF
--- a/providers/openai/gpt-4o-audio-preview-2025-06-03.yaml
+++ b/providers/openai/gpt-4o-audio-preview-2025-06-03.yaml
@@ -20,7 +20,7 @@ modalities:
     output:
         - text
         - audio
-mode: chat
+mode: audio_transcription
 model: gpt-4o-audio-preview-2025-06-03
 params:
     - defaultValue: 16384
@@ -32,3 +32,5 @@ removeParams:
 sources:
     - https://developers.openai.com/docs/models/gpt-4o-audio-preview
 status: preview
+supportedModes:
+    - chat

--- a/providers/openai/gpt-4o-mini-search-preview-2025-03-11.yaml
+++ b/providers/openai/gpt-4o-mini-search-preview-2025-03-11.yaml
@@ -24,6 +24,7 @@ params:
 removeParams:
     - tool_choice
     - parallel_tool_calls
+    - temperature
 sources:
     - https://developers.openai.com/docs/models/gpt-4o-mini-search-preview
 status: preview

--- a/providers/openai/gpt-4o-mini-search-preview.yaml
+++ b/providers/openai/gpt-4o-mini-search-preview.yaml
@@ -25,6 +25,7 @@ params:
 removeParams:
     - tool_choice
     - parallel_tool_calls
+    - temperature
 sources:
     - https://developers.openai.com/api/docs/models/gpt-4o-mini-search-preview
 status: preview

--- a/providers/openai/gpt-4o-search-preview.yaml
+++ b/providers/openai/gpt-4o-search-preview.yaml
@@ -26,6 +26,7 @@ params:
 removeParams:
     - tool_choice
     - parallel_tool_calls
+    - temperature
 sources:
     - https://developers.openai.com/api/docs/models/gpt-4o-search-preview
 status: preview

--- a/providers/openai/gpt-5-chat-latest.yaml
+++ b/providers/openai/gpt-5-chat-latest.yaml
@@ -43,4 +43,3 @@ removeParams:
 sources:
     - https://developers.openai.com/docs/models/gpt-5-chat-latest
     - https://developers.openai.com/docs/models/gpt-5
-thinking: true

--- a/providers/openai/gpt-5-search-api-2025-10-14.yaml
+++ b/providers/openai/gpt-5-search-api-2025-10-14.yaml
@@ -35,4 +35,3 @@ removeParams:
 sources:
     - https://developers.openai.com/api/docs/models/gpt-5
 status: active
-thinking: true

--- a/providers/openai/gpt-5-search-api.yaml
+++ b/providers/openai/gpt-5-search-api.yaml
@@ -31,4 +31,3 @@ params:
 sources:
     - https://developers.openai.com/api/docs/guides/tools-web-search/
     - https://developers.openai.com/api/docs/models/gpt-5
-thinking: true

--- a/providers/openai/gpt-5.4-mini-2026-03-17.yaml
+++ b/providers/openai/gpt-5.4-mini-2026-03-17.yaml
@@ -26,11 +26,13 @@ mode: chat
 model: gpt-5.4-mini-2026-03-17
 params:
     - defaultValue: 128
-      key: max_tokens
+      key: max_completion_tokens
       maxValue: 128000
       minValue: 1
     - defaultValue: medium
       key: reasoning_effort
+removeParams:
+    - max_tokens
 sources:
     - https://developers.openai.com/api/docs/pricing
     - https://developers.openai.com/api/docs/deprecations

--- a/providers/openai/gpt-5.4-mini.yaml
+++ b/providers/openai/gpt-5.4-mini.yaml
@@ -26,11 +26,13 @@ mode: chat
 model: gpt-5.4-mini
 params:
     - defaultValue: 128000
-      key: max_tokens
+      key: max_completion_tokens
       maxValue: 128000
       minValue: 1
     - defaultValue: medium
       key: reasoning_effort
+removeParams:
+    - max_tokens
 sources:
     - https://developers.openai.com/api/docs/models/gpt-5.4-mini
     - https://developers.openai.com/api/docs/guides/latest-model

--- a/providers/openai/gpt-5.4-nano-2026-03-17.yaml
+++ b/providers/openai/gpt-5.4-nano-2026-03-17.yaml
@@ -26,12 +26,14 @@ mode: chat
 model: gpt-5.4-nano-2026-03-17
 params:
     - defaultValue: 128
-      key: max_tokens
+      key: max_completion_tokens
       maxValue: 128000
       minValue: 1
     - defaultValue: medium
       key: reasoning_effort
       type: string
+removeParams:
+    - max_tokens
 sources:
     - https://developers.openai.com/api/docs/models/gpt-5.4-nano
 thinking: true

--- a/providers/openai/gpt-5.4-nano.yaml
+++ b/providers/openai/gpt-5.4-nano.yaml
@@ -25,9 +25,11 @@ mode: chat
 model: gpt-5.4-nano
 params:
     - defaultValue: 128
-      key: max_tokens
+      key: max_completion_tokens
       maxValue: 128000
       minValue: 1
+removeParams:
+    - max_tokens
 sources:
     - https://developers.openai.com/api/docs/models/gpt-5.4-nano
 status: active

--- a/providers/openai/gpt-audio-1.5.yaml
+++ b/providers/openai/gpt-audio-1.5.yaml
@@ -21,7 +21,7 @@ modalities:
     output:
         - text
         - audio
-mode: chat
+mode: audio_transcription
 model: gpt-audio-1.5
 params:
     - defaultValue: 128
@@ -32,3 +32,5 @@ sources:
     - https://developers.openai.com/api/docs/models/gpt-audio-1.5
     - https://developers.openai.com/docs/guides/prompt-caching
 status: active
+supportedModes:
+    - chat

--- a/providers/openai/gpt-audio-2025-08-28.yaml
+++ b/providers/openai/gpt-audio-2025-08-28.yaml
@@ -21,7 +21,7 @@ modalities:
     output:
         - text
         - audio
-mode: chat
+mode: audio_transcription
 model: gpt-audio-2025-08-28
 params:
     - defaultValue: 128
@@ -31,3 +31,5 @@ params:
 sources:
     - https://developers.openai.com/docs/models/gpt-audio
 status: active
+supportedModes:
+    - chat

--- a/providers/openai/gpt-audio-mini-2025-10-06.yaml
+++ b/providers/openai/gpt-audio-mini-2025-10-06.yaml
@@ -23,7 +23,7 @@ modalities:
     output:
         - text
         - audio
-mode: chat
+mode: audio_transcription
 model: gpt-audio-mini-2025-10-06
 params:
     - key: max_tokens
@@ -31,3 +31,5 @@ params:
 sources:
     - https://developers.openai.com/docs/models/gpt-audio-mini
 status: active
+supportedModes:
+    - chat

--- a/providers/openai/gpt-audio.yaml
+++ b/providers/openai/gpt-audio.yaml
@@ -21,7 +21,7 @@ modalities:
     output:
         - text
         - audio
-mode: chat
+mode: audio_transcription
 model: gpt-audio
 params:
     - key: max_tokens
@@ -29,3 +29,5 @@ params:
 sources:
     - https://developers.openai.com/api/docs/models/gpt-audio
 status: active
+supportedModes:
+    - chat

--- a/providers/openai/o3-2025-04-16.yaml
+++ b/providers/openai/o3-2025-04-16.yaml
@@ -25,7 +25,7 @@ mode: chat
 model: o3-2025-04-16
 params:
     - defaultValue: 100000
-      key: max_tokens
+      key: max_completion_tokens
       maxValue: 100000
       minValue: 1
     - defaultValue: 1
@@ -35,6 +35,8 @@ params:
     - defaultValue: medium
       key: reasoning_effort
       type: string
+removeParams:
+    - max_tokens
 sources:
     - https://developers.openai.com/api/docs/models/o3
 thinking: true

--- a/providers/openai/o3.yaml
+++ b/providers/openai/o3.yaml
@@ -33,6 +33,7 @@ params:
       key: reasoning_effort
 removeParams:
     - max_tokens
+    - temperature
 sources:
     - https://developers.openai.com/api/docs/models/o3
     - https://developers.openai.com/api/docs/pricing


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes model configuration for request modes and accepted/removed parameters, which can alter how requests are constructed and may break callers relying on previous defaults. Scope is limited to OpenAI provider YAML config (no code changes).
> 
> **Overview**
> Updates OpenAI model YAMLs to better match API capabilities and parameter support.
> 
> Audio-capable models (`gpt-audio*`, `gpt-4o-audio-preview-*`) switch their default `mode` from `chat` to `audio_transcription` while explicitly listing `supportedModes: [chat]`.
> 
> Search preview models (`gpt-4o*-search-preview*`) now strip `temperature` via `removeParams`. Several reasoning/chat models adjust token parameter semantics by preferring `max_completion_tokens` and removing `max_tokens` where applicable (including `gpt-5.4-*` and `o3-2025-04-16`), and `o3` also removes `temperature`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf6fc0c699a51ad219818ee257f45e36e6e3811c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->