### PR TITLE
feat(google-vertex): add new models [bot]

### DIFF
--- a/providers/google-vertex/anthropic/claude-opus-4-7.yaml
+++ b/providers/google-vertex/anthropic/claude-opus-4-7.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: anthropic/claude-opus-4-7

--- a/providers/google-vertex/deepseek-ai/deepseek-ocr-maas.yaml
+++ b/providers/google-vertex/deepseek-ai/deepseek-ocr-maas.yaml
@@ -1,7 +1,7 @@
 costs:
     - input_cost_per_token: 3.e-7
       output_cost_per_token: 0.0000012
-      region: global # docs specify us-central1 but the model is only available via global inference
+      region: global
 features:
     - function_calling
     - structured_output

--- a/providers/google-vertex/deepseek-ai/deepseek-v3.1-maas.yaml
+++ b/providers/google-vertex/deepseek-ai/deepseek-v3.1-maas.yaml
@@ -4,7 +4,7 @@ costs:
       input_cost_per_token_batches: 3.e-7
       output_cost_per_token: 0.0000017
       output_cost_per_token_batches: 8.5e-7
-      region: us-west2 # docs specify us-central1 but the model is available via us-west2 inference
+      region: us-west2
 features:
     - function_calling
     - tool_choice


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `google-vertex`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only changes to model metadata with no runtime logic changes; risk is limited to potential misconfiguration affecting model selection/region routing.
> 
> **Overview**
> Adds a new Google Vertex model definition for `anthropic/claude-opus-4-7` (currently marked with `mode: unknown`).
> 
> Cleans up the DeepSeek MaaS model YAMLs by removing inline commentary from the `region` fields (keeping `deepseek-ocr-maas` as `global` and `deepseek-v3.1-maas` as `us-west2`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a87b45c134e29154f5c74d0a8a7b2832f7700a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->