### PR TITLE
feat(together-ai): add new models [bot]

### DIFF
--- a/providers/together-ai/vidu/vidu-q3-turbo.yaml
+++ b/providers/together-ai/vidu/vidu-q3-turbo.yaml
@@ -1,0 +1,8 @@
+costs:
+    - input_cost_per_token: 0
+      output_cost_per_token: 0
+      region: "*"
+mode: unknown
+model: vidu/vidu-q3-turbo
+supportedModes:
+    - video

--- a/providers/together-ai/vidu/vidu-q3.yaml
+++ b/providers/together-ai/vidu/vidu-q3.yaml
@@ -1,0 +1,8 @@
+costs:
+    - input_cost_per_token: 0
+      output_cost_per_token: 0
+      region: "*"
+mode: unknown
+model: vidu/vidu-q3
+supportedModes:
+    - video


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `together-ai`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adds two new Together AI model definition YAMLs, with no changes to runtime logic. Main risk is misconfiguration (e.g., `mode: unknown`/cost fields) affecting model discovery or selection for these new entries.
> 
> **Overview**
> Registers two new Together AI model configs, `vidu/vidu-q3` and `vidu/vidu-q3-turbo`, under `providers/together-ai/vidu/`.
> 
> Each definition sets zero token costs, `mode: unknown`, and declares `supportedModes: [video]` to enable these models to be surfaced as video-capable options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c563924255f9ac41321c05488ac6baffb5b0dcb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->