### PR TITLE
fix: feature

### DIFF
--- a/providers/openai/o3.yaml
+++ b/providers/openai/o3.yaml
@@ -7,7 +7,6 @@ costs:
       region: "*"
 features:
     - function_calling
-    - parallel_function_calling
     - system_messages
     - tool_choice
     - prompt_caching


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk config-only change that adjusts declared model capabilities for `o3`. Potential impact is limited to feature gating if any code relied on `parallel_function_calling` being advertised.
> 
> **Overview**
> Removes `parallel_function_calling` from the declared `features` list in `providers/openai/o3.yaml`, so `o3` is no longer advertised as supporting parallel tool/function calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 526ababfb6ff05ae028ea80c138c95f8e277f091. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->