### PR TITLE
feat(aws-bedrock): add new models [bot]

### DIFF
--- a/providers/aws-bedrock/eu.anthropic.claude-opus-4-7.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-opus-4-7.yaml
@@ -1,0 +1,11 @@
+costs:
+    - region: eu-west-3
+    - region: eu-west-2
+    - region: eu-west-1
+    - region: eu-south-2
+    - region: eu-south-1
+    - region: eu-north-1
+    - region: eu-central-2
+    - region: eu-central-1
+mode: unknown
+model: eu.anthropic.claude-opus-4-7

--- a/providers/aws-bedrock/global.anthropic.claude-opus-4-7.yaml
+++ b/providers/aws-bedrock/global.anthropic.claude-opus-4-7.yaml
@@ -1,0 +1,34 @@
+costs:
+    - region: us-west-2
+    - region: us-west-1
+    - region: us-east-2
+    - region: us-east-1
+    - region: sa-east-1
+    - region: mx-central-1
+    - region: il-central-1
+    - region: eu-west-3
+    - region: eu-west-2
+    - region: eu-west-1
+    - region: eu-south-2
+    - region: eu-south-1
+    - region: eu-north-1
+    - region: eu-central-2
+    - region: eu-central-1
+    - region: ca-west-1
+    - region: ca-central-1
+    - region: ap-southeast-7
+    - region: ap-southeast-6
+    - region: ap-southeast-5
+    - region: ap-southeast-4
+    - region: ap-southeast-3
+    - region: ap-southeast-2
+    - region: ap-southeast-1
+    - region: ap-south-2
+    - region: ap-south-1
+    - region: ap-northeast-3
+    - region: ap-northeast-2
+    - region: ap-northeast-1
+    - region: ap-east-2
+    - region: af-south-1
+mode: unknown
+model: global.anthropic.claude-opus-4-7

--- a/providers/aws-bedrock/jp.anthropic.claude-opus-4-7.yaml
+++ b/providers/aws-bedrock/jp.anthropic.claude-opus-4-7.yaml
@@ -1,0 +1,5 @@
+costs:
+    - region: ap-northeast-3
+    - region: ap-northeast-1
+mode: unknown
+model: jp.anthropic.claude-opus-4-7

--- a/providers/aws-bedrock/us.anthropic.claude-opus-4-7.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-opus-4-7.yaml
@@ -1,0 +1,9 @@
+costs:
+    - region: us-west-2
+    - region: us-west-1
+    - region: us-east-2
+    - region: us-east-1
+    - region: ca-west-1
+    - region: ca-central-1
+mode: unknown
+model: us.anthropic.claude-opus-4-7


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `aws-bedrock`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds new provider config files only; no runtime logic changes, with risk mainly limited to incorrect region/cost metadata affecting model selection or pricing displays.
> 
> **Overview**
> Adds new AWS Bedrock model configuration YAMLs for `anthropic.claude-opus-4-7` with `global`, `us`, `eu`, and `jp` variants.
> 
> Each new file declares the model identifier, sets `mode: unknown`, and enumerates the AWS regions used for cost/availability mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5982e772a7a097b01ca3b4c212ded6523c19e76b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->