### PR TITLE
remove deepinfra unsupported features

### DIFF
--- a/providers/deepinfra/ByteDance/Seed-1.8.yaml
+++ b/providers/deepinfra/ByteDance/Seed-1.8.yaml
@@ -16,7 +16,6 @@ costs:
 features:
     - function_calling
     - prompt_caching
-    - structured_output
 limits:
     context_window: 256000
     max_output_tokens: 256000

--- a/providers/deepinfra/ByteDance/Seed-2.0-mini.yaml
+++ b/providers/deepinfra/ByteDance/Seed-2.0-mini.yaml
@@ -17,7 +17,6 @@ features:
     - function_calling
     - json_output
     - prompt_caching
-    - structured_output
 limits:
     context_window: 256000
 modalities:

--- a/providers/deepinfra/ByteDance/Seed-2.0-pro.yaml
+++ b/providers/deepinfra/ByteDance/Seed-2.0-pro.yaml
@@ -16,7 +16,6 @@ costs:
 features:
     - function_calling
     - prompt_caching
-    - structured_output
     - json_output
 limits:
     context_window: 256000

--- a/providers/deepinfra/MiniMaxAI/MiniMax-M2.1.yaml
+++ b/providers/deepinfra/MiniMaxAI/MiniMax-M2.1.yaml
@@ -6,7 +6,6 @@ costs:
 features:
     - prompt_caching
     - function_calling
-    - structured_output
     - json_output
 limits:
     context_window: 196608

--- a/providers/deepinfra/MiniMaxAI/MiniMax-M2.5.yaml
+++ b/providers/deepinfra/MiniMaxAI/MiniMax-M2.5.yaml
@@ -6,7 +6,6 @@ costs:
 features:
     - function_calling
     - prompt_caching
-    - structured_output
 limits:
     context_window: 196608
     max_output_tokens: 131072

--- a/providers/deepinfra/Qwen/Qwen3-Max-Thinking.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Max-Thinking.yaml
@@ -23,7 +23,6 @@ features:
     - function_calling
     - json_output
     - prompt_caching
-    - structured_output
 limits:
     context_window: 256000
     max_output_tokens: 16384

--- a/providers/deepinfra/Qwen/Qwen3-Max.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Max.yaml
@@ -23,7 +23,6 @@ features:
     - function_calling
     - json_output
     - prompt_caching
-    - structured_output
     - tool_choice
 limits:
     context_window: 262144

--- a/providers/deepinfra/deepseek-ai/DeepSeek-R1-0528-Turbo.yaml
+++ b/providers/deepinfra/deepseek-ai/DeepSeek-R1-0528-Turbo.yaml
@@ -5,7 +5,6 @@ costs:
 features:
     - function_calling
     - tool_choice
-    - structured_output
     - json_output
 limits:
     context_window: 32768

--- a/providers/deepinfra/meta-llama/Llama-3.2-3B-Instruct.yaml
+++ b/providers/deepinfra/meta-llama/Llama-3.2-3B-Instruct.yaml
@@ -2,9 +2,6 @@ costs:
     - input_cost_per_token: 2.e-8
       output_cost_per_token: 2.e-8
       region: "*"
-features:
-    - function_calling
-    - tool_choice
 limits:
     context_window: 131072
     max_input_tokens: 131072

--- a/providers/deepinfra/mistralai/Mistral-Small-24B-Instruct-2501.yaml
+++ b/providers/deepinfra/mistralai/Mistral-Small-24B-Instruct-2501.yaml
@@ -3,8 +3,6 @@ costs:
       output_cost_per_token: 8.e-8
       region: "*"
 features:
-    - function_calling
-    - tool_choice
     - structured_output
     - json_output
 limits:

--- a/providers/deepinfra/stepfun-ai/Step-3.5-Flash.yaml
+++ b/providers/deepinfra/stepfun-ai/Step-3.5-Flash.yaml
@@ -6,7 +6,6 @@ costs:
 features:
     - function_calling
     - prompt_caching
-    - structured_output
 limits:
     context_window: 262144
     max_output_tokens: 262144


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk metadata-only change, but it can affect capability detection (e.g., clients may stop attempting `structured_output`/tool calling on these DeepInfra models).
> 
> **Overview**
> Removes the `structured_output` feature flag from multiple DeepInfra model manifests (ByteDance Seed, MiniMax, Qwen3 Max, DeepSeek R1 Turbo, and Step-3.5-Flash), aligning advertised capabilities with expected provider support.
> 
> Also drops the entire `features` block from `meta-llama/Llama-3.2-3B-Instruct` and removes `function_calling`/`tool_choice` from `mistralai/Mistral-Small-24B-Instruct-2501`, leaving it advertised primarily for `structured_output`/`json_output`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25bf71e2653d6da4343540a0b19e859b55946b3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->