### PR TITLE
fix: deprecate models

### DIFF
--- a/providers/openrouter/stepfun/step-3.5-flash:free.yaml
+++ b/providers/openrouter/stepfun/step-3.5-flash:free.yaml
@@ -18,4 +18,5 @@ model: stepfun/step-3.5-flash:free
 sources:
     - https://openrouter.ai/stepfun/step-3.5-flash:free/api
     - https://openrouter.ai/stepfun/step-3.5-flash/api
+status: retired
 thinking: true

--- a/providers/sambanova/Llama-3.3-Swallow-70B-Instruct-v0.4.yaml
+++ b/providers/sambanova/Llama-3.3-Swallow-70B-Instruct-v0.4.yaml
@@ -15,4 +15,4 @@ modalities:
         - text
 mode: chat
 model: Llama-3.3-Swallow-70B-Instruct-v0.4
-status: preview
+status: deprecated

--- a/providers/sambanova/Qwen3-235B.yaml
+++ b/providers/sambanova/Qwen3-235B.yaml
@@ -17,4 +17,4 @@ model: Qwen3-235B
 sources:
     - https://docs.sambanova.ai/docs/en/features/function-calling
     - https://docs.sambanova.ai/docs/en/build/reasoning
-status: preview
+status: deprecated

--- a/providers/sambanova/Qwen3-32B.yaml
+++ b/providers/sambanova/Qwen3-32B.yaml
@@ -19,5 +19,5 @@ model: Qwen3-32B
 sources:
     - https://docs.sambanova.ai/docs/en/features/function-calling
     - https://docs.sambanova.ai/docs/en/build/reasoning
-status: preview
+status: deprecated
 thinking: true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Only updates model metadata (`status`) in provider YAML configs; no runtime logic changes, but may affect model selection/visibility where `status` is honored.
> 
> **Overview**
> **Updates model lifecycle statuses in provider configs.**
> 
> Marks `openrouter/stepfun/step-3.5-flash:free` as `retired` and changes three SambaNova models (`Llama-3.3-Swallow-70B-Instruct-v0.4`, `Qwen3-235B`, `Qwen3-32B`) from `preview` to `deprecated`, signaling they should no longer be recommended/used by default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5deb188f8270dee40ecafd9657b159be0c16f9a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->