### PR TITLE
feat(mistral-ai): add new models [bot]

### DIFF
--- a/providers/mistral-ai/mistral-medium-2604.yaml
+++ b/providers/mistral-ai/mistral-medium-2604.yaml
@@ -1,0 +1,15 @@
+features:
+    - function_calling
+limits:
+    context_window: 262144
+modalities:
+    input:
+        - image
+mode: unknown
+model: mistral-medium-2604
+params:
+    - defaultValue: 0.7
+      key: temperature
+status: active
+supportedModes:
+    - chat

--- a/providers/mistral-ai/mistral-medium-3.5.0.yaml
+++ b/providers/mistral-ai/mistral-medium-3.5.0.yaml
@@ -1,0 +1,15 @@
+features:
+    - function_calling
+limits:
+    context_window: 262144
+modalities:
+    input:
+        - image
+mode: unknown
+model: mistral-medium-3.5.0
+params:
+    - defaultValue: 0.7
+      key: temperature
+status: active
+supportedModes:
+    - chat

--- a/providers/mistral-ai/mistral-medium-3.5.yaml
+++ b/providers/mistral-ai/mistral-medium-3.5.yaml
@@ -1,0 +1,15 @@
+features:
+    - function_calling
+limits:
+    context_window: 262144
+modalities:
+    input:
+        - image
+mode: unknown
+model: mistral-medium-3.5
+params:
+    - defaultValue: 0.7
+      key: temperature
+status: active
+supportedModes:
+    - chat

--- a/providers/mistral-ai/mistral-medium-3.yaml
+++ b/providers/mistral-ai/mistral-medium-3.yaml
@@ -1,0 +1,15 @@
+features:
+    - function_calling
+limits:
+    context_window: 262144
+modalities:
+    input:
+        - image
+mode: unknown
+model: mistral-medium-3
+params:
+    - defaultValue: 0.7
+      key: temperature
+status: active
+supportedModes:
+    - chat

--- a/providers/mistral-ai/mistral-medium-c21211-r0-75.yaml
+++ b/providers/mistral-ai/mistral-medium-c21211-r0-75.yaml
@@ -1,0 +1,15 @@
+features:
+    - function_calling
+limits:
+    context_window: 262144
+modalities:
+    input:
+        - image
+mode: unknown
+model: mistral-medium-c21211-r0-75
+params:
+    - defaultValue: 0.7
+      key: temperature
+status: active
+supportedModes:
+    - chat


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `mistral-ai`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds new provider model definition YAMLs only; low risk aside from potential catalog/validation issues if any required metadata (e.g., costs/sources/mode) is missing or incorrect.
> 
> **Overview**
> Registers five new `mistral-ai` model config files: `mistral-medium-3`, `mistral-medium-3.5`, `mistral-medium-3.5.0`, `mistral-medium-2604`, and `mistral-medium-c21211-r0-75`.
> 
> Each definition marks the model as **active** and chat-capable with `function_calling`, a `262144` context window, image input support, and a default `temperature` of `0.7`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f75ec4562ba5dc3850a2a4d99f4b9e031ebdfdb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->