### PR TITLE
remove param

### DIFF
--- a/providers/mistral-ai/mistral-large-latest.yaml
+++ b/providers/mistral-ai/mistral-large-latest.yaml
@@ -23,6 +23,8 @@ model: mistral-large-latest
 params:
     - defaultValue: 0.3
       key: temperature
+removeParams:
+    - reasoning_effort
 sources:
     - https://docs.mistral.ai/models/mistral-large-3-25-12
 status: active

--- a/providers/mistral-ai/mistral-small-2506.yaml
+++ b/providers/mistral-ai/mistral-small-2506.yaml
@@ -19,6 +19,8 @@ model: mistral-small-2506
 params:
     - defaultValue: 0.3
       key: temperature
+removeParams:
+    - reasoning_effort
 sources:
     - https://docs.mistral.ai/models/mistral-small-3-2-25-06
     - https://docs.mistral.ai/capabilities/vision

--- a/providers/openai/computer-use-preview.yaml
+++ b/providers/openai/computer-use-preview.yaml
@@ -27,6 +27,8 @@ params:
       minValue: 1
 removeParams:
     - stream
+    - max_tokens
+    - max_completion_tokens
 sources:
     - https://developers.openai.com/api/docs/models/computer-use-preview
     - https://developers.openai.com/api/docs/guides/tools-computer-use

--- a/providers/openai/gpt-5-codex.yaml
+++ b/providers/openai/gpt-5-codex.yaml
@@ -29,6 +29,7 @@ params:
       minValue: 1
 removeParams:
     - max_tokens
+    - max_completion_tokens
 sources:
     - https://developers.openai.com/docs/models/gpt-5-codex
 status: active

--- a/providers/openai/gpt-5-pro-2025-10-06.yaml
+++ b/providers/openai/gpt-5-pro-2025-10-06.yaml
@@ -30,6 +30,7 @@ params:
       minValue: 1
 removeParams:
     - max_tokens
+    - max_completion_tokens
 sources:
     - https://developers.openai.com/api/docs/models/gpt-5-pro
 supportedModes:

--- a/providers/openai/gpt-5-pro.yaml
+++ b/providers/openai/gpt-5-pro.yaml
@@ -31,6 +31,7 @@ removeParams:
     - "n"
     - parallel_tool_calls
     - max_tokens
+    - max_completion_tokens
 sources:
     - https://developers.openai.com/api/docs/models/gpt-5-pro
 status: active

--- a/providers/openai/gpt-5.1-codex-max.yaml
+++ b/providers/openai/gpt-5.1-codex-max.yaml
@@ -29,6 +29,9 @@ params:
       minValue: 1
     - defaultValue: medium
       key: reasoning_effort
+removeParams:
+    - max_tokens
+    - max_completion_tokens
 sources:
     - https://developers.openai.com/api/docs/models/gpt-5.1-codex-max
 status: active

--- a/providers/openai/gpt-5.1-codex-mini.yaml
+++ b/providers/openai/gpt-5.1-codex-mini.yaml
@@ -29,6 +29,7 @@ params:
       minValue: 1
 removeParams:
     - max_tokens
+    - max_completion_tokens
 sources:
     - https://developers.openai.com/api/docs/models/gpt-5.1-codex-mini
 status: active

--- a/providers/openai/gpt-5.1-codex.yaml
+++ b/providers/openai/gpt-5.1-codex.yaml
@@ -27,6 +27,9 @@ params:
       key: max_tokens
       maxValue: 128000
       minValue: 1
+removeParams:
+    - max_tokens
+    - max_completion_tokens
 sources:
     - https://developers.openai.com/api/docs/models/gpt-5.1-codex
 status: active

--- a/providers/openai/gpt-5.2-codex.yaml
+++ b/providers/openai/gpt-5.2-codex.yaml
@@ -31,6 +31,7 @@ params:
       key: reasoning_effort
 removeParams:
     - max_tokens
+    - max_completion_tokens
 sources:
     - https://developers.openai.com/api/docs/models/gpt-5.2-codex
 supportedModes:

--- a/providers/openai/gpt-5.2-pro-2025-12-11.yaml
+++ b/providers/openai/gpt-5.2-pro-2025-12-11.yaml
@@ -30,6 +30,7 @@ params:
       key: reasoning_effort
 removeParams:
     - max_tokens
+    - max_completion_tokens
 sources:
     - https://developers.openai.com/api/docs/models/gpt-5.2-pro
 supportedModes:

--- a/providers/openai/gpt-5.2-pro.yaml
+++ b/providers/openai/gpt-5.2-pro.yaml
@@ -29,6 +29,9 @@ params:
       maxValue: 128000
       minValue: 1
     - key: reasoning_effort
+removeParams:
+    - max_tokens
+    - max_completion_tokens
 sources:
     - https://developers.openai.com/api/docs/models/gpt-5.2-pro
 supportedModes:

--- a/providers/openai/gpt-5.3-codex.yaml
+++ b/providers/openai/gpt-5.3-codex.yaml
@@ -31,6 +31,7 @@ params:
       key: reasoning_effort
 removeParams:
     - max_tokens
+    - max_completion_tokens
 sources:
     - https://developers.openai.com/api/docs/models/gpt-5.3-codex
     - https://developers.openai.com/docs/pricing

--- a/providers/openai/gpt-5.4-pro-2026-03-05.yaml
+++ b/providers/openai/gpt-5.4-pro-2026-03-05.yaml
@@ -37,6 +37,7 @@ params:
       type: string
 removeParams:
     - max_tokens
+    - max_completion_tokens
 sources:
     - https://developers.openai.com/api/docs/models/gpt-5.4-pro
 supportedModes:

--- a/providers/openai/gpt-5.4-pro.yaml
+++ b/providers/openai/gpt-5.4-pro.yaml
@@ -41,6 +41,7 @@ removeParams:
     - "n"
     - stop
     - max_tokens
+    - max_completion_tokens
 sources:
     - https://developers.openai.com/api/docs/models/gpt-5.4-pro
     - https://developers.openai.com/docs/pricing

--- a/providers/openai/o1-pro.yaml
+++ b/providers/openai/o1-pro.yaml
@@ -37,6 +37,8 @@ removeParams:
     - stop
     - "n"
     - parallel_tool_calls
+    - max_tokens
+    - max_completion_tokens
 sources:
     - https://developers.openai.com/api/docs/models/o1-pro
 status: active

--- a/providers/openai/o3-deep-research.yaml
+++ b/providers/openai/o3-deep-research.yaml
@@ -32,6 +32,8 @@ removeParams:
     - top_p
     - stop
     - "n"
+    - max_tokens
+    - max_completion_tokens
 sources:
     - https://developers.openai.com/api/docs/models/o3-deep-research
     - https://developers.openai.com/api/docs/guides/deep-research

--- a/providers/openai/o3-pro.yaml
+++ b/providers/openai/o3-pro.yaml
@@ -30,6 +30,7 @@ params:
       key: reasoning_effort
 removeParams:
     - max_tokens
+    - max_completion_tokens
     - temperature
     - top_p
     - "n"

--- a/providers/openai/o4-mini-deep-research.yaml
+++ b/providers/openai/o4-mini-deep-research.yaml
@@ -28,6 +28,8 @@ params:
 removeParams:
     - tool_choice
     - parallel_tool_calls
+    - max_tokens
+    - max_completion_tokens
 sources:
     - https://developers.openai.com/api/docs/guides/deep-research
     - https://developers.openai.com/api/docs/models/o4-mini-deep-research


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes provider model YAML configs to strip additional request parameters (notably token limit fields and `reasoning_effort`), which could alter how callers control output length or reasoning behavior for these models. Risk is moderate because it affects runtime request shaping across multiple OpenAI/Mistral model definitions.
> 
> **Overview**
> **Updates model provider configs to remove unsupported/undesired request parameters.** Mistral `mistral-large-latest` and `mistral-small-2506` now explicitly strip `reasoning_effort`.
> 
> Across several OpenAI `responses` models (e.g., `gpt-5*`, `o1-pro`, `o3*`, `o4-mini-deep-research`, `computer-use-preview`), `removeParams` is expanded to also drop `max_tokens` and/or `max_completion_tokens`, preventing those fields from being forwarded in requests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb428bfc40c821d6374449f2f5423bf86e07b84f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->