### PR TITLE
feat(anthropic): update model YAMLs [bot]

### DIFF
--- a/providers/anthropic/claude-4-sonnet-20250514.yaml
+++ b/providers/anthropic/claude-4-sonnet-20250514.yaml
@@ -6,12 +6,14 @@ costs:
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: "*"
+deprecationDate: "2026-04-14"
 features:
     - function_calling
     - tool_choice
     - prompt_caching
     - cache_control
     - assistant_prefill
+isDeprecated: true
 limits:
     context_window: 1000000
     max_input_tokens: 1000000

--- a/providers/anthropic/claude-opus-4-1.yaml
+++ b/providers/anthropic/claude-opus-4-1.yaml
@@ -33,6 +33,7 @@ params:
       maxValue: 32000
     - defaultValue: null
       key: thinking
+provisioning: serverless
 removeParams:
     - temperature
     - top_p

--- a/providers/anthropic/claude-opus-4-6.yaml
+++ b/providers/anthropic/claude-opus-4-6.yaml
@@ -31,6 +31,7 @@ model: claude-opus-4-6
 params:
     - key: max_tokens
       maxValue: 128000
+provisioning: serverless
 status: active
 supportedModes:
     - chat


### PR DESCRIPTION
Auto-generated by poc-agent for provider `anthropic`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because these config changes can alter model selection/availability (deprecation handling) and provisioning behavior at runtime. No code logic changes, but incorrect metadata could impact routing and billing expectations.
> 
> **Overview**
> Marks `claude-4-sonnet-20250514` as **deprecated** by adding `isDeprecated: true` and a `deprecationDate`.
> 
> Adds `provisioning: serverless` to `claude-opus-4-1` and `claude-opus-4-6` model YAMLs to reflect their deployment mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 281740d2217e945fb643c5b3eb7a0217ef497bc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->