### PR TITLE
fix: remove sampling parameters

### DIFF
--- a/providers/anthropic/claude-opus-4-7.yaml
+++ b/providers/anthropic/claude-opus-4-7.yaml
@@ -37,7 +37,12 @@ params:
       maxValue: 128000
       minValue: 1
 provisioning: serverless
+removeParams:
+    - temperature
+    - top_p
+    - top_k
 sources:
+    - https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7
     - https://platform.claude.com/docs/en/build-with-claude/vision
     - https://platform.claude.com/docs/en/build-with-claude/extended-thinking
     - https://platform.claude.com/docs/en/build-with-claude/pdf-support


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk config-only change that alters which request parameters are allowed for `claude-opus-4-7`; impact is limited to clients relying on these sampling params.
> 
> **Overview**
> Updates the `claude-opus-4-7` model config to explicitly strip sampling parameters (`temperature`, `top_p`, `top_k`) via `removeParams`.
> 
> Adds a new source link for Claude 4.7 release notes in `sources`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6187e803d461e769566b2b39b41b4dcee215ff3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->