### PR TITLE
fix: xai-params

### DIFF
--- a/providers/google-vertex/mongodb/voyage-4-large.yaml
+++ b/providers/google-vertex/mongodb/voyage-4-large.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 1.2e-7
-      region: "*"
+      region: us-central1
 limits:
     context_window: 32000
     max_input_tokens: 32000

--- a/providers/xai/grok-4.20-multi-agent-0309.yaml
+++ b/providers/xai/grok-4.20-multi-agent-0309.yaml
@@ -18,7 +18,8 @@ modalities:
 mode: responses
 model: grok-4.20-multi-agent-0309
 removeParams:
-    - reasoning_effort
+    - max_tokens
+    - max_completion_tokens
 status: active
 supportedModes:
     - responses

--- a/providers/xai/grok-4.20-multi-agent-beta-0309-exp-ma.yaml
+++ b/providers/xai/grok-4.20-multi-agent-beta-0309-exp-ma.yaml
@@ -11,6 +11,7 @@ features:
     - structured_output
     - prompt_caching
     - tool_choice
+isDeprecated: true
 limits:
     context_window: 2000000
 modalities:
@@ -22,8 +23,9 @@ modalities:
 mode: responses
 model: grok-4.20-multi-agent-beta-0309-exp-ma
 removeParams:
-    - reasoning_effort
-status: preview
+    - max_tokens
+    - max_completion_tokens
+status: retired
 supportedModes:
     - responses
 thinking: true

--- a/providers/xai/grok-4.20-multi-agent-beta-0309.yaml
+++ b/providers/xai/grok-4.20-multi-agent-beta-0309.yaml
@@ -18,7 +18,8 @@ modalities:
 mode: responses
 model: grok-4.20-multi-agent-beta-0309
 removeParams:
-    - reasoning_effort
+    - max_tokens
+    - max_completion_tokens
 sources:
     - https://docs.x.ai/developers/models#models-and-pricing
 supportedModes:

--- a/providers/xai/grok-4.20-multi-agent-beta-latest.yaml
+++ b/providers/xai/grok-4.20-multi-agent-beta-latest.yaml
@@ -18,7 +18,8 @@ modalities:
 mode: responses
 model: grok-4.20-multi-agent-beta-latest
 removeParams:
-    - reasoning_effort
+    - max_tokens
+    - max_completion_tokens
 sources:
     - https://docs.x.ai/developers/models#models-and-pricing
 status: preview

--- a/providers/xai/grok-4.20-multi-agent-experimental-beta-0304.yaml
+++ b/providers/xai/grok-4.20-multi-agent-experimental-beta-0304.yaml
@@ -17,7 +17,8 @@ modalities:
 mode: responses
 model: grok-4.20-multi-agent-experimental-beta-0304
 removeParams:
-    - reasoning_effort
+    - max_tokens
+    - max_completion_tokens
 supportedModes:
     - responses
 thinking: true

--- a/providers/xai/grok-4.20-multi-agent-experimental-beta-latest.yaml
+++ b/providers/xai/grok-4.20-multi-agent-experimental-beta-latest.yaml
@@ -19,7 +19,8 @@ modalities:
 mode: responses
 model: grok-4.20-multi-agent-experimental-beta-latest
 removeParams:
-    - reasoning_effort
+    - max_tokens
+    - max_completion_tokens
 status: preview
 supportedModes:
     - responses

--- a/providers/xai/grok-4.20-multi-agent-latest.yaml
+++ b/providers/xai/grok-4.20-multi-agent-latest.yaml
@@ -17,7 +17,8 @@ modalities:
 mode: responses
 model: grok-4.20-multi-agent-latest
 removeParams:
-    - reasoning_effort
+    - max_tokens
+    - max_completion_tokens
 supportedModes:
     - responses
 thinking: true

--- a/providers/xai/grok-4.20-multi-agent.yaml
+++ b/providers/xai/grok-4.20-multi-agent.yaml
@@ -20,7 +20,8 @@ modalities:
 mode: responses
 model: grok-4.20-multi-agent
 removeParams:
-    - reasoning_effort
+    - max_tokens
+    - max_completion_tokens
 status: active
 supportedModes:
     - responses


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Provider config changes can affect request payloads and model availability at runtime (parameter stripping and status/deprecation updates), but no core code logic is modified.
> 
> **Overview**
> Updates provider model YAMLs to better match upstream constraints.
> 
> For `mongodb/voyage-4-large` on Google Vertex, the cost `region` is narrowed from `"*"` to `us-central1`. For multiple xAI Grok 4.20 multi-agent variants, `removeParams` is updated to drop `max_tokens`/`max_completion_tokens` instead of `reasoning_effort`, and `grok-4.20-multi-agent-beta-0309-exp-ma` is additionally marked `isDeprecated: true` with status changed from *preview* to *retired*.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ad42ca81d0e06c64fffb0bad4c7992f1fd053b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->