### PR TITLE
feat(deepinfra): update model YAMLs [bot]

### DIFF
--- a/providers/deepinfra/BAAI/bge-base-en-v1.5.yaml
+++ b/providers/deepinfra/BAAI/bge-base-en-v1.5.yaml
@@ -7,12 +7,15 @@ limits:
 modalities:
     input:
         - text
+    output:
+        - embedding
 mode: embedding
 model: BAAI/bge-base-en-v1.5
+provisioning: serverless
 removeParams:
     - max_tokens
 sources:
-    - https://deepinfra.com/BAAI/bge-base-en-v1.5/api
+    - https://deepinfra.com/BAAI/bge-base-en-v1.5
 status: active
 supportedModes:
     - embedding

--- a/providers/deepinfra/BAAI/bge-en-icl.yaml
+++ b/providers/deepinfra/BAAI/bge-en-icl.yaml
@@ -4,15 +4,16 @@ costs:
 modalities:
     input:
         - text
+        - image
     output:
         - embedding
 mode: embedding
 model: BAAI/bge-en-icl
+provisioning: serverless
 removeParams:
     - max_tokens
 sources:
     - https://deepinfra.com/BAAI/bge-en-icl
-    - https://deepinfra.com/BAAI/bge-en-icl/api
 status: active
 supportedModes:
     - embedding

--- a/providers/deepinfra/BAAI/bge-large-en-v1.5.yaml
+++ b/providers/deepinfra/BAAI/bge-large-en-v1.5.yaml
@@ -11,10 +11,11 @@ modalities:
         - embedding
 mode: embedding
 model: BAAI/bge-large-en-v1.5
+provisioning: serverless
 removeParams:
     - max_tokens
 sources:
-    - https://deepinfra.com/BAAI/bge-large-en-v1.5/api
+    - https://deepinfra.com/BAAI/bge-large-en-v1.5
 status: active
 supportedModes:
     - embedding

--- a/providers/deepinfra/BAAI/bge-m3-multi.yaml
+++ b/providers/deepinfra/BAAI/bge-m3-multi.yaml
@@ -11,11 +11,11 @@ modalities:
         - embedding
 mode: embedding
 model: BAAI/bge-m3-multi
+provisioning: serverless
 removeParams:
     - max_tokens
 sources:
-    - https://deepinfra.com/BAAI/bge-m3-multi/api
-    - https://huggingface.co/BAAI/bge-m3
+    - https://deepinfra.com/BAAI/bge-m3-multi
 status: active
 supportedModes:
     - embedding

--- a/providers/deepinfra/BAAI/bge-m3.yaml
+++ b/providers/deepinfra/BAAI/bge-m3.yaml
@@ -8,7 +8,6 @@ limits:
 modalities:
     input:
         - text
-        - image
     output:
         - embedding
 mode: embedding

--- a/providers/deepinfra/BAAI/bge-m3.yaml
+++ b/providers/deepinfra/BAAI/bge-m3.yaml
@@ -8,13 +8,16 @@ limits:
 modalities:
     input:
         - text
+        - image
     output:
         - embedding
 mode: embedding
 model: BAAI/bge-m3
+provisioning: serverless
 removeParams:
     - max_tokens
 sources:
-    - https://deepinfra.com/BAAI/bge-m3/api
+    - https://deepinfra.com/BAAI/bge-m3
+status: active
 supportedModes:
     - embedding

--- a/providers/deepinfra/Bria/Bria-3.2-vector.yaml
+++ b/providers/deepinfra/Bria/Bria-3.2-vector.yaml
@@ -3,13 +3,14 @@ costs:
       region: "*"
 modalities:
     input:
-        - image
+        - text
     output:
         - image
 mode: image
 model: Bria/Bria-3.2-vector
+provisioning: serverless
 sources:
-    - https://deepinfra.com/Bria/Bria-3.2-vector/api
+    - https://deepinfra.com/Bria/Bria-3.2-vector
 status: active
 supportedModes:
     - image

--- a/providers/deepinfra/Bria/Bria-3.2.yaml
+++ b/providers/deepinfra/Bria/Bria-3.2.yaml
@@ -8,8 +8,9 @@ modalities:
         - image
 mode: image
 model: Bria/Bria-3.2
+provisioning: serverless
 sources:
-    - https://deepinfra.com/Bria/Bria-3.2/api
+    - https://deepinfra.com/Bria/Bria-3.2
 status: active
 supportedModes:
     - image

--- a/providers/deepinfra/Bria/blur_background.yaml
+++ b/providers/deepinfra/Bria/blur_background.yaml
@@ -8,7 +8,9 @@ modalities:
         - image
 mode: image
 model: Bria/blur_background
+provisioning: serverless
 sources:
-    - https://deepinfra.com/Bria/blur_background/api
+    - https://deepinfra.com/Bria/blur_background
+status: active
 supportedModes:
     - image

--- a/providers/deepinfra/Bria/enhance.yaml
+++ b/providers/deepinfra/Bria/enhance.yaml
@@ -8,8 +8,9 @@ modalities:
         - image
 mode: image
 model: Bria/enhance
+provisioning: serverless
 sources:
-    - https://deepinfra.com/Bria/enhance/api
+    - https://deepinfra.com/Bria/enhance
 status: active
 supportedModes:
     - image

--- a/providers/deepinfra/Bria/erase.yaml
+++ b/providers/deepinfra/Bria/erase.yaml
@@ -8,8 +8,9 @@ modalities:
         - image
 mode: image
 model: Bria/erase
+provisioning: serverless
 sources:
-    - https://deepinfra.com/Bria/erase/api
+    - https://deepinfra.com/Bria/erase
 status: active
 supportedModes:
     - image

--- a/providers/deepinfra/Bria/erase_foreground.yaml
+++ b/providers/deepinfra/Bria/erase_foreground.yaml
@@ -8,9 +8,9 @@ modalities:
         - image
 mode: image
 model: Bria/erase_foreground
+provisioning: serverless
 sources:
     - https://deepinfra.com/Bria/erase_foreground
-    - https://deepinfra.com/Bria/erase_foreground/api
 status: active
 supportedModes:
     - image

--- a/providers/deepinfra/Bria/expand.yaml
+++ b/providers/deepinfra/Bria/expand.yaml
@@ -8,8 +8,9 @@ modalities:
         - image
 mode: image
 model: Bria/expand
+provisioning: serverless
 sources:
-    - https://deepinfra.com/Bria/expand/api
+    - https://deepinfra.com/Bria/expand
 status: active
 supportedModes:
     - image

--- a/providers/deepinfra/Bria/fibo.yaml
+++ b/providers/deepinfra/Bria/fibo.yaml
@@ -9,8 +9,9 @@ modalities:
         - image
 mode: image
 model: Bria/fibo
+provisioning: serverless
 sources:
-    - https://deepinfra.com/Bria/fibo/api
+    - https://deepinfra.com/Bria/fibo
 status: active
 supportedModes:
     - image

--- a/providers/deepinfra/Bria/fibo_edit.yaml
+++ b/providers/deepinfra/Bria/fibo_edit.yaml
@@ -9,7 +9,9 @@ modalities:
         - image
 mode: image
 model: Bria/fibo_edit
+provisioning: serverless
 sources:
-    - https://deepinfra.com/Bria/fibo_edit/api
+    - https://deepinfra.com/Bria/fibo_edit
+status: active
 supportedModes:
     - image

--- a/providers/deepinfra/Bria/gen_fill.yaml
+++ b/providers/deepinfra/Bria/gen_fill.yaml
@@ -9,9 +9,9 @@ modalities:
         - image
 mode: image
 model: Bria/gen_fill
+provisioning: serverless
 sources:
     - https://deepinfra.com/Bria/gen_fill
-    - https://deepinfra.com/Bria/gen_fill/api
 status: active
 supportedModes:
     - image

--- a/providers/deepinfra/Bria/remove_background.yaml
+++ b/providers/deepinfra/Bria/remove_background.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_image: 0
+    - input_cost_per_image: 0.018
       region: "*"
 modalities:
     input:
@@ -8,8 +8,9 @@ modalities:
         - image
 mode: image
 model: Bria/remove_background
+provisioning: serverless
 sources:
-    - https://deepinfra.com/Bria/remove_background/api
+    - https://deepinfra.com/Bria/remove_background
 status: active
 supportedModes:
     - image

--- a/providers/deepinfra/Bria/replace_background.yaml
+++ b/providers/deepinfra/Bria/replace_background.yaml
@@ -8,8 +8,9 @@ modalities:
         - image
 mode: image
 model: Bria/replace_background
+provisioning: serverless
 sources:
-    - https://deepinfra.com/Bria/replace_background/api
+    - https://deepinfra.com/Bria/replace_background
 status: active
 supportedModes:
     - image

--- a/providers/deepinfra/ByteDance/Seed-1.8.yaml
+++ b/providers/deepinfra/ByteDance/Seed-1.8.yaml
@@ -15,6 +15,7 @@ costs:
                 from: 128000
 features:
     - function_calling
+    - json_output
     - prompt_caching
 limits:
     context_window: 256000
@@ -28,8 +29,9 @@ modalities:
         - text
 mode: chat
 model: ByteDance/Seed-1.8
+provisioning: serverless
 sources:
-    - https://deepinfra.com/ByteDance/Seed-1.8/api
+    - https://deepinfra.com/ByteDance/Seed-1.8
 supportedModes:
     - chat
 thinking: true

--- a/providers/deepinfra/ByteDance/Seed-2.0-mini.yaml
+++ b/providers/deepinfra/ByteDance/Seed-2.0-mini.yaml
@@ -27,8 +27,10 @@ modalities:
         - text
 mode: chat
 model: ByteDance/Seed-2.0-mini
+provisioning: serverless
 sources:
-    - https://deepinfra.com/ByteDance/Seed-2.0-mini/api
+    - https://deepinfra.com/ByteDance/Seed-2.0-mini
+status: active
 supportedModes:
     - chat
 thinking: true

--- a/providers/deepinfra/ByteDance/Seedream-4.5.yaml
+++ b/providers/deepinfra/ByteDance/Seedream-4.5.yaml
@@ -9,8 +9,9 @@ modalities:
         - image
 mode: image
 model: ByteDance/Seedream-4.5
+provisioning: serverless
 sources:
-    - https://deepinfra.com/ByteDance/Seedream-4.5/api
+    - https://deepinfra.com/ByteDance/Seedream-4.5
 status: active
 supportedModes:
     - image

--- a/providers/deepinfra/ByteDance/Seedream-4.yaml
+++ b/providers/deepinfra/ByteDance/Seedream-4.yaml
@@ -9,8 +9,9 @@ modalities:
         - image
 mode: image
 model: ByteDance/Seedream-4
+provisioning: serverless
 sources:
-    - https://deepinfra.com/ByteDance/Seedream-4/api
+    - https://deepinfra.com/ByteDance/Seedream-4
 status: active
 supportedModes:
     - image

--- a/providers/deepinfra/ClarityAI/creative.yaml
+++ b/providers/deepinfra/ClarityAI/creative.yaml
@@ -9,8 +9,9 @@ modalities:
         - image
 mode: image
 model: ClarityAI/creative
+provisioning: serverless
 sources:
-    - https://api.deepinfra.com/models/ClarityAI/creative
+    - https://deepinfra.com/ClarityAI/creative
 status: active
 supportedModes:
     - image

--- a/providers/deepinfra/ClarityAI/crystal.yaml
+++ b/providers/deepinfra/ClarityAI/crystal.yaml
@@ -8,7 +8,9 @@ modalities:
         - image
 mode: image
 model: ClarityAI/crystal
+provisioning: serverless
 sources:
-    - https://deepinfra.com/ClarityAI/crystal/voice
+    - https://deepinfra.com/ClarityAI/crystal
+status: active
 supportedModes:
     - image

--- a/providers/deepinfra/ClarityAI/flux.yaml
+++ b/providers/deepinfra/ClarityAI/flux.yaml
@@ -4,13 +4,14 @@ costs:
 modalities:
     input:
         - image
+        - text
     output:
         - image
 mode: image
 model: ClarityAI/flux
+provisioning: serverless
 sources:
     - https://deepinfra.com/ClarityAI/flux
-    - https://deepinfra.com/ClarityAI/flux/api
 status: active
 supportedModes:
     - image

--- a/providers/deepinfra/MiniMaxAI/MiniMax-M2.1.yaml
+++ b/providers/deepinfra/MiniMaxAI/MiniMax-M2.1.yaml
@@ -3,10 +3,12 @@ costs:
       input_cost_per_token: 2.7e-7
       output_cost_per_token: 9.5e-7
       region: "*"
+deprecationDate: "2026-04-15"
 features:
     - prompt_caching
     - function_calling
     - json_output
+isDeprecated: true
 limits:
     context_window: 196608
     max_output_tokens: 131072

--- a/providers/deepinfra/MiniMaxAI/MiniMax-M2.5.yaml
+++ b/providers/deepinfra/MiniMaxAI/MiniMax-M2.5.yaml
@@ -5,6 +5,7 @@ costs:
       region: "*"
 features:
     - function_calling
+    - json_output
     - prompt_caching
 limits:
     context_window: 196608
@@ -17,8 +18,10 @@ modalities:
         - text
 mode: chat
 model: MiniMaxAI/MiniMax-M2.5
+provisioning: serverless
 sources:
-    - https://deepinfra.com/MiniMaxAI/MiniMax-M2.5/api
+    - https://deepinfra.com/MiniMaxAI/MiniMax-M2.5
+status: active
 supportedModes:
     - chat
 thinking: true

--- a/providers/deepinfra/PaddlePaddle/PaddleOCR-VL-0.9B.yaml
+++ b/providers/deepinfra/PaddlePaddle/PaddleOCR-VL-0.9B.yaml
@@ -3,7 +3,6 @@ costs:
       output_cost_per_token: 8.e-7
       region: "*"
 features:
-    - structured_output
     - json_output
     - prompt_caching
 limits:
@@ -18,6 +17,7 @@ modalities:
         - text
 mode: chat
 model: PaddlePaddle/PaddleOCR-VL-0.9B
+provisioning: serverless
 sources:
     - https://deepinfra.com/PaddlePaddle/PaddleOCR-VL-0.9B
 status: active

--- a/providers/deepinfra/PrunaAI/p-image-Edit.yaml
+++ b/providers/deepinfra/PrunaAI/p-image-Edit.yaml
@@ -9,8 +9,9 @@ modalities:
         - image
 mode: image
 model: PrunaAI/p-image-Edit
+provisioning: serverless
 sources:
     - https://deepinfra.com/PrunaAI/p-image-Edit
-    - https://deepinfra.com/PrunaAI/p-image-Edit/api
+status: active
 supportedModes:
     - image

--- a/providers/deepinfra/PrunaAI/p-image.yaml
+++ b/providers/deepinfra/PrunaAI/p-image.yaml
@@ -8,9 +8,9 @@ modalities:
         - image
 mode: image
 model: PrunaAI/p-image
+provisioning: serverless
 sources:
     - https://deepinfra.com/PrunaAI/p-image
-    - https://deepinfra.com/PrunaAI/p-image/api
 status: active
 supportedModes:
     - image

--- a/providers/deepinfra/Qwen/Qwen-Image-Edit-Max.yaml
+++ b/providers/deepinfra/Qwen/Qwen-Image-Edit-Max.yaml
@@ -3,11 +3,13 @@ costs:
       region: "*"
 modalities:
     input:
+        - text
         - image
     output:
         - image
 mode: image
 model: Qwen/Qwen-Image-Edit-Max
+provisioning: serverless
 sources:
     - https://deepinfra.com/Qwen/Qwen-Image-Edit-Max
 status: active

--- a/providers/deepinfra/Qwen/Qwen-Image-Edit.yaml
+++ b/providers/deepinfra/Qwen/Qwen-Image-Edit.yaml
@@ -9,8 +9,9 @@ modalities:
         - image
 mode: image
 model: Qwen/Qwen-Image-Edit
+provisioning: serverless
 sources:
-    - https://deepinfra.com/Qwen/Qwen-Image-Edit/api
+    - https://deepinfra.com/Qwen/Qwen-Image-Edit
 status: active
 supportedModes:
     - image

--- a/providers/deepinfra/Qwen/Qwen-Image-Max.yaml
+++ b/providers/deepinfra/Qwen/Qwen-Image-Max.yaml
@@ -8,8 +8,9 @@ modalities:
         - image
 mode: image
 model: Qwen/Qwen-Image-Max
+provisioning: serverless
 sources:
-    - https://deepinfra.com/Qwen/Qwen-Image-Max/api
+    - https://deepinfra.com/Qwen/Qwen-Image-Max
 status: active
 supportedModes:
     - image

--- a/providers/deepinfra/Qwen/Qwen3-Embedding-0.6B-batch.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Embedding-0.6B-batch.yaml
@@ -8,7 +8,6 @@ limits:
 modalities:
     input:
         - text
-        - image
     output:
         - embedding
 mode: embedding

--- a/providers/deepinfra/Qwen/Qwen3-Embedding-0.6B-batch.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Embedding-0.6B-batch.yaml
@@ -8,15 +8,16 @@ limits:
 modalities:
     input:
         - text
+        - image
     output:
         - embedding
 mode: embedding
 model: Qwen/Qwen3-Embedding-0.6B-batch
+provisioning: serverless
 removeParams:
     - max_tokens
 sources:
-    - https://deepinfra.com/Qwen/Qwen3-Embedding-0.6B-batch/api
-    - https://huggingface.co/Qwen/Qwen3-Embedding-0.6B
+    - https://deepinfra.com/Qwen/Qwen3-Embedding-0.6B-batch
 status: active
 supportedModes:
     - embedding

--- a/providers/deepinfra/Qwen/Qwen3-Embedding-0.6B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Embedding-0.6B.yaml
@@ -7,7 +7,6 @@ limits:
 modalities:
     input:
         - text
-        - image
     output:
         - embedding
 mode: embedding

--- a/providers/deepinfra/Qwen/Qwen3-Embedding-0.6B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Embedding-0.6B.yaml
@@ -7,15 +7,16 @@ limits:
 modalities:
     input:
         - text
+        - image
     output:
         - embedding
 mode: embedding
 model: Qwen/Qwen3-Embedding-0.6B
+provisioning: serverless
 removeParams:
     - max_tokens
 sources:
-    - https://deepinfra.com/Qwen/Qwen3-Embedding-0.6B/api
-    - https://huggingface.co/Qwen/Qwen3-Embedding-0.6B
+    - https://deepinfra.com/Qwen/Qwen3-Embedding-0.6B
 status: active
 supportedModes:
     - embedding

--- a/providers/deepinfra/Qwen/Qwen3-Embedding-4B-batch.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Embedding-4B-batch.yaml
@@ -12,11 +12,11 @@ modalities:
         - embedding
 mode: embedding
 model: Qwen/Qwen3-Embedding-4B-batch
+provisioning: serverless
 removeParams:
     - max_tokens
 sources:
-    - https://deepinfra.com/Qwen/Qwen3-Embedding-4B-batch/api
-    - https://huggingface.co/Qwen/Qwen3-Embedding-4B
+    - https://deepinfra.com/Qwen/Qwen3-Embedding-4B-batch
 status: active
 supportedModes:
     - embedding

--- a/providers/deepinfra/Qwen/Qwen3-Embedding-4B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Embedding-4B.yaml
@@ -8,7 +8,6 @@ limits:
 modalities:
     input:
         - text
-        - image
     output:
         - embedding
 mode: embedding

--- a/providers/deepinfra/Qwen/Qwen3-Embedding-4B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Embedding-4B.yaml
@@ -8,15 +8,16 @@ limits:
 modalities:
     input:
         - text
+        - image
     output:
         - embedding
 mode: embedding
 model: Qwen/Qwen3-Embedding-4B
+provisioning: serverless
 removeParams:
     - max_tokens
 sources:
-    - https://deepinfra.com/Qwen/Qwen3-Embedding-4B/api
-    - https://huggingface.co/Qwen/Qwen3-Embedding-4B
+    - https://deepinfra.com/Qwen/Qwen3-Embedding-4B
 status: active
 supportedModes:
     - embedding

--- a/providers/deepinfra/Qwen/Qwen3-Embedding-8B-batch.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Embedding-8B-batch.yaml
@@ -8,15 +8,16 @@ limits:
 modalities:
     input:
         - text
+        - image
     output:
         - embedding
 mode: embedding
 model: Qwen/Qwen3-Embedding-8B-batch
+provisioning: serverless
 removeParams:
     - max_tokens
 sources:
-    - https://deepinfra.com/Qwen/Qwen3-Embedding-8B-batch/api
-    - https://huggingface.co/Qwen/Qwen3-Embedding-8B
+    - https://deepinfra.com/Qwen/Qwen3-Embedding-8B-batch
 status: active
 supportedModes:
     - embedding

--- a/providers/deepinfra/Qwen/Qwen3-Embedding-8B-batch.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Embedding-8B-batch.yaml
@@ -8,7 +8,6 @@ limits:
 modalities:
     input:
         - text
-        - image
     output:
         - embedding
 mode: embedding

--- a/providers/deepinfra/Qwen/Qwen3-Embedding-8B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Embedding-8B.yaml
@@ -8,7 +8,6 @@ limits:
 modalities:
     input:
         - text
-        - image
     output:
         - embedding
 mode: embedding

--- a/providers/deepinfra/Qwen/Qwen3-Embedding-8B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Embedding-8B.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-8
+    - input_cost_per_token: 1.e-8
       region: "*"
 limits:
     context_window: 32768
@@ -8,15 +8,16 @@ limits:
 modalities:
     input:
         - text
+        - image
     output:
         - embedding
 mode: embedding
 model: Qwen/Qwen3-Embedding-8B
+provisioning: serverless
 removeParams:
     - max_tokens
 sources:
-    - https://deepinfra.com/Qwen/Qwen3-Embedding-8B/api
-    - https://huggingface.co/Qwen/Qwen3-Embedding-8B
+    - https://deepinfra.com/Qwen/Qwen3-Embedding-8B
 status: active
 supportedModes:
     - embedding

--- a/providers/deepinfra/Wan-AI/Wan2.6-Image-Edit.yaml
+++ b/providers/deepinfra/Wan-AI/Wan2.6-Image-Edit.yaml
@@ -3,12 +3,15 @@ costs:
       region: "*"
 modalities:
     input:
+        - text
         - image
     output:
         - image
 mode: image
 model: Wan-AI/Wan2.6-Image-Edit
+provisioning: serverless
 sources:
-    - https://deepinfra.com/Wan-AI/Wan2.6-Image-Edit/api
+    - https://deepinfra.com/Wan-AI/Wan2.6-Image-Edit
+status: active
 supportedModes:
     - image

--- a/providers/deepinfra/Wan-AI/Wan2.6-T2I.yaml
+++ b/providers/deepinfra/Wan-AI/Wan2.6-T2I.yaml
@@ -8,7 +8,9 @@ modalities:
         - image
 mode: image
 model: Wan-AI/Wan2.6-T2I
+provisioning: serverless
 sources:
-    - https://deepinfra.com/Wan-AI/Wan2.6-T2I/api
+    - https://deepinfra.com/Wan-AI/Wan2.6-T2I
+status: active
 supportedModes:
     - image

--- a/providers/deepinfra/black-forest-labs/FLUX-1-Redux-dev.yaml
+++ b/providers/deepinfra/black-forest-labs/FLUX-1-Redux-dev.yaml
@@ -8,7 +8,9 @@ modalities:
         - image
 mode: image
 model: black-forest-labs/FLUX-1-Redux-dev
+provisioning: serverless
 sources:
-    - https://deepinfra.com/black-forest-labs/FLUX-1-Redux-dev/api
+    - https://deepinfra.com/black-forest-labs/FLUX-1-Redux-dev
+status: active
 supportedModes:
     - image

--- a/providers/deepinfra/black-forest-labs/FLUX-1-dev.yaml
+++ b/providers/deepinfra/black-forest-labs/FLUX-1-dev.yaml
@@ -8,8 +8,9 @@ modalities:
         - image
 mode: image
 model: black-forest-labs/FLUX-1-dev
+provisioning: serverless
 sources:
-    - https://api.deepinfra.com/models/black-forest-labs/FLUX-1-dev
+    - https://deepinfra.com/black-forest-labs/FLUX-1-dev
 status: active
 supportedModes:
     - image

--- a/providers/deepinfra/black-forest-labs/FLUX-1-schnell.yaml
+++ b/providers/deepinfra/black-forest-labs/FLUX-1-schnell.yaml
@@ -8,8 +8,9 @@ modalities:
         - image
 mode: image
 model: black-forest-labs/FLUX-1-schnell
+provisioning: serverless
 sources:
-    - https://deepinfra.com/black-forest-labs/FLUX-1-schnell/api
+    - https://deepinfra.com/black-forest-labs/FLUX-1-schnell
 status: active
 supportedModes:
     - image

--- a/providers/deepinfra/black-forest-labs/FLUX-1.1-pro.yaml
+++ b/providers/deepinfra/black-forest-labs/FLUX-1.1-pro.yaml
@@ -8,7 +8,8 @@ modalities:
         - image
 mode: image
 model: black-forest-labs/FLUX-1.1-pro
+provisioning: serverless
 sources:
-    - https://deepinfra.com/black-forest-labs/FLUX-1.1-pro/api
+    - https://deepinfra.com/black-forest-labs/FLUX-1.1-pro
 supportedModes:
     - image

--- a/providers/deepinfra/black-forest-labs/FLUX-2-dev.yaml
+++ b/providers/deepinfra/black-forest-labs/FLUX-2-dev.yaml
@@ -4,12 +4,14 @@ costs:
 modalities:
     input:
         - text
+        - image
     output:
         - image
 mode: image
 model: black-forest-labs/FLUX-2-dev
+provisioning: serverless
 sources:
-    - https://deepinfra.com/black-forest-labs/FLUX-2-dev/api
+    - https://deepinfra.com/black-forest-labs/FLUX-2-dev
 status: active
 supportedModes:
     - image

--- a/providers/deepinfra/black-forest-labs/FLUX-2-klein-4b.yaml
+++ b/providers/deepinfra/black-forest-labs/FLUX-2-klein-4b.yaml
@@ -9,8 +9,9 @@ modalities:
         - image
 mode: image
 model: black-forest-labs/FLUX-2-klein-4b
+provisioning: serverless
 sources:
-    - https://deepinfra.com/black-forest-labs/FLUX-2-klein-4b/api
+    - https://deepinfra.com/black-forest-labs/FLUX-2-klein-4b
 status: active
 supportedModes:
     - image

--- a/providers/deepinfra/black-forest-labs/FLUX-2-klein-9b.yaml
+++ b/providers/deepinfra/black-forest-labs/FLUX-2-klein-9b.yaml
@@ -4,12 +4,14 @@ costs:
 modalities:
     input:
         - text
+        - image
     output:
         - image
 mode: image
 model: black-forest-labs/FLUX-2-klein-9b
+provisioning: serverless
 sources:
-    - https://deepinfra.com/black-forest-labs/FLUX-2-klein-9b/api
+    - https://deepinfra.com/black-forest-labs/FLUX-2-klein-9b
 status: active
 supportedModes:
     - image

--- a/providers/deepinfra/black-forest-labs/FLUX-2-max.yaml
+++ b/providers/deepinfra/black-forest-labs/FLUX-2-max.yaml
@@ -10,8 +10,9 @@ modalities:
         - image
 mode: image
 model: black-forest-labs/FLUX-2-max
+provisioning: serverless
 sources:
-    - https://deepinfra.com/black-forest-labs/FLUX-2-max/api
+    - https://deepinfra.com/black-forest-labs/FLUX-2-max
 status: active
 supportedModes:
     - image

--- a/providers/deepinfra/black-forest-labs/FLUX-2-pro.yaml
+++ b/providers/deepinfra/black-forest-labs/FLUX-2-pro.yaml
@@ -9,8 +9,9 @@ modalities:
         - image
 mode: image
 model: black-forest-labs/FLUX-2-pro
+provisioning: serverless
 sources:
-    - https://deepinfra.com/black-forest-labs/FLUX-2-pro/api
+    - https://deepinfra.com/black-forest-labs/FLUX-2-pro
 status: active
 supportedModes:
     - image

--- a/providers/deepinfra/black-forest-labs/FLUX-pro.yaml
+++ b/providers/deepinfra/black-forest-labs/FLUX-pro.yaml
@@ -8,7 +8,9 @@ modalities:
         - image
 mode: image
 model: black-forest-labs/FLUX-pro
+provisioning: serverless
 sources:
-    - https://deepinfra.com/black-forest-labs/FLUX-pro/api
+    - https://deepinfra.com/black-forest-labs/FLUX-pro
+status: active
 supportedModes:
     - image

--- a/providers/deepinfra/black-forest-labs/FLUX.1-Kontext-dev.yaml
+++ b/providers/deepinfra/black-forest-labs/FLUX.1-Kontext-dev.yaml
@@ -9,8 +9,9 @@ modalities:
         - image
 mode: image
 model: black-forest-labs/FLUX.1-Kontext-dev
+provisioning: serverless
 sources:
-    - https://deepinfra.com/black-forest-labs/FLUX.1-Kontext-dev/api
-    - https://deepinfra.com/flux
+    - https://deepinfra.com/black-forest-labs/FLUX.1-Kontext-dev
+status: active
 supportedModes:
     - image

--- a/providers/deepinfra/deepseek-ai/Janus-Pro-7B.yaml
+++ b/providers/deepinfra/deepseek-ai/Janus-Pro-7B.yaml
@@ -12,8 +12,9 @@ modalities:
         - text
 mode: image
 model: deepseek-ai/Janus-Pro-7B
+provisioning: serverless
 sources:
-    - https://deepinfra.com/deepseek-ai/Janus-Pro-7B/api
-    - https://huggingface.co/deepseek-ai/Janus-Pro-7B
+    - https://deepinfra.com/deepseek-ai/Janus-Pro-7B
+status: active
 supportedModes:
     - image

--- a/providers/deepinfra/google/embeddinggemma-300m.yaml
+++ b/providers/deepinfra/google/embeddinggemma-300m.yaml
@@ -11,11 +11,11 @@ modalities:
         - embedding
 mode: embedding
 model: google/embeddinggemma-300m
+provisioning: serverless
 removeParams:
     - max_tokens
 sources:
-    - https://deepinfra.com/google/embeddinggemma-300m/api
-    - https://huggingface.co/google/embeddinggemma-300m
+    - https://deepinfra.com/google/embeddinggemma-300m
 status: active
 supportedModes:
     - embedding

--- a/providers/deepinfra/intfloat/e5-base-v2.yaml
+++ b/providers/deepinfra/intfloat/e5-base-v2.yaml
@@ -11,10 +11,11 @@ modalities:
         - embedding
 mode: embedding
 model: intfloat/e5-base-v2
+provisioning: serverless
 removeParams:
     - max_tokens
 sources:
-    - https://deepinfra.com/intfloat/e5-base-v2/api
+    - https://deepinfra.com/intfloat/e5-base-v2
 status: active
 supportedModes:
     - embedding

--- a/providers/deepinfra/intfloat/e5-large-v2.yaml
+++ b/providers/deepinfra/intfloat/e5-large-v2.yaml
@@ -12,10 +12,11 @@ modalities:
         - embedding
 mode: embedding
 model: intfloat/e5-large-v2
+provisioning: serverless
 removeParams:
     - max_tokens
 sources:
-    - https://deepinfra.com/intfloat/e5-large-v2/api
+    - https://deepinfra.com/intfloat/e5-large-v2
 status: active
 supportedModes:
     - embedding

--- a/providers/deepinfra/intfloat/multilingual-e5-large-instruct.yaml
+++ b/providers/deepinfra/intfloat/multilingual-e5-large-instruct.yaml
@@ -11,11 +11,11 @@ modalities:
         - embedding
 mode: embedding
 model: intfloat/multilingual-e5-large-instruct
+provisioning: serverless
 removeParams:
     - max_tokens
 sources:
-    - https://deepinfra.com/intfloat/multilingual-e5-large-instruct/api
-    - https://huggingface.co/intfloat/multilingual-e5-large-instruct
+    - https://deepinfra.com/intfloat/multilingual-e5-large-instruct
 status: active
 supportedModes:
     - embedding

--- a/providers/deepinfra/intfloat/multilingual-e5-large.yaml
+++ b/providers/deepinfra/intfloat/multilingual-e5-large.yaml
@@ -11,10 +11,11 @@ modalities:
         - embedding
 mode: embedding
 model: intfloat/multilingual-e5-large
+provisioning: serverless
 removeParams:
     - max_tokens
 sources:
-    - https://deepinfra.com/intfloat/multilingual-e5-large/api
+    - https://deepinfra.com/intfloat/multilingual-e5-large
 status: active
 supportedModes:
     - embedding

--- a/providers/deepinfra/moonshotai/Kimi-K2.5-Turbo.yaml
+++ b/providers/deepinfra/moonshotai/Kimi-K2.5-Turbo.yaml
@@ -3,11 +3,13 @@ costs:
       input_cost_per_token: 6.e-7
       output_cost_per_token: 0.000003
       region: "*"
+deprecationDate: "2026-04-15"
 features:
     - prompt_caching
     - function_calling
     - structured_output
     - json_output
+isDeprecated: true
 limits:
     context_window: 262144
     max_input_tokens: 262144

--- a/providers/deepinfra/openai/gpt-oss-120b-Turbo.yaml
+++ b/providers/deepinfra/openai/gpt-oss-120b-Turbo.yaml
@@ -4,7 +4,7 @@ costs:
       region: "*"
 features:
     - function_calling
-    - structured_output
+    - json_output
     - prompt_caching
 limits:
     context_window: 131072
@@ -18,8 +18,8 @@ mode: chat
 model: openai/gpt-oss-120b-Turbo
 params:
     - key: reasoning_effort
+provisioning: serverless
 sources:
-    - https://deepinfra.com/openai/gpt-oss-120b-Turbo/api
     - https://deepinfra.com/openai/gpt-oss-120b-Turbo
 status: active
 supportedModes:

--- a/providers/deepinfra/sentence-transformers/all-MiniLM-L12-v2.yaml
+++ b/providers/deepinfra/sentence-transformers/all-MiniLM-L12-v2.yaml
@@ -11,10 +11,11 @@ modalities:
         - embedding
 mode: embedding
 model: sentence-transformers/all-MiniLM-L12-v2
+provisioning: serverless
 removeParams:
     - max_tokens
 sources:
-    - https://deepinfra.com/sentence-transformers/all-MiniLM-L12-v2/api
+    - https://deepinfra.com/sentence-transformers/all-MiniLM-L12-v2
 status: active
 supportedModes:
     - embedding

--- a/providers/deepinfra/sentence-transformers/all-MiniLM-L6-v2.yaml
+++ b/providers/deepinfra/sentence-transformers/all-MiniLM-L6-v2.yaml
@@ -11,10 +11,10 @@ modalities:
         - embedding
 mode: embedding
 model: sentence-transformers/all-MiniLM-L6-v2
+provisioning: serverless
 removeParams:
     - max_tokens
 sources:
-    - https://deepinfra.com/sentence-transformers/all-MiniLM-L6-v2/api
     - https://deepinfra.com/sentence-transformers/all-MiniLM-L6-v2
 status: active
 supportedModes:

--- a/providers/deepinfra/sentence-transformers/all-mpnet-base-v2.yaml
+++ b/providers/deepinfra/sentence-transformers/all-mpnet-base-v2.yaml
@@ -11,6 +11,7 @@ modalities:
         - embedding
 mode: embedding
 model: sentence-transformers/all-mpnet-base-v2
+provisioning: serverless
 removeParams:
     - max_tokens
 sources:

--- a/providers/deepinfra/sentence-transformers/clip-ViT-B-32.yaml
+++ b/providers/deepinfra/sentence-transformers/clip-ViT-B-32.yaml
@@ -1,3 +1,6 @@
+costs:
+    - input_cost_per_token: 5.e-9
+      region: "*"
 limits:
     output_vector_size: 512
 modalities:
@@ -8,9 +11,10 @@ modalities:
         - embedding
 mode: embedding
 model: sentence-transformers/clip-ViT-B-32
+provisioning: serverless
 removeParams:
     - max_tokens
 sources:
-    - https://deepinfra.com/sentence-transformers/clip-ViT-B-32/api
+    - https://deepinfra.com/sentence-transformers/clip-ViT-B-32
 supportedModes:
     - embedding

--- a/providers/deepinfra/sentence-transformers/multi-qa-mpnet-base-dot-v1.yaml
+++ b/providers/deepinfra/sentence-transformers/multi-qa-mpnet-base-dot-v1.yaml
@@ -7,15 +7,16 @@ limits:
 modalities:
     input:
         - text
+        - image
     output:
         - embedding
 mode: embedding
 model: sentence-transformers/multi-qa-mpnet-base-dot-v1
+provisioning: serverless
 removeParams:
     - max_tokens
 sources:
-    - https://deepinfra.com/sentence-transformers/multi-qa-mpnet-base-dot-v1/api
-    - https://huggingface.co/sentence-transformers/multi-qa-mpnet-base-dot-v1
+    - https://deepinfra.com/sentence-transformers/multi-qa-mpnet-base-dot-v1
 status: active
 supportedModes:
     - embedding

--- a/providers/deepinfra/sentence-transformers/paraphrase-MiniLM-L6-v2.yaml
+++ b/providers/deepinfra/sentence-transformers/paraphrase-MiniLM-L6-v2.yaml
@@ -11,10 +11,11 @@ modalities:
         - embedding
 mode: embedding
 model: sentence-transformers/paraphrase-MiniLM-L6-v2
+provisioning: serverless
 removeParams:
     - max_tokens
 sources:
-    - https://deepinfra.com/sentence-transformers/paraphrase-MiniLM-L6-v2/api
+    - https://deepinfra.com/sentence-transformers/paraphrase-MiniLM-L6-v2
 status: active
 supportedModes:
     - embedding

--- a/providers/deepinfra/shibing624/text2vec-base-chinese.yaml
+++ b/providers/deepinfra/shibing624/text2vec-base-chinese.yaml
@@ -12,10 +12,10 @@ modalities:
         - embedding
 mode: embedding
 model: shibing624/text2vec-base-chinese
+provisioning: serverless
 removeParams:
     - max_tokens
 sources:
-    - https://deepinfra.com/shibing624/text2vec-base-chinese/api
     - https://deepinfra.com/shibing624/text2vec-base-chinese
 status: active
 supportedModes:

--- a/providers/deepinfra/stabilityai/sdxl-turbo.yaml
+++ b/providers/deepinfra/stabilityai/sdxl-turbo.yaml
@@ -9,7 +9,8 @@ modalities:
         - image
 mode: image
 model: stabilityai/sdxl-turbo
+provisioning: serverless
 sources:
-    - https://deepinfra.com/stabilityai/sdxl-turbo/api
+    - https://deepinfra.com/stabilityai/sdxl-turbo
 supportedModes:
     - image

--- a/providers/deepinfra/thenlper/gte-base.yaml
+++ b/providers/deepinfra/thenlper/gte-base.yaml
@@ -7,7 +7,6 @@ limits:
 modalities:
     input:
         - text
-        - image
     output:
         - embedding
 mode: embedding

--- a/providers/deepinfra/thenlper/gte-base.yaml
+++ b/providers/deepinfra/thenlper/gte-base.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 8.e-9
+    - input_cost_per_token: 5.e-9
       region: "*"
 limits:
     max_input_tokens: 512
@@ -7,15 +7,16 @@ limits:
 modalities:
     input:
         - text
+        - image
     output:
         - embedding
 mode: embedding
 model: thenlper/gte-base
+provisioning: serverless
 removeParams:
     - max_tokens
 sources:
     - https://deepinfra.com/thenlper/gte-base
-    - https://deepinfra.com/thenlper/gte-base/api
 status: active
 supportedModes:
     - embedding

--- a/providers/deepinfra/thenlper/gte-large.yaml
+++ b/providers/deepinfra/thenlper/gte-large.yaml
@@ -11,9 +11,11 @@ modalities:
         - embedding
 mode: embedding
 model: thenlper/gte-large
+provisioning: serverless
 removeParams:
     - max_tokens
 sources:
-    - https://deepinfra.com/thenlper/gte-large/api
+    - https://deepinfra.com/thenlper/gte-large
+status: active
 supportedModes:
     - embedding

--- a/providers/deepinfra/zai-org/GLM-4.7.yaml
+++ b/providers/deepinfra/zai-org/GLM-4.7.yaml
@@ -6,7 +6,6 @@ costs:
 features:
     - prompt_caching
     - function_calling
-    - structured_output
     - json_output
 limits:
     context_window: 202752
@@ -20,11 +19,9 @@ modalities:
         - text
 mode: chat
 model: zai-org/GLM-4.7
+provisioning: serverless
 sources:
-    - https://docs.z.ai/guides/llm/glm-4.7
-    - https://huggingface.co/zai-org/GLM-4.7
-    - https://huggingface.co/zai-org/GLM-4.7/resolve/main/config.json
-    - https://deepinfra.com/zai-org/GLM-4.7/api
+    - https://deepinfra.com/zai-org/GLM-4.7
 status: active
 supportedModes:
     - chat


### PR DESCRIPTION
Auto-generated by poc-agent for provider `deepinfra`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily config-only YAML updates, but changes to costs, supported modalities/features, and deprecation flags can affect pricing calculations and model selection/availability at runtime.
> 
> **Overview**
> Updates a large set of DeepInfra model YAMLs to standardize metadata, including adding `provisioning: serverless`, normalizing `sources` URLs (dropping many `/api` links), and filling in missing `status: active` and `modalities.output` entries.
> 
> Also adjusts capability flags for specific chat models (e.g., adds `json_output`) and updates select model attributes like input modalities and pricing (notably `Bria/remove_background` cost and `Qwen/Qwen3-Embedding-8B` token cost), plus marks some models as deprecated via `isDeprecated`/`deprecationDate`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89f98a4a837704be115b1713f605dca6f4aeefa1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->