### PR TITLE
feat(deepinfra): add new models [bot]

### DIFF
--- a/providers/deepinfra/google/gemma-4-26B-A4B-it.yaml
+++ b/providers/deepinfra/google/gemma-4-26B-A4B-it.yaml
@@ -1,0 +1,15 @@
+costs:
+    - cache_read_input_token_cost: 1.e-8
+      input_cost_per_token: 8.e-8
+      output_cost_per_token: 3.5e-7
+      region: "*"
+features:
+    - prompt_caching
+limits:
+    context_window: 262144
+    max_tokens: 262144
+modalities:
+    input:
+        - image
+mode: unknown
+model: google/gemma-4-26B-A4B-it

--- a/providers/deepinfra/google/gemma-4-31B-it.yaml
+++ b/providers/deepinfra/google/gemma-4-31B-it.yaml
@@ -1,0 +1,15 @@
+costs:
+    - cache_read_input_token_cost: 1.99999995e-8
+      input_cost_per_token: 1.3e-7
+      output_cost_per_token: 3.8e-7
+      region: "*"
+features:
+    - prompt_caching
+limits:
+    context_window: 262144
+    max_tokens: 262144
+modalities:
+    input:
+        - image
+mode: unknown
+model: google/gemma-4-31B-it


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `deepinfra`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds two new DeepInfra model definition YAMLs; risk is low since it’s config-only, though missing optional fields (e.g., `status`/`sources`) could affect discovery/validation if required by tooling.
> 
> **Overview**
> Adds two new DeepInfra model config files for `google/gemma-4-26B-A4B-it` and `google/gemma-4-31B-it`, including token pricing (with prompt-cache read costs), very large `context_window`/`max_tokens` limits (262144), and `image` input modality.
> 
> Both models are marked `mode: unknown` and enable `prompt_caching`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89a86a7e9c361cb3b9c2d808903837f1632cb7c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->