### PR TITLE
fix: model messages

### DIFF
--- a/.github/scripts/build-unified-json.ts
+++ b/.github/scripts/build-unified-json.ts
@@ -69,6 +69,8 @@ function main(): void {
           fs.readFileSync(modelFilePath, 'utf-8'),
         ) as ModelConfig;
         if (!modelData.costs || modelData.costs.length === 0) continue;
+        // TODO: revert — temporarily skipping google-vertex google/ models
+        if (providerName === 'google-vertex' && modelData.model.startsWith('google/')) continue;
         configs.push(
           buildUnifiedConfig(modelData, providerName, defaultProviderParams),
         );

--- a/.github/scripts/build-unified-json.ts
+++ b/.github/scripts/build-unified-json.ts
@@ -69,8 +69,9 @@ function main(): void {
           fs.readFileSync(modelFilePath, 'utf-8'),
         ) as ModelConfig;
         if (!modelData.costs || modelData.costs.length === 0) continue;
-        // TODO: revert — temporarily skipping google-vertex google/ models
-        if (providerName === 'google-vertex' && modelData.model.startsWith('google/')) continue;
+        // TODO: revert — temporarily skipping google-vertex google/ models with unsupported modes
+        const SKIPPED_VERTEX_MODES = new Set(['text_to_speech', 'audio_transcription', 'audio_translation', 'realtime']);
+        if (providerName === 'google-vertex' && modelData.model.startsWith('google/') && SKIPPED_VERTEX_MODES.has(modelData.mode)) continue;
         configs.push(
           buildUnifiedConfig(modelData, providerName, defaultProviderParams),
         );

--- a/providers/aws-bedrock/mistral.mistral-7b-instruct-v0:2.yaml
+++ b/providers/aws-bedrock/mistral.mistral-7b-instruct-v0:2.yaml
@@ -26,13 +26,14 @@ costs:
     - input_cost_per_token: 1.8e-7
       output_cost_per_token: 2.4e-7
       region: ap-south-1
-features:
-    - system_messages
 limits:
     context_window: 32000
     max_input_tokens: 32000
     max_output_tokens: 8192
     max_tokens: 8192
+messages:
+    options:
+        - user
 modalities:
     input:
         - text

--- a/providers/aws-bedrock/mistral.mixtral-8x7b-instruct-v0:1.yaml
+++ b/providers/aws-bedrock/mistral.mixtral-8x7b-instruct-v0:1.yaml
@@ -26,13 +26,14 @@ costs:
     - input_cost_per_token: 5.4e-7
       output_cost_per_token: 8.4e-7
       region: ap-south-1
-features:
-    - system_messages
 limits:
     context_window: 32000
     max_input_tokens: 32000
     max_output_tokens: 4096
     max_tokens: 4096
+messages:
+    options:
+        - user
 modalities:
     input:
         - text


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes which models are emitted into `dist/ai-models.json` (skipping some `google-vertex` `google/*` modes) and adjusts message-role compatibility for two Bedrock models, which could affect downstream consumers relying on the previous metadata.
> 
> **Overview**
> **Adjusts model metadata generation** by temporarily filtering out `google-vertex` models under `google/*` when their `mode` is one of `text_to_speech`, `audio_transcription`, `audio_translation`, or `realtime`, preventing unsupported entries from being included in the unified JSON.
> 
> **Updates AWS Bedrock Mistral configs** (`mistral-7b-instruct` and `mixtral-8x7b-instruct`) to drop the `system_messages` feature flag and explicitly declare `messages.options: [user]`, tightening the advertised allowed message roles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b62e07fb30531847808f9ca6d2f8b6aafb5dc0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->