### PR TITLE
fix: bedrock feautures and sources.

### DIFF
--- a/providers/aws-bedrock/amazon.nova-lite-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.nova-lite-v1:0.yaml
@@ -141,10 +141,7 @@ params:
 removeParams:
     - "n"
 sources:
-    - https://docs.aws.amazon.com/nova/latest/userguide/what-is-nova.html
-    - https://docs.aws.amazon.com/nova/latest/userguide/complete-request-schema.html
-    - https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html
-    - https://docs.aws.amazon.com/nova/latest/userguide/modalities-image.html
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-amazon-nova-lite.html
 status: active
 supportedModes:
     - chat

--- a/providers/aws-bedrock/amazon.titan-tg1-large.yaml
+++ b/providers/aws-bedrock/amazon.titan-tg1-large.yaml
@@ -31,8 +31,7 @@ params:
 removeParams:
     - "n"
 sources:
-    - https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-titan-text.html
-    - https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference-supported-models-features.html
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-amazon-titan-text-large.html
 status: active
 supportedModes:
     - chat

--- a/providers/aws-bedrock/deepseek.v3.2.yaml
+++ b/providers/aws-bedrock/deepseek.v3.2.yaml
@@ -29,7 +29,6 @@ costs:
       region: ap-northeast-1
 features:
     - function_calling
-    - json_output
 limits:
     context_window: 128000
     max_output_tokens: 8000
@@ -47,8 +46,7 @@ params:
       maxValue: 8000
       minValue: 1
 sources:
-    - https://api-docs.deepseek.com/quick_start/pricing
-    - https://api-docs.deepseek.com/api/create-chat-completion
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-deepseek-deepseek-v3-2.html
 status: active
 supportedModes:
     - chat

--- a/providers/aws-bedrock/default.yaml
+++ b/providers/aws-bedrock/default.yaml
@@ -3,6 +3,9 @@ documentation:
     - https://aws.amazon.com/bedrock/pricing/
     - https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-lifecycle.html
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/structured-output.html
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference-supported-models-features.html
 messages:
     options:
         - system

--- a/providers/aws-bedrock/mistral.magistral-small-2509.yaml
+++ b/providers/aws-bedrock/mistral.magistral-small-2509.yaml
@@ -51,9 +51,7 @@ params:
       maxValue: 8192
       minValue: 1
 sources:
-    - https://docs.mistral.ai/models/magistral-small-1-2-25-09
-    - https://docs.mistral.ai/getting-started/models/
-    - https://docs.mistral.ai/capabilities/reasoning/
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-mistral-ai-magistral-small-2509.html
 status: active
 supportedModes:
     - chat

--- a/providers/aws-bedrock/nvidia.nemotron-nano-12b-v2.yaml
+++ b/providers/aws-bedrock/nvidia.nemotron-nano-12b-v2.yaml
@@ -51,8 +51,6 @@ params:
       minValue: 1
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-nvidia-nvidia-nemotron-nano-12b-v2-vl-bf16.html
-    - https://build.nvidia.com/nvidia/nemotron-nano-12b-v2-vl/modelcard
-    - https://docs.api.nvidia.com/nim/reference/nvidia-nemotron-nano-12b-v2-vl
 status: active
 supportedModes:
     - chat

--- a/providers/aws-bedrock/nvidia.nemotron-nano-9b-v2.yaml
+++ b/providers/aws-bedrock/nvidia.nemotron-nano-9b-v2.yaml
@@ -49,9 +49,6 @@ params:
       maxValue: 8192
       minValue: 1
 sources:
-    - https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html
-    - https://build.nvidia.com/nvidia/nvidia-nemotron-nano-9b-v2/modelcard
-    - https://docs.api.nvidia.com/nim/reference/nvidia-nvidia-nemotron-nano-9b-v2
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-nvidia-nvidia-nemotron-nano-9b-v2.html
 status: active
 supportedModes:

--- a/providers/aws-bedrock/us.mistral.pixtral-large-2502-v1:0.yaml
+++ b/providers/aws-bedrock/us.mistral.pixtral-large-2502-v1:0.yaml
@@ -10,7 +10,6 @@ costs:
       region: us-east-1
 features:
     - function_calling
-    - structured_output
 limits:
     context_window: 128000
     max_input_tokens: 128000

--- a/providers/aws-bedrock/us.writer.palmyra-x5-v1:0.yaml
+++ b/providers/aws-bedrock/us.writer.palmyra-x5-v1:0.yaml
@@ -13,7 +13,6 @@ costs:
       region: us-east-1
 features:
     - function_calling
-    - structured_output
 limits:
     context_window: 1048192
     max_input_tokens: 1040000
@@ -48,8 +47,6 @@ removeParams:
     - "n"
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-palmyra-x5.html
-    - https://aws.amazon.com/marketplace/pp/prodview-aaysji6xh2mgi
-    - https://aws.amazon.com/bedrock/writer/
 status: active
 supportedModes:
     - chat

--- a/providers/aws-bedrock/writer.palmyra-vision-7b.yaml
+++ b/providers/aws-bedrock/writer.palmyra-vision-7b.yaml
@@ -28,7 +28,6 @@ params:
       maxValue: 4096
       minValue: 1
 sources:
-    - https://dev.writer.com/home/models
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-writer-palmyra.html
 status: active
 supportedModes:

--- a/providers/aws-bedrock/zai.glm-4.7.yaml
+++ b/providers/aws-bedrock/zai.glm-4.7.yaml
@@ -31,7 +31,6 @@ costs:
       region: ap-northeast-1
 features:
     - function_calling
-    - json_output
 limits:
     context_window: 128000
     max_output_tokens: 4000


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Config-only updates to model metadata (features and documentation links) with no runtime code changes; low risk aside from potential capability gating in consumers of these flags.
> 
> **Overview**
> Updates AWS Bedrock provider model metadata to better reflect supported capabilities and official documentation.
> 
> This removes unsupported feature flags (notably `json_output`/`structured_output`) from several model YAMLs, refreshes `sources` to point at Bedrock model cards, and expands `providers/aws-bedrock/default.yaml` documentation links to include structured output, prompt caching, and conversation features references.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 912d4bcd542584adf59bb2f024cecad177b1b960. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->