### PR TITLE
fix: retire models

### DIFF
--- a/providers/openrouter/allenai/olmo-2-0325-32b-instruct.yaml
+++ b/providers/openrouter/allenai/olmo-2-0325-32b-instruct.yaml
@@ -2,6 +2,7 @@ costs:
     - input_cost_per_token: 5.e-8
       output_cost_per_token: 2.e-7
       region: "*"
+isDeprecated: true
 limits:
     context_window: 128000
 modalities:
@@ -13,5 +14,6 @@ mode: chat
 model: allenai/olmo-2-0325-32b-instruct
 sources:
     - https://openrouter.ai/allenai/olmo-2-0325-32b-instruct/api
+status: retired
 supportedModes:
     - chat

--- a/providers/openrouter/meituan/longcat-flash-chat.yaml
+++ b/providers/openrouter/meituan/longcat-flash-chat.yaml
@@ -8,6 +8,7 @@ features:
     - prompt_caching
     - structured_output
     - tool_choice
+isDeprecated: true
 limits:
     context_window: 131072
     max_output_tokens: 131072
@@ -21,5 +22,6 @@ mode: chat
 model: meituan/longcat-flash-chat
 sources:
     - https://openrouter.ai/meituan/longcat-flash-chat/api
+status: retired
 supportedModes:
     - chat

--- a/providers/openrouter/openai/gpt-3.5-turbo-instruct.yaml
+++ b/providers/openrouter/openai/gpt-3.5-turbo-instruct.yaml
@@ -5,6 +5,7 @@ costs:
 features:
     - json_output
     - structured_output
+isDeprecated: true
 limits:
     context_window: 4095
     max_output_tokens: 4096
@@ -18,5 +19,6 @@ mode: chat
 model: openai/gpt-3.5-turbo-instruct
 sources:
     - https://openrouter.ai/openai/gpt-3.5-turbo-instruct/api
+status: retired
 supportedModes:
     - chat

--- a/providers/openrouter/openai/gpt-4-turbo-preview.yaml
+++ b/providers/openrouter/openai/gpt-4-turbo-preview.yaml
@@ -7,6 +7,7 @@ features:
     - json_output
     - structured_output
     - tool_choice
+isDeprecated: true
 limits:
     context_window: 128000
     max_output_tokens: 4096
@@ -20,5 +21,6 @@ mode: chat
 model: openai/gpt-4-turbo-preview
 sources:
     - https://openrouter.ai/openai/gpt-4-turbo-preview/api
+status: retired
 supportedModes:
     - chat


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk metadata-only change: updates model catalog entries to flag four OpenRouter models as deprecated/retired, with no runtime logic changes.
> 
> **Overview**
> Marks four OpenRouter model definitions (`allenai/olmo-2-0325-32b-instruct`, `meituan/longcat-flash-chat`, `openai/gpt-3.5-turbo-instruct`, `openai/gpt-4-turbo-preview`) as **deprecated** by adding `isDeprecated: true` and setting `status: retired` in their YAML configs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 298ffae93f97c626eb56a8241864f5ac26b8d9a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->