### PR TITLE
remove param

### DIFF
--- a/providers/mistral-ai/magistral-medium-2509.yaml
+++ b/providers/mistral-ai/magistral-medium-2509.yaml
@@ -22,6 +22,8 @@ model: magistral-medium-2509
 params:
     - defaultValue: 0.7
       key: temperature
+removeParams:
+    - reasoning_effort
 sources:
     - https://docs.mistral.ai/models/magistral-medium-1-2-25-09
     - https://docs.mistral.ai/capabilities/reasoning

--- a/providers/mistral-ai/magistral-medium-latest.yaml
+++ b/providers/mistral-ai/magistral-medium-latest.yaml
@@ -14,6 +14,8 @@ model: magistral-medium-latest
 params:
     - defaultValue: 0.7
       key: temperature
+removeParams:
+    - reasoning_effort
 sources:
     - https://docs.mistral.ai/models/magistral-medium-1-2-25-09
     - https://docs.mistral.ai/capabilities/reasoning/

--- a/providers/mistral-ai/magistral-small-2509.yaml
+++ b/providers/mistral-ai/magistral-small-2509.yaml
@@ -20,6 +20,8 @@ model: magistral-small-2509
 params:
     - defaultValue: 0.7
       key: temperature
+removeParams:
+    - reasoning_effort
 sources:
     - https://docs.mistral.ai/models/magistral-small-1-2-25-09
     - https://docs.mistral.ai/capabilities/reasoning/native

--- a/providers/mistral-ai/magistral-small-latest.yaml
+++ b/providers/mistral-ai/magistral-small-latest.yaml
@@ -20,6 +20,8 @@ model: magistral-small-latest
 params:
     - defaultValue: 0.7
       key: temperature
+removeParams:
+    - reasoning_effort
 sources:
     - https://docs.mistral.ai/models/magistral-small-1-2-25-09
     - https://docs.mistral.ai/capabilities/reasoning


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk config-only change that stops sending the unsupported `reasoning_effort` parameter to these Mistral Magistral models; main risk is any callers relying on that knob will no longer be able to set it.
> 
> **Overview**
> Adds `removeParams: [reasoning_effort]` to the Mistral Magistral model YAML configs (`magistral-*-2509` and `magistral-*-latest`) so the runtime strips the `reasoning_effort` parameter when building requests for these models.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd6af02de0a8024648d50014d74f26be5a486066. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->