### PR TITLE
feat(openrouter): add new models [bot]

### DIFF
--- a/providers/openrouter/anthropic/claude-opus-4.6-fast.yaml
+++ b/providers/openrouter/anthropic/claude-opus-4.6-fast.yaml
@@ -1,0 +1,17 @@
+costs:
+    - cache_creation_input_token_cost: 0.0000375
+      cache_read_input_token_cost: 0.000003
+      input_cost_per_token: 0.00003
+      output_cost_per_token: 0.00015
+      region: "*"
+limits:
+    context_window: 1000000
+    max_output_tokens: 128000
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
+mode: chat
+model: anthropic/claude-opus-4.6-fast

--- a/providers/openrouter/google/gemma-4-26b-a4b-it:free.yaml
+++ b/providers/openrouter/google/gemma-4-26b-a4b-it:free.yaml
@@ -1,0 +1,23 @@
+costs:
+    - input_cost_per_token: 0
+      output_cost_per_token: 0
+      region: "*"
+limits:
+    context_window: 262144
+    max_output_tokens: 32768
+modalities:
+    input:
+        - image
+        - text
+        - video
+    output:
+        - text
+mode: chat
+model: google/gemma-4-26b-a4b-it:free
+params:
+    - defaultValue: 1
+      key: temperature
+    - defaultValue: 0.95
+      key: top_p
+    - defaultValue: 64
+      key: top_k

--- a/providers/openrouter/google/gemma-4-31b-it:free.yaml
+++ b/providers/openrouter/google/gemma-4-31b-it:free.yaml
@@ -1,0 +1,23 @@
+costs:
+    - input_cost_per_token: 0
+      output_cost_per_token: 0
+      region: "*"
+limits:
+    context_window: 262144
+    max_output_tokens: 32768
+modalities:
+    input:
+        - image
+        - text
+        - video
+    output:
+        - text
+mode: chat
+model: google/gemma-4-31b-it:free
+params:
+    - defaultValue: 1
+      key: temperature
+    - defaultValue: 0.95
+      key: top_p
+    - defaultValue: 64
+      key: top_k

--- a/providers/openrouter/z-ai/glm-5.1.yaml
+++ b/providers/openrouter/z-ai/glm-5.1.yaml
@@ -1,0 +1,18 @@
+costs:
+    - input_cost_per_token: 0.00000126
+      output_cost_per_token: 0.00000396
+      region: "*"
+limits:
+    context_window: 202752
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: chat
+model: z-ai/glm-5.1
+params:
+    - defaultValue: 1
+      key: temperature
+    - defaultValue: 0.95
+      key: top_p


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `openrouter`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only introduces new provider metadata/config files and does not change runtime logic. Main risk is misconfigured pricing/limits or parameter defaults affecting model selection or cost estimates.
> 
> **Overview**
> Registers four new OpenRouter chat models via YAML metadata: `anthropic/claude-opus-4.6-fast`, `google/gemma-4-26b-a4b-it:free`, `google/gemma-4-31b-it:free`, and `z-ai/glm-5.1`.
> 
> Each new file defines **token pricing**, **context/output limits**, and **supported modalities** (including image/video inputs for the Gemma models), plus default sampling `params` where applicable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80b932ba9fd2328b3ceab124fc9aee0fca3869a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->