### PR TITLE
feat(anthropic): update model YAMLs [bot]

### DIFF
--- a/providers/anthropic/claude-opus-4-7.yaml
+++ b/providers/anthropic/claude-opus-4-7.yaml
@@ -14,6 +14,7 @@ features:
     - tool_choice
     - prompt_caching
     - assistant_prefill
+    - structured_output
     - code_execution
 limits:
     context_window: 1000000

--- a/providers/anthropic/claude-opus-4-7.yaml
+++ b/providers/anthropic/claude-opus-4-7.yaml
@@ -1,2 +1,46 @@
-mode: unknown
+costs:
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      input_cost_per_token_batches: 0.0000025
+      output_cost_per_token: 0.000025
+      output_cost_per_token_batches: 0.0000125
+      region: "*"
+features:
+    - function_calling
+    - parallel_function_calling
+    - cache_control
+    - system_messages
+    - tool_choice
+    - prompt_caching
+    - assistant_prefill
+    - code_execution
+limits:
+    context_window: 1000000
+    max_input_tokens: 1000000
+    max_output_tokens: 128000
+    max_tokens: 128000
+    tool_use_system_prompt_tokens: 346
+modalities:
+    input:
+        - text
+        - image
+        - pdf
+    output:
+        - text
+mode: chat
 model: claude-opus-4-7
+params:
+    - defaultValue: 256
+      key: max_tokens
+      maxValue: 128000
+      minValue: 1
+provisioning: serverless
+sources:
+    - https://platform.claude.com/docs/en/build-with-claude/vision
+    - https://platform.claude.com/docs/en/build-with-claude/extended-thinking
+    - https://platform.claude.com/docs/en/build-with-claude/pdf-support
+status: active
+supportedModes:
+    - chat
+thinking: true


### PR DESCRIPTION
Auto-generated by poc-agent for provider `anthropic`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change adding a new model definition; risk is limited to incorrect pricing/limits/capability flags affecting routing or UI expectations.
> 
> **Overview**
> Adds/updates `providers/anthropic/claude-opus-4-7.yaml` to fully define the `claude-opus-4-7` model, including per-token pricing (with batch and cache rates), supported features (tools/function calling, prompt caching, structured output, code execution), and modality support (text/image/pdf).
> 
> Sets operational metadata like `mode: chat`, `thinking: true`, serverless provisioning, and very large context/output limits plus a configurable `max_tokens` param range.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 251d38b87332d1f29b4d4f1d5cba8965dfba37c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->