### PR TITLE
feat(gemini): fix gemini model features

### DIFF
--- a/providers/google-gemini/gemma-3-12b-it.yaml
+++ b/providers/google-gemini/gemma-3-12b-it.yaml
@@ -3,8 +3,6 @@ costs:
       output_cost_per_token: 0
       region: "*"
 features:
-    - function_calling
-    - structured_output
     - system_messages
     - tool_choice
 limits:

--- a/providers/google-gemini/gemma-3-1b-it.yaml
+++ b/providers/google-gemini/gemma-3-1b-it.yaml
@@ -5,10 +5,8 @@ costs:
       output_cost_per_token: 0
       region: "*"
 features:
-    - function_calling
     - system_messages
     - tool_choice
-    - structured_output
 limits:
     context_window: 32768
     max_input_tokens: 32768

--- a/providers/google-gemini/gemma-3-27b-it.yaml
+++ b/providers/google-gemini/gemma-3-27b-it.yaml
@@ -8,9 +8,7 @@ costs:
       output_cost_per_token: 0
       region: "*"
 features:
-    - function_calling
     - tool_choice
-    - structured_output
     - prompt_caching
 limits:
     context_window: 128000

--- a/providers/google-gemini/gemma-3-4b-it.yaml
+++ b/providers/google-gemini/gemma-3-4b-it.yaml
@@ -3,8 +3,6 @@ costs:
       output_cost_per_token: 0
       region: "*"
 features:
-    - function_calling
-    - structured_output
     - system_messages
     - tool_choice
 limits:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk metadata-only change that only affects advertised capabilities for these Gemini Gemma models. Main risk is clients relying on `function_calling`/`structured_output` now seeing those features disabled.
> 
> **Overview**
> Updates the Google Gemini Gemma 3 model YAMLs to stop advertising unsupported features by removing `function_calling` and `structured_output` from the `features` list for `gemma-3-1b-it`, `gemma-3-4b-it`, `gemma-3-12b-it`, and `gemma-3-27b-it`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit beb0ef0f3e32384066b991eb8ebcc1e7d8d741d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->