### PR TITLE
feat(openai): update model YAMLs [bot]

### DIFF
--- a/providers/openai/gpt-5.4-mini-2026-03-17.yaml
+++ b/providers/openai/gpt-5.4-mini-2026-03-17.yaml
@@ -31,13 +31,16 @@ params:
       minValue: 1
     - defaultValue: medium
       key: reasoning_effort
+provisioning: serverless
 removeParams:
     - max_tokens
 sources:
-    - https://developers.openai.com/api/docs/pricing
-    - https://developers.openai.com/api/docs/deprecations
+    - https://developers.openai.com/api/docs/models/gpt-5.4-mini
     - https://developers.openai.com/api/docs/guides/reasoning
     - https://developers.openai.com/api/docs/guides/structured-outputs
+    - https://developers.openai.com/docs/guides/prompt-caching
+    - https://developers.openai.com/docs/guides/function-calling
+status: active
 supportedModes:
     - chat
 thinking: true

--- a/providers/openai/gpt-5.4-mini.yaml
+++ b/providers/openai/gpt-5.4-mini.yaml
@@ -31,6 +31,7 @@ params:
       minValue: 1
     - defaultValue: medium
       key: reasoning_effort
+provisioning: serverless
 removeParams:
     - max_tokens
 sources:
@@ -39,4 +40,5 @@ sources:
 status: active
 supportedModes:
     - chat
+    - responses
 thinking: true

--- a/providers/openai/gpt-5.4-nano-2026-03-17.yaml
+++ b/providers/openai/gpt-5.4-nano-2026-03-17.yaml
@@ -32,10 +32,12 @@ params:
     - defaultValue: medium
       key: reasoning_effort
       type: string
+provisioning: serverless
 removeParams:
     - max_tokens
 sources:
     - https://developers.openai.com/api/docs/models/gpt-5.4-nano
+status: active
 supportedModes:
     - chat
 thinking: true

--- a/providers/openai/gpt-5.4-nano.yaml
+++ b/providers/openai/gpt-5.4-nano.yaml
@@ -28,6 +28,7 @@ params:
       key: max_completion_tokens
       maxValue: 128000
       minValue: 1
+provisioning: serverless
 removeParams:
     - max_tokens
 sources:


### PR DESCRIPTION
Auto-generated by poc-agent for provider `openai`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config/metadata-only changes to model YAMLs; main impact is how these models are advertised/selected (e.g., `supportedModes`) rather than runtime logic.
> 
> **Overview**
> Updates the OpenAI `gpt-5.4-mini` and `gpt-5.4-nano` model YAMLs (including `-2026-03-17` variants) to mark **`provisioning: serverless`** and set/confirm **`status: active`**.
> 
> Refreshes model documentation `sources` (adds links for prompt caching and function calling) and expands `gpt-5.4-mini` `supportedModes` to include `responses`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3beaf4ac6a2859377026efbcac252a4e442e5d74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->