### PR TITLE
feat(deepinfra): add new models [bot]

### DIFF
--- a/providers/deepinfra/zai-org/GLM-5.1.yaml
+++ b/providers/deepinfra/zai-org/GLM-5.1.yaml
@@ -1,0 +1,12 @@
+costs:
+    - cache_read_input_token_cost: 2.60000006e-7
+      input_cost_per_token: 0.0000014
+      output_cost_per_token: 0.0000044
+      region: "*"
+features:
+    - prompt_caching
+limits:
+    context_window: 202752
+    max_tokens: 202752
+mode: unknown
+model: zai-org/GLM-5.1


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `deepinfra`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only adds a new provider model YAML entry and does not modify runtime logic. Risk is limited to potential misconfiguration of costs/limits/feature flags for this model.
> 
> **Overview**
> Adds a new DeepInfra model definition `providers/deepinfra/zai-org/GLM-5.1.yaml` for `zai-org/GLM-5.1`, specifying token pricing (including cache-read pricing), enabling `prompt_caching`, and setting very large `context_window`/`max_tokens` limits. The model is marked with `mode: unknown`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4534ad868eccde1f338d6d493ab9574ea469fe88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->