### PR TITLE
feature fix

### DIFF
--- a/providers/deepinfra/NousResearch/Hermes-3-Llama-3.1-405B.yaml
+++ b/providers/deepinfra/NousResearch/Hermes-3-Llama-3.1-405B.yaml
@@ -3,12 +3,9 @@ costs:
       output_cost_per_token: 0.000001
       region: "*"
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
+    - json_output
 limits:
     context_window: 131072
-    max_input_tokens: 131072
 modalities:
     input:
         - text

--- a/providers/deepinfra/NousResearch/Hermes-3-Llama-3.1-70B.yaml
+++ b/providers/deepinfra/NousResearch/Hermes-3-Llama-3.1-70B.yaml
@@ -3,15 +3,10 @@ costs:
       output_cost_per_token: 3.e-7
       region: "*"
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
     - json_output
-    - system_messages
     - prompt_caching
 limits:
     context_window: 131072
-    max_input_tokens: 131072
 modalities:
     input:
         - text

--- a/providers/deepinfra/PaddlePaddle/PaddleOCR-VL-0.9B.yaml
+++ b/providers/deepinfra/PaddlePaddle/PaddleOCR-VL-0.9B.yaml
@@ -19,5 +19,5 @@ modalities:
 mode: chat
 model: PaddlePaddle/PaddleOCR-VL-0.9B
 sources:
-    - https://api.deepinfra.com/models/PaddlePaddle/PaddleOCR-VL-0.9B
+    - https://deepinfra.com/PaddlePaddle/PaddleOCR-VL-0.9B
 status: active

--- a/providers/deepinfra/Qwen/Qwen2.5-VL-32B-Instruct.yaml
+++ b/providers/deepinfra/Qwen/Qwen2.5-VL-32B-Instruct.yaml
@@ -3,12 +3,9 @@ costs:
       output_cost_per_token: 6.e-7
       region: "*"
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
+    - json_output
 limits:
     context_window: 128000
-    max_input_tokens: 128000
 modalities:
     input:
         - text
@@ -19,5 +16,4 @@ mode: chat
 model: Qwen/Qwen2.5-VL-32B-Instruct
 sources:
     - https://deepinfra.com/Qwen/Qwen2.5-VL-32B-Instruct/api
-    - https://deepinfra.com/docs/advanced/function_calling
 status: active

--- a/providers/deepinfra/Sao10K/L3.3-70B-Euryale-v2.3.yaml
+++ b/providers/deepinfra/Sao10K/L3.3-70B-Euryale-v2.3.yaml
@@ -4,10 +4,8 @@ costs:
       region: "*"
 features:
     - json_output
-    - structured_output
 limits:
     context_window: 131072
-    max_input_tokens: 131072
 modalities:
     input:
         - text
@@ -17,5 +15,4 @@ mode: chat
 model: Sao10K/L3.3-70B-Euryale-v2.3
 sources:
     - https://deepinfra.com/Sao10K/L3.3-70B-Euryale-v2.3
-    - https://deepinfra.com/Sao10K/L3.3-70B-Euryale-v2.3/api
 status: active

--- a/providers/deepinfra/deepseek-ai/DeepSeek-R1-Distill-Llama-70B.yaml
+++ b/providers/deepinfra/deepseek-ai/DeepSeek-R1-Distill-Llama-70B.yaml
@@ -3,9 +3,7 @@ costs:
       output_cost_per_token: 8.e-7
       region: "*"
 features:
-    - function_calling
     - json_output
-    - structured_output
 limits:
     context_window: 131072
     max_input_tokens: 131072
@@ -20,6 +18,4 @@ mode: chat
 model: deepseek-ai/DeepSeek-R1-Distill-Llama-70B
 sources:
     - https://deepinfra.com/deepseek-ai/DeepSeek-R1-Distill-Llama-70B/api
-    - https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Llama-70B
-    - https://openrouter.ai/deepseek/deepseek-r1-distill-llama-70b/api
 thinking: true

--- a/providers/deepinfra/meta-llama/Llama-3.2-11B-Vision-Instruct.yaml
+++ b/providers/deepinfra/meta-llama/Llama-3.2-11B-Vision-Instruct.yaml
@@ -3,14 +3,10 @@ costs:
       output_cost_per_token: 4.9e-8
       region: "*"
 features:
-    - function_calling
-    - system_messages
     - json_output
-    - structured_output
     - prompt_caching
 limits:
     context_window: 131072
-    max_input_tokens: 131072
 modalities:
     input:
         - text

--- a/providers/deepinfra/meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8.yaml
+++ b/providers/deepinfra/meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8.yaml
@@ -3,9 +3,6 @@ costs:
       output_cost_per_token: 6.e-7
       region: "*"
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
     - json_output
 limits:
     context_window: 1048576

--- a/providers/deepinfra/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B.yaml
+++ b/providers/deepinfra/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B.yaml
@@ -6,8 +6,6 @@ costs:
 features:
     - prompt_caching
     - function_calling
-    - structured_output
-    - json_output
 limits:
     context_window: 262144
 modalities:

--- a/providers/deepinfra/nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL.yaml
+++ b/providers/deepinfra/nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL.yaml
@@ -2,12 +2,8 @@ costs:
     - input_cost_per_token: 2.e-7
       output_cost_per_token: 6.e-7
       region: "*"
-features:
-    - function_calling
-    - system_messages
 limits:
     context_window: 128000
-    max_output_tokens: 8192
     max_tokens: 8192
 modalities:
     input:
@@ -20,6 +16,4 @@ mode: chat
 model: nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL
 sources:
     - https://deepinfra.com/nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL
-    - https://build.nvidia.com/nvidia/nemotron-nano-12b-v2-vl
-    - https://huggingface.co/nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16
 thinking: true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Updates model YAML metadata that drives capability routing (e.g., JSON/tooling support) and token limits, which could change how requests are constructed for these DeepInfra models. Risk is moderate because incorrect flags/limits may break tool calling/structured output expectations at runtime.
> 
> **Overview**
> Normalizes several DeepInfra model manifests by **removing tool/function/structured-output feature flags** and leaving (or adding) `json_output` as the declared capability for multiple models (Hermes 70B/405B, Qwen2.5-VL-32B, Llama 3.2 Vision, Llama 4 Maverick, Euryale, DeepSeek distill).
> 
> Cleans up metadata by dropping some `max_input_tokens` entries, removing the `features` block entirely for `NVIDIA-Nemotron-Nano-12B-v2-VL`, and adjusting `sources` URLs (notably PaddleOCR and Qwen docs link removal).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c4f03b8a5631928a867160b7b37e5a4536ee89f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->