### PR TITLE
feat(cerebras): update model YAMLs [bot]

### DIFF
--- a/providers/cerebras/gpt-oss-120b.yaml
+++ b/providers/cerebras/gpt-oss-120b.yaml
@@ -27,13 +27,13 @@ params:
       maxValue: 40000
     - defaultValue: medium
       key: reasoning_effort
+provisioning: serverless
 removeParams:
     - stream
 sources:
     - https://inference-docs.cerebras.ai/models/openai-oss
     - https://inference-docs.cerebras.ai/capabilities/reasoning
     - https://inference-docs.cerebras.ai/capabilities/prompt-caching
-    - https://inference-docs.cerebras.ai/support/deprecation
 status: active
 supportedModes:
     - chat

--- a/providers/cerebras/llama3.1-8b.yaml
+++ b/providers/cerebras/llama3.1-8b.yaml
@@ -8,6 +8,7 @@ features:
     - tool_choice
     - structured_output
     - system_messages
+    - json_output
 limits:
     context_window: 32000
     max_output_tokens: 8000
@@ -22,6 +23,7 @@ model: llama3.1-8b
 params:
     - key: max_tokens
       maxValue: 8000
+provisioning: serverless
 sources:
     - https://inference-docs.cerebras.ai/models/llama-31-8b
     - https://inference-docs.cerebras.ai/capabilities/tool-use
@@ -30,5 +32,5 @@ sources:
     - https://inference-docs.cerebras.ai/api-reference/chat-completions
 status: active
 supportedModes:
-    - completion
     - chat
+    - completion

--- a/providers/cerebras/qwen-3-235b-a22b-instruct-2507.yaml
+++ b/providers/cerebras/qwen-3-235b-a22b-instruct-2507.yaml
@@ -15,12 +15,6 @@ limits:
     max_input_tokens: 131000
     max_output_tokens: 40000
     max_tokens: 40000
-messages:
-    options:
-        - system
-        - user
-        - assistant
-        - developer
 modalities:
     input:
         - text
@@ -33,6 +27,7 @@ params:
       maxValue: 40000
     - key: seed
       type: number
+provisioning: serverless
 sources:
     - https://inference-docs.cerebras.ai/models/qwen-3-235b-2507
     - https://inference-docs.cerebras.ai/capabilities/prompt-caching
@@ -43,3 +38,4 @@ sources:
 status: preview
 supportedModes:
     - chat
+    - completion

--- a/providers/cerebras/zai-glm-4.7.yaml
+++ b/providers/cerebras/zai-glm-4.7.yaml
@@ -27,6 +27,7 @@ params:
       maxValue: 40000
     - key: reasoning_effort
       type: string
+provisioning: serverless
 sources:
     - https://inference-docs.cerebras.ai/models/zai-glm-47
     - https://inference-docs.cerebras.ai/resources/glm-47-migration


### PR DESCRIPTION
Auto-generated by poc-agent for provider `cerebras`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk metadata-only changes to Cerebras model descriptors (provisioning/modes/features) with no runtime logic changes. Main risk is misdeclaring capabilities (e.g., `completion` support or `json_output`) which could affect routing/validation at integration time.
> 
> **Overview**
> Marks multiple Cerebras models as **`provisioning: serverless`** (including `gpt-oss-120b`, `llama3.1-8b`, `qwen-3-235b-a22b-instruct-2507`, and `zai-glm-4.7`).
> 
> Updates declared capabilities by adding `json_output` to `llama3.1-8b`, and expands `supportedModes` to include `completion` for `llama3.1-8b` and `qwen-3-235b-a22b-instruct-2507`; also drops an outdated `gpt-oss-120b` source URL and removes a redundant `messages` options block from the Qwen YAML.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 745194eb9b3f89fcd2b6693fa5c431e9b3861dac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->