### PR TITLE
feat(aws-bedrock): update model YAMLs [bot]

### DIFF
--- a/providers/aws-bedrock/eu.anthropic.claude-opus-4-7.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-opus-4-7.yaml
@@ -43,7 +43,6 @@ features:
     - assistant_prefill
     - cache_control
     - function_calling
-    - json_output
     - prompt_caching
     - structured_output
     - system_messages

--- a/providers/aws-bedrock/eu.anthropic.claude-opus-4-7.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-opus-4-7.yaml
@@ -1,11 +1,81 @@
 costs:
-    - region: eu-west-3
-    - region: eu-west-2
-    - region: eu-west-1
-    - region: eu-south-2
-    - region: eu-south-1
-    - region: eu-north-1
-    - region: eu-central-2
-    - region: eu-central-1
-mode: unknown
+    - cache_creation_input_token_cost: 0.000006875
+      cache_read_input_token_cost: 5.5e-7
+      input_cost_per_token: 0.0000055
+      output_cost_per_token: 0.0000275
+      region: eu-west-3
+    - cache_creation_input_token_cost: 0.000006875
+      cache_read_input_token_cost: 5.5e-7
+      input_cost_per_token: 0.0000055
+      output_cost_per_token: 0.0000275
+      region: eu-west-2
+    - cache_creation_input_token_cost: 0.000006875
+      cache_read_input_token_cost: 5.5e-7
+      input_cost_per_token: 0.0000055
+      output_cost_per_token: 0.0000275
+      region: eu-west-1
+    - cache_creation_input_token_cost: 0.000006875
+      cache_read_input_token_cost: 5.5e-7
+      input_cost_per_token: 0.0000055
+      output_cost_per_token: 0.0000275
+      region: eu-south-2
+    - cache_creation_input_token_cost: 0.000006875
+      cache_read_input_token_cost: 5.5e-7
+      input_cost_per_token: 0.0000055
+      output_cost_per_token: 0.0000275
+      region: eu-south-1
+    - cache_creation_input_token_cost: 0.000006875
+      cache_read_input_token_cost: 5.5e-7
+      input_cost_per_token: 0.0000055
+      output_cost_per_token: 0.0000275
+      region: eu-north-1
+    - cache_creation_input_token_cost: 0.000006875
+      cache_read_input_token_cost: 5.5e-7
+      input_cost_per_token: 0.0000055
+      output_cost_per_token: 0.0000275
+      region: eu-central-2
+    - cache_creation_input_token_cost: 0.000006875
+      cache_read_input_token_cost: 5.5e-7
+      input_cost_per_token: 0.0000055
+      output_cost_per_token: 0.0000275
+      region: eu-central-1
+features:
+    - assistant_prefill
+    - cache_control
+    - function_calling
+    - json_output
+    - prompt_caching
+    - structured_output
+    - system_messages
+    - tool_choice
+limits:
+    context_window: 1000000
+    max_output_tokens: 128000
+    max_tokens: 128000
+    tool_use_system_prompt_tokens: 346
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
+mode: chat
 model: eu.anthropic.claude-opus-4-7
+params:
+    - defaultValue: 4096
+      key: max_tokens
+      maxValue: 128000
+      minValue: 1
+    - key: thinking
+      type: json
+provisioning: serverless
+removeParams:
+    - "n"
+sources:
+    - https://platform.claude.com/docs/en/docs/about-claude/models
+    - https://platform.claude.com/docs/en/about-claude/pricing
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference-support.html
+status: preview
+supportedModes:
+    - chat
+thinking: true

--- a/providers/aws-bedrock/global.anthropic.claude-opus-4-7.yaml
+++ b/providers/aws-bedrock/global.anthropic.claude-opus-4-7.yaml
@@ -1,34 +1,192 @@
 costs:
-    - region: us-west-2
-    - region: us-west-1
-    - region: us-east-2
-    - region: us-east-1
-    - region: sa-east-1
-    - region: mx-central-1
-    - region: il-central-1
-    - region: eu-west-3
-    - region: eu-west-2
-    - region: eu-west-1
-    - region: eu-south-2
-    - region: eu-south-1
-    - region: eu-north-1
-    - region: eu-central-2
-    - region: eu-central-1
-    - region: ca-west-1
-    - region: ca-central-1
-    - region: ap-southeast-7
-    - region: ap-southeast-6
-    - region: ap-southeast-5
-    - region: ap-southeast-4
-    - region: ap-southeast-3
-    - region: ap-southeast-2
-    - region: ap-southeast-1
-    - region: ap-south-2
-    - region: ap-south-1
-    - region: ap-northeast-3
-    - region: ap-northeast-2
-    - region: ap-northeast-1
-    - region: ap-east-2
-    - region: af-south-1
-mode: unknown
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: us-west-2
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: us-west-1
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: us-east-2
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: us-east-1
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: sa-east-1
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: mx-central-1
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: il-central-1
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: eu-west-3
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: eu-west-2
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: eu-west-1
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: eu-south-2
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: eu-south-1
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: eu-north-1
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: eu-central-2
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: eu-central-1
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: ca-west-1
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: ca-central-1
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: ap-southeast-7
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: ap-southeast-6
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: ap-southeast-5
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: ap-southeast-4
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: ap-southeast-3
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: ap-southeast-2
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: ap-southeast-1
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: ap-south-2
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: ap-south-1
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: ap-northeast-3
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: ap-northeast-2
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: ap-northeast-1
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: ap-east-2
+    - cache_creation_input_token_cost: 0.00000625
+      cache_read_input_token_cost: 5.e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: af-south-1
+features:
+    - function_calling
+    - system_messages
+    - prompt_caching
+    - cache_control
+    - structured_output
+    - tool_choice
+limits:
+    context_window: 1000000
+    max_output_tokens: 128000
+    max_tokens: 128000
+    tool_use_system_prompt_tokens: 346
+modalities:
+    input:
+        - text
+        - image
+        - pdf
+    output:
+        - text
+mode: chat
 model: global.anthropic.claude-opus-4-7
+params:
+    - defaultValue: 512
+      key: max_tokens
+      maxValue: 128000
+      minValue: 1
+provisioning: serverless
+removeParams:
+    - "n"
+sources:
+    - https://platform.claude.com/docs/en/docs/about-claude/models
+    - https://platform.claude.com/docs/en/about-claude/pricing
+    - https://platform.claude.com/docs/en/build-with-claude/claude-in-amazon-bedrock-research-preview
+status: preview
+supportedModes:
+    - chat

--- a/providers/aws-bedrock/global.anthropic.claude-opus-4-7.yaml
+++ b/providers/aws-bedrock/global.anthropic.claude-opus-4-7.yaml
@@ -190,3 +190,4 @@ sources:
 status: preview
 supportedModes:
     - chat
+thinking: true

--- a/providers/aws-bedrock/jp.anthropic.claude-opus-4-7.yaml
+++ b/providers/aws-bedrock/jp.anthropic.claude-opus-4-7.yaml
@@ -1,5 +1,52 @@
 costs:
-    - region: ap-northeast-3
-    - region: ap-northeast-1
-mode: unknown
+    - cache_creation_input_token_cost: 0.000006875
+      cache_read_input_token_cost: 5.5e-7
+      input_cost_per_token: 0.0000055
+      output_cost_per_token: 0.0000275
+      region: ap-northeast-3
+    - cache_creation_input_token_cost: 0.000006875
+      cache_read_input_token_cost: 5.5e-7
+      input_cost_per_token: 0.0000055
+      output_cost_per_token: 0.0000275
+      region: ap-northeast-1
+features:
+    - function_calling
+    - parallel_function_calling
+    - system_messages
+    - tool_choice
+    - prompt_caching
+    - cache_control
+    - structured_output
+    - assistant_prefill
+limits:
+    context_window: 1000000
+    max_output_tokens: 128000
+    max_tokens: 128000
+    tool_use_system_prompt_tokens: 346
+modalities:
+    input:
+        - text
+        - image
+        - pdf
+    output:
+        - text
+mode: chat
 model: jp.anthropic.claude-opus-4-7
+params:
+    - defaultValue: 512
+      key: max_tokens
+      maxValue: 128000
+      minValue: 1
+    - key: top_k
+      minValue: 0
+provisioning: serverless
+removeParams:
+    - "n"
+sources:
+    - https://platform.claude.com/docs/en/docs/about-claude/models
+    - https://platform.claude.com/docs/en/about-claude/pricing
+    - https://platform.claude.com/docs/en/build-with-claude/claude-in-amazon-bedrock-research-preview
+status: active
+supportedModes:
+    - chat
+thinking: true

--- a/providers/aws-bedrock/us.anthropic.claude-opus-4-7.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-opus-4-7.yaml
@@ -1,9 +1,72 @@
 costs:
-    - region: us-west-2
-    - region: us-west-1
-    - region: us-east-2
-    - region: us-east-1
-    - region: ca-west-1
-    - region: ca-central-1
-mode: unknown
+    - cache_creation_input_token_cost: 0.000006875
+      cache_read_input_token_cost: 5.5e-7
+      input_cost_per_token: 0.0000055
+      output_cost_per_token: 0.0000275
+      region: us-west-2
+    - cache_creation_input_token_cost: 0.000006875
+      cache_read_input_token_cost: 5.5e-7
+      input_cost_per_token: 0.0000055
+      output_cost_per_token: 0.0000275
+      region: us-west-1
+    - cache_creation_input_token_cost: 0.000006875
+      cache_read_input_token_cost: 5.5e-7
+      input_cost_per_token: 0.0000055
+      output_cost_per_token: 0.0000275
+      region: us-east-2
+    - cache_creation_input_token_cost: 0.000006875
+      cache_read_input_token_cost: 5.5e-7
+      input_cost_per_token: 0.0000055
+      output_cost_per_token: 0.0000275
+      region: us-east-1
+    - cache_creation_input_token_cost: 0.000006875
+      cache_read_input_token_cost: 5.5e-7
+      input_cost_per_token: 0.0000055
+      output_cost_per_token: 0.0000275
+      region: ca-west-1
+    - cache_creation_input_token_cost: 0.000006875
+      cache_read_input_token_cost: 5.5e-7
+      input_cost_per_token: 0.0000055
+      output_cost_per_token: 0.0000275
+      region: ca-central-1
+features:
+    - cache_control
+    - function_calling
+    - prompt_caching
+    - system_messages
+    - tool_choice
+limits:
+    context_window: 1000000
+    max_output_tokens: 128000
+    max_tokens: 128000
+modalities:
+    input:
+        - text
+        - image
+        - pdf
+    output:
+        - text
+mode: chat
 model: us.anthropic.claude-opus-4-7
+params:
+    - defaultValue: 512
+      key: max_tokens
+      maxValue: 128000
+      minValue: 1
+    - defaultValue: 1
+      key: temperature
+      maxValue: 1
+      minValue: 0
+provisioning: serverless
+removeParams:
+    - "n"
+sources:
+    - https://platform.claude.com/docs/en/docs/about-claude/models
+    - https://platform.claude.com/docs/en/about-claude/pricing
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference.html
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-claude.html
+status: preview
+supportedModes:
+    - chat
+thinking: true


### PR DESCRIPTION
Auto-generated by poc-agent for provider `aws-bedrock`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates model configuration used for capability detection and cost calculation; incorrect values could affect pricing estimates or feature gating, but changes are limited to provider YAML data.
> 
> **Overview**
> Replaces the placeholder `mode: unknown`/region-only entries for `*.anthropic.claude-opus-4-7` with full model metadata across `us`, `eu`, `jp`, and `global` profiles.
> 
> Adds per-region token and prompt-cache pricing (`input_cost_per_token`, `output_cost_per_token`, and cache read/creation costs), declares supported features and modalities, sets large context/output limits, and defines supported params/removals (e.g., `max_tokens`, `temperature`, `top_k`, `thinking`) along with `status`, `sources`, and `supportedModes`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f504af7f9641cb51368ad76f267ec90667962700. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->