### PR TITLE
feat(openrouter): update model YAMLs [bot]

### DIFF
--- a/providers/openrouter/baidu/ernie-4.5-21b-a3b.yaml
+++ b/providers/openrouter/baidu/ernie-4.5-21b-a3b.yaml
@@ -16,7 +16,10 @@ modalities:
         - text
 mode: chat
 model: baidu/ernie-4.5-21b-a3b
+provisioning: serverless
 sources:
+    - https://openrouter.ai/baidu/ernie-4.5-21b-a3b
     - https://openrouter.ai/baidu/ernie-4.5-21b-a3b/api
+status: active
 supportedModes:
     - chat

--- a/providers/openrouter/bytedance-seed/seed-2.0-lite.yaml
+++ b/providers/openrouter/bytedance-seed/seed-2.0-lite.yaml
@@ -35,8 +35,10 @@ params:
     - defaultValue: medium
       key: reasoning_effort
       type: string
+provisioning: serverless
 sources:
     - https://openrouter.ai/bytedance-seed/seed-2.0-lite/api
+    - https://openrouter.ai/bytedance-seed/seed-2.0-lite
 supportedModes:
     - chat
 thinking: true

--- a/providers/openrouter/deepseek/deepseek-v3.2-speciale.yaml
+++ b/providers/openrouter/deepseek/deepseek-v3.2-speciale.yaml
@@ -1,5 +1,6 @@
 costs:
-    - input_cost_per_token: 4.e-7
+    - cache_read_input_token_cost: 2.e-7
+      input_cost_per_token: 4.e-7
       output_cost_per_token: 0.0000012
       region: "*"
 features:
@@ -17,8 +18,10 @@ modalities:
         - text
 mode: chat
 model: deepseek/deepseek-v3.2-speciale
+provisioning: serverless
 sources:
     - https://openrouter.ai/deepseek/deepseek-v3.2-speciale/api
+status: active
 supportedModes:
     - chat
 thinking: true

--- a/providers/openrouter/google/gemini-3.1-flash-lite-preview.yaml
+++ b/providers/openrouter/google/gemini-3.1-flash-lite-preview.yaml
@@ -1,5 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 8.333333333333334e-8
+      cache_read_input_audio_token_cost: 5.e-8
       cache_read_input_token_cost: 2.5e-8
       input_cost_per_audio_token: 5.e-7
       input_cost_per_token: 2.5e-7
@@ -34,6 +35,7 @@ params:
     - defaultValue: minimal
       key: reasoning_effort
       type: string
+provisioning: serverless
 sources:
     - https://openrouter.ai/google/gemini-3.1-flash-lite-preview/api
 supportedModes:

--- a/providers/openrouter/minimax/minimax-m2.7.yaml
+++ b/providers/openrouter/minimax/minimax-m2.7.yaml
@@ -24,8 +24,11 @@ params:
       key: temperature
     - defaultValue: 0.95
       key: top_p
+provisioning: serverless
 sources:
     - https://openrouter.ai/minimax/minimax-m2.7/api
+    - https://openrouter.ai/minimax/minimax-m2.7
+status: active
 supportedModes:
     - chat
 thinking: true

--- a/providers/openrouter/mistralai/mistral-small-2603.yaml
+++ b/providers/openrouter/mistralai/mistral-small-2603.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 1.5e-7
+    - cache_read_input_token_cost: 1.5e-8
       input_cost_per_token: 1.5e-7
       output_cost_per_token: 6.e-7
       region: "*"

--- a/providers/openrouter/mistralai/mistral-small-2603.yaml
+++ b/providers/openrouter/mistralai/mistral-small-2603.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 1.5e-8
+    - cache_read_input_token_cost: 1.5e-7
       input_cost_per_token: 1.5e-7
       output_cost_per_token: 6.e-7
       region: "*"
@@ -23,12 +23,12 @@ params:
     - defaultValue: high
       key: reasoning_effort
       type: string
+provisioning: serverless
 removeParams:
     - "n"
 sources:
+    - https://openrouter.ai/mistralai/mistral-small-2603
     - https://openrouter.ai/mistralai/mistral-small-2603/api
-    - https://docs.mistral.ai/getting-started/models/
-    - https://docs.mistral.ai/capabilities/reasoning/
 supportedModes:
     - chat
 thinking: true

--- a/providers/openrouter/nvidia/nemotron-3-super-120b-a12b.yaml
+++ b/providers/openrouter/nvidia/nemotron-3-super-120b-a12b.yaml
@@ -21,8 +21,9 @@ params:
       key: temperature
     - defaultValue: 0.95
       key: top_p
+provisioning: serverless
 sources:
-    - https://openrouter.ai/nvidia/nemotron-3-super-120b-a12b/api
+    - https://openrouter.ai/nvidia/nemotron-3-super-120b-a12b
 supportedModes:
     - chat
 thinking: true

--- a/providers/openrouter/openai/gpt-5.4-mini.yaml
+++ b/providers/openrouter/openai/gpt-5.4-mini.yaml
@@ -27,6 +27,7 @@ params:
       maxValue: 128000
     - key: reasoning_effort
       type: string
+provisioning: serverless
 sources:
     - https://openrouter.ai/openai/gpt-5.4-mini/api
 status: active

--- a/providers/openrouter/openai/gpt-5.4-nano.yaml
+++ b/providers/openrouter/openai/gpt-5.4-nano.yaml
@@ -25,8 +25,11 @@ model: openai/gpt-5.4-nano
 params:
     - key: reasoning_effort
       type: string
+provisioning: serverless
 sources:
     - https://openrouter.ai/openai/gpt-5.4-nano/api
+    - https://openrouter.ai/openai/gpt-5.4-nano
+status: active
 supportedModes:
     - chat
 thinking: true

--- a/providers/openrouter/qwen/qwen3-max.yaml
+++ b/providers/openrouter/qwen/qwen3-max.yaml
@@ -1,5 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 1.56e-7
+    - cache_creation_input_token_cost: 9.75e-7
+      cache_read_input_token_cost: 1.56e-7
       input_cost_per_token: 7.8e-7
       output_cost_per_token: 0.0000039
       region: "*"
@@ -31,7 +32,9 @@ modalities:
         - text
 mode: chat
 model: qwen/qwen3-max
+provisioning: serverless
 sources:
+    - https://openrouter.ai/qwen/qwen3-max
     - https://openrouter.ai/qwen/qwen3-max/api
 supportedModes:
     - chat

--- a/providers/openrouter/qwen/qwen3-vl-32b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen3-vl-32b-instruct.yaml
@@ -19,7 +19,9 @@ modalities:
         - text
 mode: chat
 model: qwen/qwen3-vl-32b-instruct
+provisioning: serverless
 sources:
+    - https://openrouter.ai/qwen/qwen3-vl-32b-instruct
     - https://openrouter.ai/qwen/qwen3-vl-32b-instruct/api
 supportedModes:
     - chat

--- a/providers/openrouter/qwen/qwen3.5-9b.yaml
+++ b/providers/openrouter/qwen/qwen3.5-9b.yaml
@@ -20,6 +20,7 @@ modalities:
         - text
 mode: chat
 model: qwen/qwen3.5-9b
+provisioning: serverless
 sources:
     - https://openrouter.ai/qwen/qwen3.5-9b/api
 supportedModes:

--- a/providers/openrouter/xiaomi/mimo-v2-omni.yaml
+++ b/providers/openrouter/xiaomi/mimo-v2-omni.yaml
@@ -4,6 +4,7 @@ costs:
       output_cost_per_token: 0.000002
       region: "*"
 features:
+    - code_execution
     - function_calling
     - json_output
     - prompt_caching
@@ -27,8 +28,11 @@ params:
       key: temperature
     - defaultValue: 0.95
       key: top_p
+provisioning: serverless
 sources:
+    - https://openrouter.ai/xiaomi/mimo-v2-omni
     - https://openrouter.ai/xiaomi/mimo-v2-omni/api
+status: active
 supportedModes:
     - chat
 thinking: true

--- a/providers/openrouter/xiaomi/mimo-v2-pro.yaml
+++ b/providers/openrouter/xiaomi/mimo-v2-pro.yaml
@@ -34,8 +34,10 @@ params:
       key: temperature
     - defaultValue: 0.95
       key: top_p
+provisioning: serverless
 sources:
     - https://openrouter.ai/xiaomi/mimo-v2-pro/api
+    - https://openrouter.ai/xiaomi/mimo-v2-pro
 status: active
 supportedModes:
     - chat


### PR DESCRIPTION
Auto-generated by poc-agent for provider `openrouter`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only changes, but incorrect pricing/source metadata could affect downstream display, routing, or cost estimation for the listed models.
> 
> **Overview**
> Updates multiple OpenRouter model YAMLs to mark models as **`provisioning: serverless`** and, for several entries, set **`status: active`**.
> 
> Normalizes `sources` by adding/ordering the non-`/api` OpenRouter model URLs, and tweaks cost metadata (e.g., adds cache read/creation token cost fields, including audio cache reads for Gemini). Also adds `code_execution` to `xiaomi/mimo-v2-omni`’s feature list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d738a03e0a1b3cdcef567657a4b37832feee1840. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->