### PR TITLE
feat(together-ai): add new models [bot]

### DIFF
--- a/providers/together-ai/Qwen/Qwen3.5-122B-A10B-FP8.yaml
+++ b/providers/together-ai/Qwen/Qwen3.5-122B-A10B-FP8.yaml
@@ -1,0 +1,10 @@
+costs:
+    - input_cost_per_token: 0
+      output_cost_per_token: 0
+      region: "*"
+limits:
+    context_window: 262144
+mode: unknown
+model: Qwen/Qwen3.5-122B-A10B-FP8
+supportedModes:
+    - chat

--- a/providers/together-ai/Wan-AI/wan2.7-i2v.yaml
+++ b/providers/together-ai/Wan-AI/wan2.7-i2v.yaml
@@ -1,0 +1,8 @@
+costs:
+    - input_cost_per_token: 0
+      output_cost_per_token: 0
+      region: "*"
+mode: unknown
+model: Wan-AI/wan2.7-i2v
+supportedModes:
+    - video

--- a/providers/together-ai/Wan-AI/wan2.7-r2v.yaml
+++ b/providers/together-ai/Wan-AI/wan2.7-r2v.yaml
@@ -1,0 +1,8 @@
+costs:
+    - input_cost_per_token: 0
+      output_cost_per_token: 0
+      region: "*"
+mode: unknown
+model: Wan-AI/wan2.7-r2v
+supportedModes:
+    - video

--- a/providers/together-ai/google/veo-3.1-test-debug.yaml
+++ b/providers/together-ai/google/veo-3.1-test-debug.yaml
@@ -1,0 +1,8 @@
+costs:
+    - input_cost_per_token: 0
+      output_cost_per_token: 0
+      region: "*"
+mode: unknown
+model: google/veo-3.1-test-debug
+supportedModes:
+    - video


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `together-ai`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because it only adds new Together.ai model metadata YAMLs; main risk is incorrect `mode`/pricing metadata (set to `unknown`/0) potentially affecting model selection or billing display.
> 
> **Overview**
> Adds four new Together.ai model definition YAMLs: `Qwen/Qwen3.5-122B-A10B-FP8` (chat, `context_window: 262144`) plus three video models (`Wan-AI/wan2.7-i2v`, `Wan-AI/wan2.7-r2v`, `google/veo-3.1-test-debug`).
> 
> Each entry includes placeholder `costs` (0 per token, region `*`) and sets `mode: unknown` while declaring `supportedModes` (`chat` or `video`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39c537c34b764b124f0dff90811851c804053fd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->