### PR TITLE
add reasoning effort in remove params for grok 4 series models

### DIFF
--- a/providers/xai/grok-4-0709.yaml
+++ b/providers/xai/grok-4-0709.yaml
@@ -18,4 +18,6 @@ modalities:
         - text
 mode: chat
 model: grok-4-0709
+removeParams:
+    - reasoning_effort
 thinking: true

--- a/providers/xai/grok-4-1-fast-non-reasoning-latest.yaml
+++ b/providers/xai/grok-4-1-fast-non-reasoning-latest.yaml
@@ -20,4 +20,6 @@ modalities:
         - text
 mode: chat
 model: grok-4-1-fast-non-reasoning-latest
+removeParams:
+    - reasoning_effort
 status: active

--- a/providers/xai/grok-4-1-fast-non-reasoning.yaml
+++ b/providers/xai/grok-4-1-fast-non-reasoning.yaml
@@ -17,6 +17,8 @@ modalities:
         - text
 mode: chat
 model: grok-4-1-fast-non-reasoning
+removeParams:
+    - reasoning_effort
 sources:
     - https://docs.x.ai/developers/models#models-and-pricing
 status: active

--- a/providers/xai/grok-4-1-fast-reasoning-latest.yaml
+++ b/providers/xai/grok-4-1-fast-reasoning-latest.yaml
@@ -19,5 +19,7 @@ modalities:
         - text
 mode: chat
 model: grok-4-1-fast-reasoning-latest
+removeParams:
+    - reasoning_effort
 status: active
 thinking: true

--- a/providers/xai/grok-4-1-fast-reasoning.yaml
+++ b/providers/xai/grok-4-1-fast-reasoning.yaml
@@ -19,6 +19,8 @@ modalities:
         - text
 mode: chat
 model: grok-4-1-fast-reasoning
+removeParams:
+    - reasoning_effort
 sources:
     - https://docs.x.ai/developers/models#models-and-pricing
 status: active

--- a/providers/xai/grok-4-1-fast.yaml
+++ b/providers/xai/grok-4-1-fast.yaml
@@ -20,5 +20,7 @@ modalities:
         - text
 mode: chat
 model: grok-4-1-fast
+removeParams:
+    - reasoning_effort
 status: active
 thinking: true

--- a/providers/xai/grok-4-fast-non-reasoning-latest.yaml
+++ b/providers/xai/grok-4-fast-non-reasoning-latest.yaml
@@ -18,6 +18,8 @@ modalities:
         - text
 mode: chat
 model: grok-4-fast-non-reasoning-latest
+removeParams:
+    - reasoning_effort
 sources:
     - https://docs.x.ai/developers/models#models-and-pricing
 status: active

--- a/providers/xai/grok-4-fast-non-reasoning.yaml
+++ b/providers/xai/grok-4-fast-non-reasoning.yaml
@@ -20,5 +20,7 @@ modalities:
         - text
 mode: chat
 model: grok-4-fast-non-reasoning
+removeParams:
+    - reasoning_effort
 sources:
     - https://docs.x.ai/developers/models#models-and-pricing

--- a/providers/xai/grok-4-fast-reasoning-latest.yaml
+++ b/providers/xai/grok-4-fast-reasoning-latest.yaml
@@ -19,6 +19,8 @@ modalities:
         - text
 mode: chat
 model: grok-4-fast-reasoning-latest
+removeParams:
+    - reasoning_effort
 sources:
     - https://docs.x.ai/developers/models#models-and-pricing
 status: active

--- a/providers/xai/grok-4-fast-reasoning.yaml
+++ b/providers/xai/grok-4-fast-reasoning.yaml
@@ -20,6 +20,8 @@ modalities:
         - text
 mode: chat
 model: grok-4-fast-reasoning
+removeParams:
+    - reasoning_effort
 sources:
     - https://docs.x.ai/developers/models#models-and-pricing
 status: active

--- a/providers/xai/grok-4-fast.yaml
+++ b/providers/xai/grok-4-fast.yaml
@@ -18,6 +18,8 @@ modalities:
         - text
 mode: chat
 model: grok-4-fast
+removeParams:
+    - reasoning_effort
 sources:
     - https://docs.x.ai/developers/models#models-and-pricing
 status: active

--- a/providers/xai/grok-4-latest.yaml
+++ b/providers/xai/grok-4-latest.yaml
@@ -20,5 +20,7 @@ modalities:
         - text
 mode: chat
 model: grok-4-latest
+removeParams:
+    - reasoning_effort
 status: active
 thinking: true

--- a/providers/xai/grok-4.20-0309-non-reasoning.yaml
+++ b/providers/xai/grok-4.20-0309-non-reasoning.yaml
@@ -16,4 +16,6 @@ modalities:
         - text
 mode: chat
 model: grok-4.20-0309-non-reasoning
+removeParams:
+    - reasoning_effort
 status: active

--- a/providers/xai/grok-4.20-0309-reasoning.yaml
+++ b/providers/xai/grok-4.20-0309-reasoning.yaml
@@ -20,5 +20,7 @@ modalities:
         - text
 mode: chat
 model: grok-4.20-0309-reasoning
+removeParams:
+    - reasoning_effort
 status: active
 thinking: true

--- a/providers/xai/grok-4.20-0309.yaml
+++ b/providers/xai/grok-4.20-0309.yaml
@@ -19,4 +19,6 @@ modalities:
         - text
 mode: chat
 model: grok-4.20-0309
+removeParams:
+    - reasoning_effort
 status: active

--- a/providers/xai/grok-4.20-beta-0309-non-reasoning.yaml
+++ b/providers/xai/grok-4.20-beta-0309-non-reasoning.yaml
@@ -18,6 +18,8 @@ modalities:
         - text
 mode: chat
 model: grok-4.20-beta-0309-non-reasoning
+removeParams:
+    - reasoning_effort
 sources:
     - https://docs.x.ai/developers/models#models-and-pricing
 status: active

--- a/providers/xai/grok-4.20-beta-0309-reasoning.yaml
+++ b/providers/xai/grok-4.20-beta-0309-reasoning.yaml
@@ -19,6 +19,8 @@ modalities:
         - text
 mode: chat
 model: grok-4.20-beta-0309-reasoning
+removeParams:
+    - reasoning_effort
 sources:
     - https://docs.x.ai/developers/models#models-and-pricing
 thinking: true

--- a/providers/xai/grok-4.20-beta-0309.yaml
+++ b/providers/xai/grok-4.20-beta-0309.yaml
@@ -20,6 +20,8 @@ modalities:
         - text
 mode: chat
 model: grok-4.20-beta-0309
+removeParams:
+    - reasoning_effort
 sources:
     - https://docs.x.ai/developers/models#models-and-pricing
 status: preview

--- a/providers/xai/grok-4.20-beta-latest-non-reasoning.yaml
+++ b/providers/xai/grok-4.20-beta-latest-non-reasoning.yaml
@@ -18,6 +18,8 @@ modalities:
         - text
 mode: chat
 model: grok-4.20-beta-latest-non-reasoning
+removeParams:
+    - reasoning_effort
 sources:
     - https://docs.x.ai/developers/models#models-and-pricing
 status: active

--- a/providers/xai/grok-4.20-beta-latest-reasoning.yaml
+++ b/providers/xai/grok-4.20-beta-latest-reasoning.yaml
@@ -20,4 +20,6 @@ modalities:
         - text
 mode: chat
 model: grok-4.20-beta-latest-reasoning
+removeParams:
+    - reasoning_effort
 thinking: true

--- a/providers/xai/grok-4.20-beta-latest.yaml
+++ b/providers/xai/grok-4.20-beta-latest.yaml
@@ -18,6 +18,8 @@ modalities:
         - text
 mode: chat
 model: grok-4.20-beta-latest
+removeParams:
+    - reasoning_effort
 sources:
     - https://docs.x.ai/developers/models#models-and-pricing
 status: preview

--- a/providers/xai/grok-4.20-beta-non-reasoning.yaml
+++ b/providers/xai/grok-4.20-beta-non-reasoning.yaml
@@ -21,6 +21,8 @@ modalities:
         - text
 mode: chat
 model: grok-4.20-beta-non-reasoning
+removeParams:
+    - reasoning_effort
 sources:
     - https://docs.x.ai/developers/models#models-and-pricing
 status: active

--- a/providers/xai/grok-4.20-beta-reasoning.yaml
+++ b/providers/xai/grok-4.20-beta-reasoning.yaml
@@ -20,6 +20,8 @@ modalities:
         - text
 mode: chat
 model: grok-4.20-beta-reasoning
+removeParams:
+    - reasoning_effort
 sources:
     - https://docs.x.ai/developers/models#models-and-pricing
 status: active

--- a/providers/xai/grok-4.20-beta.yaml
+++ b/providers/xai/grok-4.20-beta.yaml
@@ -19,6 +19,8 @@ modalities:
         - text
 mode: chat
 model: grok-4.20-beta
+removeParams:
+    - reasoning_effort
 sources:
     - https://docs.x.ai/developers/models#models-and-pricing
 status: preview

--- a/providers/xai/grok-4.20-experimental-beta-0304-non-reasoning.yaml
+++ b/providers/xai/grok-4.20-experimental-beta-0304-non-reasoning.yaml
@@ -20,6 +20,8 @@ modalities:
         - text
 mode: chat
 model: grok-4.20-experimental-beta-0304-non-reasoning
+removeParams:
+    - reasoning_effort
 sources:
     - https://docs.x.ai/developers/models#models-and-pricing
 status: active

--- a/providers/xai/grok-4.20-experimental-beta-0304-reasoning.yaml
+++ b/providers/xai/grok-4.20-experimental-beta-0304-reasoning.yaml
@@ -19,6 +19,8 @@ modalities:
         - text
 mode: chat
 model: grok-4.20-experimental-beta-0304-reasoning
+removeParams:
+    - reasoning_effort
 sources:
     - https://docs.x.ai/developers/models#models-and-pricing
 status: preview

--- a/providers/xai/grok-4.20-experimental-beta-0304.yaml
+++ b/providers/xai/grok-4.20-experimental-beta-0304.yaml
@@ -18,4 +18,6 @@ modalities:
         - text
 mode: chat
 model: grok-4.20-experimental-beta-0304
+removeParams:
+    - reasoning_effort
 status: preview

--- a/providers/xai/grok-4.20-experimental-beta-latest.yaml
+++ b/providers/xai/grok-4.20-experimental-beta-latest.yaml
@@ -20,6 +20,8 @@ modalities:
         - text
 mode: chat
 model: grok-4.20-experimental-beta-latest
+removeParams:
+    - reasoning_effort
 sources:
     - https://docs.x.ai/developers/models#models-and-pricing
 status: preview

--- a/providers/xai/grok-4.20-experimental-beta-non-reasoning-latest.yaml
+++ b/providers/xai/grok-4.20-experimental-beta-non-reasoning-latest.yaml
@@ -24,6 +24,8 @@ params:
       key: max_tokens
       maxValue: 131072
       minValue: 1
+removeParams:
+    - reasoning_effort
 sources:
     - https://docs.x.ai/developers/models#models-and-pricing
 status: preview

--- a/providers/xai/grok-4.20-experimental-beta-reasoning-latest.yaml
+++ b/providers/xai/grok-4.20-experimental-beta-reasoning-latest.yaml
@@ -20,6 +20,8 @@ modalities:
         - text
 mode: chat
 model: grok-4.20-experimental-beta-reasoning-latest
+removeParams:
+    - reasoning_effort
 sources:
     - https://docs.x.ai/developers/models#models-and-pricing
 status: active

--- a/providers/xai/grok-4.20-multi-agent-0309.yaml
+++ b/providers/xai/grok-4.20-multi-agent-0309.yaml
@@ -17,5 +17,7 @@ modalities:
         - text
 mode: chat
 model: grok-4.20-multi-agent-0309
+removeParams:
+    - reasoning_effort
 status: active
 thinking: true

--- a/providers/xai/grok-4.20-multi-agent-beta-0309-exp-ma.yaml
+++ b/providers/xai/grok-4.20-multi-agent-beta-0309-exp-ma.yaml
@@ -21,5 +21,7 @@ modalities:
         - text
 mode: chat
 model: grok-4.20-multi-agent-beta-0309-exp-ma
+removeParams:
+    - reasoning_effort
 status: preview
 thinking: true

--- a/providers/xai/grok-4.20-multi-agent-beta-0309.yaml
+++ b/providers/xai/grok-4.20-multi-agent-beta-0309.yaml
@@ -17,6 +17,8 @@ modalities:
         - text
 mode: chat
 model: grok-4.20-multi-agent-beta-0309
+removeParams:
+    - reasoning_effort
 sources:
     - https://docs.x.ai/developers/models#models-and-pricing
 thinking: true

--- a/providers/xai/grok-4.20-multi-agent-beta-latest.yaml
+++ b/providers/xai/grok-4.20-multi-agent-beta-latest.yaml
@@ -17,6 +17,8 @@ modalities:
         - text
 mode: chat
 model: grok-4.20-multi-agent-beta-latest
+removeParams:
+    - reasoning_effort
 sources:
     - https://docs.x.ai/developers/models#models-and-pricing
 status: preview

--- a/providers/xai/grok-4.20-multi-agent-experimental-beta-0304.yaml
+++ b/providers/xai/grok-4.20-multi-agent-experimental-beta-0304.yaml
@@ -16,4 +16,6 @@ modalities:
         - text
 mode: chat
 model: grok-4.20-multi-agent-experimental-beta-0304
+removeParams:
+    - reasoning_effort
 thinking: true

--- a/providers/xai/grok-4.20-multi-agent-experimental-beta-latest.yaml
+++ b/providers/xai/grok-4.20-multi-agent-experimental-beta-latest.yaml
@@ -18,5 +18,7 @@ modalities:
         - text
 mode: chat
 model: grok-4.20-multi-agent-experimental-beta-latest
+removeParams:
+    - reasoning_effort
 status: preview
 thinking: true

--- a/providers/xai/grok-4.20-multi-agent-latest.yaml
+++ b/providers/xai/grok-4.20-multi-agent-latest.yaml
@@ -16,4 +16,6 @@ modalities:
         - text
 mode: chat
 model: grok-4.20-multi-agent-latest
+removeParams:
+    - reasoning_effort
 thinking: true

--- a/providers/xai/grok-4.20-multi-agent.yaml
+++ b/providers/xai/grok-4.20-multi-agent.yaml
@@ -19,5 +19,7 @@ modalities:
         - text
 mode: chat
 model: grok-4.20-multi-agent
+removeParams:
+    - reasoning_effort
 status: active
 thinking: true

--- a/providers/xai/grok-4.20-non-reasoning-gv2.yaml
+++ b/providers/xai/grok-4.20-non-reasoning-gv2.yaml
@@ -18,3 +18,5 @@ modalities:
         - text
 mode: chat
 model: grok-4.20-non-reasoning-gv2
+removeParams:
+    - reasoning_effort

--- a/providers/xai/grok-4.20-non-reasoning-latest.yaml
+++ b/providers/xai/grok-4.20-non-reasoning-latest.yaml
@@ -20,4 +20,6 @@ modalities:
         - text
 mode: chat
 model: grok-4.20-non-reasoning-latest
+removeParams:
+    - reasoning_effort
 status: active

--- a/providers/xai/grok-4.20-non-reasoning.yaml
+++ b/providers/xai/grok-4.20-non-reasoning.yaml
@@ -20,3 +20,5 @@ modalities:
         - text
 mode: chat
 model: grok-4.20-non-reasoning
+removeParams:
+    - reasoning_effort

--- a/providers/xai/grok-4.20-reasoning-gv2.yaml
+++ b/providers/xai/grok-4.20-reasoning-gv2.yaml
@@ -17,4 +17,6 @@ modalities:
         - text
 mode: chat
 model: grok-4.20-reasoning-gv2
+removeParams:
+    - reasoning_effort
 thinking: true

--- a/providers/xai/grok-4.20-reasoning-latest.yaml
+++ b/providers/xai/grok-4.20-reasoning-latest.yaml
@@ -16,5 +16,7 @@ modalities:
         - text
 mode: chat
 model: grok-4.20-reasoning-latest
+removeParams:
+    - reasoning_effort
 status: active
 thinking: true

--- a/providers/xai/grok-4.20-reasoning.yaml
+++ b/providers/xai/grok-4.20-reasoning.yaml
@@ -17,5 +17,7 @@ modalities:
         - text
 mode: chat
 model: grok-4.20-reasoning
+removeParams:
+    - reasoning_effort
 status: active
 thinking: true

--- a/providers/xai/grok-4.20.yaml
+++ b/providers/xai/grok-4.20.yaml
@@ -19,5 +19,7 @@ modalities:
         - text
 mode: chat
 model: grok-4.20
+removeParams:
+    - reasoning_effort
 status: active
 thinking: true

--- a/providers/xai/grok-4.yaml
+++ b/providers/xai/grok-4.yaml
@@ -20,5 +20,7 @@ modalities:
         - text
 mode: chat
 model: grok-4
+removeParams:
+    - reasoning_effort
 status: active
 thinking: true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low-risk config-only change, but it affects request shaping for all Grok 4 variants and could change behavior for callers that previously set `reasoning_effort`.
> 
> **Overview**
> Adds `removeParams: [reasoning_effort]` to all `providers/xai/grok-4*` model definitions (including `4`, `4-latest`, `4-fast`, `4-1-fast`, and `4.20*` variants) so the system strips `reasoning_effort` from requests for these models.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33f49592b2b4f6d62aa7a506199822f2ca247f90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->