### PR TITLE
fix: bedrock params

### DIFF
--- a/providers/aws-bedrock/ai21.jamba-1-5-large-v1:0.yaml
+++ b/providers/aws-bedrock/ai21.jamba-1-5-large-v1:0.yaml
@@ -5,7 +5,6 @@ costs:
 features:
     - function_calling
     - system_messages
-    - json_output
 limits:
     context_window: 256000
     max_input_tokens: 256000

--- a/providers/aws-bedrock/amazon.nova-lite-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.nova-lite-v1:0.yaml
@@ -145,4 +145,3 @@ sources:
 status: active
 supportedModes:
     - chat
-thinking: true

--- a/providers/aws-bedrock/apac.amazon.nova-lite-v1:0.yaml
+++ b/providers/aws-bedrock/apac.amazon.nova-lite-v1:0.yaml
@@ -81,4 +81,3 @@ sources:
 status: active
 supportedModes:
     - chat
-thinking: true

--- a/providers/aws-bedrock/ca.amazon.nova-lite-v1:0.yaml
+++ b/providers/aws-bedrock/ca.amazon.nova-lite-v1:0.yaml
@@ -51,4 +51,3 @@ sources:
 status: active
 supportedModes:
     - chat
-thinking: true

--- a/providers/aws-bedrock/eu.amazon.nova-2-lite-v1:0.yaml
+++ b/providers/aws-bedrock/eu.amazon.nova-2-lite-v1:0.yaml
@@ -53,4 +53,3 @@ sources:
 status: active
 supportedModes:
     - chat
-thinking: true

--- a/providers/aws-bedrock/eu.mistral.pixtral-large-2502-v1:0.yaml
+++ b/providers/aws-bedrock/eu.mistral.pixtral-large-2502-v1:0.yaml
@@ -14,7 +14,6 @@ costs:
 features:
     - function_calling
     - system_messages
-    - json_output
 limits:
     context_window: 128000
     max_input_tokens: 128000

--- a/providers/aws-bedrock/global.amazon.nova-2-lite-v1:0.yaml
+++ b/providers/aws-bedrock/global.amazon.nova-2-lite-v1:0.yaml
@@ -134,4 +134,3 @@ sources:
 status: active
 supportedModes:
     - chat
-thinking: true

--- a/providers/aws-bedrock/google.gemma-3-27b-it.yaml
+++ b/providers/aws-bedrock/google.gemma-3-27b-it.yaml
@@ -29,8 +29,6 @@ costs:
     - input_cost_per_token: 2.8e-7
       output_cost_per_token: 4.6e-7
       region: ap-northeast-1
-features:
-    - function_calling
 limits:
     context_window: 128000
     max_input_tokens: 128000

--- a/providers/aws-bedrock/jp.amazon.nova-2-lite-v1:0.yaml
+++ b/providers/aws-bedrock/jp.amazon.nova-2-lite-v1:0.yaml
@@ -37,4 +37,3 @@ sources:
 status: active
 supportedModes:
     - chat
-thinking: true

--- a/providers/aws-bedrock/mistral.mistral-large-2407-v1:0.yaml
+++ b/providers/aws-bedrock/mistral.mistral-large-2407-v1:0.yaml
@@ -5,7 +5,6 @@ costs:
 features:
     - function_calling
     - system_messages
-    - json_output
 limits:
     context_window: 128000
     max_input_tokens: 128000

--- a/providers/aws-bedrock/moonshotai.kimi-k2.5.yaml
+++ b/providers/aws-bedrock/moonshotai.kimi-k2.5.yaml
@@ -49,6 +49,8 @@ params:
       maxValue: 16000
       minValue: 1
 provisioning: serverless
+removeParams:
+    - reasoning_effort
 sources:
     - https://github.com/MoonshotAI/Kimi-K2.5
     - https://aws.amazon.com/about-aws/whats-new/2026/02/amazon-bedrock-adds-support-six-open-weights-models/

--- a/providers/aws-bedrock/nvidia.nemotron-nano-12b-v2.yaml
+++ b/providers/aws-bedrock/nvidia.nemotron-nano-12b-v2.yaml
@@ -50,7 +50,7 @@ params:
       maxValue: 8192
       minValue: 1
 provisioning: serverless
-remove_params:
+removeParams:
     - reasoning_effort
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-nvidia-nvidia-nemotron-nano-12b-v2-vl-bf16.html

--- a/providers/aws-bedrock/nvidia.nemotron-nano-12b-v2.yaml
+++ b/providers/aws-bedrock/nvidia.nemotron-nano-12b-v2.yaml
@@ -50,6 +50,8 @@ params:
       maxValue: 8192
       minValue: 1
 provisioning: serverless
+remove_params:
+    - reasoning_effort
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-nvidia-nvidia-nemotron-nano-12b-v2-vl-bf16.html
 status: active

--- a/providers/aws-bedrock/nvidia.nemotron-nano-3-30b.yaml
+++ b/providers/aws-bedrock/nvidia.nemotron-nano-3-30b.yaml
@@ -47,9 +47,10 @@ params:
     - key: max_tokens
       maxValue: 8192
 provisioning: serverless
+removeParams:
+    - reasoning_effort
 sources:
-    - https://aws.amazon.com/about-aws/whats-new/2025/12/nvidia-nemotron-3-nano-amazon-bedrock/
-    - https://build.nvidia.com/nvidia/nemotron-3-nano-30b-a3b/modelcard
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-nvidia-nemotron-nano-3-30b.html
 status: active
 supportedModes:
     - chat

--- a/providers/aws-bedrock/nvidia.nemotron-nano-9b-v2.yaml
+++ b/providers/aws-bedrock/nvidia.nemotron-nano-9b-v2.yaml
@@ -49,7 +49,7 @@ params:
       maxValue: 8192
       minValue: 1
 provisioning: serverless
-remove_params:
+removeParams:
     - reasoning_effort
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-nvidia-nvidia-nemotron-nano-9b-v2.html

--- a/providers/aws-bedrock/nvidia.nemotron-nano-9b-v2.yaml
+++ b/providers/aws-bedrock/nvidia.nemotron-nano-9b-v2.yaml
@@ -49,6 +49,8 @@ params:
       maxValue: 8192
       minValue: 1
 provisioning: serverless
+remove_params:
+    - reasoning_effort
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-nvidia-nvidia-nemotron-nano-9b-v2.html
 status: active

--- a/providers/aws-bedrock/nvidia.nemotron-super-3-120b.yaml
+++ b/providers/aws-bedrock/nvidia.nemotron-super-3-120b.yaml
@@ -60,6 +60,7 @@ params:
       maxValue: 32768
 removeParams:
     - "n"
+    - reasoning_effort
 sources:
     - https://build.nvidia.com/nvidia/nemotron-3-super-120b/modelcard
     - https://aws.amazon.com/marketplace/pp/prodview-pb4o36dbo6dzi

--- a/providers/aws-bedrock/us.amazon.nova-2-lite-v1:0.yaml
+++ b/providers/aws-bedrock/us.amazon.nova-2-lite-v1:0.yaml
@@ -56,4 +56,3 @@ sources:
 status: active
 supportedModes:
     - chat
-thinking: true

--- a/providers/aws-bedrock/us.amazon.nova-lite-v1:0.yaml
+++ b/providers/aws-bedrock/us.amazon.nova-lite-v1:0.yaml
@@ -65,4 +65,3 @@ sources:
 status: active
 supportedModes:
     - chat
-thinking: true

--- a/providers/aws-bedrock/zai.glm-4.7.yaml
+++ b/providers/aws-bedrock/zai.glm-4.7.yaml
@@ -48,6 +48,8 @@ params:
       maxValue: 4000
       minValue: 1
 provisioning: serverless
+removeParams:
+    - reasoning_effort
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-zai-glm-4-7.html
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html

--- a/providers/aws-bedrock/zai.glm-5.yaml
+++ b/providers/aws-bedrock/zai.glm-5.yaml
@@ -25,6 +25,8 @@ params:
       key: max_tokens
       maxValue: 128000
       minValue: 1
+removeParams:
+    - reasoning_effort
 sources:
     - https://aws.amazon.com/about-aws/whats-new/2026/03/amazon-bedrock-minimax-glm/
     - https://docs.z.ai/guides/llm/glm-5


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches multiple Bedrock model definition YAMLs that drive supported feature flags and request parameter filtering; mistakes could cause invalid requests or incorrectly disable/enable capabilities for these models.
> 
> **Overview**
> Adjusts AWS Bedrock model metadata to better match supported request parameters and capabilities.
> 
> Removes the `json_output` feature flag from several models (AI21 Jamba and Mistral Pixtral/Mistral Large), drops `thinking: true` from multiple Amazon Nova Lite / Nova 2 Lite regional configs, and removes the `function_calling` feature block from `google.gemma-3-27b-it`.
> 
> Adds `removeParams: [reasoning_effort]` for Moonshot Kimi, multiple NVIDIA Nemotron models (including adding it alongside existing `removeParams` on Nemotron Super), and ZAI GLM models, plus updates Nemotron Nano 3 30B sources to include the AWS model card link.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56ad9c3f99a0231a7fbb00d3a4345a97dca92753. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->