### PR TITLE
feat(openrouter): add new models [bot]

### DIFF
--- a/providers/openrouter/anthropic/claude-opus-4.7.yaml
+++ b/providers/openrouter/anthropic/claude-opus-4.7.yaml
@@ -1,0 +1,24 @@
+costs:
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: "*"
+features:
+    - function_calling
+    - json_output
+    - prompt_caching
+    - structured_output
+    - tool_choice
+limits:
+    context_window: 1000000
+    max_output_tokens: 128000
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
+mode: chat
+model: anthropic/claude-opus-4.7
+thinking: true

--- a/providers/openrouter/openai/gpt-4-1106-preview.yaml
+++ b/providers/openrouter/openai/gpt-4-1106-preview.yaml
@@ -1,0 +1,19 @@
+costs:
+    - input_cost_per_token: 0.00001
+      output_cost_per_token: 0.00003
+      region: "*"
+features:
+    - function_calling
+    - json_output
+    - structured_output
+    - tool_choice
+limits:
+    context_window: 128000
+    max_output_tokens: 4096
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: chat
+model: openai/gpt-4-1106-preview


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `openrouter`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adds new provider metadata files (costs/features/limits) and does not change runtime logic, but incorrect values could affect model selection, limits, or cost calculations.
> 
> **Overview**
> Registers two additional OpenRouter models by adding YAML definitions for `anthropic/claude-opus-4.7` (includes *prompt caching*, image input, very large context/output limits, and `thinking: true`) and `openai/gpt-4-1106-preview`.
> 
> Each file specifies token pricing, supported features (function/tool calling + structured/JSON output), and `context_window`/`max_output_tokens` limits to be used by the rest of the system.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90eb7e14b47b0e15093e155d46754c45b7ea8fbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->