### PR TITLE
feat(mistral-ai): update model YAMLs [bot]

### DIFF
--- a/providers/mistral-ai/ministral-14b-latest.yaml
+++ b/providers/mistral-ai/ministral-14b-latest.yaml
@@ -4,16 +4,24 @@ costs:
       region: "*"
 features:
     - function_calling
+    - parallel_function_calling
+    - tool_choice
+    - structured_output
+    - json_output
 limits:
     context_window: 262144
 modalities:
     input:
+        - text
         - image
+    output:
+        - text
 mode: chat
 model: ministral-14b-latest
 params:
     - defaultValue: 0.3
       key: temperature
+provisioning: serverless
 sources:
     - https://docs.mistral.ai/models/ministral-3-14b-25-12
     - https://docs.mistral.ai/capabilities/function_calling

--- a/providers/mistral-ai/voxtral-mini-2602.yaml
+++ b/providers/mistral-ai/voxtral-mini-2602.yaml
@@ -3,11 +3,17 @@ costs:
       region: "*"
 limits:
     context_window: 16384
+modalities:
+    input:
+        - audio
+    output:
+        - text
 mode: audio_transcription
 model: voxtral-mini-2602
 params:
     - defaultValue: 0
       key: temperature
+provisioning: serverless
 sources:
     - https://docs.mistral.ai/models/voxtral-mini-transcribe-26-02
 status: active


### PR DESCRIPTION
Auto-generated by poc-agent for provider `mistral-ai`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk YAML metadata updates that only affect model capability/mode declarations and provisioning hints; primary risk is mis-declared modalities/features impacting routing or UI feature gating.
> 
> **Overview**
> Updates Mistral AI provider model descriptors to better reflect current capabilities and I/O.
> 
> `ministral-14b-latest` now advertises additional chat features (parallel tool calls, tool choice, structured/JSON output), explicitly declares text+image input with text output, and marks provisioning as `serverless`.
> 
> `voxtral-mini-2602` now declares audio input with text output via a new `modalities` block and also marks provisioning as `serverless`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac380b43694176277add2c6ced1fee3211198d02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->