### PR TITLE
feat(openrouter): add new models [bot]

### DIFF
--- a/providers/openrouter/moonshotai/kimi-k2.6.yaml
+++ b/providers/openrouter/moonshotai/kimi-k2.6.yaml
@@ -1,0 +1,23 @@
+costs:
+    - cache_read_input_token_cost: 2.e-7
+      input_cost_per_token: 6.e-7
+      output_cost_per_token: 0.0000028
+      region: "*"
+features:
+    - function_calling
+    - json_output
+    - prompt_caching
+    - structured_output
+    - tool_choice
+limits:
+    context_window: 262144
+    max_output_tokens: 262144
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
+mode: chat
+model: moonshotai/kimi-k2.6
+thinking: true


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `openrouter`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new OpenRouter model definition YAML without changing any runtime logic; impact is limited to model catalog/metadata consumption.
> 
> **Overview**
> Registers a new OpenRouter model entry, `moonshotai/kimi-k2.6`, including token pricing, supported features (e.g., tool/function calling, structured/JSON output, prompt caching), and modalities (text+image input).
> 
> Configures very large limits (`context_window` and `max_output_tokens` at 262,144) and marks the model as `thinking: true`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3691ebea4fdbcfc8d05367f14a5009c0c11df16c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->