### PR TITLE
feat(openrouter): backfill features and thinking [bot]

### DIFF
--- a/providers/openrouter/ai21/jamba-large-1.7.yaml
+++ b/providers/openrouter/ai21/jamba-large-1.7.yaml
@@ -4,8 +4,8 @@ costs:
       region: "*"
 features:
     - function_calling
+    - json_output
     - tool_choice
-    - system_messages
 limits:
     context_window: 256000
     max_output_tokens: 4096

--- a/providers/openrouter/aion-labs/aion-1.0-mini.yaml
+++ b/providers/openrouter/aion-labs/aion-1.0-mini.yaml
@@ -2,10 +2,6 @@ costs:
     - input_cost_per_token: 7.e-7
       output_cost_per_token: 0.0000014
       region: "*"
-features:
-    - tool_choice
-    - system_messages
-    - function_calling
 limits:
     context_window: 131072
     max_output_tokens: 32768

--- a/providers/openrouter/aion-labs/aion-1.0.yaml
+++ b/providers/openrouter/aion-labs/aion-1.0.yaml
@@ -2,9 +2,6 @@ costs:
     - input_cost_per_token: 0.000004
       output_cost_per_token: 0.000008
       region: "*"
-features:
-    - function_calling
-    - tool_choice
 limits:
     context_window: 131072
     max_output_tokens: 32768

--- a/providers/openrouter/aion-labs/aion-2.0.yaml
+++ b/providers/openrouter/aion-labs/aion-2.0.yaml
@@ -4,8 +4,6 @@ costs:
       output_cost_per_token: 0.0000016
       region: "*"
 features:
-    - function_calling
-    - tool_choice
     - prompt_caching
 limits:
     context_window: 131072

--- a/providers/openrouter/aion-labs/aion-rp-llama-3.1-8b.yaml
+++ b/providers/openrouter/aion-labs/aion-rp-llama-3.1-8b.yaml
@@ -2,9 +2,6 @@ costs:
     - input_cost_per_token: 8.e-7
       output_cost_per_token: 0.0000016
       region: "*"
-features:
-    - function_calling
-    - tool_choice
 limits:
     context_window: 32768
     max_output_tokens: 32768

--- a/providers/openrouter/alibaba/tongyi-deepresearch-30b-a3b.yaml
+++ b/providers/openrouter/alibaba/tongyi-deepresearch-30b-a3b.yaml
@@ -4,7 +4,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - system_messages
+    - json_output
+    - prompt_caching
+    - structured_output
+    - tool_choice
 limits:
     context_window: 131072
 modalities:

--- a/providers/openrouter/allenai/olmo-2-0325-32b-instruct.yaml
+++ b/providers/openrouter/allenai/olmo-2-0325-32b-instruct.yaml
@@ -2,9 +2,6 @@ costs:
     - input_cost_per_token: 5.e-8
       output_cost_per_token: 2.e-7
       region: "*"
-features:
-    - function_calling
-    - tool_choice
 limits:
     context_window: 128000
 modalities:

--- a/providers/openrouter/allenai/olmo-3-32b-think.yaml
+++ b/providers/openrouter/allenai/olmo-3-32b-think.yaml
@@ -4,10 +4,8 @@ costs:
       region: "*"
 deprecationDate: "2026-04-06"
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
     - json_output
+    - structured_output
 limits:
     context_window: 65536
     max_output_tokens: 65536

--- a/providers/openrouter/allenai/olmo-3.1-32b-instruct.yaml
+++ b/providers/openrouter/allenai/olmo-3.1-32b-instruct.yaml
@@ -4,9 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - structured_output
     - json_output
+    - structured_output
+    - tool_choice
 limits:
     context_window: 65536
 modalities:

--- a/providers/openrouter/alpindale/goliath-120b.yaml
+++ b/providers/openrouter/alpindale/goliath-120b.yaml
@@ -3,8 +3,7 @@ costs:
       output_cost_per_token: 0.0000075
       region: "*"
 features:
-    - function_calling
-    - tool_choice
+    - json_output
 limits:
     context_window: 6144
     max_output_tokens: 1024

--- a/providers/openrouter/amazon/nova-lite-v1.yaml
+++ b/providers/openrouter/amazon/nova-lite-v1.yaml
@@ -4,8 +4,6 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - system_messages
 limits:
     context_window: 300000
     max_output_tokens: 5120

--- a/providers/openrouter/amazon/nova-micro-v1.yaml
+++ b/providers/openrouter/amazon/nova-micro-v1.yaml
@@ -4,7 +4,6 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
 limits:
     context_window: 128000
     max_output_tokens: 5120

--- a/providers/openrouter/amazon/nova-premier-v1.yaml
+++ b/providers/openrouter/amazon/nova-premier-v1.yaml
@@ -5,8 +5,7 @@ costs:
       region: "*"
 features:
     - function_calling
-    - system_messages
-    - tool_choice
+    - prompt_caching
 limits:
     context_window: 1000000
     max_input_tokens: 968000

--- a/providers/openrouter/amazon/nova-pro-v1.yaml
+++ b/providers/openrouter/amazon/nova-pro-v1.yaml
@@ -4,7 +4,6 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
 limits:
     context_window: 300000
     max_output_tokens: 5120

--- a/providers/openrouter/anthracite-org/magnum-v4-72b.yaml
+++ b/providers/openrouter/anthracite-org/magnum-v4-72b.yaml
@@ -2,6 +2,8 @@ costs:
     - input_cost_per_token: 0.000003
       output_cost_per_token: 0.000005
       region: "*"
+features:
+    - json_output
 limits:
     context_window: 16384
     max_output_tokens: 2048

--- a/providers/openrouter/anthropic/claude-3-haiku.yaml
+++ b/providers/openrouter/anthropic/claude-3-haiku.yaml
@@ -6,8 +6,8 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
     - prompt_caching
+    - tool_choice
 limits:
     context_window: 200000
     max_output_tokens: 4096

--- a/providers/openrouter/anthropic/claude-3.5-haiku.yaml
+++ b/providers/openrouter/anthropic/claude-3.5-haiku.yaml
@@ -6,8 +6,8 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
     - prompt_caching
+    - tool_choice
 limits:
     context_window: 200000
     max_output_tokens: 8192

--- a/providers/openrouter/anthropic/claude-haiku-4.5.yaml
+++ b/providers/openrouter/anthropic/claude-haiku-4.5.yaml
@@ -6,10 +6,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
     - prompt_caching
-    - assistant_prefill
     - structured_output
+    - tool_choice
 limits:
     context_window: 200000
     max_input_tokens: 200000

--- a/providers/openrouter/anthropic/claude-opus-4.1.yaml
+++ b/providers/openrouter/anthropic/claude-opus-4.1.yaml
@@ -6,9 +6,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
     - prompt_caching
-    - assistant_prefill
+    - structured_output
+    - tool_choice
 limits:
     context_window: 200000
     max_output_tokens: 32000

--- a/providers/openrouter/anthropic/claude-opus-4.5.yaml
+++ b/providers/openrouter/anthropic/claude-opus-4.5.yaml
@@ -6,10 +6,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
     - prompt_caching
-    - assistant_prefill
     - structured_output
+    - tool_choice
 limits:
     context_window: 200000
     max_input_tokens: 200000

--- a/providers/openrouter/anthropic/claude-opus-4.6-fast.yaml
+++ b/providers/openrouter/anthropic/claude-opus-4.6-fast.yaml
@@ -4,6 +4,12 @@ costs:
       input_cost_per_token: 0.00003
       output_cost_per_token: 0.00015
       region: "*"
+features:
+    - function_calling
+    - json_output
+    - prompt_caching
+    - structured_output
+    - tool_choice
 limits:
     context_window: 1000000
     max_output_tokens: 128000
@@ -15,3 +21,4 @@ modalities:
         - text
 mode: chat
 model: anthropic/claude-opus-4.6-fast
+thinking: true

--- a/providers/openrouter/anthropic/claude-opus-4.6.yaml
+++ b/providers/openrouter/anthropic/claude-opus-4.6.yaml
@@ -6,10 +6,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - structured_output
+    - json_output
     - prompt_caching
-    - system_messages
+    - structured_output
+    - tool_choice
 limits:
     context_window: 1000000
     max_output_tokens: 128000

--- a/providers/openrouter/anthropic/claude-opus-4.yaml
+++ b/providers/openrouter/anthropic/claude-opus-4.yaml
@@ -6,9 +6,8 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
     - prompt_caching
-    - assistant_prefill
+    - tool_choice
 limits:
     context_window: 200000
     max_input_tokens: 200000

--- a/providers/openrouter/anthropic/claude-sonnet-4.5.yaml
+++ b/providers/openrouter/anthropic/claude-sonnet-4.5.yaml
@@ -19,9 +19,10 @@ costs:
                 from: 200000
 features:
     - function_calling
-    - tool_choice
+    - json_output
     - prompt_caching
-    - assistant_prefill
+    - structured_output
+    - tool_choice
 limits:
     context_window: 1000000
     max_output_tokens: 64000

--- a/providers/openrouter/anthropic/claude-sonnet-4.6.yaml
+++ b/providers/openrouter/anthropic/claude-sonnet-4.6.yaml
@@ -6,11 +6,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - system_messages
-    - structured_output
-    - prompt_caching
     - json_output
+    - prompt_caching
+    - structured_output
+    - tool_choice
 limits:
     context_window: 1000000
     max_output_tokens: 128000

--- a/providers/openrouter/anthropic/claude-sonnet-4.yaml
+++ b/providers/openrouter/anthropic/claude-sonnet-4.yaml
@@ -19,10 +19,8 @@ costs:
                 from: 200000
 features:
     - function_calling
-    - tool_choice
     - prompt_caching
-    - assistant_prefill
-    - structured_output
+    - tool_choice
 limits:
     context_window: 200000
     max_output_tokens: 64000

--- a/providers/openrouter/arcee-ai/maestro-reasoning.yaml
+++ b/providers/openrouter/arcee-ai/maestro-reasoning.yaml
@@ -2,9 +2,6 @@ costs:
     - input_cost_per_token: 9.e-7
       output_cost_per_token: 0.0000033
       region: "*"
-features:
-    - function_calling
-    - tool_choice
 limits:
     context_window: 131072
     max_output_tokens: 32000

--- a/providers/openrouter/arcee-ai/trinity-large-thinking.yaml
+++ b/providers/openrouter/arcee-ai/trinity-large-thinking.yaml
@@ -4,9 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
+    - json_output
     - structured_output
     - tool_choice
-    - json_output
 limits:
     context_window: 262144
     max_output_tokens: 262144

--- a/providers/openrouter/arcee-ai/trinity-mini.yaml
+++ b/providers/openrouter/arcee-ai/trinity-mini.yaml
@@ -4,8 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
     - structured_output
+    - tool_choice
 limits:
     context_window: 131072
     max_output_tokens: 131072

--- a/providers/openrouter/arcee-ai/trinity-mini:free.yaml
+++ b/providers/openrouter/arcee-ai/trinity-mini:free.yaml
@@ -21,5 +21,5 @@ model: arcee-ai/trinity-mini:free
 sources:
     - https://openrouter.ai/arcee-ai/trinity-mini:free/api
     - https://openrouter.ai/arcee-ai/trinity-mini/api
-status: active
+status: retired
 thinking: true

--- a/providers/openrouter/baidu/ernie-4.5-21b-a3b-thinking.yaml
+++ b/providers/openrouter/baidu/ernie-4.5-21b-a3b-thinking.yaml
@@ -2,9 +2,6 @@ costs:
     - input_cost_per_token: 7.e-8
       output_cost_per_token: 2.8e-7
       region: "*"
-features:
-    - function_calling
-    - tool_choice
 limits:
     context_window: 131072
     max_output_tokens: 65536

--- a/providers/openrouter/baidu/ernie-4.5-21b-a3b.yaml
+++ b/providers/openrouter/baidu/ernie-4.5-21b-a3b.yaml
@@ -18,4 +18,3 @@ mode: chat
 model: baidu/ernie-4.5-21b-a3b
 sources:
     - https://openrouter.ai/baidu/ernie-4.5-21b-a3b/api
-thinking: true

--- a/providers/openrouter/baidu/ernie-4.5-300b-a47b.yaml
+++ b/providers/openrouter/baidu/ernie-4.5-300b-a47b.yaml
@@ -2,6 +2,9 @@ costs:
     - input_cost_per_token: 2.8e-7
       output_cost_per_token: 0.0000011
       region: "*"
+features:
+    - json_output
+    - structured_output
 limits:
     context_window: 123000
     max_output_tokens: 12000

--- a/providers/openrouter/bytedance-seed/seed-1.6-flash.yaml
+++ b/providers/openrouter/bytedance-seed/seed-1.6-flash.yaml
@@ -11,8 +11,9 @@ costs:
                 from: 128000
 features:
     - function_calling
-    - tool_choice
+    - json_output
     - structured_output
+    - tool_choice
 limits:
     context_window: 262144
     max_output_tokens: 32768

--- a/providers/openrouter/bytedance-seed/seed-1.6.yaml
+++ b/providers/openrouter/bytedance-seed/seed-1.6.yaml
@@ -11,9 +11,9 @@ costs:
                 from: 128000
 features:
     - function_calling
-    - tool_choice
+    - json_output
     - structured_output
-    - system_messages
+    - tool_choice
 limits:
     context_window: 262144
     max_output_tokens: 32768

--- a/providers/openrouter/bytedance-seed/seed-2.0-lite.yaml
+++ b/providers/openrouter/bytedance-seed/seed-2.0-lite.yaml
@@ -11,9 +11,9 @@ costs:
                 from: 128000
 features:
     - function_calling
+    - json_output
     - structured_output
     - tool_choice
-    - prompt_caching
 limits:
     context_window: 262144
     max_output_tokens: 131072

--- a/providers/openrouter/bytedance-seed/seed-2.0-mini.yaml
+++ b/providers/openrouter/bytedance-seed/seed-2.0-mini.yaml
@@ -11,9 +11,9 @@ costs:
                 from: 128000
 features:
     - function_calling
-    - tool_choice
+    - json_output
     - structured_output
-    - prompt_caching
+    - tool_choice
 limits:
     context_window: 262144
     max_output_tokens: 131072

--- a/providers/openrouter/cognitivecomputations/dolphin-mistral-24b-venice-edition:free.yaml
+++ b/providers/openrouter/cognitivecomputations/dolphin-mistral-24b-venice-edition:free.yaml
@@ -3,9 +3,8 @@ costs:
       output_cost_per_token: 0
       region: "*"
 features:
-    - function_calling
+    - json_output
     - structured_output
-    - tool_choice
 limits:
     context_window: 32768
 modalities:

--- a/providers/openrouter/cohere/command-a.yaml
+++ b/providers/openrouter/cohere/command-a.yaml
@@ -3,10 +3,8 @@ costs:
       output_cost_per_token: 0.00001
       region: "*"
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
     - json_output
+    - structured_output
 limits:
     context_window: 256000
     max_output_tokens: 8192

--- a/providers/openrouter/cohere/command-r-08-2024.yaml
+++ b/providers/openrouter/cohere/command-r-08-2024.yaml
@@ -4,10 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - system_messages
-    - structured_output
     - json_output
+    - structured_output
+    - tool_choice
 limits:
     context_window: 128000
     max_output_tokens: 4000

--- a/providers/openrouter/cohere/command-r-plus-08-2024.yaml
+++ b/providers/openrouter/cohere/command-r-plus-08-2024.yaml
@@ -6,7 +6,6 @@ features:
     - function_calling
     - json_output
     - structured_output
-    - system_messages
     - tool_choice
 limits:
     context_window: 128000

--- a/providers/openrouter/cohere/command-r7b-12-2024.yaml
+++ b/providers/openrouter/cohere/command-r7b-12-2024.yaml
@@ -3,8 +3,7 @@ costs:
       output_cost_per_token: 1.5e-7
       region: "*"
 features:
-    - function_calling
-    - tool_choice
+    - json_output
     - structured_output
 limits:
     context_window: 128000

--- a/providers/openrouter/deepcogito/cogito-v2.1-671b.yaml
+++ b/providers/openrouter/deepcogito/cogito-v2.1-671b.yaml
@@ -3,10 +3,8 @@ costs:
       output_cost_per_token: 0.00000125
       region: "*"
 features:
-    - function_calling
-    - tool_choice
+    - json_output
     - structured_output
-    - system_messages
 limits:
     context_window: 128000
 modalities:

--- a/providers/openrouter/deepseek/deepseek-chat-v3-0324.yaml
+++ b/providers/openrouter/deepseek/deepseek-chat-v3-0324.yaml
@@ -5,8 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
     - prompt_caching
+    - structured_output
+    - tool_choice
 limits:
     context_window: 163840
 modalities:
@@ -18,3 +20,4 @@ mode: chat
 model: deepseek/deepseek-chat-v3-0324
 sources:
     - https://openrouter.ai/deepseek/deepseek-chat-v3-0324/api
+thinking: true

--- a/providers/openrouter/deepseek/deepseek-chat-v3.1.yaml
+++ b/providers/openrouter/deepseek/deepseek-chat-v3.1.yaml
@@ -4,8 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
+    - json_output
+    - structured_output
     - tool_choice
-    - assistant_prefill
 limits:
     context_window: 32768
     max_output_tokens: 7168

--- a/providers/openrouter/deepseek/deepseek-chat.yaml
+++ b/providers/openrouter/deepseek/deepseek-chat.yaml
@@ -4,8 +4,8 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
     - json_output
+    - tool_choice
 limits:
     context_window: 163840
     max_output_tokens: 163840

--- a/providers/openrouter/deepseek/deepseek-r1-0528.yaml
+++ b/providers/openrouter/deepseek/deepseek-r1-0528.yaml
@@ -5,10 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
     - prompt_caching
-    - assistant_prefill
     - structured_output
+    - tool_choice
 limits:
     context_window: 163840
     max_output_tokens: 65536

--- a/providers/openrouter/deepseek/deepseek-r1-distill-llama-70b.yaml
+++ b/providers/openrouter/deepseek/deepseek-r1-distill-llama-70b.yaml
@@ -3,9 +3,7 @@ costs:
       output_cost_per_token: 8.e-7
       region: "*"
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
+    - json_output
 limits:
     context_window: 131072
     max_output_tokens: 16384

--- a/providers/openrouter/deepseek/deepseek-r1-distill-qwen-32b.yaml
+++ b/providers/openrouter/deepseek/deepseek-r1-distill-qwen-32b.yaml
@@ -3,6 +3,7 @@ costs:
       output_cost_per_token: 2.9e-7
       region: "*"
 features:
+    - json_output
     - structured_output
 limits:
     context_window: 32768

--- a/providers/openrouter/deepseek/deepseek-v3.1-terminus.yaml
+++ b/providers/openrouter/deepseek/deepseek-v3.1-terminus.yaml
@@ -4,7 +4,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - system_messages
+    - json_output
+    - prompt_caching
+    - structured_output
+    - tool_choice
 limits:
     context_window: 163840
 modalities:

--- a/providers/openrouter/deepseek/deepseek-v3.2-exp.yaml
+++ b/providers/openrouter/deepseek/deepseek-v3.2-exp.yaml
@@ -4,9 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
     - structured_output
-    - system_messages
+    - tool_choice
 limits:
     context_window: 163840
     max_output_tokens: 65536

--- a/providers/openrouter/deepseek/deepseek-v3.2-speciale.yaml
+++ b/providers/openrouter/deepseek/deepseek-v3.2-speciale.yaml
@@ -3,8 +3,9 @@ costs:
       output_cost_per_token: 0.0000012
       region: "*"
 features:
+    - json_output
+    - prompt_caching
     - structured_output
-    - system_messages
 limits:
     context_window: 163840
     max_output_tokens: 163840

--- a/providers/openrouter/deepseek/deepseek-v3.2.yaml
+++ b/providers/openrouter/deepseek/deepseek-v3.2.yaml
@@ -4,8 +4,10 @@ costs:
       region: "*"
 features:
     - function_calling
+    - json_output
+    - prompt_caching
+    - structured_output
     - tool_choice
-    - assistant_prefill
 limits:
     context_window: 163840
     max_input_tokens: 163840

--- a/providers/openrouter/essentialai/rnj-1-instruct.yaml
+++ b/providers/openrouter/essentialai/rnj-1-instruct.yaml
@@ -4,6 +4,7 @@ costs:
       region: "*"
 features:
     - function_calling
+    - json_output
     - structured_output
     - tool_choice
 limits:
@@ -17,4 +18,3 @@ mode: chat
 model: essentialai/rnj-1-instruct
 sources:
     - https://openrouter.ai/essentialai/rnj-1-instruct/api
-thinking: true

--- a/providers/openrouter/google/gemini-2.5-flash-image.yaml
+++ b/providers/openrouter/google/gemini-2.5-flash-image.yaml
@@ -7,10 +7,9 @@ costs:
       output_cost_per_token: 0.0000025
       region: "*"
 features:
+    - json_output
     - prompt_caching
     - structured_output
-    - system_messages
-    - tool_choice
 limits:
     context_window: 32768
     max_output_tokens: 32768

--- a/providers/openrouter/google/gemini-2.5-flash-lite-preview-09-2025.yaml
+++ b/providers/openrouter/google/gemini-2.5-flash-lite-preview-09-2025.yaml
@@ -7,8 +7,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
+    - prompt_caching
     - structured_output
+    - tool_choice
 limits:
     context_window: 1048576
     max_output_tokens: 65535

--- a/providers/openrouter/google/gemini-2.5-flash-lite.yaml
+++ b/providers/openrouter/google/gemini-2.5-flash-lite.yaml
@@ -5,8 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
+    - prompt_caching
     - structured_output
+    - tool_choice
 limits:
     context_window: 1048576
     max_output_tokens: 65535

--- a/providers/openrouter/google/gemini-2.5-flash.yaml
+++ b/providers/openrouter/google/gemini-2.5-flash.yaml
@@ -7,10 +7,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - system_messages
-    - tool_choice
-    - structured_output
+    - json_output
     - prompt_caching
+    - structured_output
+    - tool_choice
 limits:
     context_window: 1048576
     max_output_tokens: 65535

--- a/providers/openrouter/google/gemini-2.5-pro-preview-05-06.yaml
+++ b/providers/openrouter/google/gemini-2.5-pro-preview-05-06.yaml
@@ -20,10 +20,10 @@ costs:
                 from: 200000
 features:
     - function_calling
-    - system_messages
-    - tool_choice
-    - structured_output
+    - json_output
     - prompt_caching
+    - structured_output
+    - tool_choice
 limits:
     context_window: 1048576
     max_output_tokens: 65536

--- a/providers/openrouter/google/gemini-2.5-pro-preview.yaml
+++ b/providers/openrouter/google/gemini-2.5-pro-preview.yaml
@@ -20,10 +20,10 @@ costs:
                 from: 200000
 features:
     - function_calling
-    - tool_choice
-    - structured_output
-    - system_messages
+    - json_output
     - prompt_caching
+    - structured_output
+    - tool_choice
 limits:
     context_window: 1048576
     max_output_tokens: 65536

--- a/providers/openrouter/google/gemini-2.5-pro.yaml
+++ b/providers/openrouter/google/gemini-2.5-pro.yaml
@@ -23,10 +23,10 @@ costs:
                 from: 200000
 features:
     - function_calling
-    - system_messages
-    - tool_choice
-    - structured_output
+    - json_output
     - prompt_caching
+    - structured_output
+    - tool_choice
 limits:
     context_window: 1048576
     max_input_tokens: 1048576

--- a/providers/openrouter/google/gemini-3-flash-preview.yaml
+++ b/providers/openrouter/google/gemini-3-flash-preview.yaml
@@ -7,10 +7,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - system_messages
-    - structured_output
+    - json_output
     - prompt_caching
+    - structured_output
+    - tool_choice
 limits:
     context_window: 1048576
     max_output_tokens: 65536

--- a/providers/openrouter/google/gemini-3-pro-image-preview.yaml
+++ b/providers/openrouter/google/gemini-3-pro-image-preview.yaml
@@ -4,9 +4,7 @@ costs:
       output_cost_per_token: 0.000012
       region: "*"
 features:
-    - function_calling
-    - tool_choice
-    - system_messages
+    - json_output
     - prompt_caching
     - structured_output
 limits:

--- a/providers/openrouter/google/gemini-3.1-flash-image-preview.yaml
+++ b/providers/openrouter/google/gemini-3.1-flash-image-preview.yaml
@@ -4,10 +4,8 @@ costs:
       output_cost_per_token: 0.000003
       region: "*"
 features:
-    - function_calling
-    - tool_choice
+    - json_output
     - structured_output
-    - system_messages
 limits:
     context_window: 65536
     max_output_tokens: 65536

--- a/providers/openrouter/google/gemini-3.1-flash-lite-preview.yaml
+++ b/providers/openrouter/google/gemini-3.1-flash-lite-preview.yaml
@@ -7,9 +7,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - structured_output
+    - json_output
     - prompt_caching
+    - structured_output
+    - tool_choice
 limits:
     context_window: 1048576
     max_output_tokens: 65536

--- a/providers/openrouter/google/gemini-3.1-pro-preview-customtools.yaml
+++ b/providers/openrouter/google/gemini-3.1-pro-preview-customtools.yaml
@@ -18,11 +18,10 @@ costs:
                 from: 200000
 features:
     - function_calling
-    - tool_choice
-    - structured_output
-    - system_messages
-    - prompt_caching
     - json_output
+    - prompt_caching
+    - structured_output
+    - tool_choice
 limits:
     context_window: 1048576
     max_output_tokens: 65536

--- a/providers/openrouter/google/gemini-3.1-pro-preview.yaml
+++ b/providers/openrouter/google/gemini-3.1-pro-preview.yaml
@@ -17,11 +17,10 @@ costs:
                 from: 200000
 features:
     - function_calling
-    - tool_choice
-    - structured_output
-    - system_messages
+    - json_output
     - prompt_caching
-    - code_execution
+    - structured_output
+    - tool_choice
 limits:
     context_window: 1048576
     max_input_tokens: 1048576

--- a/providers/openrouter/google/gemma-2-27b-it.yaml
+++ b/providers/openrouter/google/gemma-2-27b-it.yaml
@@ -3,10 +3,8 @@ costs:
       output_cost_per_token: 6.5e-7
       region: "*"
 features:
-    - function_calling
-    - tool_choice
+    - json_output
     - structured_output
-    - system_messages
 limits:
     context_window: 8192
     max_output_tokens: 2048

--- a/providers/openrouter/google/gemma-2-9b-it.yaml
+++ b/providers/openrouter/google/gemma-2-9b-it.yaml
@@ -2,10 +2,6 @@ costs:
     - input_cost_per_token: 3.e-8
       output_cost_per_token: 9.e-8
       region: "*"
-features:
-    - function_calling
-    - tool_choice
-    - structured_output
 limits:
     context_window: 8192
 modalities:

--- a/providers/openrouter/google/gemma-3-12b-it.yaml
+++ b/providers/openrouter/google/gemma-3-12b-it.yaml
@@ -3,9 +3,8 @@ costs:
       output_cost_per_token: 1.3e-7
       region: "*"
 features:
-    - function_calling
+    - json_output
     - structured_output
-    - system_messages
 limits:
     context_window: 131072
 modalities:

--- a/providers/openrouter/google/gemma-3-12b-it:free.yaml
+++ b/providers/openrouter/google/gemma-3-12b-it:free.yaml
@@ -2,10 +2,6 @@ costs:
     - input_cost_per_token: 0
       output_cost_per_token: 0
       region: "*"
-features:
-    - function_calling
-    - tool_choice
-    - structured_output
 limits:
     context_window: 32768
     max_output_tokens: 8192

--- a/providers/openrouter/google/gemma-3-27b-it.yaml
+++ b/providers/openrouter/google/gemma-3-27b-it.yaml
@@ -3,9 +3,8 @@ costs:
       output_cost_per_token: 1.6e-7
       region: "*"
 features:
-    - function_calling
+    - json_output
     - structured_output
-    - tool_choice
 limits:
     context_window: 131072
     max_output_tokens: 16384

--- a/providers/openrouter/google/gemma-3-27b-it:free.yaml
+++ b/providers/openrouter/google/gemma-3-27b-it:free.yaml
@@ -3,10 +3,6 @@ costs:
       output_cost_per_token: 0
       region: "*"
 features:
-    - function_calling
-    - tool_choice
-    - system_messages
-    - structured_output
     - json_output
 limits:
     context_window: 131072

--- a/providers/openrouter/google/gemma-3-4b-it.yaml
+++ b/providers/openrouter/google/gemma-3-4b-it.yaml
@@ -3,9 +3,7 @@ costs:
       output_cost_per_token: 8.e-8
       region: "*"
 features:
-    - function_calling
-    - structured_output
-    - tool_choice
+    - json_output
 limits:
     context_window: 131072
 modalities:

--- a/providers/openrouter/google/gemma-3-4b-it:free.yaml
+++ b/providers/openrouter/google/gemma-3-4b-it:free.yaml
@@ -3,9 +3,7 @@ costs:
       output_cost_per_token: 0
       region: "*"
 features:
-    - function_calling
-    - tool_choice
-    - system_messages
+    - json_output
 limits:
     context_window: 32768
     max_output_tokens: 8192

--- a/providers/openrouter/google/gemma-3n-e2b-it:free.yaml
+++ b/providers/openrouter/google/gemma-3n-e2b-it:free.yaml
@@ -3,7 +3,6 @@ costs:
       output_cost_per_token: 0
       region: "*"
 features:
-    - system_messages
     - json_output
 limits:
     context_window: 8192

--- a/providers/openrouter/google/gemma-3n-e4b-it:free.yaml
+++ b/providers/openrouter/google/gemma-3n-e4b-it:free.yaml
@@ -3,9 +3,6 @@ costs:
       output_cost_per_token: 0
       region: "*"
 features:
-    - function_calling
-    - system_messages
-    - tool_choice
     - json_output
 limits:
     context_window: 8192

--- a/providers/openrouter/google/gemma-4-26b-a4b-it.yaml
+++ b/providers/openrouter/google/gemma-4-26b-a4b-it.yaml
@@ -4,8 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - structured_output
     - json_output
+    - structured_output
+    - tool_choice
 limits:
     context_window: 262144
     max_output_tokens: 262144

--- a/providers/openrouter/google/gemma-4-26b-a4b-it:free.yaml
+++ b/providers/openrouter/google/gemma-4-26b-a4b-it:free.yaml
@@ -2,6 +2,10 @@ costs:
     - input_cost_per_token: 0
       output_cost_per_token: 0
       region: "*"
+features:
+    - function_calling
+    - json_output
+    - tool_choice
 limits:
     context_window: 262144
     max_output_tokens: 32768
@@ -21,3 +25,4 @@ params:
       key: top_p
     - defaultValue: 64
       key: top_k
+thinking: true

--- a/providers/openrouter/google/gemma-4-31b-it.yaml
+++ b/providers/openrouter/google/gemma-4-31b-it.yaml
@@ -4,6 +4,8 @@ costs:
       region: "*"
 features:
     - function_calling
+    - json_output
+    - structured_output
     - tool_choice
 limits:
     context_window: 262144

--- a/providers/openrouter/google/gemma-4-31b-it:free.yaml
+++ b/providers/openrouter/google/gemma-4-31b-it:free.yaml
@@ -2,6 +2,10 @@ costs:
     - input_cost_per_token: 0
       output_cost_per_token: 0
       region: "*"
+features:
+    - function_calling
+    - json_output
+    - tool_choice
 limits:
     context_window: 262144
     max_output_tokens: 32768
@@ -21,3 +25,4 @@ params:
       key: top_p
     - defaultValue: 64
       key: top_k
+thinking: true

--- a/providers/openrouter/google/lyria-3-clip-preview.yaml
+++ b/providers/openrouter/google/lyria-3-clip-preview.yaml
@@ -2,6 +2,8 @@ costs:
     - input_cost_per_token: 0
       output_cost_per_token: 0
       region: "*"
+features:
+    - json_output
 limits:
     context_window: 1048576
     max_output_tokens: 65536

--- a/providers/openrouter/google/lyria-3-pro-preview.yaml
+++ b/providers/openrouter/google/lyria-3-pro-preview.yaml
@@ -2,6 +2,8 @@ costs:
     - input_cost_per_token: 0
       output_cost_per_token: 0
       region: "*"
+features:
+    - json_output
 limits:
     context_window: 1048576
     max_output_tokens: 65536

--- a/providers/openrouter/gryphe/mythomax-l2-13b.yaml
+++ b/providers/openrouter/gryphe/mythomax-l2-13b.yaml
@@ -3,9 +3,8 @@ costs:
       output_cost_per_token: 6.e-8
       region: "*"
 features:
-    - function_calling
+    - json_output
     - structured_output
-    - tool_choice
 limits:
     context_window: 4096
     max_output_tokens: 4096

--- a/providers/openrouter/ibm-granite/granite-4.0-h-micro.yaml
+++ b/providers/openrouter/ibm-granite/granite-4.0-h-micro.yaml
@@ -2,10 +2,6 @@ costs:
     - input_cost_per_token: 1.7e-8
       output_cost_per_token: 1.1e-7
       region: "*"
-features:
-    - function_calling
-    - tool_choice
-    - system_messages
 limits:
     context_window: 131000
 modalities:

--- a/providers/openrouter/inception/mercury-2.yaml
+++ b/providers/openrouter/inception/mercury-2.yaml
@@ -5,8 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
+    - prompt_caching
     - structured_output
+    - tool_choice
 limits:
     context_window: 128000
     max_output_tokens: 50000

--- a/providers/openrouter/inflection/inflection-3-pi.yaml
+++ b/providers/openrouter/inflection/inflection-3-pi.yaml
@@ -2,9 +2,6 @@ costs:
     - input_cost_per_token: 0.0000025
       output_cost_per_token: 0.00001
       region: "*"
-features:
-    - function_calling
-    - tool_choice
 limits:
     context_window: 8000
     max_output_tokens: 1024

--- a/providers/openrouter/inflection/inflection-3-productivity.yaml
+++ b/providers/openrouter/inflection/inflection-3-productivity.yaml
@@ -2,9 +2,6 @@ costs:
     - input_cost_per_token: 0.0000025
       output_cost_per_token: 0.00001
       region: "*"
-features:
-    - function_calling
-    - tool_choice
 limits:
     context_window: 8000
     max_output_tokens: 1024

--- a/providers/openrouter/kwaipilot/kat-coder-pro-v2.yaml
+++ b/providers/openrouter/kwaipilot/kat-coder-pro-v2.yaml
@@ -5,6 +5,9 @@ costs:
       region: "*"
 features:
     - function_calling
+    - json_output
+    - prompt_caching
+    - structured_output
     - tool_choice
 limits:
     context_window: 256000

--- a/providers/openrouter/liquid/lfm-2.5-1.2b-instruct:free.yaml
+++ b/providers/openrouter/liquid/lfm-2.5-1.2b-instruct:free.yaml
@@ -2,8 +2,6 @@ costs:
     - input_cost_per_token: 0
       output_cost_per_token: 0
       region: "*"
-features:
-    - tool_choice
 limits:
     context_window: 32768
 modalities:

--- a/providers/openrouter/liquid/lfm-2.5-1.2b-thinking:free.yaml
+++ b/providers/openrouter/liquid/lfm-2.5-1.2b-thinking:free.yaml
@@ -2,9 +2,6 @@ costs:
     - input_cost_per_token: 0
       output_cost_per_token: 0
       region: "*"
-features:
-    - system_messages
-    - function_calling
 limits:
     context_window: 32768
 modalities:

--- a/providers/openrouter/mancer/weaver.yaml
+++ b/providers/openrouter/mancer/weaver.yaml
@@ -2,6 +2,8 @@ costs:
     - input_cost_per_token: 7.5e-7
       output_cost_per_token: 0.000001
       region: "*"
+features:
+    - json_output
 limits:
     context_window: 8000
     max_output_tokens: 2000

--- a/providers/openrouter/meituan/longcat-flash-chat.yaml
+++ b/providers/openrouter/meituan/longcat-flash-chat.yaml
@@ -4,6 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
+    - json_output
+    - prompt_caching
+    - structured_output
     - tool_choice
 limits:
     context_window: 131072

--- a/providers/openrouter/meta-llama/llama-3-70b-instruct.yaml
+++ b/providers/openrouter/meta-llama/llama-3-70b-instruct.yaml
@@ -2,9 +2,6 @@ costs:
     - input_cost_per_token: 5.1e-7
       output_cost_per_token: 7.4e-7
       region: "*"
-features:
-    - function_calling
-    - tool_choice
 limits:
     context_window: 8192
     max_output_tokens: 8000

--- a/providers/openrouter/meta-llama/llama-3-8b-instruct.yaml
+++ b/providers/openrouter/meta-llama/llama-3-8b-instruct.yaml
@@ -5,8 +5,6 @@ costs:
 features:
     - function_calling
     - json_output
-    - structured_output
-    - system_messages
     - tool_choice
 limits:
     context_window: 8192

--- a/providers/openrouter/meta-llama/llama-3.1-70b-instruct.yaml
+++ b/providers/openrouter/meta-llama/llama-3.1-70b-instruct.yaml
@@ -4,9 +4,8 @@ costs:
       region: "*"
 features:
     - function_calling
+    - json_output
     - tool_choice
-    - system_messages
-    - structured_output
 limits:
     context_window: 131072
     max_tokens: 131072

--- a/providers/openrouter/meta-llama/llama-3.1-8b-instruct.yaml
+++ b/providers/openrouter/meta-llama/llama-3.1-8b-instruct.yaml
@@ -4,6 +4,8 @@ costs:
       region: "*"
 features:
     - function_calling
+    - json_output
+    - structured_output
     - tool_choice
 limits:
     context_window: 16384

--- a/providers/openrouter/meta-llama/llama-3.2-11b-vision-instruct.yaml
+++ b/providers/openrouter/meta-llama/llama-3.2-11b-vision-instruct.yaml
@@ -3,7 +3,7 @@ costs:
       output_cost_per_token: 4.9e-8
       region: "*"
 features:
-    - system_messages
+    - json_output
 limits:
     context_window: 131072
     max_output_tokens: 16384

--- a/providers/openrouter/meta-llama/llama-3.2-1b-instruct.yaml
+++ b/providers/openrouter/meta-llama/llama-3.2-1b-instruct.yaml
@@ -2,8 +2,6 @@ costs:
     - input_cost_per_token: 2.7e-8
       output_cost_per_token: 2.e-7
       region: "*"
-features:
-    - system_messages
 limits:
     context_window: 60000
     max_output_tokens: 4096

--- a/providers/openrouter/meta-llama/llama-3.2-3b-instruct.yaml
+++ b/providers/openrouter/meta-llama/llama-3.2-3b-instruct.yaml
@@ -2,8 +2,6 @@ costs:
     - input_cost_per_token: 5.1e-8
       output_cost_per_token: 3.4e-7
       region: "*"
-features:
-    - system_messages
 limits:
     context_window: 80000
 modalities:

--- a/providers/openrouter/meta-llama/llama-3.2-3b-instruct:free.yaml
+++ b/providers/openrouter/meta-llama/llama-3.2-3b-instruct:free.yaml
@@ -2,9 +2,6 @@ costs:
     - input_cost_per_token: 0
       output_cost_per_token: 0
       region: "*"
-features:
-    - function_calling
-    - system_messages
 limits:
     context_window: 131072
 modalities:

--- a/providers/openrouter/meta-llama/llama-3.3-70b-instruct.yaml
+++ b/providers/openrouter/meta-llama/llama-3.3-70b-instruct.yaml
@@ -4,8 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
     - structured_output
+    - tool_choice
 limits:
     context_window: 131072
     max_input_tokens: 131072

--- a/providers/openrouter/meta-llama/llama-3.3-70b-instruct:free.yaml
+++ b/providers/openrouter/meta-llama/llama-3.3-70b-instruct:free.yaml
@@ -5,7 +5,6 @@ costs:
 features:
     - function_calling
     - tool_choice
-    - system_messages
 limits:
     context_window: 65536
 modalities:

--- a/providers/openrouter/meta-llama/llama-4-maverick.yaml
+++ b/providers/openrouter/meta-llama/llama-4-maverick.yaml
@@ -3,8 +3,10 @@ costs:
       output_cost_per_token: 6.e-7
       region: "*"
 features:
-    - system_messages
+    - function_calling
+    - json_output
     - structured_output
+    - tool_choice
 limits:
     context_window: 1048576
     max_output_tokens: 16384

--- a/providers/openrouter/meta-llama/llama-4-scout.yaml
+++ b/providers/openrouter/meta-llama/llama-4-scout.yaml
@@ -4,10 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - system_messages
-    - tool_choice
-    - structured_output
     - json_output
+    - structured_output
+    - tool_choice
 limits:
     context_window: 327680
     max_output_tokens: 16384

--- a/providers/openrouter/meta-llama/llama-guard-3-8b.yaml
+++ b/providers/openrouter/meta-llama/llama-guard-3-8b.yaml
@@ -2,9 +2,6 @@ costs:
     - input_cost_per_token: 2.e-8
       output_cost_per_token: 6.e-8
       region: "*"
-features:
-    - system_messages
-    - tool_choice
 limits:
     context_window: 131072
 modalities:

--- a/providers/openrouter/meta-llama/llama-guard-4-12b.yaml
+++ b/providers/openrouter/meta-llama/llama-guard-4-12b.yaml
@@ -3,7 +3,7 @@ costs:
       output_cost_per_token: 1.8e-7
       region: "*"
 features:
-    - system_messages
+    - json_output
 limits:
     context_window: 163840
 modalities:

--- a/providers/openrouter/microsoft/phi-4.yaml
+++ b/providers/openrouter/microsoft/phi-4.yaml
@@ -3,9 +3,8 @@ costs:
       output_cost_per_token: 1.4e-7
       region: "*"
 features:
+    - json_output
     - structured_output
-    - function_calling
-    - tool_choice
 limits:
     context_window: 16384
     max_output_tokens: 16384

--- a/providers/openrouter/microsoft/wizardlm-2-8x22b.yaml
+++ b/providers/openrouter/microsoft/wizardlm-2-8x22b.yaml
@@ -2,10 +2,6 @@ costs:
     - input_cost_per_token: 6.2e-7
       output_cost_per_token: 6.2e-7
       region: "*"
-features:
-    - function_calling
-    - tool_choice
-    - system_messages
 limits:
     context_window: 65535
     max_output_tokens: 8000

--- a/providers/openrouter/minimax/minimax-01.yaml
+++ b/providers/openrouter/minimax/minimax-01.yaml
@@ -2,9 +2,6 @@ costs:
     - input_cost_per_token: 2.e-7
       output_cost_per_token: 0.0000011
       region: "*"
-features:
-    - function_calling
-    - tool_choice
 limits:
     context_window: 1000192
     max_output_tokens: 1000192

--- a/providers/openrouter/minimax/minimax-m1.yaml
+++ b/providers/openrouter/minimax/minimax-m1.yaml
@@ -8,7 +8,7 @@ costs:
                 from: 200000
 features:
     - function_calling
-    - system_messages
+    - tool_choice
 limits:
     context_window: 1000000
     max_output_tokens: 40000

--- a/providers/openrouter/minimax/minimax-m2-her.yaml
+++ b/providers/openrouter/minimax/minimax-m2-her.yaml
@@ -5,9 +5,7 @@ costs:
       output_cost_per_token: 0.0000012
       region: "*"
 features:
-    - function_calling
-    - system_messages
-    - tool_choice
+    - prompt_caching
 limits:
     context_window: 65536
     max_output_tokens: 2048

--- a/providers/openrouter/minimax/minimax-m2.1.yaml
+++ b/providers/openrouter/minimax/minimax-m2.1.yaml
@@ -5,9 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - structured_output
     - json_output
+    - prompt_caching
+    - structured_output
+    - tool_choice
 limits:
     context_window: 196608
     max_input_tokens: 196608

--- a/providers/openrouter/minimax/minimax-m2.5.yaml
+++ b/providers/openrouter/minimax/minimax-m2.5.yaml
@@ -2,6 +2,13 @@ costs:
     - input_cost_per_token: 1.18e-7
       output_cost_per_token: 9.9e-7
       region: "*"
+features:
+    - function_calling
+    - json_output
+    - parallel_function_calling
+    - prompt_caching
+    - structured_output
+    - tool_choice
 limits:
     context_window: 196608
     max_output_tokens: 65536

--- a/providers/openrouter/minimax/minimax-m2.5:free.yaml
+++ b/providers/openrouter/minimax/minimax-m2.5:free.yaml
@@ -4,9 +4,7 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - structured_output
-    - system_messages
+    - json_output
 limits:
     context_window: 196608
     max_output_tokens: 196608

--- a/providers/openrouter/minimax/minimax-m2.7.yaml
+++ b/providers/openrouter/minimax/minimax-m2.7.yaml
@@ -5,8 +5,9 @@ costs:
       region: "*"
 features:
     - function_calling
+    - json_output
+    - prompt_caching
     - tool_choice
-    - structured_output
 limits:
     context_window: 204800
     max_output_tokens: 131072

--- a/providers/openrouter/minimax/minimax-m2.yaml
+++ b/providers/openrouter/minimax/minimax-m2.yaml
@@ -5,9 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
     - prompt_caching
     - structured_output
+    - tool_choice
 limits:
     context_window: 196608
     max_input_tokens: 196608

--- a/providers/openrouter/mistralai/codestral-2508.yaml
+++ b/providers/openrouter/mistralai/codestral-2508.yaml
@@ -5,9 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - structured_output
+    - json_output
     - prompt_caching
+    - structured_output
+    - tool_choice
 limits:
     context_window: 256000
 modalities:

--- a/providers/openrouter/mistralai/devstral-2512.yaml
+++ b/providers/openrouter/mistralai/devstral-2512.yaml
@@ -6,6 +6,7 @@ costs:
 features:
     - function_calling
     - json_output
+    - prompt_caching
     - structured_output
     - tool_choice
 limits:

--- a/providers/openrouter/mistralai/devstral-medium.yaml
+++ b/providers/openrouter/mistralai/devstral-medium.yaml
@@ -5,9 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
+    - prompt_caching
     - structured_output
-    - system_messages
+    - tool_choice
 limits:
     context_window: 131072
 modalities:

--- a/providers/openrouter/mistralai/devstral-small.yaml
+++ b/providers/openrouter/mistralai/devstral-small.yaml
@@ -5,6 +5,8 @@ costs:
       region: "*"
 features:
     - function_calling
+    - json_output
+    - prompt_caching
     - structured_output
     - tool_choice
 limits:

--- a/providers/openrouter/mistralai/ministral-14b-2512.yaml
+++ b/providers/openrouter/mistralai/ministral-14b-2512.yaml
@@ -5,9 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - structured_output
     - json_output
+    - prompt_caching
+    - structured_output
+    - tool_choice
 limits:
     context_window: 262144
 modalities:

--- a/providers/openrouter/mistralai/ministral-3b-2512.yaml
+++ b/providers/openrouter/mistralai/ministral-3b-2512.yaml
@@ -5,9 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - structured_output
     - json_output
+    - prompt_caching
+    - structured_output
+    - tool_choice
 limits:
     context_window: 131072
 modalities:

--- a/providers/openrouter/mistralai/ministral-8b-2512.yaml
+++ b/providers/openrouter/mistralai/ministral-8b-2512.yaml
@@ -5,9 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - structured_output
     - json_output
+    - prompt_caching
+    - structured_output
+    - tool_choice
 limits:
     context_window: 262144
     max_input_tokens: 262144

--- a/providers/openrouter/mistralai/mistral-large-2407.yaml
+++ b/providers/openrouter/mistralai/mistral-large-2407.yaml
@@ -5,9 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - structured_output
     - json_output
+    - prompt_caching
+    - structured_output
+    - tool_choice
 limits:
     context_window: 131072
     max_output_tokens: 4096

--- a/providers/openrouter/mistralai/mistral-large-2411.yaml
+++ b/providers/openrouter/mistralai/mistral-large-2411.yaml
@@ -5,9 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
+    - prompt_caching
     - structured_output
-    - system_messages
+    - tool_choice
 limits:
     context_window: 131072
 modalities:

--- a/providers/openrouter/mistralai/mistral-large-2512.yaml
+++ b/providers/openrouter/mistralai/mistral-large-2512.yaml
@@ -5,11 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - parallel_function_calling
-    - tool_choice
-    - structured_output
-    - prompt_caching
     - json_output
+    - prompt_caching
+    - structured_output
+    - tool_choice
 limits:
     context_window: 262144
     max_input_tokens: 262144

--- a/providers/openrouter/mistralai/mistral-large.yaml
+++ b/providers/openrouter/mistralai/mistral-large.yaml
@@ -5,8 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
+    - prompt_caching
     - structured_output
+    - tool_choice
 limits:
     context_window: 128000
 modalities:

--- a/providers/openrouter/mistralai/mistral-medium-3.1.yaml
+++ b/providers/openrouter/mistralai/mistral-medium-3.1.yaml
@@ -5,9 +5,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - parallel_function_calling
+    - json_output
+    - prompt_caching
     - structured_output
-    - system_messages
     - tool_choice
 limits:
     context_window: 131072

--- a/providers/openrouter/mistralai/mistral-medium-3.yaml
+++ b/providers/openrouter/mistralai/mistral-medium-3.yaml
@@ -5,6 +5,8 @@ costs:
       region: "*"
 features:
     - function_calling
+    - json_output
+    - prompt_caching
     - structured_output
     - tool_choice
 limits:

--- a/providers/openrouter/mistralai/mistral-nemo.yaml
+++ b/providers/openrouter/mistralai/mistral-nemo.yaml
@@ -4,9 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - system_messages
+    - json_output
     - structured_output
+    - tool_choice
 limits:
     context_window: 131072
     max_output_tokens: 16384

--- a/providers/openrouter/mistralai/mistral-saba.yaml
+++ b/providers/openrouter/mistralai/mistral-saba.yaml
@@ -5,9 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
+    - prompt_caching
     - structured_output
-    - system_messages
+    - tool_choice
 limits:
     context_window: 32768
     max_tokens: 32768

--- a/providers/openrouter/mistralai/mistral-small-24b-instruct-2501.yaml
+++ b/providers/openrouter/mistralai/mistral-small-24b-instruct-2501.yaml
@@ -3,10 +3,7 @@ costs:
       output_cost_per_token: 8.e-8
       region: "*"
 features:
-    - function_calling
-    - structured_output
-    - system_messages
-    - tool_choice
+    - json_output
 limits:
     context_window: 32768
     max_output_tokens: 16384

--- a/providers/openrouter/mistralai/mistral-small-2603.yaml
+++ b/providers/openrouter/mistralai/mistral-small-2603.yaml
@@ -5,9 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
+    - json_output
+    - prompt_caching
     - structured_output
     - tool_choice
-    - prompt_caching
 limits:
     context_window: 262144
 modalities:

--- a/providers/openrouter/mistralai/mistral-small-3.1-24b-instruct.yaml
+++ b/providers/openrouter/mistralai/mistral-small-3.1-24b-instruct.yaml
@@ -4,8 +4,8 @@ costs:
       output_cost_per_token: 1.1e-7
       region: "*"
 features:
-    - function_calling
-    - tool_choice
+    - json_output
+    - prompt_caching
     - structured_output
 limits:
     context_window: 131072

--- a/providers/openrouter/mistralai/mistral-small-3.2-24b-instruct.yaml
+++ b/providers/openrouter/mistralai/mistral-small-3.2-24b-instruct.yaml
@@ -4,8 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
     - structured_output
+    - tool_choice
 limits:
     context_window: 128000
 modalities:

--- a/providers/openrouter/mistralai/mixtral-8x22b-instruct.yaml
+++ b/providers/openrouter/mistralai/mixtral-8x22b-instruct.yaml
@@ -5,9 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - structured_output
     - json_output
+    - prompt_caching
+    - structured_output
+    - tool_choice
 limits:
     context_window: 65536
 modalities:

--- a/providers/openrouter/mistralai/mixtral-8x7b-instruct.yaml
+++ b/providers/openrouter/mistralai/mixtral-8x7b-instruct.yaml
@@ -4,9 +4,8 @@ costs:
       region: "*"
 features:
     - function_calling
+    - json_output
     - tool_choice
-    - system_messages
-    - structured_output
 limits:
     context_window: 32768
     max_output_tokens: 16384

--- a/providers/openrouter/mistralai/pixtral-large-2411.yaml
+++ b/providers/openrouter/mistralai/pixtral-large-2411.yaml
@@ -5,9 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
+    - prompt_caching
     - structured_output
-    - system_messages
+    - tool_choice
 limits:
     context_window: 131072
     max_output_tokens: 4096

--- a/providers/openrouter/mistralai/voxtral-small-24b-2507.yaml
+++ b/providers/openrouter/mistralai/voxtral-small-24b-2507.yaml
@@ -6,9 +6,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - structured_output
     - json_output
+    - prompt_caching
+    - structured_output
+    - tool_choice
 limits:
     context_window: 32000
 modalities:

--- a/providers/openrouter/moonshotai/kimi-k2-0905.yaml
+++ b/providers/openrouter/moonshotai/kimi-k2-0905.yaml
@@ -5,10 +5,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - structured_output
-    - system_messages
     - json_output
+    - structured_output
+    - tool_choice
 limits:
     context_window: 131072
 modalities:

--- a/providers/openrouter/moonshotai/kimi-k2-thinking.yaml
+++ b/providers/openrouter/moonshotai/kimi-k2-thinking.yaml
@@ -5,9 +5,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - system_messages
+    - json_output
     - structured_output
+    - tool_choice
 limits:
     context_window: 131072
 modalities:

--- a/providers/openrouter/moonshotai/kimi-k2.5.yaml
+++ b/providers/openrouter/moonshotai/kimi-k2.5.yaml
@@ -5,8 +5,11 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
+    - parallel_function_calling
+    - prompt_caching
     - structured_output
+    - tool_choice
 limits:
     context_window: 262144
     max_output_tokens: 262144

--- a/providers/openrouter/moonshotai/kimi-k2.yaml
+++ b/providers/openrouter/moonshotai/kimi-k2.yaml
@@ -5,7 +5,6 @@ costs:
 features:
     - function_calling
     - tool_choice
-    - structured_output
 limits:
     context_window: 131072
     max_output_tokens: 131072

--- a/providers/openrouter/nex-agi/deepseek-v3.1-nex-n1.yaml
+++ b/providers/openrouter/nex-agi/deepseek-v3.1-nex-n1.yaml
@@ -4,8 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
     - structured_output
+    - tool_choice
 limits:
     context_window: 131072
     max_output_tokens: 163840

--- a/providers/openrouter/nousresearch/hermes-2-pro-llama-3-8b.yaml
+++ b/providers/openrouter/nousresearch/hermes-2-pro-llama-3-8b.yaml
@@ -3,9 +3,8 @@ costs:
       output_cost_per_token: 1.4e-7
       region: "*"
 features:
-    - function_calling
-    - structured_output
     - json_output
+    - structured_output
 limits:
     context_window: 8192
     max_output_tokens: 8192

--- a/providers/openrouter/nousresearch/hermes-3-llama-3.1-405b.yaml
+++ b/providers/openrouter/nousresearch/hermes-3-llama-3.1-405b.yaml
@@ -3,10 +3,7 @@ costs:
       output_cost_per_token: 0.000001
       region: "*"
 features:
-    - function_calling
-    - tool_choice
-    - system_messages
-    - structured_output
+    - json_output
 limits:
     context_window: 131072
     max_output_tokens: 16384

--- a/providers/openrouter/nousresearch/hermes-3-llama-3.1-405b:free.yaml
+++ b/providers/openrouter/nousresearch/hermes-3-llama-3.1-405b:free.yaml
@@ -2,10 +2,6 @@ costs:
     - input_cost_per_token: 0
       output_cost_per_token: 0
       region: "*"
-features:
-    - function_calling
-    - tool_choice
-    - system_messages
 limits:
     context_window: 131072
 modalities:

--- a/providers/openrouter/nousresearch/hermes-3-llama-3.1-70b.yaml
+++ b/providers/openrouter/nousresearch/hermes-3-llama-3.1-70b.yaml
@@ -3,9 +3,6 @@ costs:
       output_cost_per_token: 3.e-7
       region: "*"
 features:
-    - function_calling
-    - structured_output
-    - system_messages
     - json_output
 limits:
     context_window: 131072

--- a/providers/openrouter/nousresearch/hermes-4-405b.yaml
+++ b/providers/openrouter/nousresearch/hermes-4-405b.yaml
@@ -3,10 +3,7 @@ costs:
       output_cost_per_token: 0.000003
       region: "*"
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
-    - system_messages
+    - json_output
 limits:
     context_window: 131072
 modalities:

--- a/providers/openrouter/nousresearch/hermes-4-70b.yaml
+++ b/providers/openrouter/nousresearch/hermes-4-70b.yaml
@@ -3,9 +3,6 @@ costs:
       output_cost_per_token: 4.e-7
       region: "*"
 features:
-    - function_calling
-    - structured_output
-    - system_messages
     - json_output
 limits:
     context_window: 131072

--- a/providers/openrouter/nvidia/llama-3.1-nemotron-70b-instruct.yaml
+++ b/providers/openrouter/nvidia/llama-3.1-nemotron-70b-instruct.yaml
@@ -4,9 +4,8 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - structured_output
     - json_output
+    - tool_choice
 limits:
     context_window: 131072
     max_output_tokens: 16384

--- a/providers/openrouter/nvidia/llama-3.1-nemotron-ultra-253b-v1.yaml
+++ b/providers/openrouter/nvidia/llama-3.1-nemotron-ultra-253b-v1.yaml
@@ -3,9 +3,8 @@ costs:
       output_cost_per_token: 0.0000018
       region: "*"
 features:
-    - function_calling
+    - json_output
     - structured_output
-    - tool_choice
 limits:
     context_window: 131072
 modalities:

--- a/providers/openrouter/nvidia/llama-3.3-nemotron-super-49b-v1.5.yaml
+++ b/providers/openrouter/nvidia/llama-3.3-nemotron-super-49b-v1.5.yaml
@@ -4,6 +4,8 @@ costs:
       region: "*"
 features:
     - function_calling
+    - json_output
+    - tool_choice
 limits:
     context_window: 131072
 modalities:

--- a/providers/openrouter/nvidia/nemotron-3-nano-30b-a3b.yaml
+++ b/providers/openrouter/nvidia/nemotron-3-nano-30b-a3b.yaml
@@ -4,10 +4,8 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - structured_output
-    - system_messages
     - json_output
+    - tool_choice
 limits:
     context_window: 262144
 modalities:

--- a/providers/openrouter/nvidia/nemotron-3-nano-30b-a3b:free.yaml
+++ b/providers/openrouter/nvidia/nemotron-3-nano-30b-a3b:free.yaml
@@ -5,7 +5,6 @@ costs:
 features:
     - function_calling
     - tool_choice
-    - structured_output
 limits:
     context_window: 256000
 modalities:

--- a/providers/openrouter/nvidia/nemotron-3-super-120b-a12b.yaml
+++ b/providers/openrouter/nvidia/nemotron-3-super-120b-a12b.yaml
@@ -2,6 +2,11 @@ costs:
     - input_cost_per_token: 1.e-7
       output_cost_per_token: 5.e-7
       region: "*"
+features:
+    - function_calling
+    - json_output
+    - prompt_caching
+    - tool_choice
 limits:
     context_window: 262144
 modalities:

--- a/providers/openrouter/nvidia/nemotron-3-super-120b-a12b:free.yaml
+++ b/providers/openrouter/nvidia/nemotron-3-super-120b-a12b:free.yaml
@@ -4,9 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
     - structured_output
-    - system_messages
+    - tool_choice
 limits:
     context_window: 262144
     max_output_tokens: 262144

--- a/providers/openrouter/nvidia/nemotron-nano-12b-v2-vl.yaml
+++ b/providers/openrouter/nvidia/nemotron-nano-12b-v2-vl.yaml
@@ -2,6 +2,8 @@ costs:
     - input_cost_per_token: 2.e-7
       output_cost_per_token: 6.e-7
       region: "*"
+features:
+    - json_output
 limits:
     context_window: 131072
 modalities:

--- a/providers/openrouter/nvidia/nemotron-nano-12b-v2-vl:free.yaml
+++ b/providers/openrouter/nvidia/nemotron-nano-12b-v2-vl:free.yaml
@@ -2,6 +2,9 @@ costs:
     - input_cost_per_token: 0
       output_cost_per_token: 0
       region: "*"
+features:
+    - function_calling
+    - tool_choice
 limits:
     context_window: 128000
     max_output_tokens: 128000

--- a/providers/openrouter/nvidia/nemotron-nano-9b-v2.yaml
+++ b/providers/openrouter/nvidia/nemotron-nano-9b-v2.yaml
@@ -4,6 +4,8 @@ costs:
       region: "*"
 features:
     - function_calling
+    - json_output
+    - tool_choice
 limits:
     context_window: 131072
 modalities:

--- a/providers/openrouter/nvidia/nemotron-nano-9b-v2:free.yaml
+++ b/providers/openrouter/nvidia/nemotron-nano-9b-v2:free.yaml
@@ -4,9 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
     - structured_output
-    - system_messages
+    - tool_choice
 limits:
     context_window: 128000
 modalities:

--- a/providers/openrouter/openai/gpt-3.5-turbo-0613.yaml
+++ b/providers/openrouter/openai/gpt-3.5-turbo-0613.yaml
@@ -4,10 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - system_messages
-    - tool_choice
-    - structured_output
     - json_output
+    - structured_output
+    - tool_choice
 limits:
     context_window: 4095
     max_output_tokens: 4096

--- a/providers/openrouter/openai/gpt-3.5-turbo-16k.yaml
+++ b/providers/openrouter/openai/gpt-3.5-turbo-16k.yaml
@@ -4,8 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
     - structured_output
+    - tool_choice
 limits:
     context_window: 16385
     max_output_tokens: 4096

--- a/providers/openrouter/openai/gpt-3.5-turbo-instruct.yaml
+++ b/providers/openrouter/openai/gpt-3.5-turbo-instruct.yaml
@@ -3,8 +3,8 @@ costs:
       output_cost_per_token: 0.000002
       region: "*"
 features:
+    - json_output
     - structured_output
-    - tool_choice
 limits:
     context_window: 4095
     max_output_tokens: 4096

--- a/providers/openrouter/openai/gpt-3.5-turbo.yaml
+++ b/providers/openrouter/openai/gpt-3.5-turbo.yaml
@@ -4,8 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
     - structured_output
+    - tool_choice
 limits:
     context_window: 16385
     max_input_tokens: 16385

--- a/providers/openrouter/openai/gpt-4-0314.yaml
+++ b/providers/openrouter/openai/gpt-4-0314.yaml
@@ -2,6 +2,11 @@ costs:
     - input_cost_per_token: 0.00003
       output_cost_per_token: 0.00006
       region: "*"
+features:
+    - function_calling
+    - json_output
+    - structured_output
+    - tool_choice
 isDeprecated: true
 limits:
     context_window: 8191

--- a/providers/openrouter/openai/gpt-4-1106-preview.yaml
+++ b/providers/openrouter/openai/gpt-4-1106-preview.yaml
@@ -4,10 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - system_messages
-    - tool_choice
-    - structured_output
     - json_output
+    - structured_output
+    - tool_choice
 limits:
     context_window: 128000
     max_output_tokens: 4096

--- a/providers/openrouter/openai/gpt-4-turbo-preview.yaml
+++ b/providers/openrouter/openai/gpt-4-turbo-preview.yaml
@@ -4,11 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - parallel_function_calling
-    - system_messages
-    - tool_choice
-    - structured_output
     - json_output
+    - structured_output
+    - tool_choice
 limits:
     context_window: 128000
     max_output_tokens: 4096

--- a/providers/openrouter/openai/gpt-4-turbo.yaml
+++ b/providers/openrouter/openai/gpt-4-turbo.yaml
@@ -4,10 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - system_messages
-    - tool_choice
-    - structured_output
     - json_output
+    - structured_output
+    - tool_choice
 limits:
     context_window: 128000
     max_output_tokens: 4096

--- a/providers/openrouter/openai/gpt-4.1-mini.yaml
+++ b/providers/openrouter/openai/gpt-4.1-mini.yaml
@@ -5,11 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - parallel_function_calling
-    - system_messages
-    - tool_choice
+    - json_output
     - prompt_caching
     - structured_output
+    - tool_choice
 limits:
     context_window: 1047576
     max_output_tokens: 32768

--- a/providers/openrouter/openai/gpt-4.1-nano.yaml
+++ b/providers/openrouter/openai/gpt-4.1-nano.yaml
@@ -5,12 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - parallel_function_calling
-    - system_messages
-    - tool_choice
+    - json_output
     - prompt_caching
     - structured_output
-    - json_output
+    - tool_choice
 limits:
     context_window: 1047576
     max_input_tokens: 1047576

--- a/providers/openrouter/openai/gpt-4.1.yaml
+++ b/providers/openrouter/openai/gpt-4.1.yaml
@@ -5,11 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - parallel_function_calling
-    - system_messages
-    - tool_choice
+    - json_output
     - prompt_caching
     - structured_output
+    - tool_choice
 limits:
     context_window: 1047576
     max_input_tokens: 1047576

--- a/providers/openrouter/openai/gpt-4.yaml
+++ b/providers/openrouter/openai/gpt-4.yaml
@@ -4,8 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
     - structured_output
+    - tool_choice
 limits:
     context_window: 8191
     max_output_tokens: 4096

--- a/providers/openrouter/openai/gpt-4o-2024-05-13.yaml
+++ b/providers/openrouter/openai/gpt-4o-2024-05-13.yaml
@@ -4,9 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - parallel_function_calling
-    - tool_choice
+    - json_output
     - structured_output
+    - tool_choice
 limits:
     context_window: 128000
     max_input_tokens: 128000

--- a/providers/openrouter/openai/gpt-4o-2024-08-06.yaml
+++ b/providers/openrouter/openai/gpt-4o-2024-08-06.yaml
@@ -5,10 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - parallel_function_calling
-    - tool_choice
+    - json_output
+    - prompt_caching
     - structured_output
-    - system_messages
+    - tool_choice
 limits:
     context_window: 128000
     max_output_tokens: 16384

--- a/providers/openrouter/openai/gpt-4o-2024-11-20.yaml
+++ b/providers/openrouter/openai/gpt-4o-2024-11-20.yaml
@@ -5,9 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - system_messages
+    - json_output
+    - prompt_caching
     - structured_output
+    - tool_choice
 limits:
     context_window: 128000
     max_output_tokens: 16384

--- a/providers/openrouter/openai/gpt-4o-audio-preview.yaml
+++ b/providers/openrouter/openai/gpt-4o-audio-preview.yaml
@@ -6,10 +6,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - structured_output
-    - system_messages
     - json_output
+    - structured_output
+    - tool_choice
 limits:
     context_window: 128000
     max_output_tokens: 16384

--- a/providers/openrouter/openai/gpt-4o-mini-2024-07-18.yaml
+++ b/providers/openrouter/openai/gpt-4o-mini-2024-07-18.yaml
@@ -5,9 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
+    - prompt_caching
     - structured_output
-    - system_messages
+    - tool_choice
 limits:
     context_window: 128000
     max_input_tokens: 128000

--- a/providers/openrouter/openai/gpt-4o-mini-search-preview.yaml
+++ b/providers/openrouter/openai/gpt-4o-mini-search-preview.yaml
@@ -3,10 +3,8 @@ costs:
       output_cost_per_token: 6.e-7
       region: "*"
 features:
-    - function_calling
-    - system_messages
+    - json_output
     - structured_output
-    - tool_choice
 limits:
     context_window: 128000
     max_output_tokens: 16384

--- a/providers/openrouter/openai/gpt-4o-mini.yaml
+++ b/providers/openrouter/openai/gpt-4o-mini.yaml
@@ -5,10 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - structured_output
-    - system_messages
+    - json_output
     - prompt_caching
+    - structured_output
+    - tool_choice
 limits:
     context_window: 128000
     max_output_tokens: 16384

--- a/providers/openrouter/openai/gpt-4o-search-preview.yaml
+++ b/providers/openrouter/openai/gpt-4o-search-preview.yaml
@@ -4,10 +4,8 @@ costs:
       output_cost_per_token: 0.00001
       region: "*"
 features:
-    - system_messages
+    - json_output
     - structured_output
-    - function_calling
-    - tool_choice
 limits:
     context_window: 128000
     max_input_tokens: 128000

--- a/providers/openrouter/openai/gpt-4o.yaml
+++ b/providers/openrouter/openai/gpt-4o.yaml
@@ -5,10 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - parallel_function_calling
-    - tool_choice
-    - structured_output
     - json_output
+    - prompt_caching
+    - structured_output
+    - tool_choice
 limits:
     context_window: 128000
     max_input_tokens: 128000

--- a/providers/openrouter/openai/gpt-4o:extended.yaml
+++ b/providers/openrouter/openai/gpt-4o:extended.yaml
@@ -4,9 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - system_messages
-    - tool_choice
+    - json_output
     - structured_output
+    - tool_choice
 limits:
     context_window: 128000
     max_output_tokens: 64000

--- a/providers/openrouter/openai/gpt-5-chat.yaml
+++ b/providers/openrouter/openai/gpt-5-chat.yaml
@@ -4,11 +4,9 @@ costs:
       output_cost_per_token: 0.00001
       region: "*"
 features:
-    - function_calling
-    - tool_choice
-    - structured_output
-    - prompt_caching
     - json_output
+    - prompt_caching
+    - structured_output
 limits:
     context_window: 128000
     max_output_tokens: 16384

--- a/providers/openrouter/openai/gpt-5-codex.yaml
+++ b/providers/openrouter/openai/gpt-5-codex.yaml
@@ -5,11 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - structured_output
-    - prompt_caching
     - json_output
-    - system_messages
+    - prompt_caching
+    - structured_output
+    - tool_choice
 limits:
     context_window: 400000
     max_input_tokens: 272000

--- a/providers/openrouter/openai/gpt-5-image-mini.yaml
+++ b/providers/openrouter/openai/gpt-5-image-mini.yaml
@@ -6,10 +6,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - structured_output
-    - system_messages
+    - json_output
     - prompt_caching
+    - structured_output
+    - tool_choice
 limits:
     context_window: 400000
     max_input_tokens: 272000

--- a/providers/openrouter/openai/gpt-5-image.yaml
+++ b/providers/openrouter/openai/gpt-5-image.yaml
@@ -6,9 +6,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - system_messages
+    - json_output
+    - prompt_caching
     - structured_output
+    - tool_choice
 limits:
     context_window: 400000
     max_input_tokens: 272000

--- a/providers/openrouter/openai/gpt-5-mini.yaml
+++ b/providers/openrouter/openai/gpt-5-mini.yaml
@@ -5,9 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - structured_output
+    - json_output
     - prompt_caching
+    - structured_output
+    - tool_choice
 limits:
     context_window: 400000
     max_input_tokens: 272000

--- a/providers/openrouter/openai/gpt-5-nano.yaml
+++ b/providers/openrouter/openai/gpt-5-nano.yaml
@@ -5,9 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - structured_output
+    - json_output
     - prompt_caching
+    - structured_output
+    - tool_choice
 limits:
     context_window: 400000
     max_input_tokens: 272000

--- a/providers/openrouter/openai/gpt-5-pro.yaml
+++ b/providers/openrouter/openai/gpt-5-pro.yaml
@@ -4,9 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
     - structured_output
-    - system_messages
+    - tool_choice
 limits:
     context_window: 400000
     max_input_tokens: 272000

--- a/providers/openrouter/openai/gpt-5.1-chat.yaml
+++ b/providers/openrouter/openai/gpt-5.1-chat.yaml
@@ -6,10 +6,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - structured_output
-    - system_messages
+    - json_output
     - prompt_caching
+    - structured_output
+    - tool_choice
 limits:
     context_window: 128000
     max_output_tokens: 16384

--- a/providers/openrouter/openai/gpt-5.1-codex-max.yaml
+++ b/providers/openrouter/openai/gpt-5.1-codex-max.yaml
@@ -5,9 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
+    - prompt_caching
     - structured_output
-    - system_messages
+    - tool_choice
 limits:
     context_window: 400000
     max_input_tokens: 272000

--- a/providers/openrouter/openai/gpt-5.1-codex-mini.yaml
+++ b/providers/openrouter/openai/gpt-5.1-codex-mini.yaml
@@ -5,10 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - structured_output
-    - system_messages
+    - json_output
     - prompt_caching
+    - structured_output
+    - tool_choice
 limits:
     context_window: 400000
     max_input_tokens: 300000

--- a/providers/openrouter/openai/gpt-5.1-codex.yaml
+++ b/providers/openrouter/openai/gpt-5.1-codex.yaml
@@ -5,8 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
+    - prompt_caching
     - structured_output
+    - tool_choice
 limits:
     context_window: 400000
     max_input_tokens: 272000

--- a/providers/openrouter/openai/gpt-5.1.yaml
+++ b/providers/openrouter/openai/gpt-5.1.yaml
@@ -5,11 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - system_messages
-    - structured_output
-    - prompt_caching
     - json_output
+    - prompt_caching
+    - structured_output
+    - tool_choice
 limits:
     context_window: 400000
     max_input_tokens: 272000

--- a/providers/openrouter/openai/gpt-5.2-chat.yaml
+++ b/providers/openrouter/openai/gpt-5.2-chat.yaml
@@ -5,9 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
     - prompt_caching
     - structured_output
+    - tool_choice
 limits:
     context_window: 128000
     max_input_tokens: 128000

--- a/providers/openrouter/openai/gpt-5.2-codex.yaml
+++ b/providers/openrouter/openai/gpt-5.2-codex.yaml
@@ -5,8 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
+    - prompt_caching
     - structured_output
+    - tool_choice
 limits:
     context_window: 400000
     max_input_tokens: 272000

--- a/providers/openrouter/openai/gpt-5.2-pro.yaml
+++ b/providers/openrouter/openai/gpt-5.2-pro.yaml
@@ -4,8 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
     - structured_output
+    - tool_choice
 limits:
     context_window: 400000
     max_input_tokens: 272000

--- a/providers/openrouter/openai/gpt-5.2.yaml
+++ b/providers/openrouter/openai/gpt-5.2.yaml
@@ -5,9 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
     - prompt_caching
     - structured_output
+    - tool_choice
 limits:
     context_window: 400000
     max_input_tokens: 272000

--- a/providers/openrouter/openai/gpt-5.3-chat.yaml
+++ b/providers/openrouter/openai/gpt-5.3-chat.yaml
@@ -5,11 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - prompt_caching
-    - system_messages
-    - structured_output
     - json_output
+    - prompt_caching
+    - structured_output
+    - tool_choice
 limits:
     context_window: 128000
     max_input_tokens: 111616

--- a/providers/openrouter/openai/gpt-5.3-codex.yaml
+++ b/providers/openrouter/openai/gpt-5.3-codex.yaml
@@ -5,10 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - structured_output
-    - system_messages
     - json_output
+    - prompt_caching
+    - structured_output
+    - tool_choice
 limits:
     context_window: 400000
     max_input_tokens: 272000

--- a/providers/openrouter/openai/gpt-5.4-mini.yaml
+++ b/providers/openrouter/openai/gpt-5.4-mini.yaml
@@ -6,8 +6,8 @@ costs:
 features:
     - function_calling
     - json_output
+    - prompt_caching
     - structured_output
-    - system_messages
     - tool_choice
 limits:
     context_window: 400000

--- a/providers/openrouter/openai/gpt-5.4-nano.yaml
+++ b/providers/openrouter/openai/gpt-5.4-nano.yaml
@@ -5,8 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
+    - prompt_caching
     - structured_output
+    - tool_choice
 limits:
     context_window: 400000
     max_output_tokens: 128000

--- a/providers/openrouter/openai/gpt-5.4-pro.yaml
+++ b/providers/openrouter/openai/gpt-5.4-pro.yaml
@@ -11,9 +11,9 @@ costs:
                 from: 272000
 features:
     - function_calling
-    - tool_choice
+    - json_output
     - structured_output
-    - system_messages
+    - tool_choice
 limits:
     context_window: 1050000
     max_input_tokens: 922000

--- a/providers/openrouter/openai/gpt-5.4.yaml
+++ b/providers/openrouter/openai/gpt-5.4.yaml
@@ -4,9 +4,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
+    - prompt_caching
     - structured_output
-    - system_messages
+    - tool_choice
 limits:
     context_window: 1050000
     max_input_tokens: 922000

--- a/providers/openrouter/openai/gpt-5.yaml
+++ b/providers/openrouter/openai/gpt-5.yaml
@@ -5,9 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - structured_output
+    - json_output
     - prompt_caching
+    - structured_output
+    - tool_choice
 limits:
     context_window: 400000
     max_input_tokens: 272000

--- a/providers/openrouter/openai/gpt-audio-mini.yaml
+++ b/providers/openrouter/openai/gpt-audio-mini.yaml
@@ -6,10 +6,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - structured_output
-    - system_messages
     - json_output
+    - structured_output
+    - tool_choice
 limits:
     context_window: 128000
     max_output_tokens: 16384

--- a/providers/openrouter/openai/gpt-audio.yaml
+++ b/providers/openrouter/openai/gpt-audio.yaml
@@ -6,10 +6,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - structured_output
-    - system_messages
-    - tool_choice
     - json_output
+    - structured_output
+    - tool_choice
 limits:
     context_window: 128000
     max_output_tokens: 16384

--- a/providers/openrouter/openai/gpt-oss-120b.yaml
+++ b/providers/openrouter/openai/gpt-oss-120b.yaml
@@ -4,8 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
     - structured_output
+    - tool_choice
 limits:
     context_window: 131072
     max_input_tokens: 131072

--- a/providers/openrouter/openai/gpt-oss-120b:free.yaml
+++ b/providers/openrouter/openai/gpt-oss-120b:free.yaml
@@ -5,8 +5,6 @@ costs:
 features:
     - function_calling
     - tool_choice
-    - structured_output
-    - system_messages
 limits:
     context_window: 131072
     max_output_tokens: 131072

--- a/providers/openrouter/openai/gpt-oss-20b.yaml
+++ b/providers/openrouter/openai/gpt-oss-20b.yaml
@@ -5,10 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - parallel_function_calling
-    - tool_choice
-    - structured_output
+    - json_output
     - prompt_caching
+    - structured_output
+    - tool_choice
 limits:
     context_window: 131072
     max_input_tokens: 131072

--- a/providers/openrouter/openai/gpt-oss-20b:free.yaml
+++ b/providers/openrouter/openai/gpt-oss-20b:free.yaml
@@ -5,8 +5,6 @@ costs:
 features:
     - function_calling
     - tool_choice
-    - structured_output
-    - system_messages
 limits:
     context_window: 131072
     max_output_tokens: 131072

--- a/providers/openrouter/openai/gpt-oss-safeguard-20b.yaml
+++ b/providers/openrouter/openai/gpt-oss-safeguard-20b.yaml
@@ -5,8 +5,9 @@ costs:
       region: "*"
 features:
     - function_calling
+    - json_output
+    - prompt_caching
     - tool_choice
-    - structured_output
 limits:
     context_window: 131072
     max_output_tokens: 65536

--- a/providers/openrouter/openai/o1-pro.yaml
+++ b/providers/openrouter/openai/o1-pro.yaml
@@ -3,9 +3,8 @@ costs:
       output_cost_per_token: 0.0006
       region: "*"
 features:
-    - function_calling
+    - json_output
     - structured_output
-    - tool_choice
 limits:
     context_window: 200000
     max_output_tokens: 100000

--- a/providers/openrouter/openai/o1.yaml
+++ b/providers/openrouter/openai/o1.yaml
@@ -5,10 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - system_messages
-    - tool_choice
+    - json_output
     - prompt_caching
     - structured_output
+    - tool_choice
 limits:
     context_window: 200000
     max_input_tokens: 200000

--- a/providers/openrouter/openai/o3-deep-research.yaml
+++ b/providers/openrouter/openai/o3-deep-research.yaml
@@ -5,9 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
+    - prompt_caching
     - structured_output
-    - system_messages
+    - tool_choice
 limits:
     context_window: 200000
     max_output_tokens: 100000

--- a/providers/openrouter/openai/o3-mini-high.yaml
+++ b/providers/openrouter/openai/o3-mini-high.yaml
@@ -5,9 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - parallel_function_calling
-    - tool_choice
+    - json_output
+    - prompt_caching
     - structured_output
+    - tool_choice
 limits:
     context_window: 200000
     max_output_tokens: 100000

--- a/providers/openrouter/openai/o3-mini.yaml
+++ b/providers/openrouter/openai/o3-mini.yaml
@@ -5,9 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - parallel_function_calling
-    - tool_choice
+    - json_output
+    - prompt_caching
     - structured_output
+    - tool_choice
 limits:
     context_window: 200000
     max_output_tokens: 100000

--- a/providers/openrouter/openai/o3-pro.yaml
+++ b/providers/openrouter/openai/o3-pro.yaml
@@ -4,8 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
     - structured_output
+    - tool_choice
 limits:
     context_window: 200000
     max_output_tokens: 100000

--- a/providers/openrouter/openai/o3.yaml
+++ b/providers/openrouter/openai/o3.yaml
@@ -5,9 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
+    - prompt_caching
     - structured_output
-    - system_messages
+    - tool_choice
 limits:
     context_window: 200000
     max_output_tokens: 100000

--- a/providers/openrouter/openai/o4-mini-deep-research.yaml
+++ b/providers/openrouter/openai/o4-mini-deep-research.yaml
@@ -5,9 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
+    - prompt_caching
     - structured_output
-    - system_messages
+    - tool_choice
 limits:
     context_window: 200000
     max_output_tokens: 100000

--- a/providers/openrouter/openai/o4-mini-high.yaml
+++ b/providers/openrouter/openai/o4-mini-high.yaml
@@ -5,9 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
+    - prompt_caching
     - structured_output
-    - system_messages
+    - tool_choice
 limits:
     context_window: 200000
     max_output_tokens: 100000

--- a/providers/openrouter/openai/o4-mini.yaml
+++ b/providers/openrouter/openai/o4-mini.yaml
@@ -5,10 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
+    - json_output
+    - prompt_caching
     - structured_output
     - tool_choice
-    - system_messages
-    - prompt_caching
 limits:
     context_window: 200000
     max_output_tokens: 100000

--- a/providers/openrouter/openrouter/free.yaml
+++ b/providers/openrouter/openrouter/free.yaml
@@ -4,8 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
     - structured_output
+    - tool_choice
 limits:
     context_window: 200000
 modalities:

--- a/providers/openrouter/perplexity/sonar-deep-research.yaml
+++ b/providers/openrouter/perplexity/sonar-deep-research.yaml
@@ -3,8 +3,6 @@ costs:
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000008
       region: "*"
-features:
-    - system_messages
 limits:
     context_window: 128000
 modalities:

--- a/providers/openrouter/perplexity/sonar-pro-search.yaml
+++ b/providers/openrouter/perplexity/sonar-pro-search.yaml
@@ -4,8 +4,6 @@ costs:
       output_cost_per_token: 0.000015
       region: "*"
 features:
-    - function_calling
-    - tool_choice
     - structured_output
 limits:
     context_window: 200000

--- a/providers/openrouter/perplexity/sonar-pro.yaml
+++ b/providers/openrouter/perplexity/sonar-pro.yaml
@@ -3,9 +3,6 @@ costs:
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: "*"
-features:
-    - function_calling
-    - tool_choice
 limits:
     context_window: 200000
     max_output_tokens: 8000

--- a/providers/openrouter/perplexity/sonar-reasoning-pro.yaml
+++ b/providers/openrouter/perplexity/sonar-reasoning-pro.yaml
@@ -3,8 +3,6 @@ costs:
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000008
       region: "*"
-features:
-    - function_calling
 limits:
     context_window: 128000
 modalities:

--- a/providers/openrouter/perplexity/sonar.yaml
+++ b/providers/openrouter/perplexity/sonar.yaml
@@ -3,9 +3,6 @@ costs:
       input_cost_per_token: 0.000001
       output_cost_per_token: 0.000001
       region: "*"
-features:
-    - function_calling
-    - tool_choice
 limits:
     context_window: 127072
 modalities:

--- a/providers/openrouter/prime-intellect/intellect-3.yaml
+++ b/providers/openrouter/prime-intellect/intellect-3.yaml
@@ -4,8 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
     - structured_output
+    - tool_choice
 limits:
     context_window: 131072
     max_output_tokens: 131072

--- a/providers/openrouter/qwen/qwen-2.5-72b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen-2.5-72b-instruct.yaml
@@ -4,10 +4,8 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - system_messages
-    - structured_output
     - json_output
+    - tool_choice
 limits:
     context_window: 32768
     max_output_tokens: 8000

--- a/providers/openrouter/qwen/qwen-2.5-7b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen-2.5-7b-instruct.yaml
@@ -4,9 +4,8 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - system_messages
     - json_output
+    - tool_choice
 limits:
     context_window: 32768
     max_output_tokens: 32768

--- a/providers/openrouter/qwen/qwen-2.5-coder-32b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen-2.5-coder-32b-instruct.yaml
@@ -2,8 +2,6 @@ costs:
     - input_cost_per_token: 6.6e-7
       output_cost_per_token: 0.000001
       region: "*"
-features:
-    - tool_choice
 limits:
     context_window: 32768
     max_output_tokens: 8192

--- a/providers/openrouter/qwen/qwen-max.yaml
+++ b/providers/openrouter/qwen/qwen-max.yaml
@@ -5,9 +5,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - structured_output
     - json_output
+    - prompt_caching
+    - tool_choice
 limits:
     context_window: 32768
     max_input_tokens: 30720

--- a/providers/openrouter/qwen/qwen-plus-2025-07-28.yaml
+++ b/providers/openrouter/qwen/qwen-plus-2025-07-28.yaml
@@ -11,8 +11,9 @@ costs:
                 from: 256000
 features:
     - function_calling
-    - tool_choice
+    - json_output
     - structured_output
+    - tool_choice
 limits:
     context_window: 1000000
     max_input_tokens: 995904
@@ -32,4 +33,3 @@ params:
       minValue: 1
 sources:
     - https://openrouter.ai/qwen/qwen-plus-2025-07-28/api
-thinking: true

--- a/providers/openrouter/qwen/qwen-plus-2025-07-28:thinking.yaml
+++ b/providers/openrouter/qwen/qwen-plus-2025-07-28:thinking.yaml
@@ -11,9 +11,9 @@ costs:
                 from: 256000
 features:
     - function_calling
-    - tool_choice
+    - json_output
     - structured_output
-    - system_messages
+    - tool_choice
 limits:
     context_window: 1000000
     max_input_tokens: 995904

--- a/providers/openrouter/qwen/qwen-plus.yaml
+++ b/providers/openrouter/qwen/qwen-plus.yaml
@@ -15,8 +15,9 @@ costs:
                 from: 256000
 features:
     - function_calling
+    - json_output
+    - prompt_caching
     - tool_choice
-    - structured_output
 limits:
     context_window: 1000000
     max_input_tokens: 995904

--- a/providers/openrouter/qwen/qwen-turbo.yaml
+++ b/providers/openrouter/qwen/qwen-turbo.yaml
@@ -5,6 +5,8 @@ costs:
       region: "*"
 features:
     - function_calling
+    - json_output
+    - prompt_caching
     - tool_choice
 limits:
     context_window: 131072

--- a/providers/openrouter/qwen/qwen-vl-max.yaml
+++ b/providers/openrouter/qwen/qwen-vl-max.yaml
@@ -4,7 +4,7 @@ costs:
       region: "*"
 features:
     - function_calling
-    - structured_output
+    - json_output
     - tool_choice
 limits:
     context_window: 131072

--- a/providers/openrouter/qwen/qwen-vl-plus.yaml
+++ b/providers/openrouter/qwen/qwen-vl-plus.yaml
@@ -4,9 +4,8 @@ costs:
       output_cost_per_token: 4.095e-7
       region: "*"
 features:
-    - function_calling
-    - tool_choice
     - json_output
+    - prompt_caching
 limits:
     context_window: 131072
     max_input_tokens: 129024

--- a/providers/openrouter/qwen/qwen2.5-coder-7b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen2.5-coder-7b-instruct.yaml
@@ -3,9 +3,8 @@ costs:
       output_cost_per_token: 9.e-8
       region: "*"
 features:
+    - json_output
     - structured_output
-    - function_calling
-    - tool_choice
 limits:
     context_window: 32768
 modalities:

--- a/providers/openrouter/qwen/qwen2.5-vl-72b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen2.5-vl-72b-instruct.yaml
@@ -3,9 +3,8 @@ costs:
       output_cost_per_token: 8.e-7
       region: "*"
 features:
-    - function_calling
-    - structured_output
     - json_output
+    - structured_output
 limits:
     context_window: 32768
     max_output_tokens: 32768

--- a/providers/openrouter/qwen/qwen3-14b.yaml
+++ b/providers/openrouter/qwen/qwen3-14b.yaml
@@ -4,9 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
     - structured_output
-    - system_messages
+    - tool_choice
 limits:
     context_window: 40960
     max_output_tokens: 40960

--- a/providers/openrouter/qwen/qwen3-235b-a22b-2507.yaml
+++ b/providers/openrouter/qwen/qwen3-235b-a22b-2507.yaml
@@ -4,9 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - structured_output
     - json_output
+    - structured_output
+    - tool_choice
 limits:
     context_window: 262144
     max_input_tokens: 262144
@@ -20,3 +20,4 @@ model: qwen/qwen3-235b-a22b-2507
 sources:
     - https://openrouter.ai/qwen/qwen3-235b-a22b-2507/api
 status: active
+thinking: true

--- a/providers/openrouter/qwen/qwen3-235b-a22b-thinking-2507.yaml
+++ b/providers/openrouter/qwen/qwen3-235b-a22b-thinking-2507.yaml
@@ -4,8 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
     - structured_output
+    - tool_choice
 limits:
     context_window: 131072
     max_output_tokens: 81920

--- a/providers/openrouter/qwen/qwen3-235b-a22b.yaml
+++ b/providers/openrouter/qwen/qwen3-235b-a22b.yaml
@@ -4,8 +4,8 @@ costs:
       region: "*"
 features:
     - function_calling
+    - json_output
     - tool_choice
-    - structured_output
 limits:
     context_window: 131072
     max_input_tokens: 98304

--- a/providers/openrouter/qwen/qwen3-30b-a3b-instruct-2507.yaml
+++ b/providers/openrouter/qwen/qwen3-30b-a3b-instruct-2507.yaml
@@ -4,8 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
     - structured_output
+    - tool_choice
 limits:
     context_window: 262144
     max_output_tokens: 262144

--- a/providers/openrouter/qwen/qwen3-30b-a3b-thinking-2507.yaml
+++ b/providers/openrouter/qwen/qwen3-30b-a3b-thinking-2507.yaml
@@ -4,6 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
+    - json_output
+    - prompt_caching
+    - structured_output
     - tool_choice
 limits:
     context_window: 131072

--- a/providers/openrouter/qwen/qwen3-30b-a3b.yaml
+++ b/providers/openrouter/qwen/qwen3-30b-a3b.yaml
@@ -4,6 +4,8 @@ costs:
       region: "*"
 features:
     - function_calling
+    - json_output
+    - structured_output
     - tool_choice
 limits:
     context_window: 40960

--- a/providers/openrouter/qwen/qwen3-32b.yaml
+++ b/providers/openrouter/qwen/qwen3-32b.yaml
@@ -5,8 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
+    - prompt_caching
     - structured_output
+    - tool_choice
 limits:
     context_window: 40960
     max_output_tokens: 40960

--- a/providers/openrouter/qwen/qwen3-8b.yaml
+++ b/providers/openrouter/qwen/qwen3-8b.yaml
@@ -4,9 +4,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
+    - prompt_caching
     - structured_output
-    - system_messages
+    - tool_choice
 limits:
     context_window: 40960
     max_output_tokens: 8192

--- a/providers/openrouter/qwen/qwen3-coder-30b-a3b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen3-coder-30b-a3b-instruct.yaml
@@ -4,9 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - system_messages
+    - json_output
     - structured_output
+    - tool_choice
 limits:
     context_window: 160000
     max_output_tokens: 32768

--- a/providers/openrouter/qwen/qwen3-coder-flash.yaml
+++ b/providers/openrouter/qwen/qwen3-coder-flash.yaml
@@ -16,9 +16,9 @@ costs:
                 from: 128000
 features:
     - function_calling
-    - tool_choice
-    - structured_output
     - json_output
+    - prompt_caching
+    - tool_choice
 limits:
     context_window: 1000000
     max_input_tokens: 997952

--- a/providers/openrouter/qwen/qwen3-coder-next.yaml
+++ b/providers/openrouter/qwen/qwen3-coder-next.yaml
@@ -5,8 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
+    - prompt_caching
     - structured_output
+    - tool_choice
 limits:
     context_window: 262144
     max_output_tokens: 65536

--- a/providers/openrouter/qwen/qwen3-coder-plus.yaml
+++ b/providers/openrouter/qwen/qwen3-coder-plus.yaml
@@ -21,9 +21,10 @@ costs:
                 from: 128000
 features:
     - function_calling
-    - tool_choice
-    - structured_output
+    - json_output
     - prompt_caching
+    - structured_output
+    - tool_choice
 limits:
     context_window: 1000000
     max_input_tokens: 997952
@@ -41,4 +42,3 @@ params:
       maxValue: 65536
 sources:
     - https://openrouter.ai/qwen/qwen3-coder-plus/api
-thinking: true

--- a/providers/openrouter/qwen/qwen3-coder.yaml
+++ b/providers/openrouter/qwen/qwen3-coder.yaml
@@ -5,9 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - structured_output
     - json_output
+    - prompt_caching
+    - structured_output
+    - tool_choice
 limits:
     context_window: 262144
     max_input_tokens: 262144

--- a/providers/openrouter/qwen/qwen3-coder:free.yaml
+++ b/providers/openrouter/qwen/qwen3-coder:free.yaml
@@ -5,8 +5,6 @@ costs:
 features:
     - function_calling
     - tool_choice
-    - system_messages
-    - structured_output
 limits:
     context_window: 262000
     max_output_tokens: 262000

--- a/providers/openrouter/qwen/qwen3-max-thinking.yaml
+++ b/providers/openrouter/qwen/qwen3-max-thinking.yaml
@@ -15,8 +15,9 @@ costs:
                 from: 128000
 features:
     - function_calling
-    - tool_choice
+    - json_output
     - structured_output
+    - tool_choice
 limits:
     context_window: 262144
     max_input_tokens: 258048

--- a/providers/openrouter/qwen/qwen3-max.yaml
+++ b/providers/openrouter/qwen/qwen3-max.yaml
@@ -16,9 +16,9 @@ costs:
                 from: 128000
 features:
     - function_calling
-    - tool_choice
+    - json_output
     - prompt_caching
-    - system_messages
+    - tool_choice
 limits:
     context_window: 262144
     max_input_tokens: 258048
@@ -33,4 +33,3 @@ mode: chat
 model: qwen/qwen3-max
 sources:
     - https://openrouter.ai/qwen/qwen3-max/api
-thinking: true

--- a/providers/openrouter/qwen/qwen3-next-80b-a3b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen3-next-80b-a3b-instruct.yaml
@@ -3,10 +3,10 @@ costs:
       output_cost_per_token: 0.0000011
       region: "*"
 features:
-    - system_messages
     - function_calling
-    - tool_choice
+    - json_output
     - structured_output
+    - tool_choice
 limits:
     context_window: 262144
 modalities:

--- a/providers/openrouter/qwen/qwen3-next-80b-a3b-instruct:free.yaml
+++ b/providers/openrouter/qwen/qwen3-next-80b-a3b-instruct:free.yaml
@@ -4,8 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
+    - json_output
+    - structured_output
     - tool_choice
-    - system_messages
 limits:
     context_window: 262144
 modalities:

--- a/providers/openrouter/qwen/qwen3-next-80b-a3b-thinking.yaml
+++ b/providers/openrouter/qwen/qwen3-next-80b-a3b-thinking.yaml
@@ -4,8 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
     - structured_output
+    - tool_choice
 limits:
     context_window: 131072
     max_input_tokens: 131072

--- a/providers/openrouter/qwen/qwen3-vl-235b-a22b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen3-vl-235b-a22b-instruct.yaml
@@ -4,6 +4,10 @@ costs:
       region: "*"
 features:
     - function_calling
+    - json_output
+    - prompt_caching
+    - structured_output
+    - tool_choice
 limits:
     context_window: 262144
 modalities:

--- a/providers/openrouter/qwen/qwen3-vl-235b-a22b-thinking.yaml
+++ b/providers/openrouter/qwen/qwen3-vl-235b-a22b-thinking.yaml
@@ -4,6 +4,8 @@ costs:
       region: "*"
 features:
     - function_calling
+    - json_output
+    - structured_output
     - tool_choice
 limits:
     context_window: 131072

--- a/providers/openrouter/qwen/qwen3-vl-30b-a3b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen3-vl-30b-a3b-instruct.yaml
@@ -4,8 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
     - structured_output
+    - tool_choice
 limits:
     context_window: 131072
     max_input_tokens: 129024

--- a/providers/openrouter/qwen/qwen3-vl-30b-a3b-thinking.yaml
+++ b/providers/openrouter/qwen/qwen3-vl-30b-a3b-thinking.yaml
@@ -4,8 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
     - structured_output
+    - tool_choice
 limits:
     context_window: 131072
     max_input_tokens: 126976

--- a/providers/openrouter/qwen/qwen3-vl-32b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen3-vl-32b-instruct.yaml
@@ -4,6 +4,7 @@ costs:
       region: "*"
 features:
     - function_calling
+    - json_output
     - tool_choice
 limits:
     context_window: 131072

--- a/providers/openrouter/qwen/qwen3-vl-8b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen3-vl-8b-instruct.yaml
@@ -4,8 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
     - structured_output
+    - tool_choice
 limits:
     context_window: 131072
     max_output_tokens: 32768

--- a/providers/openrouter/qwen/qwen3-vl-8b-thinking.yaml
+++ b/providers/openrouter/qwen/qwen3-vl-8b-thinking.yaml
@@ -4,8 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
     - structured_output
+    - tool_choice
 limits:
     context_window: 131072
     max_input_tokens: 126976

--- a/providers/openrouter/qwen/qwen3.5-122b-a10b.yaml
+++ b/providers/openrouter/qwen/qwen3.5-122b-a10b.yaml
@@ -4,8 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
     - structured_output
+    - tool_choice
 limits:
     context_window: 262144
     max_input_tokens: 258048

--- a/providers/openrouter/qwen/qwen3.5-27b.yaml
+++ b/providers/openrouter/qwen/qwen3.5-27b.yaml
@@ -4,9 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
     - structured_output
-    - system_messages
+    - tool_choice
 limits:
     context_window: 262144
     max_input_tokens: 258048

--- a/providers/openrouter/qwen/qwen3.5-35b-a3b.yaml
+++ b/providers/openrouter/qwen/qwen3.5-35b-a3b.yaml
@@ -4,8 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
     - structured_output
+    - tool_choice
 limits:
     context_window: 262144
     max_input_tokens: 258048

--- a/providers/openrouter/qwen/qwen3.5-397b-a17b.yaml
+++ b/providers/openrouter/qwen/qwen3.5-397b-a17b.yaml
@@ -4,8 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
     - structured_output
+    - tool_choice
 limits:
     context_window: 262144
     max_input_tokens: 258048

--- a/providers/openrouter/qwen/qwen3.5-9b.yaml
+++ b/providers/openrouter/qwen/qwen3.5-9b.yaml
@@ -4,8 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
     - structured_output
+    - tool_choice
 limits:
     context_window: 256000
     max_output_tokens: 32768

--- a/providers/openrouter/qwen/qwen3.5-flash-02-23.yaml
+++ b/providers/openrouter/qwen/qwen3.5-flash-02-23.yaml
@@ -4,8 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
     - structured_output
+    - tool_choice
 limits:
     context_window: 1000000
     max_input_tokens: 983616

--- a/providers/openrouter/qwen/qwen3.5-plus-02-15.yaml
+++ b/providers/openrouter/qwen/qwen3.5-plus-02-15.yaml
@@ -11,8 +11,9 @@ costs:
                 from: 256000
 features:
     - function_calling
-    - tool_choice
+    - json_output
     - structured_output
+    - tool_choice
 limits:
     context_window: 1000000
     max_input_tokens: 983616

--- a/providers/openrouter/qwen/qwen3.6-plus:free.yaml
+++ b/providers/openrouter/qwen/qwen3.6-plus:free.yaml
@@ -17,4 +17,5 @@ mode: chat
 model: qwen/qwen3.6-plus:free
 sources:
     - https://openrouter.ai/qwen/qwen3.6-plus:free/api
+status: retired
 thinking: true

--- a/providers/openrouter/rekaai/reka-flash-3.yaml
+++ b/providers/openrouter/rekaai/reka-flash-3.yaml
@@ -2,10 +2,6 @@ costs:
     - input_cost_per_token: 1.e-7
       output_cost_per_token: 2.e-7
       region: "*"
-features:
-    - function_calling
-    - tool_choice
-    - json_output
 limits:
     context_window: 65536
     max_output_tokens: 65536

--- a/providers/openrouter/relace/relace-search.yaml
+++ b/providers/openrouter/relace/relace-search.yaml
@@ -5,7 +5,6 @@ costs:
 features:
     - function_calling
     - tool_choice
-    - system_messages
 limits:
     context_window: 256000
     max_output_tokens: 128000

--- a/providers/openrouter/sao10k/l3-euryale-70b.yaml
+++ b/providers/openrouter/sao10k/l3-euryale-70b.yaml
@@ -5,7 +5,6 @@ costs:
 features:
     - function_calling
     - tool_choice
-    - system_messages
 limits:
     context_window: 8192
     max_output_tokens: 8192

--- a/providers/openrouter/sao10k/l3-lunaris-8b.yaml
+++ b/providers/openrouter/sao10k/l3-lunaris-8b.yaml
@@ -2,6 +2,9 @@ costs:
     - input_cost_per_token: 4.e-8
       output_cost_per_token: 5.e-8
       region: "*"
+features:
+    - json_output
+    - structured_output
 limits:
     context_window: 8192
 modalities:

--- a/providers/openrouter/sao10k/l3.1-70b-hanami-x1.yaml
+++ b/providers/openrouter/sao10k/l3.1-70b-hanami-x1.yaml
@@ -2,10 +2,6 @@ costs:
     - input_cost_per_token: 0.000003
       output_cost_per_token: 0.000003
       region: "*"
-features:
-    - function_calling
-    - tool_choice
-    - system_messages
 limits:
     context_window: 16000
 modalities:

--- a/providers/openrouter/sao10k/l3.1-euryale-70b.yaml
+++ b/providers/openrouter/sao10k/l3.1-euryale-70b.yaml
@@ -3,7 +3,9 @@ costs:
       output_cost_per_token: 8.5e-7
       region: "*"
 features:
+    - function_calling
     - json_output
+    - tool_choice
 limits:
     context_window: 131072
     max_output_tokens: 16384

--- a/providers/openrouter/sao10k/l3.3-euryale-70b.yaml
+++ b/providers/openrouter/sao10k/l3.3-euryale-70b.yaml
@@ -3,9 +3,8 @@ costs:
       output_cost_per_token: 7.5e-7
       region: "*"
 features:
-    - function_calling
-    - structured_output
     - json_output
+    - structured_output
 limits:
     context_window: 131072
     max_output_tokens: 16384

--- a/providers/openrouter/stepfun/step-3.5-flash.yaml
+++ b/providers/openrouter/stepfun/step-3.5-flash.yaml
@@ -4,8 +4,8 @@ costs:
       region: "*"
 features:
     - function_calling
+    - json_output
     - tool_choice
-    - system_messages
 limits:
     context_window: 262144
     max_output_tokens: 65536

--- a/providers/openrouter/stepfun/step-3.5-flash:free.yaml
+++ b/providers/openrouter/stepfun/step-3.5-flash:free.yaml
@@ -4,7 +4,6 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
 limits:
     context_window: 256000
     max_output_tokens: 256000

--- a/providers/openrouter/switchpoint/router.yaml
+++ b/providers/openrouter/switchpoint/router.yaml
@@ -2,9 +2,6 @@ costs:
     - input_cost_per_token: 8.5e-7
       output_cost_per_token: 0.0000034
       region: "*"
-features:
-    - function_calling
-    - tool_choice
 limits:
     context_window: 131072
 modalities:

--- a/providers/openrouter/tencent/hunyuan-a13b-instruct.yaml
+++ b/providers/openrouter/tencent/hunyuan-a13b-instruct.yaml
@@ -3,7 +3,7 @@ costs:
       output_cost_per_token: 5.7e-7
       region: "*"
 features:
-    - function_calling
+    - json_output
     - structured_output
 limits:
     context_window: 131072

--- a/providers/openrouter/thedrummer/cydonia-24b-v4.1.yaml
+++ b/providers/openrouter/thedrummer/cydonia-24b-v4.1.yaml
@@ -2,10 +2,6 @@ costs:
     - input_cost_per_token: 3.e-7
       output_cost_per_token: 5.e-7
       region: "*"
-features:
-    - function_calling
-    - tool_choice
-    - system_messages
 limits:
     context_window: 131072
     max_output_tokens: 131072

--- a/providers/openrouter/thedrummer/rocinante-12b.yaml
+++ b/providers/openrouter/thedrummer/rocinante-12b.yaml
@@ -4,9 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - structured_output
     - json_output
+    - structured_output
+    - tool_choice
 limits:
     context_window: 32768
     max_output_tokens: 32768

--- a/providers/openrouter/thedrummer/skyfall-36b-v2.yaml
+++ b/providers/openrouter/thedrummer/skyfall-36b-v2.yaml
@@ -2,9 +2,6 @@ costs:
     - input_cost_per_token: 5.5e-7
       output_cost_per_token: 8.e-7
       region: "*"
-features:
-    - function_calling
-    - tool_choice
 limits:
     context_window: 32768
     max_output_tokens: 32768

--- a/providers/openrouter/thedrummer/unslopnemo-12b.yaml
+++ b/providers/openrouter/thedrummer/unslopnemo-12b.yaml
@@ -4,8 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
     - structured_output
+    - tool_choice
 limits:
     context_window: 32768
     max_output_tokens: 32768

--- a/providers/openrouter/tngtech/deepseek-r1t2-chimera.yaml
+++ b/providers/openrouter/tngtech/deepseek-r1t2-chimera.yaml
@@ -5,6 +5,8 @@ costs:
       region: "*"
 features:
     - function_calling
+    - json_output
+    - prompt_caching
     - structured_output
     - tool_choice
 limits:

--- a/providers/openrouter/undi95/remm-slerp-l2-13b.yaml
+++ b/providers/openrouter/undi95/remm-slerp-l2-13b.yaml
@@ -3,8 +3,8 @@ costs:
       output_cost_per_token: 6.5e-7
       region: "*"
 features:
-    - structured_output
     - json_output
+    - structured_output
 limits:
     context_window: 6144
     max_output_tokens: 4096

--- a/providers/openrouter/upstage/solar-pro-3.yaml
+++ b/providers/openrouter/upstage/solar-pro-3.yaml
@@ -5,8 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
+    - prompt_caching
     - structured_output
+    - tool_choice
 limits:
     context_window: 128000
 modalities:

--- a/providers/openrouter/writer/palmyra-x5.yaml
+++ b/providers/openrouter/writer/palmyra-x5.yaml
@@ -2,9 +2,6 @@ costs:
     - input_cost_per_token: 6.e-7
       output_cost_per_token: 0.000006
       region: "*"
-features:
-    - function_calling
-    - tool_choice
 limits:
     context_window: 1040000
     max_output_tokens: 8192

--- a/providers/openrouter/x-ai/grok-3-beta.yaml
+++ b/providers/openrouter/x-ai/grok-3-beta.yaml
@@ -5,9 +5,9 @@ costs:
       region: "*"
 features:
     - function_calling
+    - json_output
+    - prompt_caching
     - tool_choice
-    - structured_output
-    - system_messages
 limits:
     context_window: 131072
 modalities:

--- a/providers/openrouter/x-ai/grok-3-mini-beta.yaml
+++ b/providers/openrouter/x-ai/grok-3-mini-beta.yaml
@@ -5,10 +5,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - structured_output
     - json_output
     - prompt_caching
+    - tool_choice
 limits:
     context_window: 131072
 modalities:

--- a/providers/openrouter/x-ai/grok-3-mini.yaml
+++ b/providers/openrouter/x-ai/grok-3-mini.yaml
@@ -5,10 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - structured_output
-    - system_messages
     - json_output
+    - prompt_caching
+    - structured_output
+    - tool_choice
 limits:
     context_window: 131072
 modalities:

--- a/providers/openrouter/x-ai/grok-3.yaml
+++ b/providers/openrouter/x-ai/grok-3.yaml
@@ -5,10 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - structured_output
-    - system_messages
+    - json_output
     - prompt_caching
+    - structured_output
+    - tool_choice
 limits:
     context_window: 131072
 modalities:

--- a/providers/openrouter/x-ai/grok-4-fast.yaml
+++ b/providers/openrouter/x-ai/grok-4-fast.yaml
@@ -12,10 +12,10 @@ costs:
                 from: 128000
 features:
     - function_calling
-    - system_messages
-    - tool_choice
-    - structured_output
+    - json_output
     - prompt_caching
+    - structured_output
+    - tool_choice
 limits:
     context_window: 2000000
     max_output_tokens: 30000

--- a/providers/openrouter/x-ai/grok-4.1-fast.yaml
+++ b/providers/openrouter/x-ai/grok-4.1-fast.yaml
@@ -12,10 +12,10 @@ costs:
                 from: 128000
 features:
     - function_calling
-    - tool_choice
-    - structured_output
+    - json_output
     - prompt_caching
-    - system_messages
+    - structured_output
+    - tool_choice
 limits:
     context_window: 2000000
     max_output_tokens: 30000

--- a/providers/openrouter/x-ai/grok-4.20-multi-agent.yaml
+++ b/providers/openrouter/x-ai/grok-4.20-multi-agent.yaml
@@ -13,10 +13,9 @@ costs:
               - cost_per_token: 0.000012
                 from: 200000
 features:
-    - function_calling
-    - structured_output
-    - tool_choice
     - json_output
+    - prompt_caching
+    - structured_output
 limits:
     context_window: 2000000
 modalities:

--- a/providers/openrouter/x-ai/grok-4.20.yaml
+++ b/providers/openrouter/x-ai/grok-4.20.yaml
@@ -15,10 +15,10 @@ costs:
                 from: 200000
 features:
     - function_calling
-    - structured_output
     - json_output
+    - prompt_caching
+    - structured_output
     - tool_choice
-    - system_messages
 limits:
     context_window: 2000000
 modalities:

--- a/providers/openrouter/x-ai/grok-4.yaml
+++ b/providers/openrouter/x-ai/grok-4.yaml
@@ -12,9 +12,10 @@ costs:
                 from: 128000
 features:
     - function_calling
-    - parallel_function_calling
-    - tool_choice
+    - json_output
+    - prompt_caching
     - structured_output
+    - tool_choice
 limits:
     context_window: 256000
 modalities:

--- a/providers/openrouter/x-ai/grok-code-fast-1.yaml
+++ b/providers/openrouter/x-ai/grok-code-fast-1.yaml
@@ -5,10 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - structured_output
-    - system_messages
+    - json_output
     - prompt_caching
+    - structured_output
+    - tool_choice
 limits:
     context_window: 256000
     max_output_tokens: 10000

--- a/providers/openrouter/xiaomi/mimo-v2-flash.yaml
+++ b/providers/openrouter/xiaomi/mimo-v2-flash.yaml
@@ -5,8 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
+    - prompt_caching
     - structured_output
+    - tool_choice
 limits:
     context_window: 262144
     max_input_tokens: 262144

--- a/providers/openrouter/xiaomi/mimo-v2-omni.yaml
+++ b/providers/openrouter/xiaomi/mimo-v2-omni.yaml
@@ -5,8 +5,9 @@ costs:
       region: "*"
 features:
     - function_calling
+    - json_output
+    - prompt_caching
     - tool_choice
-    - structured_output
 limits:
     context_window: 262144
     max_output_tokens: 65536

--- a/providers/openrouter/xiaomi/mimo-v2-pro.yaml
+++ b/providers/openrouter/xiaomi/mimo-v2-pro.yaml
@@ -15,8 +15,9 @@ costs:
                 from: 256000
 features:
     - function_calling
+    - json_output
+    - prompt_caching
     - tool_choice
-    - structured_output
 limits:
     context_window: 1048576
     max_output_tokens: 131072

--- a/providers/openrouter/z-ai/glm-4.5-air.yaml
+++ b/providers/openrouter/z-ai/glm-4.5-air.yaml
@@ -5,8 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
+    - json_output
+    - prompt_caching
+    - structured_output
     - tool_choice
-    - system_messages
 limits:
     context_window: 131072
     max_output_tokens: 98304

--- a/providers/openrouter/z-ai/glm-4.5-air:free.yaml
+++ b/providers/openrouter/z-ai/glm-4.5-air:free.yaml
@@ -5,7 +5,6 @@ costs:
 features:
     - function_calling
     - tool_choice
-    - system_messages
 limits:
     context_window: 131072
     max_output_tokens: 96000

--- a/providers/openrouter/z-ai/glm-4.5.yaml
+++ b/providers/openrouter/z-ai/glm-4.5.yaml
@@ -5,10 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - system_messages
-    - structured_output
     - json_output
+    - prompt_caching
+    - structured_output
+    - tool_choice
 limits:
     context_window: 131072
     max_output_tokens: 98304

--- a/providers/openrouter/z-ai/glm-4.5v.yaml
+++ b/providers/openrouter/z-ai/glm-4.5v.yaml
@@ -5,9 +5,8 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - structured_output
     - prompt_caching
+    - tool_choice
 limits:
     context_window: 65536
     max_output_tokens: 16384

--- a/providers/openrouter/z-ai/glm-4.6.yaml
+++ b/providers/openrouter/z-ai/glm-4.6.yaml
@@ -4,8 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
     - structured_output
+    - tool_choice
 limits:
     context_window: 204800
     max_output_tokens: 204800

--- a/providers/openrouter/z-ai/glm-4.6v.yaml
+++ b/providers/openrouter/z-ai/glm-4.6v.yaml
@@ -4,7 +4,8 @@ costs:
       region: "*"
 features:
     - function_calling
-    - system_messages
+    - json_output
+    - structured_output
     - tool_choice
 limits:
     context_window: 131072

--- a/providers/openrouter/z-ai/glm-4.7-flash.yaml
+++ b/providers/openrouter/z-ai/glm-4.7-flash.yaml
@@ -5,9 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - structured_output
     - json_output
+    - prompt_caching
+    - structured_output
+    - tool_choice
 limits:
     context_window: 202752
 modalities:

--- a/providers/openrouter/z-ai/glm-4.7.yaml
+++ b/providers/openrouter/z-ai/glm-4.7.yaml
@@ -5,9 +5,10 @@ costs:
       region: "*"
 features:
     - function_calling
-    - tool_choice
+    - json_output
     - prompt_caching
     - structured_output
+    - tool_choice
 limits:
     context_window: 202752
     max_input_tokens: 202752

--- a/providers/openrouter/z-ai/glm-5-turbo.yaml
+++ b/providers/openrouter/z-ai/glm-5-turbo.yaml
@@ -5,6 +5,8 @@ costs:
       region: "*"
 features:
     - function_calling
+    - json_output
+    - prompt_caching
     - tool_choice
 limits:
     context_window: 202752

--- a/providers/openrouter/z-ai/glm-5.1.yaml
+++ b/providers/openrouter/z-ai/glm-5.1.yaml
@@ -2,6 +2,11 @@ costs:
     - input_cost_per_token: 0.00000126
       output_cost_per_token: 0.00000396
       region: "*"
+features:
+    - function_calling
+    - json_output
+    - structured_output
+    - tool_choice
 limits:
     context_window: 202752
 modalities:
@@ -16,3 +21,4 @@ params:
       key: temperature
     - defaultValue: 0.95
       key: top_p
+thinking: true

--- a/providers/openrouter/z-ai/glm-5.yaml
+++ b/providers/openrouter/z-ai/glm-5.yaml
@@ -4,9 +4,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - system_messages
-    - tool_choice
+    - json_output
     - structured_output
+    - tool_choice
 limits:
     context_window: 80000
     max_output_tokens: 131072

--- a/providers/openrouter/z-ai/glm-5v-turbo.yaml
+++ b/providers/openrouter/z-ai/glm-5v-turbo.yaml
@@ -5,7 +5,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - structured_output
+    - json_output
+    - prompt_caching
+    - tool_choice
 limits:
     context_window: 202752
     max_output_tokens: 131072


### PR DESCRIPTION
Auto-generated by `local.feature.py` for provider `openrouter`.

Overrides `features` and `thinking` fields in model YAMLs based on the current OpenRouter API `supported_parameters` response.

Skips models with `status: deprecated` or `status: retired`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large-scale metadata changes across many OpenRouter model YAMLs could affect capability gating (e.g., tool use/JSON mode/prompt caching) and model selection if any flags are incorrect, but no runtime logic changes are included.
> 
> **Overview**
> Updates a large set of OpenRouter model YAML definitions to **sync declared capabilities** with the current OpenRouter `supported_parameters` response.
> 
> This primarily backfills/adjusts `features` (notably `json_output`, `structured_output`, `tool_choice`, `prompt_caching`, and in some cases `function_calling`) and `thinking: true` across models, and removes previously listed unsupported features (e.g., `system_messages` in various entries).
> 
> Also updates model lifecycle metadata where applicable (e.g., marking some `:free` models as `status: retired`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d657c5e659c4326a4767b60c22f647bef921c0d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->