### PR TITLE
feat(azure-open-ai): update model YAMLs [bot]

### DIFF
--- a/providers/azure-open-ai/gpt-5-mini-2025-08-07-lite.yaml
+++ b/providers/azure-open-ai/gpt-5-mini-2025-08-07-lite.yaml
@@ -1,4 +1,5 @@
 mode: chat
 model: gpt-5-mini-2025-08-07-lite
+provisioning: serverless
 supportedModes:
     - chat

--- a/providers/azure-open-ai/gpt-5.4-mini-2026-03-17.yaml
+++ b/providers/azure-open-ai/gpt-5.4-mini-2026-03-17.yaml
@@ -1,4 +1,38 @@
+costs:
+    - cache_read_input_token_cost: 7.5e-8
+      input_cost_per_token: 7.5e-7
+      output_cost_per_token: 0.0000045
+      region: "*"
+features:
+    - function_calling
+    - parallel_function_calling
+    - system_messages
+    - tool_choice
+    - prompt_caching
+    - structured_output
+    - json_output
+limits:
+    context_window: 400000
+    max_input_tokens: 272000
+    max_output_tokens: 128000
+    max_tokens: 128000
+modalities:
+    input:
+        - text
+        - image
+        - pdf
+    output:
+        - text
 mode: chat
 model: gpt-5.4-mini-2026-03-17
+params:
+    - key: max_tokens
+      maxValue: 128000
+    - key: reasoning_effort
+      type: string
+provisioning: serverless
+status: active
 supportedModes:
     - chat
+    - responses
+thinking: true

--- a/providers/azure-open-ai/gpt-5.4-nano-2026-03-17.yaml
+++ b/providers/azure-open-ai/gpt-5.4-nano-2026-03-17.yaml
@@ -1,4 +1,43 @@
+costs:
+    - cache_read_input_token_cost: 2.e-8
+      input_cost_per_token: 2.e-7
+      output_cost_per_token: 0.00000125
+      region: "*"
+deprecationDate: "2027-03-17"
+features:
+    - function_calling
+    - parallel_function_calling
+    - system_messages
+    - tool_choice
+    - prompt_caching
+    - structured_output
+    - json_output
+limits:
+    context_window: 400000
+    max_input_tokens: 272000
+    max_output_tokens: 128000
+    max_tokens: 128000
+modalities:
+    input:
+        - text
+        - image
+        - pdf
+    output:
+        - text
 mode: chat
 model: gpt-5.4-nano-2026-03-17
+params:
+    - key: max_tokens
+      maxValue: 128000
+    - defaultValue: medium
+      key: reasoning_effort
+      type: string
+provisioning: serverless
+sources:
+    - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
+    - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/model-retirements
+status: active
 supportedModes:
     - chat
+    - responses
+thinking: true

--- a/providers/azure-open-ai/sora-2-2025-12-08.yaml
+++ b/providers/azure-open-ai/sora-2-2025-12-08.yaml
@@ -1,2 +1,30 @@
-mode: unknown
+costs:
+    - output_cost_per_second: 0.1
+      region: "*"
+modalities:
+    input:
+        - text
+        - image
+        - video
+    output:
+        - video
+        - audio
+mode: video
 model: sora-2-2025-12-08
+provisioning: serverless
+removeParams:
+    - max_tokens
+    - temperature
+    - stop
+    - top_p
+    - "n"
+    - response_format
+    - stream
+    - tool_choice
+    - parallel_tool_calls
+sources:
+    - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/video-generation
+    - https://azure.microsoft.com/en-us/products/ai-services/video-generation
+status: preview
+supportedModes:
+    - video


### PR DESCRIPTION
Auto-generated by poc-agent for provider `azure-open-ai`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Configuration-only changes but they affect model capabilities, token limits, and cost metadata, which can impact routing, budgeting, and parameter validation at runtime.
> 
> **Overview**
> Updates Azure OpenAI model YAMLs by marking `gpt-5-mini-2025-08-07-lite` as `provisioning: serverless`.
> 
> Adds full metadata for new chat models `gpt-5.4-mini-2026-03-17` and `gpt-5.4-nano-2026-03-17`, including **costs**, supported **features/tools**, very large **token limits**, `thinking: true`, and support for both `chat` and `responses` modes (plus `deprecationDate` and `sources` for nano).
> 
> Expands `sora-2-2025-12-08` from a placeholder into a `video` model definition with per-second output pricing, input/output modalities, `serverless` provisioning, preview status, and an explicit `removeParams` list to block chat-style parameters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbc8c1c699ed903be72e3ec39149f3a5d34b4696. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->