### PR TITLE
feat(deepinfra): update model YAMLs [bot]

### DIFF
--- a/providers/deepinfra/Qwen/Qwen3.5-0.8B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3.5-0.8B.yaml
@@ -4,9 +4,7 @@ costs:
       region: "*"
 features:
     - function_calling
-    - structured_output
-    - system_messages
-    - tool_choice
+    - json_output
 limits:
     context_window: 262144
     max_output_tokens: 32768
@@ -20,9 +18,10 @@ modalities:
         - text
 mode: chat
 model: Qwen/Qwen3.5-0.8B
+provisioning: serverless
 sources:
-    - https://huggingface.co/Qwen/Qwen3.5-0.8B
-    - https://deepinfra.com/Qwen/Qwen3.5-0.8B/api
+    - https://deepinfra.com/Qwen/Qwen3.5-0.8B
+status: active
 supportedModes:
     - chat
 thinking: true

--- a/providers/deepinfra/Qwen/Qwen3.5-27B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3.5-27B.yaml
@@ -4,9 +4,6 @@ costs:
       region: "*"
 features:
     - function_calling
-    - system_messages
-    - tool_choice
-    - structured_output
     - json_output
 limits:
     context_window: 262144
@@ -21,9 +18,9 @@ modalities:
         - text
 mode: chat
 model: Qwen/Qwen3.5-27B
+provisioning: serverless
 sources:
-    - https://deepinfra.com/Qwen/Qwen3.5-27B/api
-    - https://huggingface.co/Qwen/Qwen3.5-27B
+    - https://deepinfra.com/Qwen/Qwen3.5-27B
 status: active
 supportedModes:
     - chat

--- a/providers/deepinfra/Qwen/Qwen3.5-2B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3.5-2B.yaml
@@ -4,9 +4,7 @@ costs:
       region: "*"
 features:
     - function_calling
-    - system_messages
-    - structured_output
-    - tool_choice
+    - json_output
 limits:
     context_window: 262144
     max_output_tokens: 81920
@@ -20,9 +18,9 @@ modalities:
         - text
 mode: chat
 model: Qwen/Qwen3.5-2B
+provisioning: serverless
 sources:
-    - https://deepinfra.com/Qwen/Qwen3.5-2B/api
-    - https://huggingface.co/Qwen/Qwen3.5-2B
+    - https://deepinfra.com/Qwen/Qwen3.5-2B
 status: active
 supportedModes:
     - chat

--- a/providers/deepinfra/Qwen/Qwen3.5-35B-A3B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3.5-35B-A3B.yaml
@@ -1,12 +1,11 @@
 costs:
-    - input_cost_per_token: 2.2e-7
-      output_cost_per_token: 0.0000022
+    - cache_read_input_token_cost: 1.e-7
+      input_cost_per_token: 2.e-7
+      output_cost_per_token: 9.5e-7
       region: "*"
 features:
     - function_calling
-    - structured_output
     - json_output
-    - system_messages
 limits:
     context_window: 262144
     max_output_tokens: 81920
@@ -19,8 +18,9 @@ modalities:
         - text
 mode: chat
 model: Qwen/Qwen3.5-35B-A3B
+provisioning: serverless
 sources:
-    - https://deepinfra.com/Qwen/Qwen3.5-35B-A3B/api
+    - https://deepinfra.com/Qwen/Qwen3.5-35B-A3B
 status: active
 supportedModes:
     - chat

--- a/providers/deepinfra/Qwen/Qwen3.5-397B-A17B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3.5-397B-A17B.yaml
@@ -1,12 +1,11 @@
 costs:
-    - input_cost_per_token: 5.4e-7
+    - cache_read_input_token_cost: 2.7e-7
+      input_cost_per_token: 5.4e-7
       output_cost_per_token: 0.0000034
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - system_messages
-    - structured_output
+    - json_output
 limits:
     context_window: 262144
     max_output_tokens: 262144
@@ -19,8 +18,9 @@ modalities:
         - text
 mode: chat
 model: Qwen/Qwen3.5-397B-A17B
+provisioning: serverless
 sources:
-    - https://deepinfra.com/Qwen/Qwen3.5-397B-A17B/api
+    - https://deepinfra.com/Qwen/Qwen3.5-397B-A17B
 status: active
 supportedModes:
     - chat

--- a/providers/deepinfra/Qwen/Qwen3.5-4B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3.5-4B.yaml
@@ -5,9 +5,6 @@ costs:
 features:
     - function_calling
     - json_output
-    - structured_output
-    - system_messages
-    - tool_choice
     - prompt_caching
 limits:
     context_window: 262144
@@ -21,8 +18,9 @@ modalities:
         - text
 mode: chat
 model: Qwen/Qwen3.5-4B
+provisioning: serverless
 sources:
-    - https://deepinfra.com/Qwen/Qwen3.5-4B/api
+    - https://deepinfra.com/Qwen/Qwen3.5-4B
 status: active
 supportedModes:
     - chat

--- a/providers/deepinfra/Qwen/Qwen3.5-9B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3.5-9B.yaml
@@ -4,8 +4,7 @@ costs:
       region: "*"
 features:
     - function_calling
-    - system_messages
-    - structured_output
+    - json_output
 limits:
     context_window: 262144
     max_output_tokens: 262144
@@ -19,9 +18,9 @@ modalities:
         - text
 mode: chat
 model: Qwen/Qwen3.5-9B
+provisioning: serverless
 sources:
-    - https://deepinfra.com/Qwen/Qwen3.5-9B/api
-    - https://huggingface.co/Qwen/Qwen3.5-9B
+    - https://deepinfra.com/Qwen/Qwen3.5-9B
 status: active
 supportedModes:
     - chat

--- a/providers/deepinfra/Qwen/Qwen3.5-9B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3.5-9B.yaml
@@ -5,6 +5,7 @@ costs:
 features:
     - function_calling
     - json_output
+    - prompt_caching
 limits:
     context_window: 262144
     max_output_tokens: 262144

--- a/providers/deepinfra/stepfun-ai/Step-3.5-Flash.yaml
+++ b/providers/deepinfra/stepfun-ai/Step-3.5-Flash.yaml
@@ -5,6 +5,7 @@ costs:
       region: "*"
 features:
     - function_calling
+    - json_output
     - prompt_caching
 limits:
     context_window: 262144
@@ -17,8 +18,10 @@ modalities:
         - text
 mode: chat
 model: stepfun-ai/Step-3.5-Flash
+provisioning: serverless
 sources:
-    - https://deepinfra.com/stepfun-ai/Step-3.5-Flash/api
+    - https://deepinfra.com/stepfun-ai/Step-3.5-Flash
 status: active
 supportedModes:
     - chat
+thinking: true


### PR DESCRIPTION
Auto-generated by poc-agent for provider `deepinfra`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only YAML metadata updates for model catalogs; main risk is incorrect capability/cost declarations affecting routing or billing assumptions.
> 
> **Overview**
> Refreshes DeepInfra model YAML metadata for multiple `Qwen3.5-*` variants and `stepfun-ai/Step-3.5-Flash`.
> 
> Adds/normalizes declared capabilities (notably `json_output`, and `prompt_caching` where applicable), sets `provisioning: serverless`, and standardizes `sources` to the non-`/api` DeepInfra URLs. Also updates some cost fields (including adding `cache_read_input_token_cost` for select Qwen models) and marks `Step-3.5-Flash` as `thinking: true`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 221e5e368c4c5fa4cd6be82bc4cd0f77d7af14f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->