### PR TITLE
feat(openrouter): add new models [bot]

### DIFF
--- a/providers/openrouter/qwen/qwen3.6-plus.yaml
+++ b/providers/openrouter/qwen/qwen3.6-plus.yaml
@@ -1,0 +1,22 @@
+costs:
+    - input_cost_per_token: 3.25e-7
+      output_cost_per_token: 0.00000195
+      region: "*"
+features:
+    - function_calling
+    - json_output
+    - structured_output
+    - tool_choice
+limits:
+    context_window: 1000000
+    max_output_tokens: 65536
+modalities:
+    input:
+        - text
+        - image
+        - video
+    output:
+        - text
+mode: chat
+model: qwen/qwen3.6-plus
+thinking: true


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `openrouter`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new OpenRouter model definition YAML; changes are isolated to provider metadata with no runtime logic impact beyond exposing the model and its limits/costs.
> 
> **Overview**
> Adds a new OpenRouter provider model entry `qwen/qwen3.6-plus`, including token pricing, supported features (e.g., tool/function calling and structured output), modality support (text/image/video input), and configured limits (1M context window, 65,536 max output).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1cf3760fa3e34c25a453bbbb014af7a779b8dbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->