### PR TITLE
fix: remove param

### DIFF
--- a/providers/xai/grok-code-fast-1-0825.yaml
+++ b/providers/xai/grok-code-fast-1-0825.yaml
@@ -16,6 +16,8 @@ modalities:
         - text
 mode: chat
 model: grok-code-fast-1-0825
+removeParams:
+    - reasoning_effort
 sources:
     - https://docs.x.ai/developers/models#models-and-pricing
 supportedModes:

--- a/providers/xai/grok-code-fast-1.yaml
+++ b/providers/xai/grok-code-fast-1.yaml
@@ -16,6 +16,8 @@ modalities:
         - text
 mode: chat
 model: grok-code-fast-1
+removeParams:
+    - reasoning_effort
 supportedModes:
     - chat
 thinking: true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small config-only change that alters request parameter handling for two XAI model definitions; low risk aside from potentially affecting behavior if callers relied on `reasoning_effort` being passed through.
> 
> **Overview**
> Adds `removeParams: [reasoning_effort]` to the XAI provider model configs for `grok-code-fast-1` and `grok-code-fast-1-0825`, ensuring this parameter is stripped from requests for these models.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fdea94bfe9043691e0e9befc81c416c530a2b0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->