### PR TITLE
fix: add max_tokens to removeParam from embedding models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ dist/
 *.log
 .extras/
 temp/
+
+# Local scripts (not tracked)
+scripts/

--- a/providers/aws-bedrock/cohere.embed-english-v3.yaml
+++ b/providers/aws-bedrock/cohere.embed-english-v3.yaml
@@ -52,6 +52,7 @@ removeParams:
     - "n"
     - stop
     - stream
+    - max_tokens
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-embed-v3.html
 status: active

--- a/providers/aws-bedrock/cohere.embed-multilingual-v3.yaml
+++ b/providers/aws-bedrock/cohere.embed-multilingual-v3.yaml
@@ -48,6 +48,7 @@ mode: embedding
 model: cohere.embed-multilingual-v3
 removeParams:
     - stream
+    - max_tokens
 sources:
     - https://docs.cohere.com/docs/cohere-embed
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-embed-v3.html

--- a/providers/aws-bedrock/cohere.embed-v4:0.yaml
+++ b/providers/aws-bedrock/cohere.embed-v4:0.yaml
@@ -30,6 +30,7 @@ removeParams:
     - "n"
     - stop
     - stream
+    - max_tokens
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-embed-v4.html
 status: active

--- a/providers/aws-bedrock/us.amazon.nova-2-lite-v1:0.yaml
+++ b/providers/aws-bedrock/us.amazon.nova-2-lite-v1:0.yaml
@@ -29,8 +29,8 @@ features:
 limits:
     context_window: 1000000
     max_input_tokens: 1000000
-    max_output_tokens: 65536
-    max_tokens: 65536
+    max_output_tokens: 65535
+    max_tokens: 65535
 modalities:
     input:
         - text
@@ -43,9 +43,9 @@ modalities:
 mode: chat
 model: us.amazon.nova-2-lite-v1:0
 params:
-    - defaultValue: 65536
+    - defaultValue: 65535
       key: max_tokens
-      maxValue: 65536
+      maxValue: 65535
       minValue: 1
 sources:
     - https://docs.aws.amazon.com/nova/latest/nova2-userguide/what-is-nova-2.html

--- a/providers/aws-bedrock/us.cohere.embed-v4:0.yaml
+++ b/providers/aws-bedrock/us.cohere.embed-v4:0.yaml
@@ -29,6 +29,7 @@ removeParams:
     - "n"
     - stop
     - stream
+    - max_tokens
 sources:
     - https://docs.cohere.com/docs/cohere-embed
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-embed-v4.html

--- a/providers/azure-ai-foundry/Cohere-embed-v3-english.yaml
+++ b/providers/azure-ai-foundry/Cohere-embed-v3-english.yaml
@@ -11,3 +11,5 @@ modalities:
         - image
 mode: embedding
 model: Cohere-embed-v3-english
+removeParams:
+    - max_tokens

--- a/providers/azure-ai-foundry/Cohere-embed-v3-multilingual.yaml
+++ b/providers/azure-ai-foundry/Cohere-embed-v3-multilingual.yaml
@@ -11,3 +11,5 @@ modalities:
         - image
 mode: embedding
 model: Cohere-embed-v3-multilingual
+removeParams:
+    - max_tokens

--- a/providers/azure-ai-foundry/embed-v-4-0.yaml
+++ b/providers/azure-ai-foundry/embed-v-4-0.yaml
@@ -11,3 +11,5 @@ modalities:
         - image
 mode: embedding
 model: embed-v-4-0
+removeParams:
+    - max_tokens

--- a/providers/azure-open-ai/text-embedding-ada-002.yaml
+++ b/providers/azure-open-ai/text-embedding-ada-002.yaml
@@ -21,6 +21,7 @@ removeParams:
     - stream
     - tool_choice
     - parallel_tool_calls
+    - max_tokens
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
 status: active

--- a/providers/databricks/databricks-bge-large-en.yaml
+++ b/providers/databricks/databricks-bge-large-en.yaml
@@ -13,4 +13,6 @@ modalities:
         - embedding
 mode: embedding
 model: databricks-bge-large-en
+removeParams:
+    - max_tokens
 status: active

--- a/providers/databricks/databricks-gte-large-en.yaml
+++ b/providers/databricks/databricks-gte-large-en.yaml
@@ -13,4 +13,6 @@ modalities:
         - embedding
 mode: embedding
 model: databricks-gte-large-en
+removeParams:
+    - max_tokens
 status: active

--- a/providers/deepinfra/BAAI/bge-base-en-v1.5.yaml
+++ b/providers/deepinfra/BAAI/bge-base-en-v1.5.yaml
@@ -9,6 +9,8 @@ modalities:
         - text
 mode: embedding
 model: BAAI/bge-base-en-v1.5
+removeParams:
+    - max_tokens
 sources:
     - https://deepinfra.com/BAAI/bge-base-en-v1.5/api
 status: active

--- a/providers/deepinfra/BAAI/bge-en-icl.yaml
+++ b/providers/deepinfra/BAAI/bge-en-icl.yaml
@@ -8,6 +8,8 @@ modalities:
         - embedding
 mode: embedding
 model: BAAI/bge-en-icl
+removeParams:
+    - max_tokens
 sources:
     - https://deepinfra.com/BAAI/bge-en-icl
     - https://deepinfra.com/BAAI/bge-en-icl/api

--- a/providers/deepinfra/BAAI/bge-large-en-v1.5.yaml
+++ b/providers/deepinfra/BAAI/bge-large-en-v1.5.yaml
@@ -11,6 +11,8 @@ modalities:
         - embedding
 mode: embedding
 model: BAAI/bge-large-en-v1.5
+removeParams:
+    - max_tokens
 sources:
     - https://deepinfra.com/BAAI/bge-large-en-v1.5/api
 status: active

--- a/providers/deepinfra/BAAI/bge-m3-multi.yaml
+++ b/providers/deepinfra/BAAI/bge-m3-multi.yaml
@@ -11,6 +11,8 @@ modalities:
         - embedding
 mode: embedding
 model: BAAI/bge-m3-multi
+removeParams:
+    - max_tokens
 sources:
     - https://deepinfra.com/BAAI/bge-m3-multi/api
     - https://huggingface.co/BAAI/bge-m3

--- a/providers/deepinfra/BAAI/bge-m3.yaml
+++ b/providers/deepinfra/BAAI/bge-m3.yaml
@@ -12,5 +12,7 @@ modalities:
         - embedding
 mode: embedding
 model: BAAI/bge-m3
+removeParams:
+    - max_tokens
 sources:
     - https://deepinfra.com/BAAI/bge-m3/api

--- a/providers/deepinfra/Qwen/Qwen3-Embedding-0.6B-batch.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Embedding-0.6B-batch.yaml
@@ -12,6 +12,8 @@ modalities:
         - embedding
 mode: embedding
 model: Qwen/Qwen3-Embedding-0.6B-batch
+removeParams:
+    - max_tokens
 sources:
     - https://deepinfra.com/Qwen/Qwen3-Embedding-0.6B-batch/api
     - https://huggingface.co/Qwen/Qwen3-Embedding-0.6B

--- a/providers/deepinfra/Qwen/Qwen3-Embedding-0.6B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Embedding-0.6B.yaml
@@ -11,6 +11,8 @@ modalities:
         - embedding
 mode: embedding
 model: Qwen/Qwen3-Embedding-0.6B
+removeParams:
+    - max_tokens
 sources:
     - https://deepinfra.com/Qwen/Qwen3-Embedding-0.6B/api
     - https://huggingface.co/Qwen/Qwen3-Embedding-0.6B

--- a/providers/deepinfra/Qwen/Qwen3-Embedding-4B-batch.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Embedding-4B-batch.yaml
@@ -12,6 +12,8 @@ modalities:
         - embedding
 mode: embedding
 model: Qwen/Qwen3-Embedding-4B-batch
+removeParams:
+    - max_tokens
 sources:
     - https://deepinfra.com/Qwen/Qwen3-Embedding-4B-batch/api
     - https://huggingface.co/Qwen/Qwen3-Embedding-4B

--- a/providers/deepinfra/Qwen/Qwen3-Embedding-4B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Embedding-4B.yaml
@@ -12,6 +12,8 @@ modalities:
         - embedding
 mode: embedding
 model: Qwen/Qwen3-Embedding-4B
+removeParams:
+    - max_tokens
 sources:
     - https://deepinfra.com/Qwen/Qwen3-Embedding-4B/api
     - https://huggingface.co/Qwen/Qwen3-Embedding-4B

--- a/providers/deepinfra/Qwen/Qwen3-Embedding-8B-batch.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Embedding-8B-batch.yaml
@@ -12,6 +12,8 @@ modalities:
         - embedding
 mode: embedding
 model: Qwen/Qwen3-Embedding-8B-batch
+removeParams:
+    - max_tokens
 sources:
     - https://deepinfra.com/Qwen/Qwen3-Embedding-8B-batch/api
     - https://huggingface.co/Qwen/Qwen3-Embedding-8B

--- a/providers/deepinfra/Qwen/Qwen3-Embedding-8B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Embedding-8B.yaml
@@ -12,6 +12,8 @@ modalities:
         - embedding
 mode: embedding
 model: Qwen/Qwen3-Embedding-8B
+removeParams:
+    - max_tokens
 sources:
     - https://deepinfra.com/Qwen/Qwen3-Embedding-8B/api
     - https://huggingface.co/Qwen/Qwen3-Embedding-8B

--- a/providers/deepinfra/google/embeddinggemma-300m.yaml
+++ b/providers/deepinfra/google/embeddinggemma-300m.yaml
@@ -11,6 +11,8 @@ modalities:
         - embedding
 mode: embedding
 model: google/embeddinggemma-300m
+removeParams:
+    - max_tokens
 sources:
     - https://deepinfra.com/google/embeddinggemma-300m/api
     - https://huggingface.co/google/embeddinggemma-300m

--- a/providers/deepinfra/intfloat/e5-base-v2.yaml
+++ b/providers/deepinfra/intfloat/e5-base-v2.yaml
@@ -11,6 +11,8 @@ modalities:
         - embedding
 mode: embedding
 model: intfloat/e5-base-v2
+removeParams:
+    - max_tokens
 sources:
     - https://deepinfra.com/intfloat/e5-base-v2/api
 status: active

--- a/providers/deepinfra/intfloat/e5-large-v2.yaml
+++ b/providers/deepinfra/intfloat/e5-large-v2.yaml
@@ -12,6 +12,8 @@ modalities:
         - embedding
 mode: embedding
 model: intfloat/e5-large-v2
+removeParams:
+    - max_tokens
 sources:
     - https://deepinfra.com/intfloat/e5-large-v2/api
 status: active

--- a/providers/deepinfra/intfloat/multilingual-e5-large-instruct.yaml
+++ b/providers/deepinfra/intfloat/multilingual-e5-large-instruct.yaml
@@ -11,6 +11,8 @@ modalities:
         - embedding
 mode: embedding
 model: intfloat/multilingual-e5-large-instruct
+removeParams:
+    - max_tokens
 sources:
     - https://deepinfra.com/intfloat/multilingual-e5-large-instruct/api
     - https://huggingface.co/intfloat/multilingual-e5-large-instruct

--- a/providers/deepinfra/intfloat/multilingual-e5-large.yaml
+++ b/providers/deepinfra/intfloat/multilingual-e5-large.yaml
@@ -11,6 +11,8 @@ modalities:
         - embedding
 mode: embedding
 model: intfloat/multilingual-e5-large
+removeParams:
+    - max_tokens
 sources:
     - https://deepinfra.com/intfloat/multilingual-e5-large/api
 status: active

--- a/providers/deepinfra/nvidia/llama-nemotron-embed-vl-1b-v2.yaml
+++ b/providers/deepinfra/nvidia/llama-nemotron-embed-vl-1b-v2.yaml
@@ -13,6 +13,8 @@ modalities:
         - embedding
 mode: embedding
 model: nvidia/llama-nemotron-embed-vl-1b-v2
+removeParams:
+    - max_tokens
 sources:
     - https://deepinfra.com/nvidia/llama-nemotron-embed-vl-1b-v2/api
     - https://huggingface.co/nvidia/llama-nemotron-embed-vl-1b-v2

--- a/providers/deepinfra/sentence-transformers/all-MiniLM-L12-v2.yaml
+++ b/providers/deepinfra/sentence-transformers/all-MiniLM-L12-v2.yaml
@@ -11,6 +11,8 @@ modalities:
         - embedding
 mode: embedding
 model: sentence-transformers/all-MiniLM-L12-v2
+removeParams:
+    - max_tokens
 sources:
     - https://deepinfra.com/sentence-transformers/all-MiniLM-L12-v2/api
 status: active

--- a/providers/deepinfra/sentence-transformers/all-MiniLM-L6-v2.yaml
+++ b/providers/deepinfra/sentence-transformers/all-MiniLM-L6-v2.yaml
@@ -11,6 +11,8 @@ modalities:
         - embedding
 mode: embedding
 model: sentence-transformers/all-MiniLM-L6-v2
+removeParams:
+    - max_tokens
 sources:
     - https://deepinfra.com/sentence-transformers/all-MiniLM-L6-v2/api
     - https://deepinfra.com/sentence-transformers/all-MiniLM-L6-v2

--- a/providers/deepinfra/sentence-transformers/all-mpnet-base-v2.yaml
+++ b/providers/deepinfra/sentence-transformers/all-mpnet-base-v2.yaml
@@ -11,6 +11,8 @@ modalities:
         - embedding
 mode: embedding
 model: sentence-transformers/all-mpnet-base-v2
+removeParams:
+    - max_tokens
 sources:
     - https://deepinfra.com/sentence-transformers/all-mpnet-base-v2
 status: active

--- a/providers/deepinfra/sentence-transformers/clip-ViT-B-32-multilingual-v1.yaml
+++ b/providers/deepinfra/sentence-transformers/clip-ViT-B-32-multilingual-v1.yaml
@@ -8,5 +8,7 @@ modalities:
         - embedding
 mode: embedding
 model: sentence-transformers/clip-ViT-B-32-multilingual-v1
+removeParams:
+    - max_tokens
 sources:
     - https://deepinfra.com/sentence-transformers/clip-ViT-B-32-multilingual-v1

--- a/providers/deepinfra/sentence-transformers/clip-ViT-B-32.yaml
+++ b/providers/deepinfra/sentence-transformers/clip-ViT-B-32.yaml
@@ -8,5 +8,7 @@ modalities:
         - embedding
 mode: embedding
 model: sentence-transformers/clip-ViT-B-32
+removeParams:
+    - max_tokens
 sources:
     - https://deepinfra.com/sentence-transformers/clip-ViT-B-32/api

--- a/providers/deepinfra/sentence-transformers/multi-qa-mpnet-base-dot-v1.yaml
+++ b/providers/deepinfra/sentence-transformers/multi-qa-mpnet-base-dot-v1.yaml
@@ -11,6 +11,8 @@ modalities:
         - embedding
 mode: embedding
 model: sentence-transformers/multi-qa-mpnet-base-dot-v1
+removeParams:
+    - max_tokens
 sources:
     - https://deepinfra.com/sentence-transformers/multi-qa-mpnet-base-dot-v1/api
     - https://huggingface.co/sentence-transformers/multi-qa-mpnet-base-dot-v1

--- a/providers/deepinfra/sentence-transformers/paraphrase-MiniLM-L6-v2.yaml
+++ b/providers/deepinfra/sentence-transformers/paraphrase-MiniLM-L6-v2.yaml
@@ -11,6 +11,8 @@ modalities:
         - embedding
 mode: embedding
 model: sentence-transformers/paraphrase-MiniLM-L6-v2
+removeParams:
+    - max_tokens
 sources:
     - https://deepinfra.com/sentence-transformers/paraphrase-MiniLM-L6-v2/api
 status: active

--- a/providers/deepinfra/shibing624/text2vec-base-chinese.yaml
+++ b/providers/deepinfra/shibing624/text2vec-base-chinese.yaml
@@ -12,6 +12,8 @@ modalities:
         - embedding
 mode: embedding
 model: shibing624/text2vec-base-chinese
+removeParams:
+    - max_tokens
 sources:
     - https://deepinfra.com/shibing624/text2vec-base-chinese/api
     - https://deepinfra.com/shibing624/text2vec-base-chinese

--- a/providers/deepinfra/thenlper/gte-base.yaml
+++ b/providers/deepinfra/thenlper/gte-base.yaml
@@ -11,6 +11,8 @@ modalities:
         - embedding
 mode: embedding
 model: thenlper/gte-base
+removeParams:
+    - max_tokens
 sources:
     - https://deepinfra.com/thenlper/gte-base
     - https://deepinfra.com/thenlper/gte-base/api

--- a/providers/deepinfra/thenlper/gte-large.yaml
+++ b/providers/deepinfra/thenlper/gte-large.yaml
@@ -11,5 +11,7 @@ modalities:
         - embedding
 mode: embedding
 model: thenlper/gte-large
+removeParams:
+    - max_tokens
 sources:
     - https://deepinfra.com/thenlper/gte-large/api

--- a/providers/openai/text-embedding-ada-002.yaml
+++ b/providers/openai/text-embedding-ada-002.yaml
@@ -21,6 +21,7 @@ removeParams:
     - stream
     - tool_choice
     - parallel_tool_calls
+    - max_tokens
 sources:
     - https://developers.openai.com/api/docs/models/text-embedding-ada-002
     - https://developers.openai.com/docs/guides/embeddings

--- a/providers/together-ai/intfloat/multilingual-e5-large-instruct.yaml
+++ b/providers/together-ai/intfloat/multilingual-e5-large-instruct.yaml
@@ -11,6 +11,8 @@ modalities:
         - embedding
 mode: embedding
 model: intfloat/multilingual-e5-large-instruct
+removeParams:
+    - max_tokens
 sources:
     - https://docs.together.ai/docs/serverless-models
 status: active


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk config-only changes; primarily prevents unsupported `max_tokens` from being sent to embedding endpoints, with a small chance of affecting callers that relied on passing it through.
> 
> **Overview**
> Removes `max_tokens` from request parameters for many embedding model definitions (AWS Bedrock Cohere embeds, Azure AI Foundry embeddings, Azure OpenAI/OpenAI `text-embedding-ada-002`, and multiple DeepInfra/Databricks/Together embedding models) by adding it to `removeParams`.
> 
> Also corrects `us.amazon.nova-2-lite-v1:0` token limits/defaults from `65536` to `65535`, and updates `.gitignore` to exclude local `scripts/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00fb17d1a0f1689fd9ece64b54809c332976ef64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->