### PR TITLE
feat(anthropic): update model YAMLs [bot]

### DIFF
--- a/providers/anthropic/claude-4-opus-20250514.yaml
+++ b/providers/anthropic/claude-4-opus-20250514.yaml
@@ -6,6 +6,7 @@ costs:
       output_cost_per_token: 0.000075
       output_cost_per_token_batches: 0.0000375
       region: "*"
+deprecationDate: "2026-04-14"
 features:
     - function_calling
     - parallel_function_calling
@@ -14,6 +15,7 @@ features:
     - cache_control
     - assistant_prefill
     - system_messages
+isDeprecated: true
 limits:
     context_window: 200000
     max_input_tokens: 200000

--- a/providers/anthropic/claude-4-sonnet-20250514.yaml
+++ b/providers/anthropic/claude-4-sonnet-20250514.yaml
@@ -6,6 +6,8 @@ costs:
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: "*"
+isDeprecated: true
+deprecationDate: "2026-04-14"
 features:
     - function_calling
     - tool_choice

--- a/providers/anthropic/claude-4-sonnet-20250514.yaml
+++ b/providers/anthropic/claude-4-sonnet-20250514.yaml
@@ -6,7 +6,6 @@ costs:
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: "*"
-isDeprecated: true
 deprecationDate: "2026-04-14"
 features:
     - function_calling
@@ -14,6 +13,7 @@ features:
     - prompt_caching
     - cache_control
     - assistant_prefill
+isDeprecated: true
 limits:
     context_window: 1000000
     max_input_tokens: 1000000

--- a/providers/anthropic/claude-haiku-4-5-20251001.yaml
+++ b/providers/anthropic/claude-haiku-4-5-20251001.yaml
@@ -33,6 +33,7 @@ params:
       maxValue: 64000
     - defaultValue: null
       key: thinking
+provisioning: serverless
 removeParams:
     - top_p
 status: active

--- a/providers/anthropic/claude-haiku-4-5.yaml
+++ b/providers/anthropic/claude-haiku-4-5.yaml
@@ -33,6 +33,7 @@ params:
       key: max_tokens
       maxValue: 64000
       minValue: 1
+provisioning: serverless
 status: active
 supportedModes:
     - chat

--- a/providers/anthropic/claude-opus-4-1-20250805.yaml
+++ b/providers/anthropic/claude-opus-4-1-20250805.yaml
@@ -32,9 +32,11 @@ params:
       maxValue: 32000
     - defaultValue: null
       key: thinking
+provisioning: serverless
 removeParams:
     - temperature
     - top_p
+status: active
 supportedModes:
     - chat
 thinking: true

--- a/providers/anthropic/claude-opus-4-20250514.yaml
+++ b/providers/anthropic/claude-opus-4-20250514.yaml
@@ -6,12 +6,14 @@ costs:
       output_cost_per_token: 0.000075
       output_cost_per_token_batches: 0.0000375
       region: "*"
+deprecationDate: "2026-04-14"
 features:
     - function_calling
     - tool_choice
     - prompt_caching
     - cache_control
     - assistant_prefill
+isDeprecated: true
 limits:
     context_window: 200000
     max_input_tokens: 200000

--- a/providers/anthropic/claude-opus-4-5-20251101.yaml
+++ b/providers/anthropic/claude-opus-4-5-20251101.yaml
@@ -33,6 +33,7 @@ params:
       maxValue: 64000
     - defaultValue: null
       key: thinking
+provisioning: serverless
 removeParams:
     - temperature
     - top_p

--- a/providers/anthropic/claude-opus-4-5.yaml
+++ b/providers/anthropic/claude-opus-4-5.yaml
@@ -9,6 +9,7 @@ costs:
 features:
     - function_calling
     - tool_choice
+    - cache_control
     - prompt_caching
     - structured_output
     - assistant_prefill
@@ -33,6 +34,7 @@ params:
       maxValue: 64000
     - defaultValue: null
       key: thinking
+provisioning: serverless
 removeParams:
     - temperature
     - top_p

--- a/providers/anthropic/claude-sonnet-4-20250514.yaml
+++ b/providers/anthropic/claude-sonnet-4-20250514.yaml
@@ -6,6 +6,7 @@ costs:
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: "*"
+deprecationDate: "2026-04-14"
 features:
     - function_calling
     - tool_choice
@@ -13,6 +14,7 @@ features:
     - prompt_caching
     - assistant_prefill
     - system_messages
+isDeprecated: true
 limits:
     context_window: 1000000
     max_input_tokens: 1000000

--- a/providers/anthropic/claude-sonnet-4-5-20250929.yaml
+++ b/providers/anthropic/claude-sonnet-4-5-20250929.yaml
@@ -46,6 +46,7 @@ params:
       maxValue: 64000
     - defaultValue: null
       key: thinking
+provisioning: serverless
 removeParams:
     - top_p
 status: active

--- a/providers/anthropic/claude-sonnet-4-5.yaml
+++ b/providers/anthropic/claude-sonnet-4-5.yaml
@@ -32,6 +32,7 @@ params:
       maxValue: 64000
     - defaultValue: null
       key: thinking
+provisioning: serverless
 removeParams:
     - temperature
     - top_p

--- a/providers/anthropic/claude-sonnet-4-6.yaml
+++ b/providers/anthropic/claude-sonnet-4-6.yaml
@@ -10,6 +10,7 @@ features:
     - function_calling
     - tool_choice
     - prompt_caching
+    - cache_control
     - structured_output
     - assistant_prefill
 limits:
@@ -31,6 +32,7 @@ params:
       key: max_tokens
       maxValue: 64000
       minValue: 1
+provisioning: serverless
 status: active
 supportedModes:
     - chat


### PR DESCRIPTION
Auto-generated by poc-agent for provider `anthropic`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only YAML metadata updates for model catalog entries; risk is limited to incorrectly flagging models as deprecated or changing availability/feature flags if downstream consumers rely on these fields.
> 
> **Overview**
> Updates Anthropic model YAMLs to reflect new lifecycle and capability metadata.
> 
> Marks the `claude-4-*-20250514` models as deprecated by adding `isDeprecated: true` and a `deprecationDate` (`2026-04-14`). Several newer/alias models now declare `provisioning: serverless`, and `cache_control` is added to the feature lists for `claude-opus-4-5` and `claude-sonnet-4-6` (plus a small metadata fix like ensuring `claude-opus-4-1-20250805` is `status: active`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16fdaf02cd6eb746c21d0001b52a714cdc339f94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->