### PR TITLE
feat(deepinfra): add new models [bot]

### DIFF
--- a/providers/deepinfra/Qwen/Qwen3.6-35B-A3B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3.6-35B-A3B.yaml
@@ -1,0 +1,13 @@
+costs:
+    - input_cost_per_token: 2.e-7
+      output_cost_per_token: 0.000001
+      region: "*"
+limits:
+    context_window: 262144
+    max_tokens: 262144
+modalities:
+    input:
+        - image
+mode: unknown
+model: Qwen/Qwen3.6-35B-A3B
+thinking: true


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `deepinfra`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only adds a new DeepInfra model definition YAML and does not modify runtime logic or security-sensitive code paths.
> 
> **Overview**
> Adds a new DeepInfra model entry `Qwen/Qwen3.6-35B-A3B` with pricing, very large token limits (262k context/max), and metadata indicating image input support and `thinking: true` (with `mode: unknown`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fd7e9f54b4afd3378403a8e19872643a8b3577c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->