### PR TITLE
feat(mistral-ai): add new models [bot]

### DIFF
--- a/providers/mistral-ai/mistral-moderation-2603.yaml
+++ b/providers/mistral-ai/mistral-moderation-2603.yaml
@@ -1,0 +1,7 @@
+limits:
+    context_window: 131072
+mode: unknown
+model: mistral-moderation-2603
+status: active
+supportedModes:
+    - moderation


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `mistral-ai`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk config-only change, but the new model entry sets `mode: unknown`, which could affect model selection/validation if the registry expects a concrete mode.
> 
> **Overview**
> Registers a new Mistral AI moderation model by adding `providers/mistral-ai/mistral-moderation-2603.yaml`, marking it **active** with a `131072` context window and `supportedModes: [moderation]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9e7a35e9e2d82b92de64a529cd039f7a3a754a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->