### PR TITLE
feat(deepinfra): add new models [bot]

### DIFF
--- a/providers/deepinfra/Qwen/Qwen3.6-35B-A3B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3.6-35B-A3B.yaml
@@ -1,0 +1,13 @@
+costs:
+    - input_cost_per_token: 2.e-7
+      output_cost_per_token: 0.000001
+      region: "*"
+limits:
+    context_window: 262144
+    max_tokens: 262144
+modalities:
+    input:
+        - image
+mode: unknown
+model: Qwen/Qwen3.6-35B-A3B
+thinking: true


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `deepinfra`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new DeepInfra model metadata YAML (costs/limits/modalities) without changing runtime logic. Main risk is incorrect pricing/limits or capability flags leading to misconfiguration.
> 
> **Overview**
> Adds a new DeepInfra model definition `Qwen/Qwen3.6-35B-A3B` via `Qwen3.6-35B-A3B.yaml`, including token pricing, a 262k context/max token limit, image input modality, and `thinking: true` capability metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eaa2213677cdccf93da303a1fc88ec7469c4d0ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->