### PR TITLE
feat(openrouter): update model YAMLs [bot]

### DIFF
--- a/providers/openrouter/qwen/qwen3.6-plus.yaml
+++ b/providers/openrouter/qwen/qwen3.6-plus.yaml
@@ -2,6 +2,13 @@ costs:
     - input_cost_per_token: 3.25e-7
       output_cost_per_token: 0.00000195
       region: "*"
+      tiered_pricing:
+          input:
+              - cost_per_token: 0.0000013
+                from: 256000
+          output:
+              - cost_per_token: 0.0000039
+                from: 256000
 features:
     - function_calling
     - json_output
@@ -19,4 +26,6 @@ modalities:
         - text
 mode: chat
 model: qwen/qwen3.6-plus
+sources:
+    - https://openrouter.ai/qwen/qwen3.6-plus
 thinking: true


### PR DESCRIPTION
Auto-generated by poc-agent for provider `openrouter`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk YAML metadata update that only affects cost calculation/config for `qwen/qwen3.6-plus`. Potential impact is limited to billing/estimation accuracy if the new tier thresholds or rates are incorrect.
> 
> **Overview**
> Adds `tiered_pricing` to `qwen/qwen3.6-plus.yaml`, defining higher per-token input/output rates starting at 256k tokens.
> 
> Also adds a `sources` entry pointing to the OpenRouter model page for traceability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f16feb286de655775d9b4a7f7ff695608b31331. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->