### PR TITLE
feat(aws-bedrock): update model YAMLs [bot]

### DIFF
--- a/providers/aws-bedrock/amazon.nova-2-sonic-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.nova-2-sonic-v1:0.yaml
@@ -22,6 +22,7 @@ costs:
 features:
     - function_calling
     - system_messages
+    - tool_choice
 limits:
     context_window: 1000000
     max_output_tokens: 65536
@@ -40,6 +41,7 @@ params:
       key: max_tokens
       maxValue: 65536
       minValue: 1
+provisioning: serverless
 sources:
     - https://aws.amazon.com/nova/models/
     - https://docs.aws.amazon.com/nova/latest/nova2-userguide/what-is-nova-2.html

--- a/providers/aws-bedrock/amazon.nova-micro-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.nova-micro-v1:0.yaml
@@ -1,8 +1,6 @@
 costs:
-    - cache_creation_input_token_cost: 0
-      cache_read_input_token_cost: 8.75e-9
-      input_cost_per_token: 3.5e-8
-      output_cost_per_token: 1.4e-7
+    - input_cost_per_token: 4.2e-8
+      output_cost_per_token: 1.68e-7
       region: us-gov-west-1
     - cache_creation_input_token_cost: 0
       cache_read_input_token_cost: 8.75e-9
@@ -11,15 +9,18 @@ costs:
       output_cost_per_token: 1.4e-7
       output_cost_per_token_batches: 7.e-8
       region: us-east-1
-    - region: eu-west-2
+    - input_cost_per_token: 4.9e-8
+      output_cost_per_token: 1.96e-7
+      region: eu-west-2
     - input_cost_per_token: 3.7e-8
       output_cost_per_token: 1.48e-7
       region: ap-southeast-2
 features:
+    - assistant_prefill
     - function_calling
+    - prompt_caching
     - system_messages
     - tool_choice
-    - prompt_caching
 limits:
     context_window: 128000
     max_output_tokens: 5000
@@ -43,6 +44,7 @@ params:
     - key: top_k
       maxValue: 128
       minValue: 0
+provisioning: serverless
 removeParams:
     - "n"
 sources:
@@ -55,4 +57,3 @@ sources:
 status: active
 supportedModes:
     - chat
-thinking: false

--- a/providers/aws-bedrock/amazon.nova-pro-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.nova-pro-v1:0.yaml
@@ -62,6 +62,8 @@ costs:
       output_cost_per_token: 0.0000042
       output_cost_per_token_batches: 0.0000021
       region: eu-central-1
+    - region: ap-southeast-7
+    - region: ap-southeast-5
     - input_cost_per_token: 8.7e-7
       input_cost_per_token_batches: 4.35e-7
       output_cost_per_token: 0.00000348
@@ -93,15 +95,17 @@ costs:
       output_cost_per_token: 0.00000384
       output_cost_per_token_batches: 0.00000192
       region: ap-northeast-1
+    - region: ap-east-2
 features:
     - function_calling
     - system_messages
     - tool_choice
     - prompt_caching
+    - assistant_prefill
 limits:
     context_window: 300000
-    max_output_tokens: 5000
-    max_tokens: 5000
+    max_output_tokens: 10000
+    max_tokens: 10000
 modalities:
     input:
         - text
@@ -125,6 +129,7 @@ params:
     - key: top_k
       maxValue: 128
       minValue: 0
+provisioning: serverless
 removeParams:
     - "n"
 sources:

--- a/providers/aws-bedrock/amazon.nova-pro-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.nova-pro-v1:0.yaml
@@ -62,8 +62,6 @@ costs:
       output_cost_per_token: 0.0000042
       output_cost_per_token_batches: 0.0000021
       region: eu-central-1
-    - region: ap-southeast-7
-    - region: ap-southeast-5
     - input_cost_per_token: 8.7e-7
       input_cost_per_token_batches: 4.35e-7
       output_cost_per_token: 0.00000348
@@ -95,7 +93,6 @@ costs:
       output_cost_per_token: 0.00000384
       output_cost_per_token_batches: 0.00000192
       region: ap-northeast-1
-    - region: ap-east-2
 features:
     - function_calling
     - system_messages
@@ -104,8 +101,8 @@ features:
     - assistant_prefill
 limits:
     context_window: 300000
-    max_output_tokens: 10000
-    max_tokens: 10000
+    max_output_tokens: 5000
+    max_tokens: 5000
 modalities:
     input:
         - text

--- a/providers/aws-bedrock/amazon.titan-tg1-large.yaml
+++ b/providers/aws-bedrock/amazon.titan-tg1-large.yaml
@@ -28,6 +28,7 @@ params:
       minValue: 1
     - defaultValue: 0.7
       key: temperature
+provisioning: serverless
 removeParams:
     - "n"
 sources:

--- a/providers/aws-bedrock/anthropic.claude-opus-4-6-v1.yaml
+++ b/providers/aws-bedrock/anthropic.claude-opus-4-6-v1.yaml
@@ -186,11 +186,13 @@ params:
       key: max_tokens
       maxValue: 128000
       minValue: 1
+provisioning: serverless
 removeParams:
     - "n"
 sources:
     - https://platform.claude.com/docs/en/docs/about-claude/models
     - https://platform.claude.com/docs/en/docs/about-claude/pricing
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html
 status: active
 supportedModes:
     - chat

--- a/providers/aws-bedrock/anthropic.claude-sonnet-4-6.yaml
+++ b/providers/aws-bedrock/anthropic.claude-sonnet-4-6.yaml
@@ -248,9 +248,11 @@ params:
       key: max_tokens
       maxValue: 64000
       minValue: 1
+provisioning: serverless
 sources:
     - https://platform.claude.com/docs/en/docs/about-claude/models
     - https://platform.claude.com/docs/en/about-claude/pricing
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html
 status: active
 supportedModes:
     - chat

--- a/providers/aws-bedrock/jp.anthropic.claude-sonnet-4-6.yaml
+++ b/providers/aws-bedrock/jp.anthropic.claude-sonnet-4-6.yaml
@@ -40,10 +40,12 @@ params:
       key: max_tokens
       maxValue: 64000
       minValue: 1
+provisioning: serverless
 sources:
     - https://platform.claude.com/docs/en/docs/about-claude/models
     - https://platform.claude.com/docs/en/about-claude/pricing
     - https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference-support.html
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html
 status: active
 supportedModes:
     - chat

--- a/providers/aws-bedrock/meta.llama3-1-70b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/meta.llama3-1-70b-instruct-v1:0.yaml
@@ -23,10 +23,10 @@ modalities:
         - text
 mode: chat
 model: meta.llama3-1-70b-instruct-v1:0
+provisioning: serverless
 sources:
-    - https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-meta.html
-    - https://ai.meta.com/blog/meta-llama-3-1/
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html
 status: active
 supportedModes:
     - chat

--- a/providers/aws-bedrock/meta.llama3-1-8b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/meta.llama3-1-8b-instruct-v1:0.yaml
@@ -29,6 +29,7 @@ modalities:
         - text
 mode: chat
 model: meta.llama3-1-8b-instruct-v1:0
+provisioning: serverless
 removeParams:
     - "n"
 sources:

--- a/providers/aws-bedrock/minimax.minimax-m2.5.yaml
+++ b/providers/aws-bedrock/minimax.minimax-m2.5.yaml
@@ -83,6 +83,7 @@ model: minimax.minimax-m2.5
 params:
     - key: max_tokens
       maxValue: 8000
+provisioning: serverless
 removeParams:
     - "n"
     - stop
@@ -90,7 +91,6 @@ sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-minimax-minimax-m2-5.html
     - https://platform.minimax.io/docs/guides/pricing-paygo
     - https://platform.minimax.io/docs/api-reference/text-anthropic-api
-    - https://www.minimax.io/news/minimax-m25
 status: active
 supportedModes:
     - chat

--- a/providers/aws-bedrock/mistral.devstral-2-123b.yaml
+++ b/providers/aws-bedrock/mistral.devstral-2-123b.yaml
@@ -40,6 +40,7 @@ costs:
       region: ap-northeast-1
 features:
     - function_calling
+    - structured_output
 limits:
     context_window: 256000
     max_output_tokens: 32000

--- a/providers/aws-bedrock/mistral.devstral-2-123b.yaml
+++ b/providers/aws-bedrock/mistral.devstral-2-123b.yaml
@@ -40,7 +40,6 @@ costs:
       region: ap-northeast-1
 features:
     - function_calling
-    - structured_output
 limits:
     context_window: 256000
     max_output_tokens: 32000
@@ -57,6 +56,7 @@ params:
       key: max_tokens
       maxValue: 32000
       minValue: 1
+provisioning: serverless
 sources:
     - https://docs.mistral.ai/models/devstral-2-25-12
 status: active

--- a/providers/aws-bedrock/nvidia.nemotron-super-3-120b.yaml
+++ b/providers/aws-bedrock/nvidia.nemotron-super-3-120b.yaml
@@ -58,6 +58,7 @@ model: nvidia.nemotron-super-3-120b
 params:
     - key: max_tokens
       maxValue: 32768
+provisioning: serverless
 removeParams:
     - "n"
     - reasoning_effort
@@ -65,6 +66,8 @@ sources:
     - https://build.nvidia.com/nvidia/nemotron-3-super-120b/modelcard
     - https://aws.amazon.com/marketplace/pp/prodview-pb4o36dbo6dzi
     - https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-nvidia-nemotron-super-3-120b.html
+status: active
 supportedModes:
     - chat
 thinking: true

--- a/providers/aws-bedrock/us.stability.stable-conservative-upscale-v1:0.yaml
+++ b/providers/aws-bedrock/us.stability.stable-conservative-upscale-v1:0.yaml
@@ -1,9 +1,9 @@
 costs:
-    - input_cost_per_image: 0
+    - output_cost_per_image: 0.4
       region: us-west-2
-    - input_cost_per_image: 0
+    - output_cost_per_image: 0.4
       region: us-east-2
-    - input_cost_per_image: 0
+    - output_cost_per_image: 0.4
       region: us-east-1
 messages:
     options:
@@ -21,6 +21,7 @@ params:
       key: seed
       maxValue: 4294967294
       minValue: 0
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature

--- a/providers/aws-bedrock/us.stability.stable-creative-upscale-v1:0.yaml
+++ b/providers/aws-bedrock/us.stability.stable-creative-upscale-v1:0.yaml
@@ -13,6 +13,7 @@ modalities:
         - image
 mode: image
 model: us.stability.stable-creative-upscale-v1:0
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature

--- a/providers/aws-bedrock/us.stability.stable-fast-upscale-v1:0.yaml
+++ b/providers/aws-bedrock/us.stability.stable-fast-upscale-v1:0.yaml
@@ -14,6 +14,7 @@ modalities:
         - image
 mode: image
 model: us.stability.stable-fast-upscale-v1:0
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature
@@ -23,6 +24,7 @@ removeParams:
     - stream
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/stable-image-services.html
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-stability-ai-stable-image-fast-upscale.html
 status: active
 supportedModes:
     - image

--- a/providers/aws-bedrock/us.stability.stable-image-control-sketch-v1:0.yaml
+++ b/providers/aws-bedrock/us.stability.stable-image-control-sketch-v1:0.yaml
@@ -13,6 +13,7 @@ modalities:
         - image
 mode: image
 model: us.stability.stable-image-control-sketch-v1:0
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature

--- a/providers/aws-bedrock/us.stability.stable-image-control-structure-v1:0.yaml
+++ b/providers/aws-bedrock/us.stability.stable-image-control-structure-v1:0.yaml
@@ -13,6 +13,7 @@ modalities:
         - image
 mode: image
 model: us.stability.stable-image-control-structure-v1:0
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature

--- a/providers/aws-bedrock/us.stability.stable-image-erase-object-v1:0.yaml
+++ b/providers/aws-bedrock/us.stability.stable-image-erase-object-v1:0.yaml
@@ -17,6 +17,7 @@ params:
       key: seed
       maxValue: 4294967294
       minValue: 0
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature

--- a/providers/aws-bedrock/us.stability.stable-image-inpaint-v1:0.yaml
+++ b/providers/aws-bedrock/us.stability.stable-image-inpaint-v1:0.yaml
@@ -1,9 +1,9 @@
 costs:
-    - input_cost_per_image: 0.04
+    - input_cost_per_image: 0.07
       region: us-west-2
-    - input_cost_per_image: 0.04
+    - input_cost_per_image: 0.07
       region: us-east-2
-    - input_cost_per_image: 0.04
+    - input_cost_per_image: 0.07
       region: us-east-1
 messages:
     options: []
@@ -15,6 +15,7 @@ modalities:
         - image
 mode: image
 model: us.stability.stable-image-inpaint-v1:0
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature

--- a/providers/aws-bedrock/us.stability.stable-image-remove-background-v1:0.yaml
+++ b/providers/aws-bedrock/us.stability.stable-image-remove-background-v1:0.yaml
@@ -15,6 +15,7 @@ modalities:
         - image
 mode: image
 model: us.stability.stable-image-remove-background-v1:0
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature

--- a/providers/aws-bedrock/us.stability.stable-image-search-recolor-v1:0.yaml
+++ b/providers/aws-bedrock/us.stability.stable-image-search-recolor-v1:0.yaml
@@ -13,6 +13,7 @@ modalities:
         - image
 mode: image
 model: us.stability.stable-image-search-recolor-v1:0
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature
@@ -22,6 +23,7 @@ removeParams:
     - stream
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/stable-image-services.html
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-stability-ai-stable-image-search-and-recolor.html
 status: active
 supportedModes:
     - image

--- a/providers/aws-bedrock/us.stability.stable-image-search-replace-v1:0.yaml
+++ b/providers/aws-bedrock/us.stability.stable-image-search-replace-v1:0.yaml
@@ -13,6 +13,7 @@ modalities:
         - image
 mode: image
 model: us.stability.stable-image-search-replace-v1:0
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature

--- a/providers/aws-bedrock/us.stability.stable-image-style-guide-v1:0.yaml
+++ b/providers/aws-bedrock/us.stability.stable-image-style-guide-v1:0.yaml
@@ -13,6 +13,7 @@ modalities:
         - image
 mode: image
 model: us.stability.stable-image-style-guide-v1:0
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature

--- a/providers/aws-bedrock/us.stability.stable-outpaint-v1:0.yaml
+++ b/providers/aws-bedrock/us.stability.stable-outpaint-v1:0.yaml
@@ -13,6 +13,7 @@ modalities:
         - image
 mode: image
 model: us.stability.stable-outpaint-v1:0
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature

--- a/providers/aws-bedrock/us.stability.stable-style-transfer-v1:0.yaml
+++ b/providers/aws-bedrock/us.stability.stable-style-transfer-v1:0.yaml
@@ -13,6 +13,7 @@ modalities:
         - image
 mode: image
 model: us.stability.stable-style-transfer-v1:0
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature
@@ -22,7 +23,6 @@ removeParams:
     - stream
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/stable-image-services.html
-    - https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-stability-ai-stable-image-style-transfer.html
 status: active
 supportedModes:

--- a/providers/aws-bedrock/zai.glm-5.yaml
+++ b/providers/aws-bedrock/zai.glm-5.yaml
@@ -8,7 +8,6 @@ costs:
 features:
     - function_calling
     - structured_output
-    - prompt_caching
 limits:
     context_window: 200000
     max_output_tokens: 128000
@@ -25,6 +24,7 @@ params:
       key: max_tokens
       maxValue: 128000
       minValue: 1
+provisioning: serverless
 removeParams:
     - reasoning_effort
 sources:


### PR DESCRIPTION
Auto-generated by poc-agent for provider `aws-bedrock`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates model metadata used for capability gating and cost estimation; incorrect values could affect pricing calculations or enable/disable unsupported features for specific Bedrock models/regions.
> 
> **Overview**
> Refreshes AWS Bedrock provider model YAMLs to mark many models as `provisioning: serverless` and to align feature flags (notably adding `assistant_prefill`, `prompt_caching`, and `tool_choice` where supported).
> 
> Updates per-region pricing entries for several models (e.g., `amazon.nova-micro-v1:0` token costs, Stability upscale/inpaint image costs) and refreshes `sources`/metadata (e.g., adds Bedrock inference profile docs links; fixes/extends NVIDIA Nemotron model card and ensures `status: active`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 040d2b539b1ecc96856f53cf42beec19a2f59ee3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->