### PR TITLE
feat(aws-bedrock): update model YAMLs [bot]

### DIFF
--- a/providers/aws-bedrock/ai21.jamba-1-5-large-v1:0.yaml
+++ b/providers/aws-bedrock/ai21.jamba-1-5-large-v1:0.yaml
@@ -3,7 +3,9 @@ costs:
       output_cost_per_token: 0.000008
       region: us-east-1
 features:
+    - function_calling
     - system_messages
+    - json_output
 limits:
     context_window: 256000
     max_input_tokens: 256000
@@ -33,6 +35,7 @@ params:
       key: "n"
       maxValue: 16
       minValue: 1
+provisioning: serverless
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-jamba.html
     - https://www.ai21.com/jamba

--- a/providers/aws-bedrock/ai21.jamba-1-5-mini-v1:0.yaml
+++ b/providers/aws-bedrock/ai21.jamba-1-5-mini-v1:0.yaml
@@ -25,10 +25,13 @@ params:
       key: temperature
       maxValue: 2
       minValue: 0
+    - key: top_p
+      minValue: 0.01
     - defaultValue: 1
       key: "n"
       maxValue: 16
       minValue: 1
+provisioning: serverless
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-jamba.html
 status: active

--- a/providers/aws-bedrock/amazon.nova-2-multimodal-embeddings-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.nova-2-multimodal-embeddings-v1:0.yaml
@@ -16,6 +16,7 @@ modalities:
         - embedding
 mode: embedding
 model: amazon.nova-2-multimodal-embeddings-v1:0
+provisioning: serverless
 removeParams:
     - temperature
     - top_p

--- a/providers/aws-bedrock/amazon.nova-reel-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.nova-reel-v1:0.yaml
@@ -5,6 +5,8 @@ costs:
       region: eu-west-1
     - output_cost_per_second: 0.08
       region: ap-northeast-1
+deprecationDate: "2026-03-30"
+isDeprecated: true
 modalities:
     input:
         - text

--- a/providers/aws-bedrock/amazon.nova-reel-v1:1.yaml
+++ b/providers/aws-bedrock/amazon.nova-reel-v1:1.yaml
@@ -1,6 +1,8 @@
 costs:
     - output_cost_per_second: 0.08
       region: us-east-1
+deprecationDate: "2026-03-30"
+isDeprecated: true
 modalities:
     input:
         - text

--- a/providers/aws-bedrock/amazon.titan-embed-text-v1.yaml
+++ b/providers/aws-bedrock/amazon.titan-embed-text-v1.yaml
@@ -21,6 +21,7 @@ modalities:
         - embedding
 mode: embedding
 model: amazon.titan-embed-text-v1
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature

--- a/providers/aws-bedrock/amazon.titan-embed-text-v2:0.yaml
+++ b/providers/aws-bedrock/amazon.titan-embed-text-v2:0.yaml
@@ -66,6 +66,7 @@ modalities:
         - embedding
 mode: embedding
 model: amazon.titan-embed-text-v2:0
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature

--- a/providers/aws-bedrock/apac.amazon.nova-micro-v1:0.yaml
+++ b/providers/aws-bedrock/apac.amazon.nova-micro-v1:0.yaml
@@ -48,6 +48,7 @@ params:
       key: max_tokens
       maxValue: 5000
       minValue: 1
+provisioning: serverless
 sources:
     - https://docs.aws.amazon.com/nova/latest/userguide/what-is-nova.html
     - https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference-support.html

--- a/providers/aws-bedrock/apac.anthropic.claude-sonnet-4-20250514-v1:0.yaml
+++ b/providers/aws-bedrock/apac.anthropic.claude-sonnet-4-20250514-v1:0.yaml
@@ -76,6 +76,7 @@ costs:
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: ap-east-2
+deprecationDate: "2026-06-15"
 features:
     - function_calling
     - prompt_caching
@@ -83,6 +84,7 @@ features:
     - system_messages
     - tool_choice
     - assistant_prefill
+isDeprecated: true
 limits:
     context_window: 200000
     max_input_tokens: 200000

--- a/providers/aws-bedrock/au.anthropic.claude-haiku-4-5-20251001-v1:0.yaml
+++ b/providers/aws-bedrock/au.anthropic.claude-haiku-4-5-20251001-v1:0.yaml
@@ -38,6 +38,7 @@ params:
       key: max_tokens
       maxValue: 64000
       minValue: 1
+provisioning: serverless
 sources:
     - https://platform.claude.com/docs/en/docs/about-claude/models
     - https://platform.claude.com/docs/en/about-claude/pricing

--- a/providers/aws-bedrock/au.anthropic.claude-opus-4-6-v1.yaml
+++ b/providers/aws-bedrock/au.anthropic.claude-opus-4-6-v1.yaml
@@ -39,6 +39,7 @@ params:
       key: max_tokens
       maxValue: 128000
       minValue: 1
+provisioning: serverless
 removeParams:
     - "n"
 sources:

--- a/providers/aws-bedrock/au.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
+++ b/providers/aws-bedrock/au.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
@@ -6,6 +6,19 @@ costs:
       output_cost_per_token: 0.0000165
       output_cost_per_token_batches: 0.00000825
       region: ap-southeast-4
+      tiered_pricing:
+          cache_read:
+              - cost_per_token: 6.6e-7
+                from: 200000
+          cache_write:
+              - cost_per_token: 0.00000825
+                from: 200000
+          input:
+              - cost_per_token: 0.0000066
+                from: 200000
+          output:
+              - cost_per_token: 0.00002475
+                from: 200000
     - cache_creation_input_token_cost: 0.000004125
       cache_read_input_token_cost: 3.3e-7
       input_cost_per_token: 0.0000033
@@ -13,6 +26,19 @@ costs:
       output_cost_per_token: 0.0000165
       output_cost_per_token_batches: 0.00000825
       region: ap-southeast-2
+      tiered_pricing:
+          cache_read:
+              - cost_per_token: 6.6e-7
+                from: 200000
+          cache_write:
+              - cost_per_token: 0.00000825
+                from: 200000
+          input:
+              - cost_per_token: 0.0000066
+                from: 200000
+          output:
+              - cost_per_token: 0.00002475
+                from: 200000
 features:
     - function_calling
     - prompt_caching

--- a/providers/aws-bedrock/au.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
+++ b/providers/aws-bedrock/au.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
@@ -6,19 +6,6 @@ costs:
       output_cost_per_token: 0.0000165
       output_cost_per_token_batches: 0.00000825
       region: ap-southeast-4
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 6.6e-7
-                from: 200000
-          cache_write:
-              - cost_per_token: 0.00000825
-                from: 200000
-          input:
-              - cost_per_token: 0.0000066
-                from: 200000
-          output:
-              - cost_per_token: 0.00002475
-                from: 200000
     - cache_creation_input_token_cost: 0.000004125
       cache_read_input_token_cost: 3.3e-7
       input_cost_per_token: 0.0000033
@@ -26,19 +13,6 @@ costs:
       output_cost_per_token: 0.0000165
       output_cost_per_token_batches: 0.00000825
       region: ap-southeast-2
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 6.6e-7
-                from: 200000
-          cache_write:
-              - cost_per_token: 0.00000825
-                from: 200000
-          input:
-              - cost_per_token: 0.0000066
-                from: 200000
-          output:
-              - cost_per_token: 0.00002475
-                from: 200000
 features:
     - function_calling
     - prompt_caching
@@ -64,6 +38,7 @@ params:
       key: max_tokens
       maxValue: 64000
       minValue: 1
+provisioning: serverless
 removeParams:
     - "n"
 sources:

--- a/providers/aws-bedrock/cohere.embed-english-v3.yaml
+++ b/providers/aws-bedrock/cohere.embed-english-v3.yaml
@@ -46,6 +46,7 @@ modalities:
         - embedding
 mode: embedding
 model: cohere.embed-english-v3
+provisioning: serverless
 removeParams:
     - temperature
     - top_p

--- a/providers/aws-bedrock/cohere.embed-multilingual-v3.yaml
+++ b/providers/aws-bedrock/cohere.embed-multilingual-v3.yaml
@@ -46,10 +46,14 @@ modalities:
         - embedding
 mode: embedding
 model: cohere.embed-multilingual-v3
+provisioning: serverless
 removeParams:
     - stream
     - max_tokens
     - temperature
+    - top_p
+    - "n"
+    - stop
 sources:
     - https://docs.cohere.com/docs/cohere-embed
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-embed-v3.html

--- a/providers/aws-bedrock/cohere.rerank-v3-5:0.yaml
+++ b/providers/aws-bedrock/cohere.rerank-v3-5:0.yaml
@@ -18,6 +18,7 @@ modalities:
         - text
 mode: rerank
 model: cohere.rerank-v3-5:0
+provisioning: serverless
 removeParams:
     - stream
     - temperature

--- a/providers/aws-bedrock/deepseek.v3-v1:0.yaml
+++ b/providers/aws-bedrock/deepseek.v3-v1:0.yaml
@@ -27,8 +27,8 @@ features:
     - function_calling
 limits:
     context_window: 128000
-    max_output_tokens: 8000
-    max_tokens: 8000
+    max_output_tokens: 8192
+    max_tokens: 8192
 modalities:
     input:
         - text
@@ -39,8 +39,9 @@ model: deepseek.v3-v1:0
 params:
     - defaultValue: 4096
       key: max_tokens
-      maxValue: 8000
+      maxValue: 8192
       minValue: 1
+provisioning: serverless
 removeParams:
     - "n"
 sources:

--- a/providers/aws-bedrock/deepseek.v3.2.yaml
+++ b/providers/aws-bedrock/deepseek.v3.2.yaml
@@ -46,6 +46,7 @@ params:
       key: max_tokens
       maxValue: 8000
       minValue: 1
+provisioning: serverless
 sources:
     - https://api-docs.deepseek.com/quick_start/pricing
     - https://api-docs.deepseek.com/api/create-chat-completion

--- a/providers/aws-bedrock/eu.amazon.nova-2-lite-v1:0.yaml
+++ b/providers/aws-bedrock/eu.amazon.nova-2-lite-v1:0.yaml
@@ -1,25 +1,25 @@
 costs:
-    - cache_read_input_token_cost: 1.1e-7
+    - cache_read_input_token_cost: 1.21e-7
       input_cost_per_token: 4.84e-7
       output_cost_per_token: 0.000004059
       region: eu-west-3
-    - cache_read_input_token_cost: 8.5e-8
+    - cache_read_input_token_cost: 9.35e-8
       input_cost_per_token: 3.74e-7
       output_cost_per_token: 0.000003157
       region: eu-west-1
-    - cache_read_input_token_cost: 8.25e-8
+    - cache_read_input_token_cost: 9.075e-8
       input_cost_per_token: 3.63e-7
       output_cost_per_token: 0.000003205
       region: eu-south-2
-    - cache_read_input_token_cost: 8.25e-8
+    - cache_read_input_token_cost: 1.32e-7
       input_cost_per_token: 5.28e-7
       output_cost_per_token: 0.000004411
       region: eu-south-1
-    - cache_read_input_token_cost: 8.25e-8
+    - cache_read_input_token_cost: 9.075e-8
       input_cost_per_token: 3.63e-7
       output_cost_per_token: 0.000002992
       region: eu-north-1
-    - cache_read_input_token_cost: 9.75e-8
+    - cache_read_input_token_cost: 1.0725e-7
       input_cost_per_token: 4.29e-7
       output_cost_per_token: 0.000003597
       region: eu-central-1
@@ -47,6 +47,7 @@ params:
       key: max_tokens
       maxValue: 65536
       minValue: 1
+provisioning: serverless
 sources:
     - https://docs.aws.amazon.com/nova/latest/nova2-userguide/what-is-nova-2.html
     - https://docs.aws.amazon.com/ai/responsible-ai/nova-2-lite/overview.html

--- a/providers/aws-bedrock/eu.amazon.nova-2-lite-v1:0.yaml
+++ b/providers/aws-bedrock/eu.amazon.nova-2-lite-v1:0.yaml
@@ -1,26 +1,20 @@
 costs:
-    - cache_read_input_token_cost: 1.21e-7
-      input_cost_per_token: 4.84e-7
+    - input_cost_per_token: 4.84e-7
       output_cost_per_token: 0.000004059
       region: eu-west-3
-    - cache_read_input_token_cost: 9.35e-8
-      input_cost_per_token: 3.74e-7
+    - input_cost_per_token: 3.74e-7
       output_cost_per_token: 0.000003157
       region: eu-west-1
-    - cache_read_input_token_cost: 9.075e-8
-      input_cost_per_token: 3.63e-7
+    - input_cost_per_token: 3.63e-7
       output_cost_per_token: 0.000003205
       region: eu-south-2
-    - cache_read_input_token_cost: 1.32e-7
-      input_cost_per_token: 5.28e-7
+    - input_cost_per_token: 5.28e-7
       output_cost_per_token: 0.000004411
       region: eu-south-1
-    - cache_read_input_token_cost: 9.075e-8
-      input_cost_per_token: 3.63e-7
+    - input_cost_per_token: 3.63e-7
       output_cost_per_token: 0.000002992
       region: eu-north-1
-    - cache_read_input_token_cost: 1.0725e-7
-      input_cost_per_token: 4.29e-7
+    - input_cost_per_token: 4.29e-7
       output_cost_per_token: 0.000003597
       region: eu-central-1
 features:
@@ -47,7 +41,6 @@ params:
       key: max_tokens
       maxValue: 65536
       minValue: 1
-provisioning: serverless
 sources:
     - https://docs.aws.amazon.com/nova/latest/nova2-userguide/what-is-nova-2.html
     - https://docs.aws.amazon.com/ai/responsible-ai/nova-2-lite/overview.html

--- a/providers/aws-bedrock/eu.anthropic.claude-haiku-4-5-20251001-v1:0.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-haiku-4-5-20251001-v1:0.yaml
@@ -85,6 +85,7 @@ params:
       maxValue: 128000
       minValue: 1024
       type: number
+provisioning: serverless
 removeParams:
     - top_p
 sources:

--- a/providers/aws-bedrock/eu.anthropic.claude-opus-4-5-20251101-v1:0.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-opus-4-5-20251101-v1:0.yaml
@@ -83,6 +83,7 @@ params:
       maxValue: 128000
       minValue: 1024
       type: number
+provisioning: serverless
 removeParams:
     - temperature
     - top_p

--- a/providers/aws-bedrock/eu.anthropic.claude-opus-4-6-v1.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-opus-4-6-v1.yaml
@@ -83,6 +83,7 @@ params:
       key: max_tokens
       maxValue: 128000
       minValue: 1
+provisioning: serverless
 sources:
     - https://platform.claude.com/docs/en/docs/about-claude/models
     - https://platform.claude.com/docs/en/about-claude/pricing

--- a/providers/aws-bedrock/eu.anthropic.claude-sonnet-4-20250514-v1:0.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-sonnet-4-20250514-v1:0.yaml
@@ -108,6 +108,7 @@ costs:
           output:
               - cost_per_token: 0.0000225
                 from: 200001
+deprecationDate: "2026-06-15"
 features:
     - function_calling
     - tool_choice
@@ -115,6 +116,7 @@ features:
     - cache_control
     - prompt_caching
     - assistant_prefill
+isDeprecated: true
 limits:
     context_window: 200000
     max_input_tokens: 200000

--- a/providers/aws-bedrock/eu.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
@@ -86,6 +86,7 @@ params:
       type: number
     - key: tool_choice
       type: json
+provisioning: serverless
 removeParams:
     - top_p
 sources:

--- a/providers/aws-bedrock/eu.anthropic.claude-sonnet-4-6.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-sonnet-4-6.yaml
@@ -56,12 +56,12 @@ costs:
       output_cost_per_token_batches: 0.00000825
       region: eu-central-1
 features:
-    - function_calling
-    - tool_choice
-    - prompt_caching
-    - cache_control
-    - system_messages
     - assistant_prefill
+    - cache_control
+    - function_calling
+    - prompt_caching
+    - system_messages
+    - tool_choice
 limits:
     context_window: 1000000
     max_output_tokens: 64000
@@ -80,6 +80,7 @@ params:
       key: max_tokens
       maxValue: 64000
       minValue: 1
+provisioning: serverless
 sources:
     - https://platform.claude.com/docs/en/docs/about-claude/models
     - https://platform.claude.com/docs/en/about-claude/pricing

--- a/providers/aws-bedrock/eu.cohere.embed-v4:0.yaml
+++ b/providers/aws-bedrock/eu.cohere.embed-v4:0.yaml
@@ -23,6 +23,7 @@ modalities:
         - embedding
 mode: embedding
 model: eu.cohere.embed-v4:0
+provisioning: serverless
 removeParams:
     - temperature
     - top_p

--- a/providers/aws-bedrock/eu.mistral.pixtral-large-2502-v1:0.yaml
+++ b/providers/aws-bedrock/eu.mistral.pixtral-large-2502-v1:0.yaml
@@ -14,6 +14,7 @@ costs:
 features:
     - function_calling
     - system_messages
+    - json_output
 limits:
     context_window: 128000
     max_input_tokens: 128000
@@ -33,11 +34,12 @@ params:
       key: max_tokens
       maxValue: 4096
       minValue: 1
+provisioning: serverless
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-mistral-pixtral-large.html
     - https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html
     - https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference-supported-models-features.html
-    - https://docs.mistral.ai/models/pixtral-large-24-11
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html
 status: active
 supportedModes:
     - chat

--- a/providers/aws-bedrock/global.amazon.nova-2-lite-v1:0.yaml
+++ b/providers/aws-bedrock/global.amazon.nova-2-lite-v1:0.yaml
@@ -100,6 +100,8 @@ costs:
       output_cost_per_token: 0.00000301
       region: ap-east-2
 features:
+    - function_calling
+    - code_execution
     - prompt_caching
 limits:
     context_window: 1000000

--- a/providers/aws-bedrock/global.amazon.nova-2-lite-v1:0.yaml
+++ b/providers/aws-bedrock/global.amazon.nova-2-lite-v1:0.yaml
@@ -100,8 +100,6 @@ costs:
       output_cost_per_token: 0.00000301
       region: ap-east-2
 features:
-    - function_calling
-    - code_execution
     - prompt_caching
 limits:
     context_window: 1000000
@@ -123,6 +121,7 @@ params:
       key: max_tokens
       maxValue: 65536
       minValue: 1
+provisioning: serverless
 sources:
     - https://docs.aws.amazon.com/nova/latest/nova2-userguide/what-is-nova-2.html
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html

--- a/providers/aws-bedrock/global.anthropic.claude-haiku-4-5-20251001-v1:0.yaml
+++ b/providers/aws-bedrock/global.anthropic.claude-haiku-4-5-20251001-v1:0.yaml
@@ -251,6 +251,7 @@ params:
       maxValue: 128000
       minValue: 1024
       type: number
+provisioning: serverless
 removeParams:
     - top_p
 sources:

--- a/providers/aws-bedrock/global.anthropic.claude-sonnet-4-20250514-v1:0.yaml
+++ b/providers/aws-bedrock/global.anthropic.claude-sonnet-4-20250514-v1:0.yaml
@@ -32,6 +32,7 @@ costs:
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ap-northeast-1
+deprecationDate: "2026-06-15"
 features:
     - function_calling
     - prompt_caching
@@ -39,6 +40,7 @@ features:
     - system_messages
     - tool_choice
     - assistant_prefill
+isDeprecated: true
 limits:
     context_window: 200000
     max_input_tokens: 200000

--- a/providers/aws-bedrock/global.anthropic.claude-sonnet-4-6.yaml
+++ b/providers/aws-bedrock/global.anthropic.claude-sonnet-4-6.yaml
@@ -250,9 +250,11 @@ params:
       key: max_tokens
       maxValue: 64000
       minValue: 1
+provisioning: serverless
 sources:
     - https://platform.claude.com/docs/en/docs/about-claude/models
     - https://platform.claude.com/docs/en/about-claude/pricing
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference-support.html
 status: active
 supportedModes:
     - chat

--- a/providers/aws-bedrock/global.cohere.embed-v4:0.yaml
+++ b/providers/aws-bedrock/global.cohere.embed-v4:0.yaml
@@ -57,6 +57,7 @@ modalities:
         - embedding
 mode: embedding
 model: global.cohere.embed-v4:0
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature

--- a/providers/aws-bedrock/google.gemma-3-12b-it.yaml
+++ b/providers/aws-bedrock/google.gemma-3-12b-it.yaml
@@ -29,6 +29,9 @@ costs:
     - input_cost_per_token: 1.1e-7
       output_cost_per_token: 3.5e-7
       region: ap-northeast-1
+features:
+    - function_calling
+    - system_messages
 limits:
     context_window: 128000
     max_input_tokens: 128000
@@ -47,8 +50,10 @@ params:
       key: max_tokens
       maxValue: 8192
       minValue: 1
+provisioning: serverless
 sources:
     - https://huggingface.co/google/gemma-3-12b-it
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-google-gemma-3-12b-it.html
 status: active
 supportedModes:
     - chat

--- a/providers/aws-bedrock/google.gemma-3-27b-it.yaml
+++ b/providers/aws-bedrock/google.gemma-3-27b-it.yaml
@@ -49,6 +49,7 @@ params:
       key: max_tokens
       maxValue: 8192
       minValue: 1
+provisioning: serverless
 sources:
     - https://ai.google.dev/gemma/docs/core
     - https://huggingface.co/google/gemma-3-27b-it

--- a/providers/aws-bedrock/google.gemma-3-4b-it.yaml
+++ b/providers/aws-bedrock/google.gemma-3-4b-it.yaml
@@ -47,6 +47,7 @@ params:
       key: max_tokens
       maxValue: 8192
       minValue: 1
+provisioning: serverless
 sources:
     - https://huggingface.co/google/gemma-3-4b-it
 status: active

--- a/providers/aws-bedrock/jp.amazon.nova-2-lite-v1:0.yaml
+++ b/providers/aws-bedrock/jp.amazon.nova-2-lite-v1:0.yaml
@@ -25,6 +25,7 @@ params:
       key: max_tokens
       maxValue: 65536
       minValue: 1
+provisioning: serverless
 sources:
     - https://docs.aws.amazon.com/nova/latest/nova2-userguide/what-is-nova-2.html
     - https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html
@@ -32,7 +33,7 @@ sources:
     - https://aws.amazon.com/nova/models/
     - https://aws.amazon.com/about-aws/whats-new/2025/12/nova-2-foundation-models-amazon-bedrock/
     - https://cloudprice.net/models/global.amazon.nova-2-lite-v1:0
-    - https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html
+    - https://docs.aws.amazon.com/nova/latest/nova2-userguide/core-inference.html
 status: active
 supportedModes:
     - chat

--- a/providers/aws-bedrock/jp.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
+++ b/providers/aws-bedrock/jp.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
@@ -6,19 +6,6 @@ costs:
       output_cost_per_token: 0.0000165
       output_cost_per_token_batches: 0.00000825
       region: ap-northeast-3
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 6.6e-7
-                from: 200000
-          cache_write:
-              - cost_per_token: 0.00000825
-                from: 200000
-          input:
-              - cost_per_token: 0.0000066
-                from: 200000
-          output:
-              - cost_per_token: 0.00002475
-                from: 200000
     - cache_creation_input_token_cost: 0.000004125
       cache_read_input_token_cost: 3.3e-7
       input_cost_per_token: 0.0000033
@@ -26,19 +13,6 @@ costs:
       output_cost_per_token: 0.0000165
       output_cost_per_token_batches: 0.00000825
       region: ap-northeast-1
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 6.6e-7
-                from: 200000
-          cache_write:
-              - cost_per_token: 0.00000825
-                from: 200000
-          input:
-              - cost_per_token: 0.0000066
-                from: 200000
-          output:
-              - cost_per_token: 0.00002475
-                from: 200000
 features:
     - function_calling
     - prompt_caching
@@ -66,6 +40,7 @@ params:
       key: max_tokens
       maxValue: 64000
       minValue: 1
+provisioning: serverless
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html
     - https://platform.claude.com/docs/en/docs/about-claude/models

--- a/providers/aws-bedrock/jp.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
+++ b/providers/aws-bedrock/jp.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
@@ -6,6 +6,19 @@ costs:
       output_cost_per_token: 0.0000165
       output_cost_per_token_batches: 0.00000825
       region: ap-northeast-3
+      tiered_pricing:
+          cache_read:
+              - cost_per_token: 6.6e-7
+                from: 200000
+          cache_write:
+              - cost_per_token: 0.00000825
+                from: 200000
+          input:
+              - cost_per_token: 0.0000066
+                from: 200000
+          output:
+              - cost_per_token: 0.00002475
+                from: 200000
     - cache_creation_input_token_cost: 0.000004125
       cache_read_input_token_cost: 3.3e-7
       input_cost_per_token: 0.0000033
@@ -13,6 +26,19 @@ costs:
       output_cost_per_token: 0.0000165
       output_cost_per_token_batches: 0.00000825
       region: ap-northeast-1
+      tiered_pricing:
+          cache_read:
+              - cost_per_token: 6.6e-7
+                from: 200000
+          cache_write:
+              - cost_per_token: 0.00000825
+                from: 200000
+          input:
+              - cost_per_token: 0.0000066
+                from: 200000
+          output:
+              - cost_per_token: 0.00002475
+                from: 200000
 features:
     - function_calling
     - prompt_caching

--- a/providers/aws-bedrock/meta.llama3-70b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/meta.llama3-70b-instruct-v1:0.yaml
@@ -31,6 +31,7 @@ modalities:
         - text
 mode: chat
 model: meta.llama3-70b-instruct-v1:0
+provisioning: serverless
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-meta.html
 status: active

--- a/providers/aws-bedrock/minimax.minimax-m2.1.yaml
+++ b/providers/aws-bedrock/minimax.minimax-m2.1.yaml
@@ -51,6 +51,7 @@ modalities:
         - text
 mode: chat
 model: minimax.minimax-m2.1
+provisioning: serverless
 sources:
     - https://platform.minimaxi.com/docs/api-reference/text-anthropic-api
 status: active

--- a/providers/aws-bedrock/mistral.ministral-3-14b-instruct.yaml
+++ b/providers/aws-bedrock/mistral.ministral-3-14b-instruct.yaml
@@ -59,6 +59,7 @@ params:
       key: top_p
       maxValue: 1
       minValue: 0
+provisioning: serverless
 removeParams:
     - "n"
 sources:

--- a/providers/aws-bedrock/mistral.ministral-3-3b-instruct.yaml
+++ b/providers/aws-bedrock/mistral.ministral-3-3b-instruct.yaml
@@ -58,6 +58,7 @@ params:
       key: top_p
       maxValue: 1
       minValue: 0
+provisioning: serverless
 sources:
     - https://docs.mistral.ai/models/ministral-3-3b-25-12
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-mistral-chat-completion.html

--- a/providers/aws-bedrock/mistral.mistral-7b-instruct-v0:2.yaml
+++ b/providers/aws-bedrock/mistral.mistral-7b-instruct-v0:2.yaml
@@ -50,6 +50,7 @@ params:
       key: top_k
       maxValue: 200
       minValue: 1
+provisioning: serverless
 removeParams:
     - "n"
 sources:

--- a/providers/aws-bedrock/mistral.mistral-large-2407-v1:0.yaml
+++ b/providers/aws-bedrock/mistral.mistral-large-2407-v1:0.yaml
@@ -5,6 +5,7 @@ costs:
 features:
     - function_calling
     - system_messages
+    - json_output
 limits:
     context_window: 128000
     max_input_tokens: 128000
@@ -22,6 +23,7 @@ params:
       key: max_tokens
       maxValue: 8192
       minValue: 1
+provisioning: serverless
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-mistral-large-2407.html
     - https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference-supported-models-features.html

--- a/providers/aws-bedrock/mistral.mixtral-8x7b-instruct-v0:1.yaml
+++ b/providers/aws-bedrock/mistral.mixtral-8x7b-instruct-v0:1.yaml
@@ -50,6 +50,7 @@ params:
       key: top_k
       maxValue: 200
       minValue: 1
+provisioning: serverless
 removeParams:
     - "n"
 sources:

--- a/providers/aws-bedrock/mistral.voxtral-small-24b-2507.yaml
+++ b/providers/aws-bedrock/mistral.voxtral-small-24b-2507.yaml
@@ -42,6 +42,7 @@ modalities:
         - text
 mode: chat
 model: mistral.voxtral-small-24b-2507
+provisioning: serverless
 sources:
     - https://docs.mistral.ai/models/voxtral-small-25-07
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html

--- a/providers/aws-bedrock/moonshotai.kimi-k2.5.yaml
+++ b/providers/aws-bedrock/moonshotai.kimi-k2.5.yaml
@@ -48,6 +48,7 @@ params:
       key: max_tokens
       maxValue: 16000
       minValue: 1
+provisioning: serverless
 sources:
     - https://github.com/MoonshotAI/Kimi-K2.5
     - https://aws.amazon.com/about-aws/whats-new/2026/02/amazon-bedrock-adds-support-six-open-weights-models/

--- a/providers/aws-bedrock/nvidia.nemotron-nano-9b-v2.yaml
+++ b/providers/aws-bedrock/nvidia.nemotron-nano-9b-v2.yaml
@@ -48,9 +48,9 @@ params:
       key: max_tokens
       maxValue: 8192
       minValue: 1
+provisioning: serverless
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html
-    - https://build.nvidia.com/nvidia/nvidia-nemotron-nano-9b-v2/modelcard
     - https://docs.api.nvidia.com/nim/reference/nvidia-nvidia-nemotron-nano-9b-v2
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-nvidia-nvidia-nemotron-nano-9b-v2.html
 status: active

--- a/providers/aws-bedrock/openai.gpt-oss-safeguard-120b.yaml
+++ b/providers/aws-bedrock/openai.gpt-oss-safeguard-120b.yaml
@@ -29,11 +29,19 @@ costs:
     - input_cost_per_token: 1.8e-7
       output_cost_per_token: 7.1e-7
       region: ap-northeast-1
+features:
+    - function_calling
 limits:
     context_window: 128000
     max_input_tokens: 128000
-    max_output_tokens: 8192
-    max_tokens: 8192
+    max_output_tokens: 16000
+    max_tokens: 16000
+messages:
+    options:
+        - system
+        - developer
+        - user
+        - assistant
 modalities:
     input:
         - text
@@ -44,10 +52,13 @@ model: openai.gpt-oss-safeguard-120b
 params:
     - defaultValue: 512
       key: max_tokens
-      maxValue: 8192
+      maxValue: 16000
       minValue: 1
+provisioning: serverless
 sources:
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-oss-safeguard-120b.html
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-openai.html
 status: active
 supportedModes:
     - chat
+    - responses

--- a/providers/aws-bedrock/qwen.qwen3-32b-v1:0.yaml
+++ b/providers/aws-bedrock/qwen.qwen3-32b-v1:0.yaml
@@ -56,6 +56,7 @@ params:
       key: max_tokens
       maxValue: 8000
       minValue: 1
+provisioning: serverless
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-qwen-qwen3-32b.html
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html

--- a/providers/aws-bedrock/qwen.qwen3-coder-next.yaml
+++ b/providers/aws-bedrock/qwen.qwen3-coder-next.yaml
@@ -26,6 +26,7 @@ params:
       key: max_tokens
       maxValue: 16000
       minValue: 1
+provisioning: serverless
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-qwen-qwen3-coder-next.html
 status: active

--- a/providers/aws-bedrock/stability.stable-image-ultra-v1:1.yaml
+++ b/providers/aws-bedrock/stability.stable-image-ultra-v1:1.yaml
@@ -11,6 +11,7 @@ modalities:
         - image
 mode: image
 model: stability.stable-image-ultra-v1:1
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature

--- a/providers/aws-bedrock/us-gov.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
+++ b/providers/aws-bedrock/us-gov.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
@@ -68,6 +68,7 @@ params:
       type: number
     - key: tool_choice
       type: json
+provisioning: serverless
 removeParams:
     - top_p
 sources:

--- a/providers/aws-bedrock/us.amazon.nova-2-lite-v1:0.yaml
+++ b/providers/aws-bedrock/us.amazon.nova-2-lite-v1:0.yaml
@@ -29,8 +29,8 @@ features:
 limits:
     context_window: 1000000
     max_input_tokens: 1000000
-    max_output_tokens: 65535
-    max_tokens: 65535
+    max_output_tokens: 65536
+    max_tokens: 65536
 modalities:
     input:
         - text
@@ -43,10 +43,11 @@ modalities:
 mode: chat
 model: us.amazon.nova-2-lite-v1:0
 params:
-    - defaultValue: 65535
+    - defaultValue: 65536
       key: max_tokens
-      maxValue: 65535
+      maxValue: 65536
       minValue: 1
+provisioning: serverless
 sources:
     - https://docs.aws.amazon.com/nova/latest/nova2-userguide/what-is-nova-2.html
     - https://docs.aws.amazon.com/nova/latest/nova2-userguide/extended-thinking.html

--- a/providers/aws-bedrock/us.amazon.nova-lite-v1:0.yaml
+++ b/providers/aws-bedrock/us.amazon.nova-lite-v1:0.yaml
@@ -55,10 +55,14 @@ params:
       key: temperature
       maxValue: 1
       minValue: 0.00001
+provisioning: serverless
 sources:
     - https://docs.aws.amazon.com/nova/latest/userguide/what-is-nova.html
     - https://docs.aws.amazon.com/nova/latest/userguide/complete-request-schema.html
     - https://docs.aws.amazon.com/nova/latest/userguide/modalities.html
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html
 status: active
 supportedModes:
     - chat
+thinking: true

--- a/providers/aws-bedrock/us.amazon.nova-micro-v1:0.yaml
+++ b/providers/aws-bedrock/us.amazon.nova-micro-v1:0.yaml
@@ -42,6 +42,14 @@ params:
       key: max_tokens
       maxValue: 5000
       minValue: 1
+    - defaultValue: 0.7
+      key: temperature
+      maxValue: 1
+      minValue: 0
+    - key: top_k
+      maxValue: 128
+      minValue: 0
+provisioning: serverless
 sources:
     - https://aws.amazon.com/nova/pricing/
     - https://docs.aws.amazon.com/nova/latest/userguide/what-is-nova.html
@@ -49,6 +57,7 @@ sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference-support.html
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-lifecycle.html
     - https://docs.aws.amazon.com/nova/latest/userguide/complete-request-schema.html
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html
 status: active
 supportedModes:
     - chat

--- a/providers/aws-bedrock/us.anthropic.claude-opus-4-6-v1.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-opus-4-6-v1.yaml
@@ -64,6 +64,7 @@ params:
       key: max_tokens
       maxValue: 128000
       minValue: 1
+provisioning: serverless
 sources:
     - https://platform.claude.com/docs/en/docs/about-claude/models
     - https://platform.claude.com/docs/en/about-claude/pricing

--- a/providers/aws-bedrock/us.anthropic.claude-sonnet-4-20250514-v1:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-sonnet-4-20250514-v1:0.yaml
@@ -27,6 +27,7 @@ costs:
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: us-east-1
+deprecationDate: "2026-06-15"
 features:
     - function_calling
     - prompt_caching
@@ -34,6 +35,7 @@ features:
     - system_messages
     - tool_choice
     - assistant_prefill
+isDeprecated: true
 limits:
     context_window: 200000
     max_input_tokens: 200000

--- a/providers/aws-bedrock/us.deepseek.r1-v1:0.yaml
+++ b/providers/aws-bedrock/us.deepseek.r1-v1:0.yaml
@@ -27,6 +27,7 @@ params:
       key: max_tokens
       maxValue: 32768
       minValue: 1
+provisioning: serverless
 removeParams:
     - "n"
 sources:

--- a/providers/aws-bedrock/us.meta.llama3-3-70b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/us.meta.llama3-3-70b-instruct-v1:0.yaml
@@ -19,8 +19,8 @@ features:
 limits:
     context_window: 128000
     max_input_tokens: 128000
-    max_output_tokens: 4096
-    max_tokens: 4096
+    max_output_tokens: 2048
+    max_tokens: 2048
 modalities:
     input:
         - text
@@ -28,6 +28,7 @@ modalities:
         - text
 mode: chat
 model: us.meta.llama3-3-70b-instruct-v1:0
+provisioning: serverless
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-meta.html

--- a/providers/aws-bedrock/us.meta.llama3-3-70b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/us.meta.llama3-3-70b-instruct-v1:0.yaml
@@ -19,8 +19,8 @@ features:
 limits:
     context_window: 128000
     max_input_tokens: 128000
-    max_output_tokens: 2048
-    max_tokens: 2048
+    max_output_tokens: 4096
+    max_tokens: 4096
 modalities:
     input:
         - text
@@ -30,9 +30,7 @@ mode: chat
 model: us.meta.llama3-3-70b-instruct-v1:0
 provisioning: serverless
 sources:
-    - https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html
-    - https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-meta.html
-    - https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference-support.html
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-meta-llama-3-3-70b-instruct.html
 status: active
 supportedModes:
     - chat

--- a/providers/aws-bedrock/us.meta.llama4-maverick-17b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/us.meta.llama4-maverick-17b-instruct-v1:0.yaml
@@ -40,6 +40,7 @@ params:
       key: max_tokens
       maxValue: 8192
       minValue: 1
+provisioning: serverless
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-meta-llama-4-maverick-17b-instruct.html
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-meta.html

--- a/providers/aws-bedrock/us.mistral.pixtral-large-2502-v1:0.yaml
+++ b/providers/aws-bedrock/us.mistral.pixtral-large-2502-v1:0.yaml
@@ -11,6 +11,7 @@ costs:
 features:
     - function_calling
     - structured_output
+    - json_output
 limits:
     context_window: 128000
     max_input_tokens: 128000
@@ -29,6 +30,7 @@ params:
       key: max_tokens
       maxValue: 16384
       minValue: 1
+provisioning: serverless
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-mistral-pixtral-large.html
     - https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html

--- a/providers/aws-bedrock/us.writer.palmyra-x5-v1:0.yaml
+++ b/providers/aws-bedrock/us.writer.palmyra-x5-v1:0.yaml
@@ -44,6 +44,7 @@ params:
     - defaultValue: 0
       key: min_tokens
       minValue: 0
+provisioning: serverless
 removeParams:
     - "n"
 sources:

--- a/providers/aws-bedrock/writer.palmyra-vision-7b.yaml
+++ b/providers/aws-bedrock/writer.palmyra-vision-7b.yaml
@@ -8,8 +8,10 @@ costs:
     - input_cost_per_image: 0.005
       output_cost_per_token: 0.0000075
       region: us-east-1
+deprecationDate: "2026-07-13"
 features:
     - system_messages
+isDeprecated: true
 limits:
     context_window: 8000
     max_output_tokens: 4096

--- a/providers/aws-bedrock/zai.glm-4.7-flash.yaml
+++ b/providers/aws-bedrock/zai.glm-4.7-flash.yaml
@@ -54,6 +54,7 @@ model: zai.glm-4.7-flash
 params:
     - key: max_tokens
       maxValue: 4000
+provisioning: serverless
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference-supported-models-features.html
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-zai-glm-4-7-flash.html

--- a/providers/aws-bedrock/zai.glm-4.7.yaml
+++ b/providers/aws-bedrock/zai.glm-4.7.yaml
@@ -9,25 +9,25 @@ costs:
       output_cost_per_token: 0.0000022
       region: us-east-1
     - input_cost_per_token: 7.2e-7
-      output_cost_per_token: 0.00000224
+      output_cost_per_token: 0.00000264
       region: sa-east-1
     - input_cost_per_token: 6.18e-7
       output_cost_per_token: 0.000002266
       region: eu-west-2
     - input_cost_per_token: 7.2e-7
-      output_cost_per_token: 0.00000224
+      output_cost_per_token: 0.00000264
       region: eu-north-1
     - input_cost_per_token: 7.2e-7
-      output_cost_per_token: 0.00000224
+      output_cost_per_token: 0.00000264
       region: ap-southeast-3
     - input_cost_per_token: 6.18e-7
       output_cost_per_token: 0.000002266
       region: ap-southeast-2
     - input_cost_per_token: 7.2e-7
-      output_cost_per_token: 0.00000224
+      output_cost_per_token: 0.00000264
       region: ap-south-1
     - input_cost_per_token: 7.2e-7
-      output_cost_per_token: 0.00000224
+      output_cost_per_token: 0.00000264
       region: ap-northeast-1
 features:
     - function_calling
@@ -48,6 +48,7 @@ params:
       key: max_tokens
       maxValue: 4000
       minValue: 1
+provisioning: serverless
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-zai-glm-4-7.html
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html


### PR DESCRIPTION
Auto-generated by poc-agent for provider `aws-bedrock`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad updates to many Bedrock model YAMLs (capabilities, limits, pricing, and deprecation flags) could change how models are selected/configured at runtime, though changes are data-only.
> 
> **Overview**
> Updates AWS Bedrock model definition YAMLs to reflect current capabilities and lifecycle metadata.
> 
> Adds `provisioning: serverless` across many models, expands declared `features` (notably `function_calling` and `json_output`) and parameter support for a few models, and adjusts some token limits/pricing fields.
> 
> Marks several models as deprecated by adding `isDeprecated`/`deprecationDate` (e.g., Nova Reel variants, Claude Sonnet 4 20250514 regional/global entries, and `writer.palmyra-vision-7b`), and updates related `sources`/`removeParams` lists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84965f3be1068a0e5b52ce52d4823f683b25dd16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->