### PR TITLE
feat(google-gemini): add new models [bot]

### DIFF
--- a/providers/google-gemini/gemini-3.1-flash-tts-preview.yaml
+++ b/providers/google-gemini/gemini-3.1-flash-tts-preview.yaml
@@ -1,0 +1,14 @@
+limits:
+    max_input_tokens: 8192
+    max_output_tokens: 16384
+mode: unknown
+model: gemini-3.1-flash-tts-preview
+params:
+    - defaultValue: 1
+      key: temperature
+      maxValue: 2
+    - defaultValue: 0.95
+      key: top_p
+    - defaultValue: 64
+      key: top_k
+thinking: true

--- a/providers/google-gemini/gemini-robotics-er-1.6-preview.yaml
+++ b/providers/google-gemini/gemini-robotics-er-1.6-preview.yaml
@@ -1,0 +1,14 @@
+limits:
+    max_input_tokens: 131072
+    max_output_tokens: 65536
+mode: unknown
+model: gemini-robotics-er-1.6-preview
+params:
+    - defaultValue: 1
+      key: temperature
+      maxValue: 2
+    - defaultValue: 0.95
+      key: top_p
+    - defaultValue: 64
+      key: top_k
+thinking: true


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `google-gemini`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds new provider model definition YAMLs only; no runtime logic changes, with primary risk being incorrect metadata/limits for these models.
> 
> **Overview**
> Adds two new `google-gemini` model definition YAMLs: `gemini-3.1-flash-tts-preview` and `gemini-robotics-er-1.6-preview`.
> 
> Each file defines token limits plus default sampling params (`temperature`, `top_p`, `top_k`), marks `thinking: true`, and leaves `mode: unknown` for downstream handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7adf1b4cef45a1734512c3f654681fa79cb7db9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->