### PR TITLE
retire models

### DIFF
--- a/providers/aws-bedrock/cohere.embed-multilingual-v3.yaml
+++ b/providers/aws-bedrock/cohere.embed-multilingual-v3.yaml
@@ -49,6 +49,7 @@ model: cohere.embed-multilingual-v3
 removeParams:
     - stream
     - max_tokens
+    - temperature
 sources:
     - https://docs.cohere.com/docs/cohere-embed
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-embed-v3.html

--- a/providers/google-gemini/gemini-2.5-flash-preview-09-2025.yaml
+++ b/providers/google-gemini/gemini-2.5-flash-preview-09-2025.yaml
@@ -22,3 +22,4 @@ modalities:
         - pdf
 mode: chat
 model: gemini-2.5-flash-preview-09-2025
+status: retired

--- a/providers/google-vertex/gemini-2.5-flash-preview-09-2025.yaml
+++ b/providers/google-vertex/gemini-2.5-flash-preview-09-2025.yaml
@@ -13,6 +13,7 @@ features:
     - structured_output
     - code_execution
     - json_output
+isDeprecated: true
 limits:
     context_window: 1048576
     max_input_tokens: 1048576
@@ -35,7 +36,7 @@ params:
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-flash
     - https://ai.google.dev/pricing
-status: preview
+status: retired
 supportedModes:
     - chat
 thinking: true

--- a/providers/google-vertex/google/gemini-2.5-flash-preview-09-2025.yaml
+++ b/providers/google-vertex/google/gemini-2.5-flash-preview-09-2025.yaml
@@ -13,6 +13,7 @@ features:
     - structured_output
     - code_execution
     - json_output
+isDeprecated: true
 limits:
     context_window: 1048576
     max_input_tokens: 1048576
@@ -35,7 +36,7 @@ params:
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-flash
     - https://ai.google.dev/pricing
-status: preview
+status: retired
 supportedModes:
     - chat
 thinking: true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes model lifecycle metadata to `retired`, which may break users who still reference these model IDs. The Bedrock param filtering tweak is low risk but could affect request shaping if callers were sending `temperature`.
> 
> **Overview**
> Marks `gemini-2.5-flash-preview-09-2025` as **retired** across `google-gemini` and both `google-vertex` model IDs, and flags the Vertex variants with `isDeprecated: true` (replacing the prior `preview` status).
> 
> Updates the AWS Bedrock `cohere.embed-multilingual-v3` config to drop `temperature` via `removeParams`, preventing that parameter from being forwarded for embedding requests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bbe3206e2ca46587ed9b3617f6aa53ff2d32bcf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->