### PR TITLE
OpenAI feature fix

### DIFF
--- a/providers/openai/gpt-4o-search-preview-2025-03-11.yaml
+++ b/providers/openai/gpt-4o-search-preview-2025-03-11.yaml
@@ -28,6 +28,7 @@ params:
 removeParams:
     - tool_choice
     - parallel_tool_calls
+    - temperature
 sources:
     - https://developers.openai.com/api/docs/models/gpt-4o-search-preview
 status: preview

--- a/providers/openai/gpt-5-search-api-2025-10-14.yaml
+++ b/providers/openai/gpt-5-search-api-2025-10-14.yaml
@@ -6,7 +6,6 @@ costs:
       output_cost_per_token_batches: 0.000005
       region: "*"
 features:
-    - function_calling
     - system_messages
     - prompt_caching
     - structured_output

--- a/providers/openai/gpt-5-search-api.yaml
+++ b/providers/openai/gpt-5-search-api.yaml
@@ -8,7 +8,6 @@ features:
     - system_messages
     - prompt_caching
     - structured_output
-    - function_calling
 limits:
     context_window: 128000
     max_output_tokens: 128000


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes OpenAI model capability/parameter metadata (feature flags and removed params), which can affect routing/validation for callers even though it’s config-only.
> 
> **Overview**
> Adjusts OpenAI search model definitions to better match what the upstream APIs support.
> 
> `gpt-4o-search-preview-2025-03-11` now strips the `temperature` param via `removeParams`, and both `gpt-5-search-api` configs stop advertising `function_calling` in their `features` lists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a01eab82c831b96c85210cfb1bc50d7acb99045. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->