### PR TITLE
feat(together-ai): update model YAMLs [bot]

### DIFF
--- a/providers/together-ai/MiniMaxAI/MiniMax-M2.5-FP4.yaml
+++ b/providers/together-ai/MiniMaxAI/MiniMax-M2.5-FP4.yaml
@@ -16,7 +16,7 @@ modalities:
         - text
 mode: chat
 model: MiniMaxAI/MiniMax-M2.5-FP4
-provisioning: serverless
+provisioning: provisioned
 status: active
 supportedModes:
     - chat

--- a/providers/together-ai/MiniMaxAI/MiniMax-M2.5-FP4.yaml
+++ b/providers/together-ai/MiniMaxAI/MiniMax-M2.5-FP4.yaml
@@ -6,6 +6,7 @@ costs:
 features:
     - function_calling
     - structured_output
+    - json_output
 limits:
     context_window: 228700
 modalities:
@@ -15,7 +16,7 @@ modalities:
         - text
 mode: chat
 model: MiniMaxAI/MiniMax-M2.5-FP4
-provisioning: provisioned
+provisioning: serverless
 status: active
 supportedModes:
     - chat

--- a/providers/together-ai/MiniMaxAI/MiniMax-M2.5.yaml
+++ b/providers/together-ai/MiniMaxAI/MiniMax-M2.5.yaml
@@ -17,8 +17,9 @@ modalities:
         - text
 mode: chat
 model: MiniMaxAI/MiniMax-M2.5
+provisioning: serverless
 sources:
     - https://www.together.ai/models/minimax-m2-5
-    - https://docs.together.ai/docs/serverless-models
+status: active
 supportedModes:
     - chat

--- a/providers/together-ai/Qwen/Qwen2.5-7B-Instruct-Turbo.yaml
+++ b/providers/together-ai/Qwen/Qwen2.5-7B-Instruct-Turbo.yaml
@@ -17,6 +17,7 @@ modalities:
         - text
 mode: chat
 model: Qwen/Qwen2.5-7B-Instruct-Turbo
+provisioning: serverless
 sources:
     - https://docs.together.ai/docs/serverless-models
     - https://www.together.ai/pricing

--- a/providers/together-ai/Qwen/Qwen3-235B-A22B-Instruct-2507-tput.yaml
+++ b/providers/together-ai/Qwen/Qwen3-235B-A22B-Instruct-2507-tput.yaml
@@ -15,8 +15,8 @@ modalities:
         - text
 mode: chat
 model: Qwen/Qwen3-235B-A22B-Instruct-2507-tput
+provisioning: serverless
 sources:
-    - https://docs.together.ai/docs/serverless-models
     - https://docs.together.ai/docs/function-calling
     - https://docs.together.ai/docs/json-mode
 status: active

--- a/providers/together-ai/Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8.yaml
+++ b/providers/together-ai/Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8.yaml
@@ -16,9 +16,9 @@ modalities:
         - text
 mode: chat
 model: Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8
+provisioning: serverless
 sources:
     - https://www.together.ai/models/qwen3-coder-480b-a35b-instruct
-    - https://docs.together.ai/docs/serverless-models
     - https://docs.together.ai/docs/function-calling
     - https://docs.together.ai/docs/json-mode
 status: active

--- a/providers/together-ai/Qwen/Qwen3-Coder-Next-FP8.yaml
+++ b/providers/together-ai/Qwen/Qwen3-Coder-Next-FP8.yaml
@@ -17,6 +17,7 @@ modalities:
         - text
 mode: chat
 model: Qwen/Qwen3-Coder-Next-FP8
+provisioning: serverless
 sources:
     - https://docs.together.ai/docs/serverless-models
     - https://docs.together.ai/docs/function-calling

--- a/providers/together-ai/Qwen/Qwen3.5-397B-A17B.yaml
+++ b/providers/together-ai/Qwen/Qwen3.5-397B-A17B.yaml
@@ -17,9 +17,11 @@ modalities:
         - text
 mode: chat
 model: Qwen/Qwen3.5-397B-A17B
+provisioning: serverless
 sources:
     - https://www.together.ai/models/qwen3-5-397b-a17b
     - https://www.together.ai/pricing
 status: active
 supportedModes:
     - chat
+thinking: true

--- a/providers/together-ai/Qwen/Qwen3.5-9B-FP8.yaml
+++ b/providers/together-ai/Qwen/Qwen3.5-9B-FP8.yaml
@@ -4,6 +4,7 @@ costs:
       region: "*"
 features:
     - function_calling
+    - json_output
     - structured_output
 limits:
     context_window: 262144
@@ -15,7 +16,7 @@ modalities:
         - text
 mode: chat
 model: Qwen/Qwen3.5-9B-FP8
-provisioning: provisioned
+provisioning: serverless
 sources:
     - https://together.ai/models
     - https://docs.together.ai/docs/serverless-models

--- a/providers/together-ai/Qwen/Qwen3.5-9B-FP8.yaml
+++ b/providers/together-ai/Qwen/Qwen3.5-9B-FP8.yaml
@@ -16,7 +16,7 @@ modalities:
         - text
 mode: chat
 model: Qwen/Qwen3.5-9B-FP8
-provisioning: serverless
+provisioning: provisioned
 sources:
     - https://together.ai/models
     - https://docs.together.ai/docs/serverless-models

--- a/providers/together-ai/Qwen/Qwen3.5-9B.yaml
+++ b/providers/together-ai/Qwen/Qwen3.5-9B.yaml
@@ -4,17 +4,24 @@ costs:
       region: "*"
 features:
     - function_calling
+    - json_output
+    - parallel_function_calling
     - structured_output
+    - tool_choice
 limits:
     context_window: 262144
 modalities:
     input:
-        - text
         - image
+        - text
     output:
         - text
 mode: chat
 model: Qwen/Qwen3.5-9B
+provisioning: serverless
+sources:
+    - https://docs.together.ai/docs/function-calling
+    - https://docs.together.ai/docs/json-mode
 status: active
 supportedModes:
     - chat

--- a/providers/together-ai/deepseek-ai/DeepSeek-OCR-2.yaml
+++ b/providers/together-ai/deepseek-ai/DeepSeek-OCR-2.yaml
@@ -9,7 +9,9 @@ modalities:
         - text
 mode: chat
 model: deepseek-ai/DeepSeek-OCR-2
+provisioning: serverless
 sources:
     - https://huggingface.co/deepseek-ai/DeepSeek-OCR-2
+status: active
 supportedModes:
     - chat

--- a/providers/together-ai/deepseek-ai/DeepSeek-R1-Original.yaml
+++ b/providers/together-ai/deepseek-ai/DeepSeek-R1-Original.yaml
@@ -5,10 +5,7 @@ modalities:
         - text
 mode: chat
 model: deepseek-ai/DeepSeek-R1-Original
-sources:
-    - https://docs.together.ai/docs/serverless-models
-    - https://docs.together.ai/docs/deprecations
-    - https://docs.together.ai/docs/changelog
+provisioning: serverless
 status: active
 supportedModes:
     - chat

--- a/providers/together-ai/deepseek-ai/DeepSeek-R1.yaml
+++ b/providers/together-ai/deepseek-ai/DeepSeek-R1.yaml
@@ -17,6 +17,7 @@ modalities:
         - text
 mode: chat
 model: deepseek-ai/DeepSeek-R1
+provisioning: serverless
 sources:
     - https://www.together.ai/pricing
     - https://www.together.ai/models/deepseek-r1

--- a/providers/together-ai/deepseek-ai/DeepSeek-V3.1.yaml
+++ b/providers/together-ai/deepseek-ai/DeepSeek-V3.1.yaml
@@ -16,6 +16,7 @@ modalities:
         - text
 mode: chat
 model: deepseek-ai/DeepSeek-V3.1
+provisioning: serverless
 sources:
     - https://www.together.ai/pricing
     - https://docs.together.ai/docs/function-calling

--- a/providers/together-ai/deepseek-ai/DeepSeek-V3.yaml
+++ b/providers/together-ai/deepseek-ai/DeepSeek-V3.yaml
@@ -16,6 +16,7 @@ modalities:
         - text
 mode: chat
 model: deepseek-ai/DeepSeek-V3
+provisioning: serverless
 sources:
     - https://docs.together.ai/docs/serverless-models
     - https://www.together.ai/pricing

--- a/providers/together-ai/essentialai/rnj-1-instruct.yaml
+++ b/providers/together-ai/essentialai/rnj-1-instruct.yaml
@@ -14,6 +14,7 @@ modalities:
         - text
 mode: chat
 model: essentialai/rnj-1-instruct
+provisioning: serverless
 sources:
     - https://www.together.ai/models/rnj-1-instruct
 status: active

--- a/providers/together-ai/google/flash-image-2.5.yaml
+++ b/providers/together-ai/google/flash-image-2.5.yaml
@@ -9,6 +9,7 @@ modalities:
         - image
 mode: image
 model: google/flash-image-2.5
+provisioning: serverless
 sources:
     - https://www.together.ai/pricing
     - https://www.together.ai/models/gemini-flash-image-2-5

--- a/providers/together-ai/google/gemini-3-pro-image.yaml
+++ b/providers/together-ai/google/gemini-3-pro-image.yaml
@@ -2,6 +2,10 @@ costs:
     - output_cost_per_image: 0.134
       output_cost_per_image_4k: 0.24
       region: "*"
+limits:
+    max_input_tokens: 65536
+    max_output_tokens: 32768
+    max_tokens: 32768
 modalities:
     input:
         - text
@@ -12,7 +16,7 @@ mode: image
 model: google/gemini-3-pro-image
 provisioning: serverless
 sources:
-    - https://docs.together.ai/docs/serverless-models
+    - https://www.together.ai/models/nano-banana-pro
 status: active
 supportedModes:
     - image

--- a/providers/together-ai/google/gemini-3-pro-image.yaml
+++ b/providers/together-ai/google/gemini-3-pro-image.yaml
@@ -1,11 +1,7 @@
 costs:
-    - input_cost_per_image: 0.134
+    - output_cost_per_image: 0.134
       output_cost_per_image_4k: 0.24
       region: "*"
-limits:
-    max_input_tokens: 65536
-    max_output_tokens: 32768
-    max_tokens: 32768
 modalities:
     input:
         - text
@@ -14,6 +10,7 @@ modalities:
         - image
 mode: image
 model: google/gemini-3-pro-image
+provisioning: serverless
 sources:
     - https://docs.together.ai/docs/serverless-models
 status: active

--- a/providers/together-ai/google/gemma-3n-E4B-it.yaml
+++ b/providers/together-ai/google/gemma-3n-E4B-it.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-8
-      output_cost_per_token: 4.e-8
+    - input_cost_per_token: 6.e-8
+      output_cost_per_token: 1.2e-7
       region: "*"
 features:
     - structured_output
@@ -15,6 +15,7 @@ modalities:
         - text
 mode: chat
 model: google/gemma-3n-E4B-it
+provisioning: serverless
 sources:
     - https://www.together.ai/models/gemma-3n-e4b-it
     - https://docs.together.ai/docs/serverless-models

--- a/providers/together-ai/google/imagen-4.0-fast.yaml
+++ b/providers/together-ai/google/imagen-4.0-fast.yaml
@@ -8,8 +8,10 @@ modalities:
         - image
 mode: image
 model: google/imagen-4.0-fast
+provisioning: serverless
 sources:
     - https://www.together.ai/pricing
+    - https://docs.together.ai/docs/images-overview
 status: active
 supportedModes:
     - image

--- a/providers/together-ai/google/imagen-4.0-preview.yaml
+++ b/providers/together-ai/google/imagen-4.0-preview.yaml
@@ -8,8 +8,9 @@ modalities:
         - image
 mode: image
 model: google/imagen-4.0-preview
+provisioning: serverless
 sources:
-    - https://docs.together.ai/docs/serverless-models
+    - https://www.together.ai/pricing
 status: active
 supportedModes:
     - image

--- a/providers/together-ai/google/imagen-4.0-ultra.yaml
+++ b/providers/together-ai/google/imagen-4.0-ultra.yaml
@@ -3,11 +3,13 @@ costs:
       region: "*"
 modalities:
     input:
+        - text
         - image
     output:
         - image
 mode: image
 model: google/imagen-4.0-ultra
+provisioning: serverless
 sources:
     - https://www.together.ai/pricing
     - https://docs.together.ai/docs/images-overview

--- a/providers/together-ai/meta-llama/Llama-3.3-70B-Instruct-Turbo-test.yaml
+++ b/providers/together-ai/meta-llama/Llama-3.3-70B-Instruct-Turbo-test.yaml
@@ -18,6 +18,7 @@ modalities:
         - text
 mode: chat
 model: meta-llama/Llama-3.3-70B-Instruct-Turbo-test
+provisioning: serverless
 sources:
     - https://docs.together.ai/docs/function-calling
     - https://docs.together.ai/docs/json-mode

--- a/providers/together-ai/meta-llama/Llama-3.3-70B-Instruct-Turbo.yaml
+++ b/providers/together-ai/meta-llama/Llama-3.3-70B-Instruct-Turbo.yaml
@@ -15,6 +15,7 @@ modalities:
         - text
 mode: chat
 model: meta-llama/Llama-3.3-70B-Instruct-Turbo
+provisioning: serverless
 sources:
     - https://together.ai/pricing
     - https://docs.together.ai/docs/function-calling

--- a/providers/together-ai/meta-llama/Llama-Guard-4-12B.yaml
+++ b/providers/together-ai/meta-llama/Llama-Guard-4-12B.yaml
@@ -12,6 +12,7 @@ modalities:
         - text
 mode: chat
 model: meta-llama/Llama-Guard-4-12B
+provisioning: serverless
 sources:
     - https://www.together.ai/models/llama-guard-4-12b
     - https://together.ai/pricing

--- a/providers/together-ai/mistralai/Mistral-7B-Instruct-v0.2.yaml
+++ b/providers/together-ai/mistralai/Mistral-7B-Instruct-v0.2.yaml
@@ -13,7 +13,7 @@ modalities:
         - text
 mode: chat
 model: mistralai/Mistral-7B-Instruct-v0.2
-provisioning: provisioned
+provisioning: serverless
 sources:
     - https://www.together.ai/pricing
     - https://docs.together.ai/docs/function-calling

--- a/providers/together-ai/mistralai/Mistral-7B-Instruct-v0.2.yaml
+++ b/providers/together-ai/mistralai/Mistral-7B-Instruct-v0.2.yaml
@@ -13,7 +13,7 @@ modalities:
         - text
 mode: chat
 model: mistralai/Mistral-7B-Instruct-v0.2
-provisioning: serverless
+provisioning: provisioned
 sources:
     - https://www.together.ai/pricing
     - https://docs.together.ai/docs/function-calling

--- a/providers/together-ai/moonshotai/Kimi-K2-Instruct.yaml
+++ b/providers/together-ai/moonshotai/Kimi-K2-Instruct.yaml
@@ -2,9 +2,11 @@ costs:
     - input_cost_per_token: 0.000001
       output_cost_per_token: 0.000003
       region: "*"
+deprecationDate: "2026-03-06"
 features:
     - function_calling
     - structured_output
+isDeprecated: true
 limits:
     context_window: 262144
 modalities:

--- a/providers/together-ai/moonshotai/Kimi-K2.5.yaml
+++ b/providers/together-ai/moonshotai/Kimi-K2.5.yaml
@@ -16,15 +16,16 @@ messages:
         - system
         - user
         - assistant
-        - developer
 modalities:
     input:
         - text
         - image
+        - video
     output:
         - text
 mode: chat
 model: moonshotai/Kimi-K2.5
+provisioning: serverless
 sources:
     - https://www.together.ai/models/kimi-k2-5
     - https://together.ai/pricing

--- a/providers/together-ai/nvidia/parakeet-tdt-0.6b-v3.yaml
+++ b/providers/together-ai/nvidia/parakeet-tdt-0.6b-v3.yaml
@@ -8,6 +8,7 @@ modalities:
         - text
 mode: audio_transcription
 model: nvidia/parakeet-tdt-0.6b-v3
+provisioning: serverless
 sources:
     - https://www.together.ai/pricing
 status: active

--- a/providers/together-ai/openai/gpt-oss-120b.yaml
+++ b/providers/together-ai/openai/gpt-oss-120b.yaml
@@ -4,8 +4,10 @@ costs:
       region: "*"
 features:
     - function_calling
+    - parallel_function_calling
     - structured_output
     - json_output
+    - tool_choice
 limits:
     context_window: 128000
 modalities:
@@ -15,8 +17,8 @@ modalities:
         - text
 mode: chat
 model: openai/gpt-oss-120b
+provisioning: serverless
 sources:
-    - https://docs.together.ai/docs/serverless-models
     - https://docs.together.ai/docs/function-calling
     - https://docs.together.ai/docs/json-mode
 status: active

--- a/providers/together-ai/openai/gpt-oss-20b.yaml
+++ b/providers/together-ai/openai/gpt-oss-20b.yaml
@@ -23,6 +23,7 @@ modalities:
         - text
 mode: chat
 model: openai/gpt-oss-20b
+provisioning: serverless
 sources:
     - https://www.together.ai/models/gpt-oss-20b
     - https://docs.together.ai/docs/gpt-oss

--- a/providers/together-ai/zai-org/GLM-4.6.yaml
+++ b/providers/together-ai/zai-org/GLM-4.6.yaml
@@ -4,9 +4,6 @@ costs:
       region: "*"
 features:
     - function_calling
-    - json_output
-    - structured_output
-    - tool_choice
 limits:
     context_window: 198000
     max_output_tokens: 128000
@@ -22,6 +19,8 @@ provisioning: provisioned
 sources:
     - https://www.together.ai/models/glm-4-6
     - https://www.together.ai/pricing
+    - https://docs.together.ai/docs/json-mode
+    - https://docs.together.ai/docs/function-calling
 status: active
 supportedModes:
     - chat

--- a/providers/together-ai/zai-org/GLM-5.0.yaml
+++ b/providers/together-ai/zai-org/GLM-5.0.yaml
@@ -18,6 +18,7 @@ modalities:
         - text
 mode: chat
 model: zai-org/GLM-5
+provisioning: serverless
 sources:
     - https://docs.together.ai/docs/glm-5-quickstart
     - https://docs.together.ai/docs/reasoning-overview

--- a/providers/together-ai/zai-org/GLM-5.yaml
+++ b/providers/together-ai/zai-org/GLM-5.yaml
@@ -15,6 +15,7 @@ modalities:
         - text
 mode: chat
 model: zai-org/GLM-5
+provisioning: serverless
 sources:
     - https://together.ai/pricing
 status: active

--- a/providers/together-ai/zai-org/GLM-OCR.yaml
+++ b/providers/together-ai/zai-org/GLM-OCR.yaml
@@ -6,6 +6,7 @@ modalities:
         - text
 mode: chat
 model: zai-org/GLM-OCR
+provisioning: serverless
 status: active
 supportedModes:
     - chat


### PR DESCRIPTION
Auto-generated by poc-agent for provider `together-ai`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates model catalog YAMLs (provisioning mode, features, modalities, pricing fields, and deprecation flags), which can affect model selection/availability and cost calculations if consumers rely on these fields.
> 
> **Overview**
> **Updates Together.ai model YAML metadata across multiple vendors.** Most models are now explicitly marked `provisioning: serverless` and `status: active`, with sources lists cleaned up/adjusted.
> 
> Several capability descriptors are refreshed: adds `json_output` (and in a few cases `parallel_function_calling`/`tool_choice`) to select chat models, expands `moonshotai/Kimi-K2.5` input modalities to include `video`, and marks `moonshotai/Kimi-K2-Instruct` as deprecated with a `deprecationDate`.
> 
> Includes a few pricing/config corrections (e.g., `google/gemma-3n-E4B-it` token costs updated and `google/gemini-3-pro-image` cost field adjusted).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 294845da6ea8c1cddaaf406701da0f2f31880aa0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->