### PR TITLE
feat(google-vertex): update model YAMLs [bot]

### DIFF
--- a/providers/google-vertex/deepseek-ai/deepseek-ocr-maas.yaml
+++ b/providers/google-vertex/deepseek-ai/deepseek-ocr-maas.yaml
@@ -1,7 +1,7 @@
 costs:
     - input_cost_per_token: 3.e-7
       output_cost_per_token: 0.0000012
-      region: global # docs specify us-central1 but the model is only available via global inference
+      region: global
 features:
     - function_calling
     - structured_output

--- a/providers/google-vertex/deepseek-ai/deepseek-v3.1-maas.yaml
+++ b/providers/google-vertex/deepseek-ai/deepseek-v3.1-maas.yaml
@@ -4,7 +4,7 @@ costs:
       input_cost_per_token_batches: 3.e-7
       output_cost_per_token: 0.0000017
       output_cost_per_token_batches: 8.5e-7
-      region: global # docs specify us-central1 but the model is only available via global inference
+      region: global
 features:
     - function_calling
     - tool_choice

--- a/providers/google-vertex/openai/gpt-oss-20b-maas.yaml
+++ b/providers/google-vertex/openai/gpt-oss-20b-maas.yaml
@@ -7,10 +7,10 @@ costs:
       region: us-central1
 features:
     - function_calling
+    - prompt_caching
     - structured_output
     - system_messages
     - tool_choice
-    - prompt_caching
 limits:
     context_window: 131072
     max_input_tokens: 131072
@@ -23,6 +23,9 @@ modalities:
         - text
 mode: chat
 model: openai/gpt-oss-20b-maas
+params:
+    - key: reasoning_effort
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/openai/gpt-oss-20b
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/openai
@@ -30,5 +33,6 @@ sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/use-open-models
 status: active
 supportedModes:
-    - completion
     - chat
+    - completion
+thinking: true


### PR DESCRIPTION
Auto-generated by poc-agent for provider `google-vertex`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk metadata-only updates to provider model YAMLs (features/params/modes) with no runtime logic changes; primary risk is misconfigured model capabilities or region affecting downstream selection.
> 
> **Overview**
> Updates Google Vertex MaaS model YAML metadata.
> 
> For `deepseek-ocr-maas` and `deepseek-v3.1-maas`, removes the inline comment from the `costs.region: global` entry (no functional change).
> 
> For `openai/gpt-oss-20b-maas`, adds `prompt_caching` to the declared `features`, introduces a `reasoning_effort` entry under `params`, marks `provisioning: serverless`, enables `completion` under `supportedModes`, and flags the model as `thinking: true`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcef94514fd7d16809f901c962dbebd08c4e1cb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->