### PR TITLE
feat(google-vertex): add new models [bot]

### DIFF
--- a/providers/google-vertex/deepseek-ai/deepseek-ocr-maas.yaml
+++ b/providers/google-vertex/deepseek-ai/deepseek-ocr-maas.yaml
@@ -1,7 +1,7 @@
 costs:
     - input_cost_per_token: 3.e-7
       output_cost_per_token: 0.0000012
-      region: global # docs specify us-central1 but the model is only available via global inference
+      region: global
 features:
     - function_calling
     - structured_output

--- a/providers/google-vertex/deepseek-ai/deepseek-v3.1-maas.yaml
+++ b/providers/google-vertex/deepseek-ai/deepseek-v3.1-maas.yaml
@@ -4,7 +4,7 @@ costs:
       input_cost_per_token_batches: 3.e-7
       output_cost_per_token: 0.0000017
       output_cost_per_token_batches: 8.5e-7
-      region: us-west2 # docs specify us-central1 but the model is available via us-west2 inference
+      region: us-west2
 features:
     - function_calling
     - tool_choice

--- a/providers/google-vertex/xai/grok-4.20-reasoning.yaml
+++ b/providers/google-vertex/xai/grok-4.20-reasoning.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: xai/grok-4.20-reasoning


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `google-vertex`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk metadata-only changes; affects model catalog/configuration but not runtime logic. Main risk is misconfiguration (e.g., `mode: unknown` or region values) impacting model availability selection.
> 
> **Overview**
> Adds a new Google Vertex model entry for `xai/grok-4.20-reasoning` (with `mode: unknown`).
> 
> Cleans up the DeepSeek MaaS model YAMLs by removing inline comments from the `region` fields while keeping the same region values (`global` for `deepseek-ocr-maas`, `us-west2` for `deepseek-v3.1-maas`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 461eb244e2044817c69fff18c8cf6cdd8c09ae77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->