### PR TITLE
feat(google-gemini): add new models [bot]

### DIFF
--- a/providers/google-gemini/gemini-robotics-er-1.6-preview.yaml
+++ b/providers/google-gemini/gemini-robotics-er-1.6-preview.yaml
@@ -1,0 +1,14 @@
+limits:
+    max_input_tokens: 131072
+    max_output_tokens: 65536
+mode: unknown
+model: gemini-robotics-er-1.6-preview
+params:
+    - defaultValue: 1
+      key: temperature
+      maxValue: 2
+    - defaultValue: 0.95
+      key: top_p
+    - defaultValue: 64
+      key: top_k
+thinking: true


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `google-gemini`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new `google-gemini` model definition YAML without changing runtime code paths; main risk is misconfigured limits/params affecting users selecting this model.
> 
> **Overview**
> Adds a new `google-gemini` model definition for `gemini-robotics-er-1.6-preview`, including token limits, supported generation params (`temperature`, `top_p`, `top_k`), and enabling `thinking`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a85516b8eefc296d69c6dbcbbf32f9cf85a021e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->