### PR TITLE
feat(openrouter): update model YAMLs [bot]

### DIFF
--- a/providers/openrouter/minimax/minimax-m2.5:free.yaml
+++ b/providers/openrouter/minimax/minimax-m2.5:free.yaml
@@ -5,6 +5,7 @@ costs:
 features:
     - function_calling
     - json_output
+    - system_messages
 limits:
     context_window: 196608
     max_output_tokens: 196608
@@ -16,8 +17,11 @@ modalities:
         - text
 mode: chat
 model: minimax/minimax-m2.5:free
+provisioning: serverless
 sources:
+    - https://openrouter.ai/minimax/minimax-m2.5:free
     - https://openrouter.ai/minimax/minimax-m2.5:free/api
+status: active
 supportedModes:
     - chat
 thinking: true

--- a/providers/openrouter/x-ai/grok-4.20-multi-agent.yaml
+++ b/providers/openrouter/x-ai/grok-4.20-multi-agent.yaml
@@ -6,6 +6,9 @@ costs:
       output_cost_per_token_batches: 0.000003
       region: "*"
       tiered_pricing:
+          cache_read:
+              - cost_per_token: 4.e-7
+                from: 200000
           input:
               - cost_per_token: 0.000004
                 from: 200000
@@ -31,7 +34,9 @@ params:
     - defaultValue: medium
       key: reasoning_effort
       type: string
+provisioning: serverless
 sources:
+    - https://openrouter.ai/x-ai/grok-4.20-multi-agent
     - https://openrouter.ai/x-ai/grok-4.20-multi-agent/api
     - https://docs.x.ai/developers/models#models-and-pricing
 status: active

--- a/providers/openrouter/x-ai/grok-4.20.yaml
+++ b/providers/openrouter/x-ai/grok-4.20.yaml
@@ -29,6 +29,7 @@ modalities:
         - text
 mode: chat
 model: x-ai/grok-4.20
+provisioning: serverless
 sources:
     - https://openrouter.ai/x-ai/grok-4.20/api
     - https://docs.x.ai/developers/models#models-and-pricing

--- a/providers/openrouter/z-ai/glm-5-turbo.yaml
+++ b/providers/openrouter/z-ai/glm-5-turbo.yaml
@@ -19,8 +19,11 @@ modalities:
         - text
 mode: chat
 model: z-ai/glm-5-turbo
+provisioning: serverless
 sources:
+    - https://openrouter.ai/z-ai/glm-5-turbo
     - https://openrouter.ai/z-ai/glm-5-turbo/api
+status: active
 supportedModes:
     - chat
 thinking: true


### PR DESCRIPTION
Auto-generated by poc-agent for provider `openrouter`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only updates to model metadata (features, pricing tiers, sources, provisioning/status) with no code or security logic changes.
> 
> **Overview**
> Refreshes OpenRouter provider model YAMLs to better reflect current capabilities and metadata.
> 
> Adds `provisioning: serverless` (and `status: active` where missing) plus additional `sources` links for `minimax-m2.5:free`, `grok-4.20`, `grok-4.20-multi-agent`, and `glm-5-turbo`.
> 
> Extends model-specific metadata: `minimax-m2.5:free` now advertises `system_messages`, and `grok-4.20-multi-agent` adds tiered `cache_read` pricing details.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7d36d1fb20c61efbdaf8f1daa0ce7391863a98a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->