### PR TITLE
feat(aws-bedrock): update model YAMLs [bot]

### DIFF
--- a/providers/aws-bedrock/amazon.nova-canvas-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.nova-canvas-v1:0.yaml
@@ -5,6 +5,8 @@ costs:
       region: eu-west-1
     - output_cost_per_image: 0.06
       region: ap-northeast-1
+deprecationDate: "2026-09-30"
+isDeprecated: true
 modalities:
     input:
         - text

--- a/providers/aws-bedrock/amazon.nova-lite-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.nova-lite-v1:0.yaml
@@ -118,7 +118,6 @@ modalities:
         - text
         - image
         - video
-        - audio
         - pdf
         - doc
     output:
@@ -138,6 +137,7 @@ params:
       key: top_k
       maxValue: 128
       minValue: 0
+provisioning: serverless
 removeParams:
     - "n"
 sources:

--- a/providers/aws-bedrock/amazon.rerank-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.rerank-v1:0.yaml
@@ -1,11 +1,11 @@
 costs:
-    - input_cost_per_query: 0.000001
+    - input_cost_per_query: 0.001
       region: us-west-2
-    - input_cost_per_query: 0.000001
+    - input_cost_per_query: 0.001
       region: eu-central-1
-    - input_cost_per_query: 0.000001
+    - input_cost_per_query: 0.001
       region: ca-central-1
-    - input_cost_per_query: 0.000001
+    - input_cost_per_query: 0.001
       region: ap-northeast-1
 modalities:
     input:
@@ -14,6 +14,7 @@ modalities:
         - text
 mode: rerank
 model: amazon.rerank-v1:0
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature

--- a/providers/aws-bedrock/amazon.titan-embed-image-v1.yaml
+++ b/providers/aws-bedrock/amazon.titan-embed-image-v1.yaml
@@ -40,7 +40,7 @@ costs:
       input_cost_per_token_batches: 5.e-7
       region: ap-south-1
 limits:
-    max_input_tokens: 128
+    max_input_tokens: 256
     output_vector_size: 1024
 modalities:
     input:
@@ -50,6 +50,7 @@ modalities:
         - embedding
 mode: embedding
 model: amazon.titan-embed-image-v1
+provisioning: serverless
 removeParams:
     - temperature
     - top_p

--- a/providers/aws-bedrock/apac.amazon.nova-lite-v1:0.yaml
+++ b/providers/aws-bedrock/apac.amazon.nova-lite-v1:0.yaml
@@ -69,6 +69,7 @@ params:
       key: max_tokens
       maxValue: 5000
       minValue: 1
+provisioning: serverless
 sources:
     - https://docs.aws.amazon.com/nova/latest/userguide/what-is-nova.html
     - https://docs.aws.amazon.com/nova/latest/userguide/complete-request-schema.html

--- a/providers/aws-bedrock/apac.amazon.nova-pro-v1:0.yaml
+++ b/providers/aws-bedrock/apac.amazon.nova-pro-v1:0.yaml
@@ -57,6 +57,7 @@ params:
       key: max_tokens
       maxValue: 10000
       minValue: 1
+provisioning: serverless
 sources:
     - https://docs.aws.amazon.com/nova/latest/userguide/what-is-nova.html
     - https://docs.aws.amazon.com/nova/latest/userguide/complete-request-schema.html

--- a/providers/aws-bedrock/au.anthropic.claude-sonnet-4-6.yaml
+++ b/providers/aws-bedrock/au.anthropic.claude-sonnet-4-6.yaml
@@ -14,12 +14,12 @@ costs:
       output_cost_per_token_batches: 0.00000825
       region: ap-southeast-2
 features:
+    - assistant_prefill
+    - cache_control
     - function_calling
+    - prompt_caching
     - system_messages
     - tool_choice
-    - cache_control
-    - prompt_caching
-    - assistant_prefill
 limits:
     context_window: 1000000
     max_input_tokens: 1000000
@@ -40,6 +40,7 @@ params:
       key: max_tokens
       maxValue: 64000
       minValue: 1
+provisioning: serverless
 sources:
     - https://platform.claude.com/docs/en/docs/about-claude/models
     - https://platform.claude.com/docs/en/about-claude/pricing

--- a/providers/aws-bedrock/ca.amazon.nova-lite-v1:0.yaml
+++ b/providers/aws-bedrock/ca.amazon.nova-lite-v1:0.yaml
@@ -16,8 +16,8 @@ features:
 limits:
     context_window: 300000
     max_input_tokens: 300000
-    max_output_tokens: 10000
-    max_tokens: 10000
+    max_output_tokens: 5000
+    max_tokens: 5000
 modalities:
     input:
         - text
@@ -38,6 +38,7 @@ params:
       key: temperature
       maxValue: 1
       minValue: 0.00001
+provisioning: serverless
 removeParams:
     - "n"
 sources:
@@ -46,6 +47,7 @@ sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html
     - https://docs.aws.amazon.com/nova/latest/userguide/tool-use.html
     - https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference-support.html
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-amazon-nova-lite.html
 status: active
 supportedModes:
     - chat

--- a/providers/aws-bedrock/cohere.embed-v4:0.yaml
+++ b/providers/aws-bedrock/cohere.embed-v4:0.yaml
@@ -32,6 +32,7 @@ removeParams:
     - "n"
     - stop
     - stream
+    - max_tokens
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-embed-v4.html
 status: active

--- a/providers/aws-bedrock/cohere.embed-v4:0.yaml
+++ b/providers/aws-bedrock/cohere.embed-v4:0.yaml
@@ -9,6 +9,7 @@ costs:
       output_cost_per_token: 0
       region: ap-northeast-1
 limits:
+    context_window: 128000
     max_input_tokens: 128000
     output_vector_size: 1536
 modalities:
@@ -24,13 +25,13 @@ params:
       key: max_tokens
       maxValue: 128000
       minValue: 1
+provisioning: serverless
 removeParams:
     - temperature
     - top_p
     - "n"
     - stop
     - stream
-    - max_tokens
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-embed-v4.html
 status: active

--- a/providers/aws-bedrock/eu.amazon.nova-lite-v1:0.yaml
+++ b/providers/aws-bedrock/eu.amazon.nova-lite-v1:0.yaml
@@ -29,6 +29,7 @@ costs:
       region: eu-central-1
 features:
     - function_calling
+    - system_messages
     - tool_choice
     - prompt_caching
     - assistant_prefill
@@ -53,12 +54,15 @@ params:
       key: max_tokens
       maxValue: 10000
       minValue: 1
+provisioning: serverless
 sources:
     - https://docs.aws.amazon.com/nova/latest/userguide/what-is-nova.html
     - https://docs.aws.amazon.com/nova/latest/userguide/complete-request-schema.html
     - https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference-support.html
     - https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html
     - https://docs.aws.amazon.com/nova/latest/userguide/tool-use.html
+    - https://docs.aws.amazon.com/nova/latest/userguide/tool-choice.html
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference-supported-models-features.html
 status: active
 supportedModes:
     - chat

--- a/providers/aws-bedrock/eu.amazon.nova-micro-v1:0.yaml
+++ b/providers/aws-bedrock/eu.amazon.nova-micro-v1:0.yaml
@@ -58,6 +58,7 @@ params:
       key: max_tokens
       maxValue: 5000
       minValue: 1
+provisioning: serverless
 sources:
     - https://docs.aws.amazon.com/nova/latest/userguide/what-is-nova.html
     - https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference-support.html

--- a/providers/aws-bedrock/eu.amazon.nova-pro-v1:0.yaml
+++ b/providers/aws-bedrock/eu.amazon.nova-pro-v1:0.yaml
@@ -1,15 +1,21 @@
 costs:
     - cache_read_input_token_cost: 2.5e-7
       input_cost_per_token: 0.000001
+      input_cost_per_token_batches: 5.e-7
       output_cost_per_token: 0.000004
+      output_cost_per_token_batches: 0.000002
       region: il-central-1
     - cache_read_input_token_cost: 2.95e-7
       input_cost_per_token: 0.00000118
+      input_cost_per_token_batches: 5.9e-7
       output_cost_per_token: 0.00000472
+      output_cost_per_token_batches: 0.00000236
       region: eu-west-3
     - cache_read_input_token_cost: 2.3e-7
       input_cost_per_token: 9.2e-7
+      input_cost_per_token_batches: 4.6e-7
       output_cost_per_token: 0.00000368
+      output_cost_per_token_batches: 0.00000184
       region: eu-west-1
     - cache_read_input_token_cost: 2.2e-7
       input_cost_per_token: 8.8e-7
@@ -21,11 +27,15 @@ costs:
       region: eu-south-1
     - cache_read_input_token_cost: 2.175e-7
       input_cost_per_token: 8.7e-7
+      input_cost_per_token_batches: 4.35e-7
       output_cost_per_token: 0.00000348
+      output_cost_per_token_batches: 0.00000174
       region: eu-north-1
     - cache_read_input_token_cost: 2.625e-7
       input_cost_per_token: 0.00000105
+      input_cost_per_token_batches: 5.25e-7
       output_cost_per_token: 0.0000042
+      output_cost_per_token_batches: 0.0000021
       region: eu-central-1
 features:
     - function_calling
@@ -61,6 +71,7 @@ params:
       maxValue: 128
       minValue: 0
     - key: reasoning_effort
+provisioning: serverless
 removeParams:
     - "n"
 sources:
@@ -69,6 +80,7 @@ sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html
     - https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-amazon-nova-pro.html
+    - https://docs.aws.amazon.com/nova/latest/userguide/tool-use.html
 status: active
 supportedModes:
     - chat

--- a/providers/aws-bedrock/global.anthropic.claude-opus-4-5-20251101-v1:0.yaml
+++ b/providers/aws-bedrock/global.anthropic.claude-opus-4-5-20251101-v1:0.yaml
@@ -240,6 +240,7 @@ modalities:
     input:
         - text
         - image
+        - pdf
     output:
         - text
 mode: chat
@@ -251,12 +252,16 @@ params:
       maxValue: 128000
       minValue: 1024
       type: number
+provisioning: serverless
 removeParams:
     - temperature
     - top_p
 sources:
     - https://platform.claude.com/docs/en/docs/about-claude/models
     - https://platform.claude.com/docs/en/about-claude/pricing
+    - https://platform.claude.com/docs/en/build-with-claude/pdf-support
+    - https://platform.claude.com/docs/en/build-with-claude/extended-thinking
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference.html
 status: active
 supportedModes:
     - chat

--- a/providers/aws-bedrock/global.anthropic.claude-opus-4-6-v1.yaml
+++ b/providers/aws-bedrock/global.anthropic.claude-opus-4-6-v1.yaml
@@ -240,6 +240,7 @@ modalities:
     input:
         - text
         - image
+        - pdf
     output:
         - text
 mode: chat
@@ -249,10 +250,12 @@ params:
       key: max_tokens
       maxValue: 128000
       minValue: 1
+provisioning: serverless
 sources:
     - https://platform.claude.com/docs/en/docs/about-claude/models
     - https://platform.claude.com/docs/en/about-claude/pricing
     - https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html
+    - https://platform.claude.com/docs/en/build-with-claude/pdf-support
 status: active
 supportedModes:
     - chat

--- a/providers/aws-bedrock/global.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
+++ b/providers/aws-bedrock/global.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
@@ -669,6 +669,7 @@ params:
     - defaultValue: 1
       key: top_k
       minValue: 1
+provisioning: serverless
 removeParams:
     - "n"
 sources:

--- a/providers/aws-bedrock/jp.anthropic.claude-haiku-4-5-20251001-v1:0.yaml
+++ b/providers/aws-bedrock/jp.anthropic.claude-haiku-4-5-20251001-v1:0.yaml
@@ -39,6 +39,7 @@ params:
       key: max_tokens
       maxValue: 64000
       minValue: 1
+provisioning: serverless
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference-support.html
     - https://platform.claude.com/docs/en/docs/about-claude/models

--- a/providers/aws-bedrock/luma.ray-v2:0.yaml
+++ b/providers/aws-bedrock/luma.ray-v2:0.yaml
@@ -10,6 +10,7 @@ modalities:
         - video
 mode: video
 model: luma.ray-v2:0
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature
@@ -20,7 +21,6 @@ removeParams:
 sources:
     - https://lumalabs.ai/learning-hub
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-luma.html
-    - https://docs.aws.amazon.com/bedrock/latest/userguide/model-lifecycle.html
 status: active
 supportedModes:
     - video

--- a/providers/aws-bedrock/meta.llama3-8b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/meta.llama3-8b-instruct-v1:0.yaml
@@ -31,6 +31,7 @@ modalities:
         - text
 mode: chat
 model: meta.llama3-8b-instruct-v1:0
+provisioning: serverless
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-meta-llama-3-8b-instruct.html
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-meta.html

--- a/providers/aws-bedrock/minimax.minimax-m2.yaml
+++ b/providers/aws-bedrock/minimax.minimax-m2.yaml
@@ -34,9 +34,9 @@ features:
     - tool_choice
     - system_messages
 limits:
-    context_window: 200000
-    max_output_tokens: 128000
-    max_tokens: 128000
+    context_window: 1000000
+    max_output_tokens: 8000
+    max_tokens: 8000
 modalities:
     input:
         - text
@@ -45,13 +45,16 @@ modalities:
 mode: chat
 model: minimax.minimax-m2
 params:
-    - defaultValue: 128000
+    - defaultValue: 8000
       key: max_tokens
-      maxValue: 128000
+      maxValue: 8000
       minValue: 1
+provisioning: serverless
 sources:
     - https://www.minimax.io/news/minimax-m2
     - https://platform.minimax.io/docs
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-minimax-minimax-m2.html
 status: active
 supportedModes:
     - chat
+    - responses

--- a/providers/aws-bedrock/mistral.magistral-small-2509.yaml
+++ b/providers/aws-bedrock/mistral.magistral-small-2509.yaml
@@ -50,6 +50,7 @@ params:
       key: max_tokens
       maxValue: 8192
       minValue: 1
+provisioning: serverless
 sources:
     - https://docs.mistral.ai/models/magistral-small-1-2-25-09
     - https://docs.mistral.ai/getting-started/models/

--- a/providers/aws-bedrock/mistral.ministral-3-8b-instruct.yaml
+++ b/providers/aws-bedrock/mistral.ministral-3-8b-instruct.yaml
@@ -50,6 +50,15 @@ params:
       key: max_tokens
       maxValue: 8192
       minValue: 1
+    - defaultValue: 0.7
+      key: temperature
+      maxValue: 1
+      minValue: 0
+    - defaultValue: 1
+      key: top_p
+      maxValue: 1
+      minValue: 0
+provisioning: serverless
 sources:
     - https://docs.mistral.ai/models/ministral-3-8b-25-12
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-mistral-chat-completion.html

--- a/providers/aws-bedrock/mistral.mistral-large-2402-v1:0.yaml
+++ b/providers/aws-bedrock/mistral.mistral-large-2402-v1:0.yaml
@@ -54,6 +54,7 @@ params:
       key: top_p
       maxValue: 1
       minValue: 0
+provisioning: serverless
 removeParams:
     - "n"
 sources:

--- a/providers/aws-bedrock/mistral.mistral-large-3-675b-instruct.yaml
+++ b/providers/aws-bedrock/mistral.mistral-large-3-675b-instruct.yaml
@@ -11,12 +11,6 @@ costs:
     - input_cost_per_token: 6.1e-7
       output_cost_per_token: 0.00000182
       region: sa-east-1
-    - input_cost_per_token: 5.9e-7
-      output_cost_per_token: 0.00000176
-      region: eu-west-1
-    - input_cost_per_token: 5.9e-7
-      output_cost_per_token: 0.00000176
-      region: eu-south-1
     - input_cost_per_token: 5.15e-7
       output_cost_per_token: 0.000001545
       region: ap-southeast-2
@@ -49,10 +43,20 @@ params:
       key: max_tokens
       maxValue: 8192
       minValue: 1
+    - defaultValue: 0.7
+      key: temperature
+      maxValue: 1
+      minValue: 0
+    - defaultValue: 1
+      key: top_p
+      maxValue: 1
+      minValue: 0
+provisioning: serverless
 sources:
     - https://docs.mistral.ai/models/mistral-large-3-25-12
     - https://docs.mistral.ai/capabilities/vision/
     - https://docs.mistral.ai/capabilities/function_calling/
+    - https://docs.mistral.ai/capabilities/structured_output/
 status: active
 supportedModes:
     - chat

--- a/providers/aws-bedrock/mistral.mistral-small-2402-v1:0.yaml
+++ b/providers/aws-bedrock/mistral.mistral-small-2402-v1:0.yaml
@@ -29,6 +29,7 @@ params:
       key: top_p
       maxValue: 1
       minValue: 0
+provisioning: serverless
 removeParams:
     - "n"
 sources:
@@ -39,3 +40,4 @@ sources:
 status: active
 supportedModes:
     - chat
+    - completion

--- a/providers/aws-bedrock/mistral.voxtral-mini-3b-2507.yaml
+++ b/providers/aws-bedrock/mistral.voxtral-mini-3b-2507.yaml
@@ -42,6 +42,7 @@ modalities:
         - text
 mode: chat
 model: mistral.voxtral-mini-3b-2507
+provisioning: serverless
 sources:
     - https://docs.mistral.ai/models/voxtral-mini-25-07
 status: active

--- a/providers/aws-bedrock/moonshot.kimi-k2-thinking.yaml
+++ b/providers/aws-bedrock/moonshot.kimi-k2-thinking.yaml
@@ -44,6 +44,7 @@ params:
       key: temperature
       maxValue: 1
       minValue: 0
+provisioning: serverless
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-moonshot-ai-kimi-k2-thinking.html
     - https://huggingface.co/moonshotai/Kimi-K2-Thinking

--- a/providers/aws-bedrock/nvidia.nemotron-nano-12b-v2.yaml
+++ b/providers/aws-bedrock/nvidia.nemotron-nano-12b-v2.yaml
@@ -49,6 +49,7 @@ params:
       key: max_tokens
       maxValue: 8192
       minValue: 1
+provisioning: serverless
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-nvidia-nvidia-nemotron-nano-12b-v2-vl-bf16.html
     - https://build.nvidia.com/nvidia/nemotron-nano-12b-v2-vl/modelcard

--- a/providers/aws-bedrock/nvidia.nemotron-nano-3-30b.yaml
+++ b/providers/aws-bedrock/nvidia.nemotron-nano-3-30b.yaml
@@ -32,8 +32,8 @@ costs:
 features:
     - function_calling
 limits:
-    context_window: 262144
-    max_input_tokens: 262144
+    context_window: 256000
+    max_input_tokens: 256000
     max_output_tokens: 8192
     max_tokens: 8192
 modalities:
@@ -46,6 +46,7 @@ model: nvidia.nemotron-nano-3-30b
 params:
     - key: max_tokens
       maxValue: 8192
+provisioning: serverless
 sources:
     - https://aws.amazon.com/about-aws/whats-new/2025/12/nvidia-nemotron-3-nano-amazon-bedrock/
     - https://build.nvidia.com/nvidia/nemotron-3-nano-30b-a3b/modelcard

--- a/providers/aws-bedrock/openai.gpt-oss-120b-1:0.yaml
+++ b/providers/aws-bedrock/openai.gpt-oss-120b-1:0.yaml
@@ -54,9 +54,13 @@ model: openai.gpt-oss-120b-1:0
 params:
     - key: max_tokens
       maxValue: 32768
+    - key: temperature
+      maxValue: 2
+provisioning: serverless
 removeParams:
     - stream
     - stop
+    - "n"
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-openai.html
 status: active

--- a/providers/aws-bedrock/openai.gpt-oss-20b-1:0.yaml
+++ b/providers/aws-bedrock/openai.gpt-oss-20b-1:0.yaml
@@ -36,8 +36,12 @@ costs:
     - input_cost_per_token: 8.e-8
       output_cost_per_token: 3.6e-7
       region: ap-northeast-1
+features:
+    - system_messages
 limits:
     context_window: 128000
+    max_output_tokens: 16000
+    max_tokens: 16000
 messages:
     options:
         - system
@@ -58,11 +62,13 @@ params:
       minValue: 1
     - key: temperature
       maxValue: 2
+provisioning: serverless
 removeParams:
     - max_tokens
     - "n"
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-openai.html
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-oss-20b.html
 status: active
 supportedModes:
     - chat

--- a/providers/aws-bedrock/openai.gpt-oss-safeguard-20b.yaml
+++ b/providers/aws-bedrock/openai.gpt-oss-safeguard-20b.yaml
@@ -21,7 +21,7 @@ costs:
       output_cost_per_token: 2.3e-7
       region: eu-south-1
     - input_cost_per_token: 7.21e-8
-      output_cost_per_token: 2.064e-7
+      output_cost_per_token: 2.06e-7
       region: ap-southeast-2
     - input_cost_per_token: 8.e-8
       output_cost_per_token: 2.4e-7
@@ -31,11 +31,12 @@ costs:
       region: ap-northeast-1
 features:
     - system_messages
+    - function_calling
 limits:
     context_window: 128000
     max_input_tokens: 128000
-    max_output_tokens: 8192
-    max_tokens: 8192
+    max_output_tokens: 16000
+    max_tokens: 16000
 modalities:
     input:
         - text
@@ -46,10 +47,12 @@ model: openai.gpt-oss-safeguard-20b
 params:
     - defaultValue: 512
       key: max_tokens
-      maxValue: 8192
+      maxValue: 16000
       minValue: 1
+provisioning: serverless
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-openai.html
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-oss-safeguard-20b.html
 status: active
 supportedModes:
     - chat

--- a/providers/aws-bedrock/qwen.qwen3-235b-a22b-2507-v1:0.yaml
+++ b/providers/aws-bedrock/qwen.qwen3-235b-a22b-2507-v1:0.yaml
@@ -45,6 +45,7 @@ params:
       key: max_tokens
       maxValue: 8000
       minValue: 1
+provisioning: serverless
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-qwen-qwen3-235b-a22b-2507.html
     - https://aws.amazon.com/bedrock/qwen/

--- a/providers/aws-bedrock/qwen.qwen3-coder-30b-a3b-v1:0.yaml
+++ b/providers/aws-bedrock/qwen.qwen3-coder-30b-a3b-v1:0.yaml
@@ -56,6 +56,7 @@ params:
       key: max_tokens
       maxValue: 16000
       minValue: 1
+provisioning: serverless
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-qwen-qwen3-coder-30b-a3b-instruct.html
     - https://huggingface.co/Qwen/Qwen3-Coder-30B-A3B-Instruct

--- a/providers/aws-bedrock/qwen.qwen3-coder-480b-a35b-v1:0.yaml
+++ b/providers/aws-bedrock/qwen.qwen3-coder-480b-a35b-v1:0.yaml
@@ -40,6 +40,7 @@ params:
       key: max_tokens
       maxValue: 65536
       minValue: 1
+provisioning: serverless
 sources:
     - https://huggingface.co/Qwen/Qwen3-Coder-480B-A35B-Instruct
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html

--- a/providers/aws-bedrock/qwen.qwen3-next-80b-a3b.yaml
+++ b/providers/aws-bedrock/qwen.qwen3-next-80b-a3b.yaml
@@ -46,6 +46,7 @@ model: qwen.qwen3-next-80b-a3b
 params:
     - key: max_tokens
       maxValue: 8192
+provisioning: serverless
 sources:
     - https://huggingface.co/Qwen/Qwen3-Next-80B-A3B-Instruct
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-qwen-qwen3-next-80b-a3b.html

--- a/providers/aws-bedrock/qwen.qwen3-vl-235b-a22b.yaml
+++ b/providers/aws-bedrock/qwen.qwen3-vl-235b-a22b.yaml
@@ -49,9 +49,11 @@ params:
       key: max_tokens
       maxValue: 8192
       minValue: 1
+provisioning: serverless
 sources:
     - https://github.com/QwenLM/Qwen3-VL
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-qwen-qwen3-vl-235b-a22b.html
 status: active
 supportedModes:
     - chat
+    - responses

--- a/providers/aws-bedrock/stability.sd3-5-large-v1:0.yaml
+++ b/providers/aws-bedrock/stability.sd3-5-large-v1:0.yaml
@@ -1,8 +1,6 @@
 costs:
     - output_cost_per_image: 0.08
       region: us-west-2
-    - output_cost_per_image: 0.08
-      region: us-east-1
 modalities:
     input:
         - text
@@ -21,7 +19,6 @@ removeParams:
     - stream
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-diffusion-3-5-large.html
-    - https://aws.amazon.com/marketplace/pp/prodview-y6br3in45efzu
 status: active
 supportedModes:
     - image

--- a/providers/aws-bedrock/stability.sd3-5-large-v1:0.yaml
+++ b/providers/aws-bedrock/stability.sd3-5-large-v1:0.yaml
@@ -1,6 +1,8 @@
 costs:
     - output_cost_per_image: 0.08
       region: us-west-2
+    - output_cost_per_image: 0.08
+      region: us-east-1
 modalities:
     input:
         - text
@@ -9,6 +11,7 @@ modalities:
         - image
 mode: image
 model: stability.sd3-5-large-v1:0
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature
@@ -18,6 +21,7 @@ removeParams:
     - stream
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-diffusion-3-5-large.html
+    - https://aws.amazon.com/marketplace/pp/prodview-y6br3in45efzu
 status: active
 supportedModes:
     - image

--- a/providers/aws-bedrock/stability.stable-image-core-v1:1.yaml
+++ b/providers/aws-bedrock/stability.stable-image-core-v1:1.yaml
@@ -12,6 +12,7 @@ modalities:
         - image
 mode: image
 model: stability.stable-image-core-v1:1
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature

--- a/providers/aws-bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0.yaml
@@ -59,11 +59,13 @@ params:
       maxValue: 128000
       minValue: 1024
       type: number
+provisioning: serverless
 removeParams:
     - top_p
 sources:
     - https://platform.claude.com/docs/en/docs/about-claude/models
     - https://platform.claude.com/docs/en/about-claude/pricing
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html
 status: active
 supportedModes:
     - chat

--- a/providers/aws-bedrock/us.anthropic.claude-opus-4-5-20251101-v1:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-opus-4-5-20251101-v1:0.yaml
@@ -33,6 +33,13 @@ costs:
       input_cost_per_token_batches: 0.00000275
       output_cost_per_token: 0.0000275
       output_cost_per_token_batches: 0.00001375
+      region: ca-west-1
+    - cache_creation_input_token_cost: 0.000006875
+      cache_read_input_token_cost: 5.5e-7
+      input_cost_per_token: 0.0000055
+      input_cost_per_token_batches: 0.00000275
+      output_cost_per_token: 0.0000275
+      output_cost_per_token_batches: 0.00001375
       region: ca-central-1
 features:
     - assistant_prefill
@@ -63,12 +70,14 @@ params:
       maxValue: 128000
       minValue: 1024
       type: number
+provisioning: serverless
 removeParams:
     - temperature
     - top_p
 sources:
     - https://platform.claude.com/docs/en/docs/about-claude/models
     - https://platform.claude.com/docs/en/about-claude/pricing
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html
 status: active
 supportedModes:
     - chat

--- a/providers/aws-bedrock/us.anthropic.claude-opus-4-5-20251101-v1:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-opus-4-5-20251101-v1:0.yaml
@@ -33,13 +33,6 @@ costs:
       input_cost_per_token_batches: 0.00000275
       output_cost_per_token: 0.0000275
       output_cost_per_token_batches: 0.00001375
-      region: ca-west-1
-    - cache_creation_input_token_cost: 0.000006875
-      cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 0.0000055
-      input_cost_per_token_batches: 0.00000275
-      output_cost_per_token: 0.0000275
-      output_cost_per_token_batches: 0.00001375
       region: ca-central-1
 features:
     - assistant_prefill

--- a/providers/aws-bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
@@ -65,11 +65,13 @@ params:
       type: number
     - key: tool_choice
       type: json
+provisioning: serverless
 removeParams:
     - top_p
 sources:
     - https://platform.claude.com/docs/en/docs/about-claude/models
     - https://platform.claude.com/docs/en/about-claude/pricing
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html
 status: active
 supportedModes:
     - chat

--- a/providers/aws-bedrock/us.anthropic.claude-sonnet-4-6.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-sonnet-4-6.yaml
@@ -69,6 +69,7 @@ params:
       key: max_tokens
       maxValue: 64000
       minValue: 1
+provisioning: serverless
 sources:
     - https://platform.claude.com/docs/en/about-claude/models
     - https://platform.claude.com/docs/en/about-claude/pricing

--- a/providers/aws-bedrock/us.cohere.embed-v4:0.yaml
+++ b/providers/aws-bedrock/us.cohere.embed-v4:0.yaml
@@ -23,6 +23,7 @@ params:
       key: max_tokens
       maxValue: 128000
       minValue: 1
+provisioning: serverless
 removeParams:
     - temperature
     - top_p

--- a/providers/aws-bedrock/us.meta.llama3-1-70b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/us.meta.llama3-1-70b-instruct-v1:0.yaml
@@ -30,6 +30,7 @@ modalities:
         - text
 mode: chat
 model: us.meta.llama3-1-70b-instruct-v1:0
+provisioning: serverless
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference-support.html
     - https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference.html

--- a/providers/aws-bedrock/us.meta.llama3-1-8b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/us.meta.llama3-1-8b-instruct-v1:0.yaml
@@ -24,6 +24,7 @@ modalities:
         - text
 mode: chat
 model: us.meta.llama3-1-8b-instruct-v1:0
+provisioning: serverless
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-meta.html
     - https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference-supported-models-features.html

--- a/providers/aws-bedrock/us.meta.llama4-scout-17b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/us.meta.llama4-scout-17b-instruct-v1:0.yaml
@@ -33,6 +33,7 @@ params:
       key: max_tokens
       maxValue: 8000
       minValue: 1
+provisioning: serverless
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference-supported-models-features.html
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-meta.html

--- a/providers/aws-bedrock/us.writer.palmyra-x4-v1:0.yaml
+++ b/providers/aws-bedrock/us.writer.palmyra-x4-v1:0.yaml
@@ -40,6 +40,7 @@ params:
       key: top_p
       maxValue: 1
       minValue: 0
+provisioning: serverless
 removeParams:
     - "n"
 sources:


### PR DESCRIPTION
Auto-generated by poc-agent for provider `aws-bedrock`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Although code is unchanged, these config updates affect routing/provisioning metadata, advertised capabilities, and cost/token limits, which could alter runtime behavior and billing if consumed directly.
> 
> **Overview**
> Updates many `aws-bedrock` model YAMLs to reflect new provider metadata, primarily adding `provisioning: serverless` across a wide set of models.
> 
> Also adjusts model-specific settings: marks `amazon.nova-canvas-v1:0` as deprecated (with a `deprecationDate`), updates pricing (notably `amazon.rerank-v1:0` per-query cost), revises token/context limits for several models (e.g., `amazon.titan-embed-image-v1`, `ca.amazon.nova-lite-v1:0`, `minimax.minimax-m2`, `openai.gpt-oss-*`), and expands declared capabilities/IO (e.g., PDF input for some Claude models, additional params like `temperature`/`top_p`, and new `supportedModes` such as `responses`/`completion`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fef40c53120a125fcb9883ecab13c3fbc18ebd4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->