### PR TITLE
fix: region

### DIFF
--- a/providers/google-vertex/deepseek-ai/deepseek-v3.1-maas.yaml
+++ b/providers/google-vertex/deepseek-ai/deepseek-v3.1-maas.yaml
@@ -4,7 +4,7 @@ costs:
       input_cost_per_token_batches: 3.e-7
       output_cost_per_token: 0.0000017
       output_cost_per_token_batches: 8.5e-7
-      region: global # docs specify us-central1 but the model is only available via global inference
+      region: us-west2
 features:
     - function_calling
     - tool_choice

--- a/providers/google-vertex/deepseek-ai/deepseek-v3.1-maas.yaml
+++ b/providers/google-vertex/deepseek-ai/deepseek-v3.1-maas.yaml
@@ -4,7 +4,7 @@ costs:
       input_cost_per_token_batches: 3.e-7
       output_cost_per_token: 0.0000017
       output_cost_per_token_batches: 8.5e-7
-      region: us-west2
+      region: us-west2 # docs specify us-central1 but the model is available via us-west2 inference
 features:
     - function_calling
     - tool_choice

--- a/providers/sambanova/DeepSeek-V3.1-Terminus.yaml
+++ b/providers/sambanova/DeepSeek-V3.1-Terminus.yaml
@@ -8,6 +8,7 @@ features:
     - system_messages
     - structured_output
     - json_output
+isDeprecated: true
 limits:
     context_window: 128000
 messages:
@@ -27,6 +28,6 @@ sources:
     - https://docs.sambanova.ai/docs/en/features/openai-compatibility
     - https://docs.sambanova.ai/docs/api-reference/chat-completions/create-chat-based-completion
     - https://docs.sambanova.ai/docs/en/build/reasoning
-status: preview
+status: retired
 supportedModes:
     - chat


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk metadata-only updates to provider model descriptors; main impact is routing/availability selection for these models.
> 
> **Overview**
> Updates provider model metadata: the Google Vertex `deepseek-v3.1-maas` config now targets **`us-west2`** (instead of `global`) for inference.
> 
> Marks SambaNova `DeepSeek-V3.1-Terminus` as **deprecated** and changes its `status` from `preview` to `retired` to prevent it being treated as an active/preview offering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6983bdccd2563557fbfc09aaa671fcb92e50cbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->