### PR TITLE
fix: provision models

### DIFF
--- a/providers/openrouter/arcee-ai/coder-large.yaml
+++ b/providers/openrouter/arcee-ai/coder-large.yaml
@@ -11,6 +11,7 @@ modalities:
         - text
 mode: chat
 model: arcee-ai/coder-large
+provisioning: provisioned
 sources:
     - https://openrouter.ai/arcee-ai/coder-large/api
 status: active

--- a/providers/openrouter/arcee-ai/maestro-reasoning.yaml
+++ b/providers/openrouter/arcee-ai/maestro-reasoning.yaml
@@ -13,6 +13,7 @@ modalities:
         - text
 mode: chat
 model: arcee-ai/maestro-reasoning
+provisioning: provisioned
 sources:
     - https://openrouter.ai/arcee-ai/maestro-reasoning/api
 status: active

--- a/providers/openrouter/arcee-ai/spotlight.yaml
+++ b/providers/openrouter/arcee-ai/spotlight.yaml
@@ -17,6 +17,7 @@ model: arcee-ai/spotlight
 params:
     - key: max_tokens
       maxValue: 65537
+provisioning: provisioned
 sources:
     - https://openrouter.ai/arcee-ai/spotlight/api
 supportedModes:

--- a/providers/openrouter/arcee-ai/virtuoso-large.yaml
+++ b/providers/openrouter/arcee-ai/virtuoso-large.yaml
@@ -17,6 +17,7 @@ modalities:
         - text
 mode: chat
 model: arcee-ai/virtuoso-large
+provisioning: provisioned
 sources:
     - https://openrouter.ai/arcee-ai/virtuoso-large/api
 supportedModes:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk config-only change that adds a `provisioning: provisioned` flag to existing model definitions; impact is limited to how these models are classified/selected at runtime.
> 
> **Overview**
> Sets `provisioning: provisioned` on four OpenRouter Arcee model configs (`coder-large`, `maestro-reasoning`, `spotlight`, `virtuoso-large`), aligning them with other provisioned model definitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 817f309943d06bf5ba64460686f798424e035722. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->