### PR TITLE
feat(azure-open-ai): update model YAMLs [bot]

### DIFF
--- a/providers/azure-open-ai/aoai-sora-2025-02-28.yaml
+++ b/providers/azure-open-ai/aoai-sora-2025-02-28.yaml
@@ -10,6 +10,7 @@ modalities:
         - video
 mode: video
 model: aoai-sora-2025-02-28
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature

--- a/providers/azure-open-ai/aoai-sora.yaml
+++ b/providers/azure-open-ai/aoai-sora.yaml
@@ -8,6 +8,7 @@ modalities:
         - video
 mode: video
 model: aoai-sora
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature

--- a/providers/azure-open-ai/azure-tts.yaml
+++ b/providers/azure-open-ai/azure-tts.yaml
@@ -1,6 +1,7 @@
 costs:
     - input_cost_per_character: 0.000015
       region: "*"
+deprecationDate: "2026-06-18"
 modalities:
     input:
         - text
@@ -8,6 +9,7 @@ modalities:
         - audio
 mode: text_to_speech
 model: azure-tts
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature
@@ -18,5 +20,6 @@ removeParams:
     - stream
     - tool_choice
     - parallel_tool_calls
+status: active
 supportedModes:
     - text_to_speech

--- a/providers/azure-open-ai/codex-mini-2025-05-16.yaml
+++ b/providers/azure-open-ai/codex-mini-2025-05-16.yaml
@@ -6,6 +6,7 @@ costs:
 deprecationDate: "2026-11-15"
 features:
     - function_calling
+    - parallel_function_calling
     - prompt_caching
     - structured_output
     - system_messages
@@ -21,7 +22,7 @@ modalities:
         - pdf
     output:
         - text
-mode: chat
+mode: responses
 model: codex-mini-2025-05-16
 params:
     - defaultValue: 100000
@@ -31,6 +32,7 @@ params:
     - defaultValue: medium
       key: reasoning_effort
       type: string
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature
@@ -42,5 +44,5 @@ sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
 status: active
 supportedModes:
-    - chat
+    - responses
 thinking: true

--- a/providers/azure-open-ai/command-r-plus.yaml
+++ b/providers/azure-open-ai/command-r-plus.yaml
@@ -16,6 +16,7 @@ modalities:
         - text
 mode: chat
 model: command-r-plus
+provisioning: serverless
 sources:
     - https://docs.cohere.com/docs/command-r-plus
 supportedModes:

--- a/providers/azure-open-ai/computer-use-preview-2025-04-15.yaml
+++ b/providers/azure-open-ai/computer-use-preview-2025-04-15.yaml
@@ -26,6 +26,9 @@ params:
       key: max_tokens
       maxValue: 1024
       minValue: 1
+provisioning: serverless
+sources:
+    - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/computer-use
 status: preview
 supportedModes:
     - chat

--- a/providers/azure-open-ai/gpt-35-turbo-instruct-0914.yaml
+++ b/providers/azure-open-ai/gpt-35-turbo-instruct-0914.yaml
@@ -14,10 +14,13 @@ modalities:
         - text
 mode: completion
 model: gpt-35-turbo-instruct-0914
+provisioning: serverless
 removeParams:
     - tool_choice
     - parallel_tool_calls
     - response_format
+sources:
+    - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/legacy-models
 status: active
 supportedModes:
     - completion

--- a/providers/azure-open-ai/gpt-35-turbo-instruct.yaml
+++ b/providers/azure-open-ai/gpt-35-turbo-instruct.yaml
@@ -4,6 +4,7 @@ costs:
       region: "*"
 limits:
     context_window: 4097
+    max_input_tokens: 4097
     max_output_tokens: 4097
     max_tokens: 4097
 modalities:
@@ -18,6 +19,7 @@ params:
       key: max_tokens
       maxValue: 4097
       minValue: 1
+provisioning: serverless
 removeParams:
     - tool_choice
     - parallel_tool_calls

--- a/providers/azure-open-ai/gpt-4-1106-Preview.yaml
+++ b/providers/azure-open-ai/gpt-4-1106-Preview.yaml
@@ -17,6 +17,7 @@ modalities:
         - text
 mode: chat
 model: gpt-4-1106-Preview
+provisioning: serverless
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/legacy-models
 status: active

--- a/providers/azure-open-ai/gpt-4-turbo-2024-04-09.yaml
+++ b/providers/azure-open-ai/gpt-4-turbo-2024-04-09.yaml
@@ -1,21 +1,11 @@
 costs:
     - input_cost_per_token: 0.00001
       output_cost_per_token: 0.00003
-      region: global
-    - input_cost_per_token: 0.000011
-      output_cost_per_token: 0.000033
-      region: datazone_us
-    - input_cost_per_token: 0.000011
-      output_cost_per_token: 0.000033
-      region: datazone_eu
-    - input_cost_per_token: 0.00001
-      output_cost_per_token: 0.00003
       region: "*"
 features:
     - function_calling
     - parallel_function_calling
     - tool_choice
-    - structured_output
     - json_output
 limits:
     context_window: 128000
@@ -30,6 +20,7 @@ modalities:
         - text
 mode: chat
 model: gpt-4-turbo-2024-04-09
+provisioning: serverless
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/legacy-models
 status: active

--- a/providers/azure-open-ai/gpt-4-turbo-jp.yaml
+++ b/providers/azure-open-ai/gpt-4-turbo-jp.yaml
@@ -21,7 +21,9 @@ modalities:
         - text
 mode: chat
 model: gpt-4-turbo-jp
+provisioning: serverless
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/legacy-models
+    - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
 supportedModes:
     - chat

--- a/providers/azure-open-ai/gpt-4-turbo.yaml
+++ b/providers/azure-open-ai/gpt-4-turbo.yaml
@@ -18,6 +18,7 @@ modalities:
         - text
 mode: chat
 model: gpt-4-turbo
+provisioning: serverless
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/legacy-models
 supportedModes:

--- a/providers/azure-open-ai/gpt-4-vision-preview.yaml
+++ b/providers/azure-open-ai/gpt-4-vision-preview.yaml
@@ -4,6 +4,7 @@ costs:
       region: "*"
 features:
     - tool_choice
+isDeprecated: true
 limits:
     context_window: 128000
     max_input_tokens: 128000

--- a/providers/azure-open-ai/gpt-4.1-2025-04-14-text.yaml
+++ b/providers/azure-open-ai/gpt-4.1-2025-04-14-text.yaml
@@ -1,4 +1,10 @@
 costs:
+    - cache_read_input_token_cost: 5.5e-7
+      input_cost_per_token: 0.0000022
+      input_cost_per_token_batches: 0.0000011
+      output_cost_per_token: 0.0000088
+      output_cost_per_token_batches: 0.0000044
+      region: datazone_us
     - cache_read_input_token_cost: 5.e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
@@ -30,6 +36,7 @@ params:
       maxValue: 32768
     - key: max_completion_tokens
       maxValue: 32768
+provisioning: serverless
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
 status: active

--- a/providers/azure-open-ai/gpt-4.1-2025-04-14.yaml
+++ b/providers/azure-open-ai/gpt-4.1-2025-04-14.yaml
@@ -35,8 +35,10 @@ model: gpt-4.1-2025-04-14
 params:
     - key: max_tokens
       maxValue: 32768
+provisioning: serverless
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
 status: active
 supportedModes:
     - chat
+    - responses

--- a/providers/azure-open-ai/gpt-4.1-mini-2025-04-14.yaml
+++ b/providers/azure-open-ai/gpt-4.1-mini-2025-04-14.yaml
@@ -35,8 +35,10 @@ model: gpt-4.1-mini-2025-04-14
 params:
     - key: max_tokens
       maxValue: 32768
+provisioning: serverless
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
 status: active
 supportedModes:
     - chat
+    - responses

--- a/providers/azure-open-ai/gpt-4.1-mini.yaml
+++ b/providers/azure-open-ai/gpt-4.1-mini.yaml
@@ -19,6 +19,7 @@ features:
     - tool_choice
     - prompt_caching
     - structured_output
+isDeprecated: true
 limits:
     context_window: 1047576
     max_input_tokens: 1047576

--- a/providers/azure-open-ai/gpt-4.1-nano-2025-04-14.yaml
+++ b/providers/azure-open-ai/gpt-4.1-nano-2025-04-14.yaml
@@ -19,6 +19,7 @@ features:
     - tool_choice
     - prompt_caching
     - structured_output
+isDeprecated: true
 limits:
     context_window: 1047576
     max_input_tokens: 1047576

--- a/providers/azure-open-ai/gpt-4.1-nano.yaml
+++ b/providers/azure-open-ai/gpt-4.1-nano.yaml
@@ -40,6 +40,7 @@ params:
     - defaultValue: null
       key: response_format
       type: string
+provisioning: serverless
 removeParams:
     - max_tokens
 sources:
@@ -47,3 +48,4 @@ sources:
 status: active
 supportedModes:
     - chat
+    - responses

--- a/providers/azure-open-ai/gpt-4.1.yaml
+++ b/providers/azure-open-ai/gpt-4.1.yaml
@@ -26,6 +26,7 @@ features:
     - prompt_caching
     - structured_output
 limits:
+    context_window: 1047576
     max_input_tokens: 1047576
     max_output_tokens: 32768
     max_tokens: 32768
@@ -42,9 +43,7 @@ params:
       key: max_completion_tokens
       maxValue: 32768
       minValue: 1
-    - defaultValue: null
-      key: response_format
-      type: string
+provisioning: serverless
 removeParams:
     - max_tokens
 sources:
@@ -52,3 +51,4 @@ sources:
 status: active
 supportedModes:
     - chat
+    - responses

--- a/providers/azure-open-ai/gpt-4o-2024-11-20.yaml
+++ b/providers/azure-open-ai/gpt-4o-2024-11-20.yaml
@@ -6,6 +6,10 @@ costs:
     - cache_creation_input_token_cost: 0.00000138
       input_cost_per_token: 0.00000275
       output_cost_per_token: 0.000011
+      region: datazone_us
+    - cache_creation_input_token_cost: 0.00000138
+      input_cost_per_token: 0.00000275
+      output_cost_per_token: 0.000011
       region: datazone_eu
 deprecationDate: "2026-10-01"
 features:
@@ -31,6 +35,7 @@ model: gpt-4o-2024-11-20
 params:
     - key: max_tokens
       maxValue: 16384
+provisioning: serverless
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
 status: active

--- a/providers/azure-open-ai/gpt-4o-audio-mai.yaml
+++ b/providers/azure-open-ai/gpt-4o-audio-mai.yaml
@@ -28,6 +28,7 @@ params:
       key: max_tokens
       maxValue: 16384
       minValue: 1
+provisioning: serverless
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
 status: active

--- a/providers/azure-open-ai/gpt-4o-audio-preview-2024-10-01.yaml
+++ b/providers/azure-open-ai/gpt-4o-audio-preview-2024-10-01.yaml
@@ -32,6 +32,7 @@ modalities:
         - audio
 mode: chat
 model: gpt-4o-audio-preview-2024-10-01
+provisioning: serverless
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/legacy-models

--- a/providers/azure-open-ai/gpt-4o-audio-preview-2025-06-03.yaml
+++ b/providers/azure-open-ai/gpt-4o-audio-preview-2025-06-03.yaml
@@ -7,8 +7,8 @@ costs:
 features:
     - function_calling
     - parallel_function_calling
-    - tool_choice
     - system_messages
+    - tool_choice
 limits:
     context_window: 128000
     max_input_tokens: 128000
@@ -26,6 +26,7 @@ model: gpt-4o-audio-preview-2025-06-03
 params:
     - key: max_tokens
       maxValue: 16384
+provisioning: serverless
 sources:
     - https://developers.openai.com/docs/models/gpt-4o-audio-preview
 status: preview

--- a/providers/azure-open-ai/gpt-4o-canvas-2024-09-25.yaml
+++ b/providers/azure-open-ai/gpt-4o-canvas-2024-09-25.yaml
@@ -22,5 +22,6 @@ params:
       key: max_tokens
       maxValue: 16384
       minValue: 1
+provisioning: serverless
 supportedModes:
     - chat

--- a/providers/azure-open-ai/gpt-4o-mini-transcribe-2025-03-20.yaml
+++ b/providers/azure-open-ai/gpt-4o-mini-transcribe-2025-03-20.yaml
@@ -15,6 +15,7 @@ modalities:
         - text
 mode: audio_transcription
 model: gpt-4o-mini-transcribe-2025-03-20
+provisioning: serverless
 removeParams:
     - stop
     - top_p
@@ -23,7 +24,6 @@ removeParams:
     - parallel_tool_calls
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
-    - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/model-retirements
 status: preview
 supportedModes:
     - audio_transcription

--- a/providers/azure-open-ai/gpt-4o-mini-transcribe-2025-12-15.yaml
+++ b/providers/azure-open-ai/gpt-4o-mini-transcribe-2025-12-15.yaml
@@ -16,6 +16,7 @@ modalities:
         - text
 mode: audio_transcription
 model: gpt-4o-mini-transcribe-2025-12-15
+provisioning: serverless
 removeParams:
     - top_p
     - "n"

--- a/providers/azure-open-ai/gpt-4o-mini-transcribe.yaml
+++ b/providers/azure-open-ai/gpt-4o-mini-transcribe.yaml
@@ -1,8 +1,9 @@
 costs:
-    - input_cost_per_audio_token: 0.00000125
+    - input_cost_per_audio_token: 0.000003
       input_cost_per_token: 0.00000125
       output_cost_per_token: 0.000005
       region: "*"
+deprecationDate: "2026-12-15"
 limits:
     context_window: 16000
     max_input_tokens: 16000
@@ -16,6 +17,10 @@ modalities:
         - text
 mode: audio_transcription
 model: gpt-4o-mini-transcribe
+params:
+    - key: max_tokens
+      maxValue: 2000
+provisioning: serverless
 removeParams:
     - top_p
     - "n"

--- a/providers/azure-open-ai/gpt-4o-mini-tts-2025-03-20.yaml
+++ b/providers/azure-open-ai/gpt-4o-mini-tts-2025-03-20.yaml
@@ -17,6 +17,7 @@ modalities:
         - audio
 mode: text_to_speech
 model: gpt-4o-mini-tts-2025-03-20
+provisioning: serverless
 removeParams:
     - temperature
     - top_p

--- a/providers/azure-open-ai/gpt-4o-mini-tts-2025-12-15.yaml
+++ b/providers/azure-open-ai/gpt-4o-mini-tts-2025-12-15.yaml
@@ -14,6 +14,7 @@ modalities:
         - audio
 mode: text_to_speech
 model: gpt-4o-mini-tts-2025-12-15
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature

--- a/providers/azure-open-ai/gpt-4o-mini-tts.yaml
+++ b/providers/azure-open-ai/gpt-4o-mini-tts.yaml
@@ -4,6 +4,7 @@ costs:
       output_cost_per_second: 0.00025
       output_cost_per_token: 0.00001
       region: "*"
+deprecationDate: "2026-12-15"
 limits:
     max_input_tokens: 2000
 modalities:
@@ -13,6 +14,7 @@ modalities:
         - audio
 mode: text_to_speech
 model: gpt-4o-mini-tts
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature

--- a/providers/azure-open-ai/gpt-4o-mini.yaml
+++ b/providers/azure-open-ai/gpt-4o-mini.yaml
@@ -40,6 +40,7 @@ params:
       key: max_tokens
       maxValue: 16384
       minValue: 1
+provisioning: serverless
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
 status: active

--- a/providers/azure-open-ai/gpt-4o-realtime-preview-2025-06-03.yaml
+++ b/providers/azure-open-ai/gpt-4o-realtime-preview-2025-06-03.yaml
@@ -16,6 +16,7 @@ modalities:
         - audio
 mode: realtime
 model: gpt-4o-realtime-preview-2025-06-03
+provisioning: serverless
 removeParams:
     - response_format
     - "n"

--- a/providers/azure-open-ai/gpt-4o-transcribe-2025-03-20.yaml
+++ b/providers/azure-open-ai/gpt-4o-transcribe-2025-03-20.yaml
@@ -11,10 +11,12 @@ limits:
 modalities:
     input:
         - audio
+        - text
     output:
         - text
 mode: audio_transcription
 model: gpt-4o-transcribe-2025-03-20
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature

--- a/providers/azure-open-ai/gpt-4o-transcribe-diarize-2025-10-15.yaml
+++ b/providers/azure-open-ai/gpt-4o-transcribe-diarize-2025-10-15.yaml
@@ -1,4 +1,13 @@
+costs:
+    - input_cost_per_audio_token: 0.000006
+      input_cost_per_token: 0.0000025
+      output_cost_per_token: 0.00001
+      region: "*"
 deprecationDate: "2027-04-16"
+limits:
+    max_input_tokens: 16000
+    max_output_tokens: 2000
+    max_tokens: 2000
 modalities:
     input:
         - audio
@@ -6,6 +15,12 @@ modalities:
         - text
 mode: audio_transcription
 model: gpt-4o-transcribe-diarize-2025-10-15
+params:
+    - defaultValue: 0
+      key: temperature
+      maxValue: 1
+      minValue: 0
+provisioning: serverless
 removeParams:
     - max_tokens
     - top_p

--- a/providers/azure-open-ai/gpt-4o-transcribe-diarize.yaml
+++ b/providers/azure-open-ai/gpt-4o-transcribe-diarize.yaml
@@ -15,6 +15,7 @@ modalities:
         - text
 mode: audio_transcription
 model: gpt-4o-transcribe-diarize
+provisioning: serverless
 removeParams:
     - tool_choice
     - parallel_tool_calls

--- a/providers/azure-open-ai/gpt-4o-transcribe.yaml
+++ b/providers/azure-open-ai/gpt-4o-transcribe.yaml
@@ -17,6 +17,7 @@ modalities:
         - text
 mode: audio_transcription
 model: gpt-4o-transcribe
+provisioning: serverless
 removeParams:
     - tool_choice
     - parallel_tool_calls

--- a/providers/azure-open-ai/gpt-4o.yaml
+++ b/providers/azure-open-ai/gpt-4o.yaml
@@ -6,8 +6,12 @@ costs:
     - cache_read_input_token_cost: 0.000001375
       input_cost_per_token: 0.00000275
       output_cost_per_token: 0.000011
+      region: datazone_us
+    - cache_read_input_token_cost: 0.000001375
+      input_cost_per_token: 0.00000275
+      output_cost_per_token: 0.000011
       region: datazone_eu
-deprecationDate: "2026-03-31"
+deprecationDate: "2026-10-01"
 features:
     - function_calling
     - parallel_function_calling
@@ -31,6 +35,7 @@ model: gpt-4o
 params:
     - key: max_tokens
       maxValue: 16384
+provisioning: serverless
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/model-retirements
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models

--- a/providers/azure-open-ai/gpt-5-2025-08-07.yaml
+++ b/providers/azure-open-ai/gpt-5-2025-08-07.yaml
@@ -11,6 +11,7 @@ costs:
       input_cost_per_token: 0.00000125
       output_cost_per_token: 0.00001
       region: "*"
+deprecationDate: "2026-08-07"
 features:
     - function_calling
     - parallel_function_calling
@@ -37,9 +38,11 @@ params:
       maxValue: 128000
     - key: reasoning_effort
       type: string
+provisioning: serverless
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
 status: active
 supportedModes:
     - chat
+    - responses
 thinking: true

--- a/providers/azure-open-ai/gpt-5-chat-2025-08-07.yaml
+++ b/providers/azure-open-ai/gpt-5-chat-2025-08-07.yaml
@@ -30,9 +30,11 @@ params:
       key: max_tokens
       maxValue: 16384
       minValue: 1
+provisioning: serverless
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
 status: preview
 supportedModes:
     - chat
+    - responses
 thinking: true

--- a/providers/azure-open-ai/gpt-5-chat-2025-08-15.yaml
+++ b/providers/azure-open-ai/gpt-5-chat-2025-08-15.yaml
@@ -29,9 +29,11 @@ params:
       key: max_tokens
       maxValue: 16384
       minValue: 1
+provisioning: serverless
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
 status: preview
 supportedModes:
     - chat
+    - responses
 thinking: true

--- a/providers/azure-open-ai/gpt-5-chat-2025-10-03.yaml
+++ b/providers/azure-open-ai/gpt-5-chat-2025-10-03.yaml
@@ -1,6 +1,7 @@
 deprecationDate: "2026-04-15"
 features:
     - system_messages
+isDeprecated: true
 limits:
     context_window: 128000
     max_input_tokens: 111616

--- a/providers/azure-open-ai/gpt-5-chat.yaml
+++ b/providers/azure-open-ai/gpt-5-chat.yaml
@@ -11,6 +11,7 @@ features:
     - tool_choice
     - prompt_caching
     - structured_output
+isDeprecated: true
 limits:
     context_window: 128000
     max_input_tokens: 128000

--- a/providers/azure-open-ai/gpt-5-codex-2025-09-15.yaml
+++ b/providers/azure-open-ai/gpt-5-codex-2025-09-15.yaml
@@ -22,7 +22,7 @@ modalities:
         - pdf
     output:
         - text
-mode: chat
+mode: responses
 model: gpt-5-codex-2025-09-15
 params:
     - defaultValue: 128
@@ -33,5 +33,5 @@ sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
 status: active
 supportedModes:
-    - chat
+    - responses
 thinking: true

--- a/providers/azure-open-ai/gpt-5-mini-2025-08-07.yaml
+++ b/providers/azure-open-ai/gpt-5-mini-2025-08-07.yaml
@@ -19,10 +19,10 @@ deprecationDate: "2026-08-07"
 features:
     - function_calling
     - parallel_function_calling
-    - system_messages
-    - tool_choice
     - prompt_caching
     - structured_output
+    - system_messages
+    - tool_choice
 limits:
     context_window: 400000
     max_input_tokens: 272000
@@ -42,6 +42,7 @@ params:
       key: max_tokens
       maxValue: 128000
       minValue: 1
+provisioning: serverless
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
 status: active

--- a/providers/azure-open-ai/gpt-5-mini.yaml
+++ b/providers/azure-open-ai/gpt-5-mini.yaml
@@ -2,7 +2,15 @@ costs:
     - cache_read_input_token_cost: 2.75e-8
       input_cost_per_token: 2.75e-7
       output_cost_per_token: 0.0000022
+      region: datazone_us
+    - cache_read_input_token_cost: 2.75e-8
+      input_cost_per_token: 2.75e-7
+      output_cost_per_token: 0.0000022
       region: datazone_eu
+    - cache_read_input_token_cost: 2.5e-8
+      input_cost_per_token: 2.5e-7
+      output_cost_per_token: 0.000002
+      region: "*"
 deprecationDate: "2027-02-06"
 features:
     - function_calling
@@ -31,12 +39,10 @@ params:
       maxValue: 128000
       minValue: 1
     - defaultValue: null
-      key: response_format
-      type: string
-    - defaultValue: null
       key: verbosity
     - defaultValue: null
       key: reasoning
+provisioning: serverless
 removeParams:
     - temperature
     - top_p
@@ -47,4 +53,5 @@ sources:
 status: active
 supportedModes:
     - chat
+    - responses
 thinking: true

--- a/providers/azure-open-ai/gpt-5-nano-2025-08-07.yaml
+++ b/providers/azure-open-ai/gpt-5-nano-2025-08-07.yaml
@@ -33,9 +33,11 @@ params:
     - defaultValue: none
       key: reasoning_effort
       type: string
+provisioning: serverless
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
 status: active
 supportedModes:
     - chat
+    - responses
 thinking: true

--- a/providers/azure-open-ai/gpt-5-nano.yaml
+++ b/providers/azure-open-ai/gpt-5-nano.yaml
@@ -1,8 +1,4 @@
 costs:
-    - cache_read_input_token_cost: 5.e-9
-      input_cost_per_token: 5.e-8
-      output_cost_per_token: 4.e-7
-      region: global
     - cache_read_input_token_cost: 5.5e-9
       input_cost_per_token: 5.5e-8
       output_cost_per_token: 4.4e-7
@@ -11,6 +7,10 @@ costs:
       input_cost_per_token: 5.5e-8
       output_cost_per_token: 4.4e-7
       region: datazone_eu
+    - cache_read_input_token_cost: 5.e-9
+      input_cost_per_token: 5.e-8
+      output_cost_per_token: 4.e-7
+      region: "*"
 deprecationDate: "2027-02-06"
 features:
     - function_calling
@@ -39,12 +39,10 @@ params:
       maxValue: 128000
       minValue: 1
     - defaultValue: null
-      key: response_format
-      type: string
-    - defaultValue: null
       key: verbosity
     - defaultValue: null
       key: reasoning
+provisioning: serverless
 removeParams:
     - temperature
     - top_p
@@ -55,4 +53,5 @@ sources:
 status: active
 supportedModes:
     - chat
+    - responses
 thinking: true

--- a/providers/azure-open-ai/gpt-5-pro-2025-10-06.yaml
+++ b/providers/azure-open-ai/gpt-5-pro-2025-10-06.yaml
@@ -1,7 +1,7 @@
 costs:
     - input_cost_per_token: 0.000015
       output_cost_per_token: 0.00012
-      region: "*"
+      region: global
 deprecationDate: "2027-04-07"
 features:
     - function_calling
@@ -19,20 +19,24 @@ modalities:
         - image
     output:
         - text
-mode: chat
+mode: responses
 model: gpt-5-pro-2025-10-06
 params:
     - defaultValue: 128000
       key: max_tokens
       maxValue: 128000
       minValue: 1
-    - defaultValue: medium
+    - defaultValue: high
       key: reasoning_effort
       type: string
+provisioning: serverless
+removeParams:
+    - stream
+    - parallel_tool_calls
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/foundry-models/concepts/models-sold-directly-by-azure?pivots=azure-openai&tabs=global-standard-aoai%2Cstandard-chat-completions%2Cglobal-standard#gpt-5
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/reasoning
 status: active
 supportedModes:
-    - chat
+    - responses
 thinking: true

--- a/providers/azure-open-ai/gpt-5.1-2025-11-13.yaml
+++ b/providers/azure-open-ai/gpt-5.1-2025-11-13.yaml
@@ -49,6 +49,7 @@ params:
     - defaultValue: none
       key: reasoning_effort
       type: string
+provisioning: serverless
 removeParams:
     - temperature
     - top_p
@@ -59,4 +60,5 @@ sources:
 status: active
 supportedModes:
     - chat
+    - responses
 thinking: true

--- a/providers/azure-open-ai/gpt-5.1-chat-2025-11-13.yaml
+++ b/providers/azure-open-ai/gpt-5.1-chat-2025-11-13.yaml
@@ -11,6 +11,7 @@ costs:
       input_cost_per_token: 0.00000138
       output_cost_per_token: 0.000011
       region: datazone_eu
+deprecationDate: "2026-04-15"
 features:
     - function_calling
     - parallel_function_calling
@@ -18,6 +19,7 @@ features:
     - prompt_caching
     - structured_output
     - tool_choice
+isDeprecated: true
 limits:
     context_window: 128000
     max_input_tokens: 111616

--- a/providers/azure-open-ai/gpt-5.1-chat.yaml
+++ b/providers/azure-open-ai/gpt-5.1-chat.yaml
@@ -11,6 +11,7 @@ costs:
       input_cost_per_token: 0.00000138
       output_cost_per_token: 0.000011
       region: datazone_eu
+deprecationDate: "2026-04-15"
 features:
     - function_calling
     - parallel_function_calling
@@ -18,6 +19,7 @@ features:
     - tool_choice
     - prompt_caching
     - structured_output
+isDeprecated: true
 limits:
     context_window: 128000
     max_input_tokens: 111616

--- a/providers/azure-open-ai/gpt-5.1-codex-2025-11-13.yaml
+++ b/providers/azure-open-ai/gpt-5.1-codex-2025-11-13.yaml
@@ -35,14 +35,15 @@ modalities:
         - pdf
     output:
         - text
-mode: chat
+mode: responses
 model: gpt-5.1-codex-2025-11-13
 params:
     - key: max_tokens
       maxValue: 128000
+provisioning: serverless
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
 status: active
 supportedModes:
-    - chat
+    - responses
 thinking: true

--- a/providers/azure-open-ai/gpt-5.1-codex-max-2025-12-04.yaml
+++ b/providers/azure-open-ai/gpt-5.1-codex-max-2025-12-04.yaml
@@ -25,7 +25,7 @@ modalities:
         - image
     output:
         - text
-mode: chat
+mode: responses
 model: gpt-5.1-codex-max-2025-12-04
 params:
     - defaultValue: 128000
@@ -34,9 +34,10 @@ params:
       minValue: 1
     - key: reasoning_effort
       type: string
+provisioning: serverless
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
 status: active
 supportedModes:
-    - chat
+    - responses
 thinking: true

--- a/providers/azure-open-ai/gpt-5.1-codex-mini-2025-11-13.yaml
+++ b/providers/azure-open-ai/gpt-5.1-codex-mini-2025-11-13.yaml
@@ -31,7 +31,7 @@ modalities:
         - pdf
     output:
         - text
-mode: chat
+mode: responses
 model: gpt-5.1-codex-mini-2025-11-13
 params:
     - defaultValue: 128
@@ -41,9 +41,12 @@ params:
     - defaultValue: medium
       key: reasoning_effort
       type: string
+provisioning: serverless
 removeParams:
     - "n"
+sources:
+    - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
 status: active
 supportedModes:
-    - chat
+    - responses
 thinking: true

--- a/providers/azure-open-ai/gpt-5.1.yaml
+++ b/providers/azure-open-ai/gpt-5.1.yaml
@@ -35,6 +35,7 @@ modalities:
         - pdf
     output:
         - text
+        - image
 mode: chat
 model: gpt-5.1
 params:
@@ -45,9 +46,11 @@ params:
     - defaultValue: none
       key: reasoning_effort
       type: string
+provisioning: serverless
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
 status: active
 supportedModes:
     - chat
+    - responses
 thinking: true

--- a/providers/azure-open-ai/gpt-5.2-2025-12-11.yaml
+++ b/providers/azure-open-ai/gpt-5.2-2025-12-11.yaml
@@ -31,11 +31,9 @@ params:
       maxValue: 128000
       minValue: 1
     - defaultValue: null
-      key: response_format
-      type: string
-    - defaultValue: null
       key: reasoning_effort
       type: string
+provisioning: serverless
 removeParams:
     - temperature
     - top_p
@@ -46,4 +44,5 @@ sources:
 status: active
 supportedModes:
     - chat
+    - responses
 thinking: true

--- a/providers/azure-open-ai/gpt-5.2-chat-2025-12-11.yaml
+++ b/providers/azure-open-ai/gpt-5.2-chat-2025-12-11.yaml
@@ -26,8 +26,10 @@ model: gpt-5.2-chat-2025-12-11
 params:
     - key: max_tokens
       maxValue: 16384
+provisioning: serverless
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
 status: preview
 supportedModes:
     - chat
+    - responses

--- a/providers/azure-open-ai/gpt-5.2-chat-2026-02-10.yaml
+++ b/providers/azure-open-ai/gpt-5.2-chat-2026-02-10.yaml
@@ -25,9 +25,8 @@ model: gpt-5.2-chat-2026-02-10
 params:
     - key: max_tokens
       maxValue: 16384
-sources:
-    - https://learn.microsoft.com/en-us/azure/ai-foundry/foundry-models/concepts/models-sold-directly-by-azure
-    - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/model-retirements
+provisioning: serverless
 status: preview
 supportedModes:
     - chat
+    - responses

--- a/providers/azure-open-ai/gpt-5.2-chat.yaml
+++ b/providers/azure-open-ai/gpt-5.2-chat.yaml
@@ -18,7 +18,6 @@ limits:
 modalities:
     input:
         - text
-        - image
     output:
         - text
 mode: chat
@@ -26,8 +25,10 @@ model: gpt-5.2-chat
 params:
     - key: max_tokens
       maxValue: 16384
+provisioning: serverless
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
 status: preview
 supportedModes:
     - chat
+    - responses

--- a/providers/azure-open-ai/gpt-5.2-codex-2026-01-14.yaml
+++ b/providers/azure-open-ai/gpt-5.2-codex-2026-01-14.yaml
@@ -9,13 +9,17 @@ features:
     - parallel_function_calling
     - prompt_caching
     - structured_output
-    - system_messages
     - tool_choice
 limits:
     context_window: 400000
     max_input_tokens: 272000
     max_output_tokens: 128000
     max_tokens: 128000
+messages:
+    options:
+        - user
+        - assistant
+        - developer
 modalities:
     input:
         - text
@@ -23,17 +27,15 @@ modalities:
         - pdf
     output:
         - text
-mode: chat
+mode: responses
 model: gpt-5.2-codex-2026-01-14
 params:
     - defaultValue: 128
       key: max_tokens
       maxValue: 128000
       minValue: 1
-sources:
-    - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/model-retirements
-    - https://learn.microsoft.com/en-us/azure/ai-foundry/foundry-models/concepts/models-sold-directly-by-azure
+provisioning: serverless
 status: active
 supportedModes:
-    - chat
+    - responses
 thinking: true

--- a/providers/azure-open-ai/gpt-5.2.yaml
+++ b/providers/azure-open-ai/gpt-5.2.yaml
@@ -30,17 +30,14 @@ params:
       key: max_completion_tokens
       maxValue: 128000
       minValue: 1
-    - defaultValue: null
-      key: response_format
-      type: string
+provisioning: serverless
 removeParams:
     - temperature
     - top_p
     - "n"
     - max_tokens
-sources:
-    - https://learn.microsoft.com/en-us/azure/ai-foundry/foundry-models/concepts/models-sold-directly-by-azure
 status: active
 supportedModes:
     - chat
+    - responses
 thinking: true

--- a/providers/azure-open-ai/gpt-5.3-chat-2026-03-03.yaml
+++ b/providers/azure-open-ai/gpt-5.3-chat-2026-03-03.yaml
@@ -28,9 +28,11 @@ params:
       key: max_tokens
       maxValue: 16384
       minValue: 1
+provisioning: serverless
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
 status: preview
 supportedModes:
     - chat
+    - responses
 thinking: true

--- a/providers/azure-open-ai/gpt-5.3-codex-2026-02-20.yaml
+++ b/providers/azure-open-ai/gpt-5.3-codex-2026-02-20.yaml
@@ -32,10 +32,9 @@ params:
     - defaultValue: medium
       key: reasoning_effort
       type: string
-sources:
-    - https://learn.microsoft.com/en-us/azure/ai-foundry/foundry-models/concepts/models-sold-directly-by-azure
-    - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/model-retirements
+provisioning: serverless
 status: active
 supportedModes:
     - chat
+    - responses
 thinking: true

--- a/providers/azure-open-ai/gpt-5.3-codex-2026-02-24.yaml
+++ b/providers/azure-open-ai/gpt-5.3-codex-2026-02-24.yaml
@@ -23,7 +23,7 @@ modalities:
         - pdf
     output:
         - text
-mode: chat
+mode: responses
 model: gpt-5.3-codex-2026-02-24
 params:
     - defaultValue: 128
@@ -33,9 +33,10 @@ params:
     - defaultValue: medium
       key: reasoning_effort
       type: string
+provisioning: serverless
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
 status: active
 supportedModes:
-    - chat
+    - responses
 thinking: true

--- a/providers/azure-open-ai/gpt-5.4-2026-03-05.yaml
+++ b/providers/azure-open-ai/gpt-5.4-2026-03-05.yaml
@@ -43,7 +43,11 @@ params:
     - defaultValue: medium
       key: reasoning_effort
       type: string
+provisioning: serverless
+sources:
+    - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
 status: active
 supportedModes:
     - chat
+    - responses
 thinking: true

--- a/providers/azure-open-ai/gpt-5.4-pro-2026-03-05.yaml
+++ b/providers/azure-open-ai/gpt-5.4-pro-2026-03-05.yaml
@@ -16,6 +16,7 @@ costs:
 deprecationDate: "2027-09-05"
 features:
     - function_calling
+    - parallel_function_calling
     - system_messages
     - tool_choice
     - prompt_caching
@@ -30,7 +31,7 @@ modalities:
         - image
     output:
         - text
-mode: chat
+mode: responses
 model: gpt-5.4-pro-2026-03-05
 params:
     - defaultValue: 128
@@ -40,12 +41,10 @@ params:
     - defaultValue: null
       key: reasoning_effort
       type: string
+provisioning: serverless
 removeParams:
     - parallel_tool_calls
-sources:
-    - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/model-retirements
-    - https://learn.microsoft.com/en-us/azure/ai-foundry/foundry-models/concepts/models-sold-directly-by-azure
 status: active
 supportedModes:
-    - chat
+    - responses
 thinking: true

--- a/providers/azure-open-ai/gpt-5.yaml
+++ b/providers/azure-open-ai/gpt-5.yaml
@@ -11,6 +11,7 @@ costs:
       input_cost_per_token: 0.00000125
       output_cost_per_token: 0.00001
       region: "*"
+deprecationDate: "2027-02-06"
 features:
     - function_calling
     - parallel_function_calling
@@ -41,6 +42,7 @@ params:
       key: verbosity
     - defaultValue: null
       key: reasoning
+provisioning: serverless
 removeParams:
     - temperature
     - top_p
@@ -51,4 +53,5 @@ sources:
 status: active
 supportedModes:
     - chat
+    - responses
 thinking: true

--- a/providers/azure-open-ai/gpt-audio-1.5-2026-02-23.yaml
+++ b/providers/azure-open-ai/gpt-audio-1.5-2026-02-23.yaml
@@ -26,6 +26,7 @@ model: gpt-audio-1.5-2026-02-23
 params:
     - key: max_tokens
       maxValue: 16384
+provisioning: serverless
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
 status: active

--- a/providers/azure-open-ai/gpt-audio-2025-08-28.yaml
+++ b/providers/azure-open-ai/gpt-audio-2025-08-28.yaml
@@ -11,6 +11,7 @@ features:
     - system_messages
     - tool_choice
 limits:
+    context_window: 128000
     max_input_tokens: 128000
     max_output_tokens: 16384
     max_tokens: 16384
@@ -26,6 +27,7 @@ model: gpt-audio-2025-08-28
 params:
     - key: max_tokens
       maxValue: 16384
+provisioning: serverless
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
 status: active

--- a/providers/azure-open-ai/gpt-audio-mini-2025-10-06.yaml
+++ b/providers/azure-open-ai/gpt-audio-mini-2025-10-06.yaml
@@ -27,6 +27,7 @@ model: gpt-audio-mini-2025-10-06
 params:
     - key: max_tokens
       maxValue: 16384
+provisioning: serverless
 sources:
     - https://developers.openai.com/docs/models/gpt-audio-mini
 status: active

--- a/providers/azure-open-ai/gpt-image-1-2025-04-15.yaml
+++ b/providers/azure-open-ai/gpt-image-1-2025-04-15.yaml
@@ -13,6 +13,7 @@ modalities:
         - image
 mode: image
 model: gpt-image-1-2025-04-15
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature

--- a/providers/azure-open-ai/gpt-image-1-mini-2025-10-06.yaml
+++ b/providers/azure-open-ai/gpt-image-1-mini-2025-10-06.yaml
@@ -13,6 +13,7 @@ modalities:
         - image
 mode: image
 model: gpt-image-1-mini-2025-10-06
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature

--- a/providers/azure-open-ai/gpt-image-1-mini.yaml
+++ b/providers/azure-open-ai/gpt-image-1-mini.yaml
@@ -4,6 +4,7 @@ costs:
       input_cost_per_token: 0.000002
       output_cost_per_image_token: 0.000008
       region: "*"
+deprecationDate: "2027-04-07"
 modalities:
     input:
         - text
@@ -12,6 +13,7 @@ modalities:
         - image
 mode: image
 model: gpt-image-1-mini
+provisioning: serverless
 removeParams:
     - max_tokens
     - stop

--- a/providers/azure-open-ai/gpt-image-1.5-2025-12-16.yaml
+++ b/providers/azure-open-ai/gpt-image-1.5-2025-12-16.yaml
@@ -18,6 +18,7 @@ modalities:
         - image
 mode: image
 model: gpt-image-1.5-2025-12-16
+provisioning: serverless
 removeParams:
     - tool_choice
     - parallel_tool_calls

--- a/providers/azure-open-ai/gpt-image-1.5.yaml
+++ b/providers/azure-open-ai/gpt-image-1.5.yaml
@@ -1,16 +1,18 @@
 costs:
     - cache_read_input_token_cost: 0.00000125
+      input_cost_per_image_token: 0.000008
       input_cost_per_token: 0.000005
+      output_cost_per_image_token: 0.000032
       region: "*"
-limits:
-    max_tokens: 4096
 modalities:
     input:
         - text
+        - image
     output:
         - image
 mode: image
 model: gpt-image-1.5
+provisioning: serverless
 removeParams:
     - temperature
     - top_p

--- a/providers/azure-open-ai/gpt-image-1.yaml
+++ b/providers/azure-open-ai/gpt-image-1.yaml
@@ -1,10 +1,10 @@
 costs:
     - cache_read_input_token_cost: 0.00000125
+      input_cost_per_image_token: 0.00001
       input_cost_per_token: 0.000005
+      output_cost_per_image_token: 0.00004
       region: "*"
 deprecationDate: "2026-05-15"
-limits:
-    max_tokens: 4096
 modalities:
     input:
         - text
@@ -13,6 +13,7 @@ modalities:
         - image
 mode: image
 model: gpt-image-1
+provisioning: serverless
 removeParams:
     - stream
     - tool_choice

--- a/providers/azure-open-ai/gpt-realtime-1.5-2026-02-23.yaml
+++ b/providers/azure-open-ai/gpt-realtime-1.5-2026-02-23.yaml
@@ -25,6 +25,7 @@ modalities:
         - audio
 mode: realtime
 model: gpt-realtime-1.5-2026-02-23
+provisioning: serverless
 status: active
 supportedModes:
     - realtime

--- a/providers/azure-open-ai/gpt-realtime-2025-08-28.yaml
+++ b/providers/azure-open-ai/gpt-realtime-2025-08-28.yaml
@@ -28,7 +28,9 @@ modalities:
         - audio
 mode: realtime
 model: gpt-realtime-2025-08-28
+provisioning: serverless
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
+status: active
 supportedModes:
     - realtime

--- a/providers/azure-open-ai/gpt-realtime-mini-2025-10-06.yaml
+++ b/providers/azure-open-ai/gpt-realtime-mini-2025-10-06.yaml
@@ -27,6 +27,7 @@ modalities:
         - audio
 mode: realtime
 model: gpt-realtime-mini-2025-10-06
+provisioning: serverless
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
 status: active

--- a/providers/azure-open-ai/gpt-realtime-mini-2025-12-15.yaml
+++ b/providers/azure-open-ai/gpt-realtime-mini-2025-12-15.yaml
@@ -25,6 +25,7 @@ modalities:
         - audio
 mode: realtime
 model: gpt-realtime-mini-2025-12-15
+provisioning: serverless
 removeParams:
     - "n"
     - response_format

--- a/providers/azure-open-ai/gpt-realtime-mini.yaml
+++ b/providers/azure-open-ai/gpt-realtime-mini.yaml
@@ -1,8 +1,8 @@
 costs:
-    - cache_read_input_audio_token_cost: 3.e-7
+    - cache_creation_input_audio_token_cost: 3.e-7
       cache_read_input_token_cost: 6.e-8
       input_cost_per_audio_token: 0.00001
-      input_cost_per_image_token: 8.e-7
+      input_cost_per_image: 8.e-7
       input_cost_per_token: 6.e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token: 0.0000024
@@ -29,6 +29,7 @@ modalities:
         - audio
 mode: realtime
 model: gpt-realtime-mini
+provisioning: serverless
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
 status: active

--- a/providers/azure-open-ai/mistral-large-latest.yaml
+++ b/providers/azure-open-ai/mistral-large-latest.yaml
@@ -21,6 +21,7 @@ model: mistral-large-latest
 params:
     - key: max_tokens
       maxValue: 32000
+provisioning: serverless
 sources:
     - https://docs.mistral.ai/models/mistral-large-3-25-12
 status: active

--- a/providers/azure-open-ai/model-router-2025-05-19.yaml
+++ b/providers/azure-open-ai/model-router-2025-05-19.yaml
@@ -7,6 +7,8 @@ features:
     - tool_choice
     - system_messages
     - structured_output
+    - json_output
+    - prompt_caching
 limits:
     context_window: 200000
 modalities:
@@ -17,6 +19,7 @@ modalities:
         - text
 mode: chat
 model: model-router-2025-05-19
+provisioning: serverless
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/model-router
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/model-router

--- a/providers/azure-open-ai/model-router-2025-08-07.yaml
+++ b/providers/azure-open-ai/model-router-2025-08-07.yaml
@@ -1,7 +1,8 @@
 features:
     - function_calling
-    - system_messages
+    - prompt_caching
     - structured_output
+    - system_messages
     - tool_choice
 limits:
     context_window: 200000
@@ -13,6 +14,7 @@ modalities:
         - text
 mode: chat
 model: model-router-2025-08-07
+provisioning: serverless
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/model-router
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/model-router

--- a/providers/azure-open-ai/model-router-2025-11-18.yaml
+++ b/providers/azure-open-ai/model-router-2025-11-18.yaml
@@ -1,9 +1,15 @@
+costs:
+    - input_cost_per_token: 1.4e-7
+      output_cost_per_token: 0
+      region: "*"
 deprecationDate: "2027-05-20"
 features:
     - function_calling
     - system_messages
     - tool_choice
     - structured_output
+    - json_output
+    - prompt_caching
 limits:
     context_window: 200000
 modalities:
@@ -17,6 +23,7 @@ model: model-router-2025-11-18
 params:
     - key: reasoning_effort
       type: string
+provisioning: serverless
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/model-router
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/model-router

--- a/providers/azure-open-ai/model-router.yaml
+++ b/providers/azure-open-ai/model-router.yaml
@@ -4,6 +4,7 @@ features:
     - system_messages
     - tool_choice
     - structured_output
+    - prompt_caching
 limits:
     context_window: 200000
 modalities:
@@ -17,9 +18,11 @@ model: model-router
 params:
     - key: reasoning_effort
       type: string
+provisioning: serverless
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/model-router
-    - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/model-retirements
+    - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/model-router
+    - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/quotas-limits
 status: active
 supportedModes:
     - chat

--- a/providers/azure-open-ai/o1-mini-2024-09-12.yaml
+++ b/providers/azure-open-ai/o1-mini-2024-09-12.yaml
@@ -4,7 +4,17 @@ costs:
       input_cost_per_token_batches: 6.05e-7
       output_cost_per_token: 0.00000484
       output_cost_per_token_batches: 0.00000242
+      region: datazone_us
+    - cache_read_input_token_cost: 6.05e-7
+      input_cost_per_token: 0.00000121
+      input_cost_per_token_batches: 6.05e-7
+      output_cost_per_token: 0.00000484
+      output_cost_per_token_batches: 0.00000242
       region: datazone_eu
+    - cache_read_input_token_cost: 5.5e-7
+      input_cost_per_token: 0.0000011
+      output_cost_per_token: 0.0000044
+      region: "*"
 features:
     - function_calling
     - parallel_function_calling
@@ -25,6 +35,7 @@ params:
       key: max_completion_tokens
       maxValue: 65536
       minValue: 1
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature

--- a/providers/azure-open-ai/o1-mini.yaml
+++ b/providers/azure-open-ai/o1-mini.yaml
@@ -42,6 +42,7 @@ params:
       key: max_completion_tokens
       maxValue: 65536
       minValue: 1
+provisioning: serverless
 removeParams:
     - temperature
     - top_p

--- a/providers/azure-open-ai/o3-2025-04-16.yaml
+++ b/providers/azure-open-ai/o3-2025-04-16.yaml
@@ -35,6 +35,7 @@ params:
     - defaultValue: medium
       key: reasoning_effort
       type: string
+provisioning: serverless
 removeParams:
     - temperature
     - top_p
@@ -43,4 +44,5 @@ sources:
 status: active
 supportedModes:
     - chat
+    - responses
 thinking: true

--- a/providers/azure-open-ai/o3-deep-research-2025-06-26-ev3.yaml
+++ b/providers/azure-open-ai/o3-deep-research-2025-06-26-ev3.yaml
@@ -27,6 +27,7 @@ params:
     - defaultValue: high
       key: reasoning_effort
       type: string
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature

--- a/providers/azure-open-ai/o3-deep-research-2025-06-26.yaml
+++ b/providers/azure-open-ai/o3-deep-research-2025-06-26.yaml
@@ -5,7 +5,10 @@ costs:
       region: "*"
 deprecationDate: "2026-12-26"
 features:
+    - function_calling
+    - parallel_function_calling
     - prompt_caching
+    - structured_output
     - system_messages
 limits:
     context_window: 200000
@@ -25,6 +28,7 @@ params:
       key: max_completion_tokens
       maxValue: 100000
       minValue: 1
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature
@@ -39,4 +43,5 @@ sources:
 status: active
 supportedModes:
     - chat
+    - responses
 thinking: true

--- a/providers/azure-open-ai/o3-mini-2025-01-31.yaml
+++ b/providers/azure-open-ai/o3-mini-2025-01-31.yaml
@@ -22,6 +22,7 @@ features:
     - prompt_caching
     - structured_output
 limits:
+    context_window: 200000
     max_input_tokens: 200000
     max_output_tokens: 100000
     max_tokens: 100000
@@ -40,6 +41,7 @@ params:
     - defaultValue: medium
       key: reasoning_effort
       type: string
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature

--- a/providers/azure-open-ai/o3-mini-alpha-2024-12-17.yaml
+++ b/providers/azure-open-ai/o3-mini-alpha-2024-12-17.yaml
@@ -45,6 +45,7 @@ params:
       key: max_tokens
       maxValue: 100000
       minValue: 1
+provisioning: serverless
 removeParams:
     - temperature
     - top_p

--- a/providers/azure-open-ai/o3-pro-2025-06-10.yaml
+++ b/providers/azure-open-ai/o3-pro-2025-06-10.yaml
@@ -31,6 +31,7 @@ params:
     - defaultValue: high
       key: reasoning_effort
       type: string
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature

--- a/providers/azure-open-ai/o3-pro.yaml
+++ b/providers/azure-open-ai/o3-pro.yaml
@@ -27,6 +27,7 @@ params:
       key: max_tokens
       maxValue: 100000
       minValue: 1
+provisioning: serverless
 removeParams:
     - temperature
     - top_p
@@ -38,4 +39,5 @@ sources:
 status: active
 supportedModes:
     - chat
+    - responses
 thinking: true

--- a/providers/azure-open-ai/o3.yaml
+++ b/providers/azure-open-ai/o3.yaml
@@ -42,6 +42,7 @@ params:
     - defaultValue: medium
       key: reasoning_effort
       type: string
+provisioning: serverless
 removeParams:
     - temperature
     - top_p
@@ -54,4 +55,5 @@ sources:
 status: active
 supportedModes:
     - chat
+    - responses
 thinking: true

--- a/providers/azure-open-ai/o4-mini-2025-04-16.yaml
+++ b/providers/azure-open-ai/o4-mini-2025-04-16.yaml
@@ -34,6 +34,7 @@ params:
     - defaultValue: medium
       key: reasoning_effort
       type: string
+provisioning: serverless
 removeParams:
     - temperature
     - top_p
@@ -46,4 +47,5 @@ sources:
 status: active
 supportedModes:
     - chat
+    - responses
 thinking: true

--- a/providers/azure-open-ai/o4-mini.yaml
+++ b/providers/azure-open-ai/o4-mini.yaml
@@ -52,15 +52,15 @@ params:
     - defaultValue: medium
       key: reasoning_effort
       type: string
+provisioning: serverless
 removeParams:
     - top_p
     - max_tokens
     - temperature
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
-    - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/model-retirements
-    - https://azure.microsoft.com/en-us/pricing/details/azure-openai/
 status: active
 supportedModes:
     - chat
+    - responses
 thinking: true

--- a/providers/azure-open-ai/sora-2-2025-10-06.yaml
+++ b/providers/azure-open-ai/sora-2-2025-10-06.yaml
@@ -8,6 +8,7 @@ modalities:
         - video
 mode: video
 model: sora-2-2025-10-06
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature
@@ -20,6 +21,7 @@ removeParams:
     - parallel_tool_calls
 sources:
     - https://azure.microsoft.com/en-us/products/ai-services/video-generation
+    - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
 status: preview
 supportedModes:
     - video

--- a/providers/azure-open-ai/sora-2.yaml
+++ b/providers/azure-open-ai/sora-2.yaml
@@ -8,6 +8,7 @@ modalities:
         - video
 mode: video
 model: sora-2
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature

--- a/providers/azure-open-ai/sora-2025-05-02.yaml
+++ b/providers/azure-open-ai/sora-2025-05-02.yaml
@@ -5,6 +5,7 @@ modalities:
         - video
 mode: video
 model: sora-2025-05-02
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature
@@ -17,6 +18,7 @@ removeParams:
     - parallel_tool_calls
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
+    - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/video-generation
 status: preview
 supportedModes:
     - video

--- a/providers/azure-open-ai/sora.yaml
+++ b/providers/azure-open-ai/sora.yaml
@@ -5,6 +5,7 @@ modalities:
         - video
 mode: video
 model: sora
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature

--- a/providers/azure-open-ai/text-embedding-3-large.yaml
+++ b/providers/azure-open-ai/text-embedding-3-large.yaml
@@ -12,6 +12,7 @@ modalities:
         - embedding
 mode: embedding
 model: text-embedding-3-large
+provisioning: serverless
 removeParams:
     - temperature
     - top_p

--- a/providers/azure-open-ai/text-embedding-3-small.yaml
+++ b/providers/azure-open-ai/text-embedding-3-small.yaml
@@ -1,7 +1,4 @@
 costs:
-    - input_cost_per_token: 2.2e-8
-      output_cost_per_token: 0
-      region: datazone_eu
     - input_cost_per_token: 2.e-8
       output_cost_per_token: 0
       region: "*"
@@ -15,6 +12,7 @@ modalities:
         - embedding
 mode: embedding
 model: text-embedding-3-small
+provisioning: serverless
 removeParams:
     - temperature
     - top_p
@@ -25,6 +23,8 @@ removeParams:
     - tool_choice
     - parallel_tool_calls
     - max_tokens
+sources:
+    - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
 status: active
 supportedModes:
     - embedding

--- a/providers/azure-open-ai/text-embedding-ada-002-2.yaml
+++ b/providers/azure-open-ai/text-embedding-ada-002-2.yaml
@@ -13,6 +13,7 @@ modalities:
         - embedding
 mode: embedding
 model: text-embedding-ada-002-2
+provisioning: serverless
 removeParams:
     - temperature
     - stop
@@ -23,8 +24,6 @@ removeParams:
     - tool_choice
     - parallel_tool_calls
     - max_tokens
-sources:
-    - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/model-retirements
 status: active
 supportedModes:
     - embedding

--- a/providers/azure-open-ai/text-embedding-ada-002.yaml
+++ b/providers/azure-open-ai/text-embedding-ada-002.yaml
@@ -12,6 +12,7 @@ modalities:
         - embedding
 mode: embedding
 model: text-embedding-ada-002
+provisioning: serverless
 removeParams:
     - temperature
     - top_p

--- a/providers/azure-open-ai/tts-1.yaml
+++ b/providers/azure-open-ai/tts-1.yaml
@@ -11,6 +11,7 @@ modalities:
         - audio
 mode: text_to_speech
 model: tts-1
+provisioning: serverless
 removeParams:
     - temperature
     - stop
@@ -19,6 +20,9 @@ removeParams:
     - response_format
     - tool_choice
     - parallel_tool_calls
+sources:
+    - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
+    - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/text-to-speech-quickstart
 status: active
 supportedModes:
     - text_to_speech

--- a/providers/azure-open-ai/whisper-1.yaml
+++ b/providers/azure-open-ai/whisper-1.yaml
@@ -10,6 +10,7 @@ modalities:
         - text
 mode: audio_transcription
 model: whisper-1
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature
@@ -24,5 +25,5 @@ sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
 status: active
 supportedModes:
-    - audio_translation
     - audio_transcription
+    - audio_translation

--- a/providers/azure-open-ai/whisper.yaml
+++ b/providers/azure-open-ai/whisper.yaml
@@ -18,6 +18,7 @@ params:
       key: temperature
       maxValue: 1
       minValue: 0
+provisioning: serverless
 removeParams:
     - max_tokens
     - stop
@@ -30,5 +31,5 @@ sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
 status: active
 supportedModes:
-    - audio_translation
     - audio_transcription
+    - audio_translation


### PR DESCRIPTION
Auto-generated by poc-agent for provider `azure-open-ai`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches a large set of Azure OpenAI model YAMLs, which can change model selection/routing, supported modes, and cost/deprecation metadata at runtime. Risk is moderate because changes are config-only but broad and could impact downstream clients if fields are interpreted differently.
> 
> **Overview**
> **Updates `azure-open-ai` model catalog YAMLs** to add `provisioning: serverless` broadly and refresh model metadata (costs, limits, params, and `sources`).
> 
> Several models update capability flags and lifecycle fields (e.g., add `parallel_function_calling`, `prompt_caching`, `json_output`; set `isDeprecated`/`deprecationDate`; tweak `status`). A subset also changes `mode`/`supportedModes` (notably adding `responses` or switching from `chat` to `responses`) and adjusts modalities (e.g., transcription models adding text input, `gpt-5.1` adding image output).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc32fb32fed1baf9c2792adf7c6206c8776d3e5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->