### PR TITLE
feat(mistral-ai): update model YAMLs [bot]

### DIFF
--- a/providers/mistral-ai/voxtral-mini-realtime-2602.yaml
+++ b/providers/mistral-ai/voxtral-mini-realtime-2602.yaml
@@ -1,8 +1,6 @@
 costs:
     - input_cost_per_second: 0.0001
       region: "*"
-features:
-    - structured_output
 limits:
     context_window: 32768
 modalities:
@@ -18,7 +16,6 @@ params:
 provisioning: serverless
 sources:
     - https://docs.mistral.ai/models/voxtral-mini-transcribe-realtime-26-02
-    - https://mistral.ai/news/voxtral-transcribe-2
 status: active
 supportedModes:
     - realtime

--- a/providers/mistral-ai/voxtral-mini-realtime-2602.yaml
+++ b/providers/mistral-ai/voxtral-mini-realtime-2602.yaml
@@ -1,16 +1,24 @@
 costs:
     - input_cost_per_second: 0.0001
       region: "*"
+features:
+    - structured_output
 limits:
     context_window: 32768
+modalities:
+    input:
+        - audio
+    output:
+        - text
 mode: realtime
 model: voxtral-mini-realtime-2602
 params:
     - defaultValue: 0
       key: temperature
+provisioning: serverless
 sources:
     - https://docs.mistral.ai/models/voxtral-mini-transcribe-realtime-26-02
-    - https://docs.mistral.ai/capabilities/audio_transcription
+    - https://mistral.ai/news/voxtral-transcribe-2
 status: active
 supportedModes:
     - realtime

--- a/providers/mistral-ai/voxtral-mini-tts-2603.yaml
+++ b/providers/mistral-ai/voxtral-mini-tts-2603.yaml
@@ -15,6 +15,7 @@ model: voxtral-mini-tts-2603
 params:
     - defaultValue: 0.3
       key: temperature
+provisioning: serverless
 removeParams:
     - max_tokens
     - top_p


### PR DESCRIPTION
Auto-generated by poc-agent for provider `mistral-ai`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only YAML metadata changes with limited blast radius; primary risk is mislabeling modalities/provisioning affecting model selection or routing.
> 
> **Overview**
> Updates Mistral model definitions for `voxtral-mini-realtime-2602` and `voxtral-mini-tts-2603` by **adding explicit `modalities`** (audio→text for realtime transcribe; text→audio for TTS) and marking both models as **`provisioning: serverless`**.
> 
> Also removes an extra/outdated documentation source link from the realtime model’s `sources` list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 627370b2b36b49867161f71293c0738e8addd0fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->