### PR TITLE
chore: provision models

### DIFF
--- a/providers/together-ai/Hcompany/Holo3-35B-A3B.yaml
+++ b/providers/together-ai/Hcompany/Holo3-35B-A3B.yaml
@@ -11,6 +11,7 @@ modalities:
         - text
 mode: chat
 model: Hcompany/Holo3-35B-A3B
+provisioning: provisioned
 status: active
 supportedModes:
     - chat

--- a/providers/together-ai/MiniMaxAI/MiniMax-M2.5-FP4.yaml
+++ b/providers/together-ai/MiniMaxAI/MiniMax-M2.5-FP4.yaml
@@ -15,6 +15,7 @@ modalities:
         - text
 mode: chat
 model: MiniMaxAI/MiniMax-M2.5-FP4
+provisioning: provisioned
 status: active
 supportedModes:
     - chat

--- a/providers/together-ai/MiniMaxAI/MiniMax-M2.yaml
+++ b/providers/together-ai/MiniMaxAI/MiniMax-M2.yaml
@@ -16,6 +16,7 @@ modalities:
         - text
 mode: chat
 model: MiniMaxAI/MiniMax-M2
+provisioning: provisioned
 sources:
     - https://together.ai/models
     - https://docs.together.ai/docs/serverless-models

--- a/providers/together-ai/Qwen/Qwen2.5-72B.yaml
+++ b/providers/together-ai/Qwen/Qwen2.5-72B.yaml
@@ -16,6 +16,7 @@ modalities:
         - text
 mode: chat
 model: Qwen/Qwen2.5-72B
+provisioning: provisioned
 sources:
     - https://www.together.ai/pricing
 status: active

--- a/providers/together-ai/Qwen/Qwen2.5-7B-Instruct.yaml
+++ b/providers/together-ai/Qwen/Qwen2.5-7B-Instruct.yaml
@@ -14,6 +14,7 @@ modalities:
         - text
 mode: chat
 model: Qwen/Qwen2.5-7B-Instruct
+provisioning: provisioned
 status: active
 supportedModes:
     - chat

--- a/providers/together-ai/Qwen/Qwen3-30B-A3B-Instruct-2507-Lora.yaml
+++ b/providers/together-ai/Qwen/Qwen3-30B-A3B-Instruct-2507-Lora.yaml
@@ -20,6 +20,7 @@ modalities:
         - text
 mode: chat
 model: Qwen/Qwen3-30B-A3B-Instruct-2507-Lora
+provisioning: provisioned
 status: active
 supportedModes:
     - chat

--- a/providers/together-ai/Qwen/Qwen3-30B-A3B.yaml
+++ b/providers/together-ai/Qwen/Qwen3-30B-A3B.yaml
@@ -15,6 +15,7 @@ modalities:
         - text
 mode: chat
 model: Qwen/Qwen3-30B-A3B
+provisioning: provisioned
 sources:
     - https://huggingface.co/Qwen/Qwen3-30B-A3B
 status: active

--- a/providers/together-ai/Qwen/Qwen3-4B-Instruct-2507.yaml
+++ b/providers/together-ai/Qwen/Qwen3-4B-Instruct-2507.yaml
@@ -17,6 +17,7 @@ modalities:
         - text
 mode: chat
 model: Qwen/Qwen3-4B-Instruct-2507
+provisioning: provisioned
 status: active
 supportedModes:
     - chat

--- a/providers/together-ai/Qwen/Qwen3-8B-Lora.yaml
+++ b/providers/together-ai/Qwen/Qwen3-8B-Lora.yaml
@@ -9,6 +9,7 @@ modalities:
         - text
 mode: chat
 model: Qwen/Qwen3-8B-Lora
+provisioning: provisioned
 sources:
     - https://docs.together.ai/docs/fine-tuning-models
 status: active

--- a/providers/together-ai/Qwen/Qwen3-Next-80B-A3B-Instruct-FP8.yaml
+++ b/providers/together-ai/Qwen/Qwen3-Next-80B-A3B-Instruct-FP8.yaml
@@ -14,6 +14,7 @@ modalities:
         - text
 mode: chat
 model: Qwen/Qwen3-Next-80B-A3B-Instruct-FP8
+provisioning: provisioned
 sources:
     - https://docs.together.ai/docs/serverless-models
 supportedModes:

--- a/providers/together-ai/Qwen/Qwen3.5-27B.yaml
+++ b/providers/together-ai/Qwen/Qwen3.5-27B.yaml
@@ -18,6 +18,7 @@ modalities:
         - text
 mode: chat
 model: Qwen/Qwen3.5-27B
+provisioning: provisioned
 sources:
     - https://huggingface.co/Qwen/Qwen3.5-27B
 status: active

--- a/providers/together-ai/Qwen/Qwen3.5-35B-A3B.yaml
+++ b/providers/together-ai/Qwen/Qwen3.5-35B-A3B.yaml
@@ -18,6 +18,7 @@ modalities:
         - text
 mode: chat
 model: Qwen/Qwen3.5-35B-A3B
+provisioning: provisioned
 sources:
     - https://together.ai/pricing
     - https://docs.together.ai/docs/serverless-models

--- a/providers/together-ai/Qwen/Qwen3.5-397B-A17B-FP8.yaml
+++ b/providers/together-ai/Qwen/Qwen3.5-397B-A17B-FP8.yaml
@@ -17,6 +17,7 @@ modalities:
         - text
 mode: chat
 model: Qwen/Qwen3.5-397B-A17B-FP8
+provisioning: provisioned
 sources:
     - https://docs.together.ai/docs/json-mode
 supportedModes:

--- a/providers/together-ai/Qwen/Qwen3.5-9B-FP8.yaml
+++ b/providers/together-ai/Qwen/Qwen3.5-9B-FP8.yaml
@@ -15,6 +15,7 @@ modalities:
         - text
 mode: chat
 model: Qwen/Qwen3.5-9B-FP8
+provisioning: provisioned
 sources:
     - https://together.ai/models
     - https://docs.together.ai/docs/serverless-models

--- a/providers/together-ai/ServiceNow-AI/Apriel-1.5-15b-Thinker.yaml
+++ b/providers/together-ai/ServiceNow-AI/Apriel-1.5-15b-Thinker.yaml
@@ -15,6 +15,7 @@ modalities:
         - text
 mode: chat
 model: ServiceNow-AI/Apriel-1.5-15b-Thinker
+provisioning: provisioned
 sources:
     - https://together.ai/pricing
     - https://huggingface.co/ServiceNow-AI/Apriel-1.5-15b-Thinker

--- a/providers/together-ai/ServiceNow-AI/Apriel-1.6-15b-Thinker.yaml
+++ b/providers/together-ai/ServiceNow-AI/Apriel-1.6-15b-Thinker.yaml
@@ -15,6 +15,7 @@ modalities:
         - text
 mode: chat
 model: ServiceNow-AI/Apriel-1.6-15b-Thinker
+provisioning: provisioned
 sources:
     - https://www.together.ai/pricing
     - https://huggingface.co/ServiceNow-AI/Apriel-1.6-15b-Thinker

--- a/providers/together-ai/deepcogito/cogito-v1-preview-llama-70B-Turbo.yaml
+++ b/providers/together-ai/deepcogito/cogito-v1-preview-llama-70B-Turbo.yaml
@@ -12,6 +12,7 @@ limits:
     max_tokens: 4096
 mode: chat
 model: deepcogito/cogito-v1-preview-llama-70B-Turbo
+provisioning: provisioned
 status: preview
 supportedModes:
     - chat

--- a/providers/together-ai/deepseek-ai/DeepSeek-V3-0324.yaml
+++ b/providers/together-ai/deepseek-ai/DeepSeek-V3-0324.yaml
@@ -16,6 +16,7 @@ modalities:
         - text
 mode: chat
 model: deepseek-ai/DeepSeek-V3-0324
+provisioning: provisioned
 sources:
     - https://www.together.ai/models/deepseek-v3
     - https://www.together.ai/models/deepseek-v3-1

--- a/providers/together-ai/deepseek-ai/DeepSeek-V3.1-Base.yaml
+++ b/providers/together-ai/deepseek-ai/DeepSeek-V3.1-Base.yaml
@@ -11,6 +11,7 @@ modalities:
         - text
 mode: completion
 model: deepseek-ai/DeepSeek-V3.1-Base
+provisioning: provisioned
 sources:
     - https://together.ai/pricing
     - https://docs.together.ai/docs/deepseek-3-1-quickstart

--- a/providers/together-ai/deepseek-ai/DeepSeek-V3.1-Terminus.yaml
+++ b/providers/together-ai/deepseek-ai/DeepSeek-V3.1-Terminus.yaml
@@ -12,6 +12,7 @@ modalities:
         - text
 mode: chat
 model: deepseek-ai/DeepSeek-V3.1-Terminus
+provisioning: provisioned
 sources:
     - https://huggingface.co/deepseek-ai/DeepSeek-V3.1-Terminus
     - https://together.ai/pricing

--- a/providers/together-ai/meta-llama/Llama-3.1-405B.yaml
+++ b/providers/together-ai/meta-llama/Llama-3.1-405B.yaml
@@ -13,6 +13,7 @@ modalities:
         - text
 mode: chat
 model: meta-llama/Llama-3.1-405B
+provisioning: provisioned
 sources:
     - https://together.ai/pricing
 supportedModes:

--- a/providers/together-ai/meta-llama/Llama-3.3-70B-Instruct.yaml
+++ b/providers/together-ai/meta-llama/Llama-3.3-70B-Instruct.yaml
@@ -14,6 +14,7 @@ modalities:
         - text
 mode: chat
 model: meta-llama/Llama-3.3-70B-Instruct
+provisioning: provisioned
 sources:
     - https://www.together.ai/pricing
 status: active

--- a/providers/together-ai/meta-llama/Llama-4-Maverick-17B-128E.yaml
+++ b/providers/together-ai/meta-llama/Llama-4-Maverick-17B-128E.yaml
@@ -16,6 +16,7 @@ modalities:
         - text
 mode: chat
 model: meta-llama/Llama-4-Maverick-17B-128E
+provisioning: provisioned
 sources:
     - https://docs.together.ai/docs/serverless-models
     - https://docs.together.ai/docs/dedicated-models

--- a/providers/together-ai/meta-llama/Meta-Llama-3.1-70B.yaml
+++ b/providers/together-ai/meta-llama/Meta-Llama-3.1-70B.yaml
@@ -9,6 +9,7 @@ modalities:
         - text
 mode: completion
 model: meta-llama/Meta-Llama-3.1-70B
+provisioning: provisioned
 sources:
     - https://www.together.ai/pricing
 supportedModes:

--- a/providers/together-ai/mistralai/Mistral-7B-Instruct-v0.2.yaml
+++ b/providers/together-ai/mistralai/Mistral-7B-Instruct-v0.2.yaml
@@ -13,6 +13,7 @@ modalities:
         - text
 mode: chat
 model: mistralai/Mistral-7B-Instruct-v0.2
+provisioning: provisioned
 sources:
     - https://www.together.ai/pricing
     - https://docs.together.ai/docs/function-calling

--- a/providers/together-ai/nim/mistralai/mixtral-8x7b-instruct-v01.yaml
+++ b/providers/together-ai/nim/mistralai/mixtral-8x7b-instruct-v01.yaml
@@ -13,6 +13,7 @@ modalities:
         - text
 mode: chat
 model: nim/mistralai/mixtral-8x7b-instruct-v01
+provisioning: provisioned
 sources:
     - https://docs.together.ai/docs/dedicated-models
     - https://docs.together.ai/docs/serverless-models

--- a/providers/together-ai/togethercomputer/EssentialAI-RNJ-1-Instruct.yaml
+++ b/providers/together-ai/togethercomputer/EssentialAI-RNJ-1-Instruct.yaml
@@ -14,6 +14,7 @@ modalities:
         - text
 mode: chat
 model: togethercomputer/EssentialAI-RNJ-1-Instruct
+provisioning: provisioned
 sources:
     - https://docs.together.ai/docs/serverless-models
 status: active

--- a/providers/together-ai/togethercomputer/meta-llama-3.1-8B-Instruct-AWQ-INT4.yaml
+++ b/providers/together-ai/togethercomputer/meta-llama-3.1-8B-Instruct-AWQ-INT4.yaml
@@ -15,6 +15,7 @@ modalities:
         - text
 mode: chat
 model: togethercomputer/meta-llama-3.1-8B-Instruct-AWQ-INT4
+provisioning: provisioned
 sources:
     - https://www.together.ai/pricing
 status: active

--- a/providers/together-ai/zai-org/GLM-4.6.yaml
+++ b/providers/together-ai/zai-org/GLM-4.6.yaml
@@ -18,6 +18,7 @@ modalities:
         - text
 mode: chat
 model: zai-org/GLM-4.6
+provisioning: provisioned
 sources:
     - https://www.together.ai/models/glm-4-6
     - https://www.together.ai/pricing

--- a/providers/together-ai/zai-org/GLM-5-FP4.yaml
+++ b/providers/together-ai/zai-org/GLM-5-FP4.yaml
@@ -15,6 +15,7 @@ modalities:
         - text
 mode: chat
 model: zai-org/GLM-5-FP4
+provisioning: provisioned
 sources:
     - https://docs.together.ai/docs/serverless-models
     - https://together.ai/models


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Data-only metadata change across multiple model definition YAMLs; low risk aside from any downstream logic that filters/renders models based on the new `provisioning` field.
> 
> **Overview**
> Adds `provisioning: provisioned` to a set of Together.ai model definition YAMLs (across `Hcompany`, `MiniMaxAI`, `Qwen`, `ServiceNow-AI`, `deepcogito`, `deepseek-ai`, `meta-llama`, `mistralai`, `nim`, `togethercomputer`, and `zai-org`).
> 
> No other model settings (costs, limits, modalities, statuses, sources) are changed; this PR purely annotates these models as *provisioned*.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15d1b225e14b45b2e2040f0b360529a001f6bce7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->