### PR TITLE
feat(together-ai): update model YAMLs [bot]

### DIFF
--- a/providers/together-ai/Qwen/Qwen-Image-2.0-Pro.yaml
+++ b/providers/together-ai/Qwen/Qwen-Image-2.0-Pro.yaml
@@ -1,3 +1,8 @@
+costs:
+    - output_cost_per_image: 0.08
+      region: "*"
+limits:
+    max_input_tokens: 1000
 modalities:
     input:
         - text
@@ -6,9 +11,12 @@ modalities:
         - image
 mode: image
 model: Qwen/Qwen-Image-2.0-Pro
+provisioning: serverless
 sources:
     - https://docs.together.ai/docs/images-overview
     - https://docs.together.ai/docs/serverless-models#image-models
+    - https://www.together.ai/models/qwen-image-20-pro
+    - https://www.together.ai/pricing
 status: active
 supportedModes:
     - image

--- a/providers/together-ai/Qwen/Qwen-Image-2.0.yaml
+++ b/providers/together-ai/Qwen/Qwen-Image-2.0.yaml
@@ -1,10 +1,17 @@
+costs:
+    - output_cost_per_image: 0.04
+      region: "*"
 modalities:
+    input:
+        - text
     output:
         - image
 mode: image
 model: Qwen/Qwen-Image-2.0
+provisioning: serverless
 sources:
     - https://docs.together.ai/docs/serverless-models#image-models
+    - https://together.ai/pricing
 status: active
 supportedModes:
     - image

--- a/providers/together-ai/google/gemma-3-1b-pt.yaml
+++ b/providers/together-ai/google/gemma-3-1b-pt.yaml
@@ -5,6 +5,7 @@ modalities:
         - text
 mode: completion
 model: google/gemma-3-1b-pt
+provisioning: serverless
 status: active
 supportedModes:
     - completion

--- a/providers/together-ai/google/medgemma-27b-text-it.yaml
+++ b/providers/together-ai/google/medgemma-27b-text-it.yaml
@@ -12,6 +12,7 @@ modalities:
         - text
 mode: chat
 model: google/medgemma-27b-text-it
+provisioning: serverless
 sources:
     - https://huggingface.co/google/medgemma-27b-text-it
 supportedModes:


### PR DESCRIPTION
Auto-generated by poc-agent for provider `together-ai`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk metadata-only updates to Together.ai model YAMLs (pricing/provisioning/modality fields) with no runtime logic changes.
> 
> **Overview**
> Adds **pricing metadata** (`costs.output_cost_per_image`) and expands `sources` for `Qwen-Image-2.0` and `Qwen-Image-2.0-Pro`, and уточises `modalities.input` for `Qwen-Image-2.0`.
> 
> Marks `Qwen-Image-2.0(-Pro)`, `google/gemma-3-1b-pt`, and `google/medgemma-27b-text-it` as `provisioning: serverless` in their provider YAML definitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a938e03bd449fc08f0252a11a97a17bfa948134. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->