### PR TITLE
feat(google-vertex): update model YAMLs [bot]

### DIFF
--- a/providers/google-vertex/advimman/lama.yaml
+++ b/providers/google-vertex/advimman/lama.yaml
@@ -5,6 +5,7 @@ modalities:
         - image
 mode: image
 model: advimman/lama
+provisioning: provisioned
 removeParams:
     - max_tokens
     - temperature
@@ -13,5 +14,8 @@ removeParams:
     - stop
     - stream
     - tool_choice
+sources:
+    - https://console.cloud.google.com/vertex-ai/publishers/advimman/model-garden/lama
+status: active
 supportedModes:
     - image

--- a/providers/google-vertex/aisingapore/gemma-sea-lion-v4.yaml
+++ b/providers/google-vertex/aisingapore/gemma-sea-lion-v4.yaml
@@ -1,10 +1,23 @@
+features:
+    - function_calling
+    - structured_output
+    - system_messages
+limits:
+    context_window: 128000
 modalities:
     input:
         - text
+        - image
     output:
         - text
 mode: chat
 model: aisingapore/gemma-sea-lion-v4
+provisioning: provisioned
+sources:
+    - https://docs.sea-lion.ai/models/sea-lion-v4/gemma-sea-lion-v4-27b
+    - https://sea-lion.ai/models/
+    - https://deepmind.google/models/gemma/gemmaverse/sea-lion-v4/
+    - https://docs.sea-lion.ai/guides/inferencing/vertex_ai
 status: active
 supportedModes:
     - chat

--- a/providers/google-vertex/anthropic/claude-haiku-4-5.yaml
+++ b/providers/google-vertex/anthropic/claude-haiku-4-5.yaml
@@ -58,6 +58,7 @@ params:
       key: temperature
       maxValue: 1
       minValue: 0
+provisioning: serverless
 removeParams:
     - "n"
 sources:

--- a/providers/google-vertex/anthropic/claude-haiku-4-5@20251001.yaml
+++ b/providers/google-vertex/anthropic/claude-haiku-4-5@20251001.yaml
@@ -50,11 +50,11 @@ model: anthropic/claude-haiku-4-5@20251001
 params:
     - key: max_tokens
       maxValue: 64000
+provisioning: serverless
 sources:
     - https://platform.claude.com/docs/en/about-claude/pricing
     - https://platform.claude.com/docs/en/build-with-claude/claude-on-vertex-ai
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude/haiku-4-5
-    - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/deprecations/partner-models
 status: active
 supportedModes:
     - chat

--- a/providers/google-vertex/anthropic/claude-opus-4-1.yaml
+++ b/providers/google-vertex/anthropic/claude-opus-4-1.yaml
@@ -36,12 +36,14 @@ model: anthropic/claude-opus-4-1
 params:
     - key: max_tokens
       maxValue: 32000
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude/opus-4-1
     - https://platform.claude.com/docs/en/docs/about-claude/models
     - https://platform.claude.com/docs/en/docs/about-claude/pricing
     - https://platform.claude.com/docs/en/docs/build-with-claude/claude-on-vertex-ai
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/use-claude
+status: active
 supportedModes:
     - chat
 thinking: true

--- a/providers/google-vertex/anthropic/claude-opus-4-1@20250805.yaml
+++ b/providers/google-vertex/anthropic/claude-opus-4-1@20250805.yaml
@@ -38,6 +38,7 @@ model: anthropic/claude-opus-4-1@20250805
 params:
     - key: max_tokens
       maxValue: 32000
+provisioning: serverless
 sources:
     - https://platform.claude.com/docs/en/docs/about-claude/models
     - https://platform.claude.com/docs/en/about-claude/pricing

--- a/providers/google-vertex/anthropic/claude-opus-4-5.yaml
+++ b/providers/google-vertex/anthropic/claude-opus-4-5.yaml
@@ -51,6 +51,7 @@ model: anthropic/claude-opus-4-5
 params:
     - key: max_tokens
       maxValue: 64000
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude/opus-4-5
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude

--- a/providers/google-vertex/anthropic/claude-opus-4-5@20251101.yaml
+++ b/providers/google-vertex/anthropic/claude-opus-4-5@20251101.yaml
@@ -45,11 +45,13 @@ model: anthropic/claude-opus-4-5@20251101
 params:
     - key: max_tokens
       maxValue: 64000
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude/opus-4-5
     - https://platform.claude.com/docs/en/about-claude/models/overview
     - https://platform.claude.com/docs/en/about-claude/pricing
     - https://platform.claude.com/docs/en/build-with-claude/claude-on-vertex-ai
+status: active
 supportedModes:
     - chat
 thinking: true

--- a/providers/google-vertex/anthropic/claude-opus-4-6.yaml
+++ b/providers/google-vertex/anthropic/claude-opus-4-6.yaml
@@ -47,12 +47,14 @@ params:
       key: max_tokens
       maxValue: 128000
       minValue: 1
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude/opus-4-6
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/use-claude
     - https://platform.claude.com/docs/en/about-claude/models
     - https://platform.claude.com/docs/en/about-claude/pricing
     - https://platform.claude.com/docs/en/build-with-claude/claude-on-vertex-ai
+    - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/deprecations/partner-models
 status: active
 supportedModes:
     - chat

--- a/providers/google-vertex/anthropic/claude-opus-4-6@default.yaml
+++ b/providers/google-vertex/anthropic/claude-opus-4-6@default.yaml
@@ -55,6 +55,7 @@ params:
       maxValue: 128000
     - key: temperature
       maxValue: 1
+provisioning: serverless
 removeParams:
     - "n"
 sources:

--- a/providers/google-vertex/anthropic/claude-opus-4.yaml
+++ b/providers/google-vertex/anthropic/claude-opus-4.yaml
@@ -13,6 +13,7 @@ costs:
       output_cost_per_token: 0.000075
       output_cost_per_token_batches: 0.0000375
       region: global
+deprecationDate: "2026-06-15"
 features:
     - function_calling
     - tool_choice
@@ -38,11 +39,13 @@ params:
       key: max_tokens
       maxValue: 32000
       minValue: 1
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude/opus-4
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/use-claude
     - https://platform.claude.com/docs/en/docs/about-claude/models
     - https://platform.claude.com/docs/en/about-claude/pricing
+status: deprecated
 supportedModes:
     - chat
 thinking: true

--- a/providers/google-vertex/anthropic/claude-opus-4@20250514.yaml
+++ b/providers/google-vertex/anthropic/claude-opus-4@20250514.yaml
@@ -13,12 +13,14 @@ costs:
       output_cost_per_token: 0.000075
       output_cost_per_token_batches: 0.0000375
       region: global
+deprecationDate: "2026-04-14"
 features:
     - function_calling
     - cache_control
     - tool_choice
     - prompt_caching
     - assistant_prefill
+isDeprecated: true
 limits:
     context_window: 200000
     max_input_tokens: 200000

--- a/providers/google-vertex/anthropic/claude-sonnet-4-5.yaml
+++ b/providers/google-vertex/anthropic/claude-sonnet-4-5.yaml
@@ -3,20 +3,62 @@ costs:
       cache_read_input_token_cost: 3.3e-7
       input_cost_per_token: 0.0000033
       output_cost_per_token: 0.0000165
+      region: us-west4
+    - cache_creation_input_token_cost: 0.000004125
+      cache_read_input_token_cost: 3.3e-7
+      input_cost_per_token: 0.0000033
+      output_cost_per_token: 0.0000165
+      region: us-west1
+    - cache_creation_input_token_cost: 0.000004125
+      cache_read_input_token_cost: 3.3e-7
+      input_cost_per_token: 0.0000033
+      output_cost_per_token: 0.0000165
+      region: us-south1
+    - cache_creation_input_token_cost: 0.000004125
+      cache_read_input_token_cost: 3.3e-7
+      input_cost_per_token: 0.0000033
+      output_cost_per_token: 0.0000165
       region: us-east5
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 6.6e-7
-                from: 200000
-          cache_write:
-              - cost_per_token: 0.00000825
-                from: 200000
-          input:
-              - cost_per_token: 0.0000066
-                from: 200000
-          output:
-              - cost_per_token: 0.00002475
-                from: 200000
+    - cache_creation_input_token_cost: 0.000004125
+      cache_read_input_token_cost: 3.3e-7
+      input_cost_per_token: 0.0000033
+      output_cost_per_token: 0.0000165
+      region: us-east4
+    - cache_creation_input_token_cost: 0.000004125
+      cache_read_input_token_cost: 3.3e-7
+      input_cost_per_token: 0.0000033
+      output_cost_per_token: 0.0000165
+      region: us-east1
+    - cache_creation_input_token_cost: 0.000004125
+      cache_read_input_token_cost: 3.3e-7
+      input_cost_per_token: 0.0000033
+      output_cost_per_token: 0.0000165
+      region: us-central1
+    - cache_creation_input_token_cost: 0.000004125
+      cache_read_input_token_cost: 3.3e-7
+      input_cost_per_token: 0.0000033
+      output_cost_per_token: 0.0000165
+      region: southamerica-east1
+    - cache_creation_input_token_cost: 0.000004125
+      cache_read_input_token_cost: 3.3e-7
+      input_cost_per_token: 0.0000033
+      output_cost_per_token: 0.0000165
+      region: northamerica-northeast1
+    - cache_creation_input_token_cost: 0.000004125
+      cache_read_input_token_cost: 3.3e-7
+      input_cost_per_token: 0.0000033
+      output_cost_per_token: 0.0000165
+      region: me-west1
+    - cache_creation_input_token_cost: 0.000004125
+      cache_read_input_token_cost: 3.3e-7
+      input_cost_per_token: 0.0000033
+      output_cost_per_token: 0.0000165
+      region: me-central2
+    - cache_creation_input_token_cost: 0.000004125
+      cache_read_input_token_cost: 3.3e-7
+      input_cost_per_token: 0.0000033
+      output_cost_per_token: 0.0000165
+      region: me-central1
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3.e-7
       input_cost_per_token: 0.000003
@@ -24,55 +66,91 @@ costs:
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: global
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 6.e-7
-                from: 200000
-          cache_write:
-              - cost_per_token: 0.0000075
-                from: 200000
-          input:
-              - cost_per_token: 0.000006
-                from: 200000
-          output:
-              - cost_per_token: 0.0000225
-                from: 200000
+    - cache_creation_input_token_cost: 0.000004125
+      cache_read_input_token_cost: 3.3e-7
+      input_cost_per_token: 0.0000033
+      output_cost_per_token: 0.0000165
+      region: europe-west9
+    - cache_creation_input_token_cost: 0.000004125
+      cache_read_input_token_cost: 3.3e-7
+      input_cost_per_token: 0.0000033
+      output_cost_per_token: 0.0000165
+      region: europe-west8
+    - cache_creation_input_token_cost: 0.000004125
+      cache_read_input_token_cost: 3.3e-7
+      input_cost_per_token: 0.0000033
+      output_cost_per_token: 0.0000165
+      region: europe-west6
+    - cache_creation_input_token_cost: 0.000004125
+      cache_read_input_token_cost: 3.3e-7
+      input_cost_per_token: 0.0000033
+      output_cost_per_token: 0.0000165
+      region: europe-west4
+    - cache_creation_input_token_cost: 0.000004125
+      cache_read_input_token_cost: 3.3e-7
+      input_cost_per_token: 0.0000033
+      output_cost_per_token: 0.0000165
+      region: europe-west3
+    - cache_creation_input_token_cost: 0.000004125
+      cache_read_input_token_cost: 3.3e-7
+      input_cost_per_token: 0.0000033
+      output_cost_per_token: 0.0000165
+      region: europe-west2
     - cache_creation_input_token_cost: 0.000004125
       cache_read_input_token_cost: 3.3e-7
       input_cost_per_token: 0.0000033
       output_cost_per_token: 0.0000165
       region: europe-west1
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 6.6e-7
-                from: 200000
-          cache_write:
-              - cost_per_token: 0.00000825
-                from: 200000
-          input:
-              - cost_per_token: 0.0000066
-                from: 200000
-          output:
-              - cost_per_token: 0.00002475
-                from: 200000
+    - cache_creation_input_token_cost: 0.000004125
+      cache_read_input_token_cost: 3.3e-7
+      input_cost_per_token: 0.0000033
+      output_cost_per_token: 0.0000165
+      region: europe-southwest1
+    - cache_creation_input_token_cost: 0.000004125
+      cache_read_input_token_cost: 3.3e-7
+      input_cost_per_token: 0.0000033
+      output_cost_per_token: 0.0000165
+      region: europe-north1
+    - cache_creation_input_token_cost: 0.000004125
+      cache_read_input_token_cost: 3.3e-7
+      input_cost_per_token: 0.0000033
+      output_cost_per_token: 0.0000165
+      region: europe-central2
+    - cache_creation_input_token_cost: 0.000004125
+      cache_read_input_token_cost: 3.3e-7
+      input_cost_per_token: 0.0000033
+      output_cost_per_token: 0.0000165
+      region: australia-southeast1
     - cache_creation_input_token_cost: 0.000004125
       cache_read_input_token_cost: 3.3e-7
       input_cost_per_token: 0.0000033
       output_cost_per_token: 0.0000165
       region: asia-southeast1
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 6.6e-7
-                from: 200000
-          cache_write:
-              - cost_per_token: 0.00000825
-                from: 200000
-          input:
-              - cost_per_token: 0.0000066
-                from: 200000
-          output:
-              - cost_per_token: 0.00002475
-                from: 200000
+    - cache_creation_input_token_cost: 0.000004125
+      cache_read_input_token_cost: 3.3e-7
+      input_cost_per_token: 0.0000033
+      output_cost_per_token: 0.0000165
+      region: asia-south1
+    - cache_creation_input_token_cost: 0.000004125
+      cache_read_input_token_cost: 3.3e-7
+      input_cost_per_token: 0.0000033
+      output_cost_per_token: 0.0000165
+      region: asia-northeast3
+    - cache_creation_input_token_cost: 0.000004125
+      cache_read_input_token_cost: 3.3e-7
+      input_cost_per_token: 0.0000033
+      output_cost_per_token: 0.0000165
+      region: asia-northeast1
+    - cache_creation_input_token_cost: 0.000004125
+      cache_read_input_token_cost: 3.3e-7
+      input_cost_per_token: 0.0000033
+      output_cost_per_token: 0.0000165
+      region: asia-east2
+    - cache_creation_input_token_cost: 0.000004125
+      cache_read_input_token_cost: 3.3e-7
+      input_cost_per_token: 0.0000033
+      output_cost_per_token: 0.0000165
+      region: asia-east1
 features:
     - function_calling
     - cache_control
@@ -100,11 +178,13 @@ params:
       key: max_tokens
       maxValue: 64000
       minValue: 1
+provisioning: serverless
 sources:
     - https://platform.claude.com/docs/en/docs/about-claude/models
     - https://platform.claude.com/docs/en/about-claude/pricing
     - https://platform.claude.com/docs/en/build-with-claude/claude-on-vertex-ai
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/use-claude
+    - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude
 status: active
 supportedModes:
     - chat

--- a/providers/google-vertex/anthropic/claude-sonnet-4-5@20250929.yaml
+++ b/providers/google-vertex/anthropic/claude-sonnet-4-5@20250929.yaml
@@ -99,6 +99,7 @@ model: anthropic/claude-sonnet-4-5@20250929
 params:
     - key: max_tokens
       maxValue: 64000
+provisioning: serverless
 sources:
     - https://platform.claude.com/docs/en/about-claude/models
     - https://platform.claude.com/docs/en/about-claude/pricing

--- a/providers/google-vertex/anthropic/claude-sonnet-4-6.yaml
+++ b/providers/google-vertex/anthropic/claude-sonnet-4-6.yaml
@@ -46,6 +46,7 @@ params:
       maxValue: 128000
     - key: temperature
       maxValue: 1
+provisioning: serverless
 removeParams:
     - "n"
 sources:

--- a/providers/google-vertex/anthropic/claude-sonnet-4-6@default.yaml
+++ b/providers/google-vertex/anthropic/claude-sonnet-4-6@default.yaml
@@ -38,8 +38,8 @@ features:
 limits:
     context_window: 1000000
     max_input_tokens: 1000000
-    max_output_tokens: 64000
-    max_tokens: 64000
+    max_output_tokens: 128000
+    max_tokens: 128000
     tool_use_system_prompt_tokens: 346
 modalities:
     input:
@@ -52,9 +52,10 @@ mode: chat
 model: anthropic/claude-sonnet-4-6@default
 params:
     - key: max_tokens
-      maxValue: 64000
+      maxValue: 128000
     - key: temperature
       maxValue: 1
+provisioning: serverless
 removeParams:
     - "n"
 sources:

--- a/providers/google-vertex/anthropic/claude-sonnet-4.yaml
+++ b/providers/google-vertex/anthropic/claude-sonnet-4.yaml
@@ -59,6 +59,7 @@ costs:
           output:
               - cost_per_token: 0.0000225
                 from: 200000
+deprecationDate: "2026-06-15"
 features:
     - function_calling
     - tool_choice
@@ -75,13 +76,18 @@ modalities:
         - text
         - image
         - pdf
+    output:
+        - text
 mode: chat
 model: anthropic/claude-sonnet-4
 params:
     - key: max_tokens
       maxValue: 64000
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude/sonnet-4
+    - https://platform.claude.com/docs/en/docs/about-claude/models/all-models
+    - https://platform.claude.com/docs/en/docs/about-claude/pricing
 supportedModes:
     - chat
 thinking: true

--- a/providers/google-vertex/anthropic/claude-sonnet-4@20250514.yaml
+++ b/providers/google-vertex/anthropic/claude-sonnet-4@20250514.yaml
@@ -19,12 +19,14 @@ costs:
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: asia-east1
+deprecationDate: "2026-04-14"
 features:
     - function_calling
     - cache_control
     - tool_choice
     - prompt_caching
     - assistant_prefill
+isDeprecated: true
 limits:
     context_window: 1000000
     max_input_tokens: 1000000

--- a/providers/google-vertex/autogluon-ai/autogluon.yaml
+++ b/providers/google-vertex/autogluon-ai/autogluon.yaml
@@ -1,2 +1,5 @@
 mode: unknown
 model: autogluon-ai/autogluon
+provisioning: provisioned
+supportedModes:
+    - unknown

--- a/providers/google-vertex/baai/bge.yaml
+++ b/providers/google-vertex/baai/bge.yaml
@@ -5,6 +5,7 @@ modalities:
         - embedding
 mode: embedding
 model: baai/bge
+provisioning: provisioned
 removeParams:
     - max_tokens
     - temperature

--- a/providers/google-vertex/black-forest-labs/flux-2-klein-4b.yaml
+++ b/providers/google-vertex/black-forest-labs/flux-2-klein-4b.yaml
@@ -5,6 +5,7 @@ modalities:
         - image
 mode: image
 model: black-forest-labs/flux-2-klein-4b
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature
@@ -14,7 +15,10 @@ removeParams:
     - stream
     - tool_choice
 sources:
-    - https://console.cloud.google.com/vertex-ai/publishers/black-forest-labs/model-garden/flux1-schnell
+    - https://console.cloud.google.com/vertex-ai/publishers/black-forest-labs/model-garden/flux-2-klein-4b
+    - https://bfl.ai/pricing/
+    - https://bfl.ai/models/flux-2-klein
+    - https://docs.bfl.ai/flux_2/flux2_overview
 status: active
 supportedModes:
     - image

--- a/providers/google-vertex/black-forest-labs/flux1-schnell.yaml
+++ b/providers/google-vertex/black-forest-labs/flux1-schnell.yaml
@@ -7,6 +7,7 @@ modalities:
         - image
 mode: image
 model: black-forest-labs/flux1-schnell
+provisioning: provisioned
 removeParams:
     - max_tokens
     - temperature
@@ -15,5 +16,8 @@ removeParams:
     - stop
     - stream
     - tool_choice
+sources:
+    - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/open-models/xdit
+status: active
 supportedModes:
     - image

--- a/providers/google-vertex/bytedance/stable-diffusion-xl-lightning.yaml
+++ b/providers/google-vertex/bytedance/stable-diffusion-xl-lightning.yaml
@@ -5,6 +5,7 @@ modalities:
         - image
 mode: image
 model: bytedance/stable-diffusion-xl-lightning
+provisioning: provisioned
 removeParams:
     - max_tokens
     - temperature

--- a/providers/google-vertex/cambai/mars7.yaml
+++ b/providers/google-vertex/cambai/mars7.yaml
@@ -5,6 +5,7 @@ modalities:
         - audio
 mode: text_to_speech
 model: cambai/mars7
+provisioning: serverless
 removeParams:
     - tool_choice
     - stop

--- a/providers/google-vertex/cambai/mars8.yaml
+++ b/providers/google-vertex/cambai/mars8.yaml
@@ -5,11 +5,15 @@ modalities:
         - audio
 mode: text_to_speech
 model: cambai/mars8
+provisioning: serverless
 removeParams:
     - "n"
     - tool_choice
+    - max_tokens
+    - stop
 sources:
     - https://docs.camb.ai/models.md
     - https://docs.camb.ai/choosing-a-model.md
+status: active
 supportedModes:
     - text_to_speech

--- a/providers/google-vertex/contextualai/rerank-v2-instruct.yaml
+++ b/providers/google-vertex/contextualai/rerank-v2-instruct.yaml
@@ -1,3 +1,8 @@
+costs:
+    - input_cost_per_token: 5.e-8
+      region: global
+limits:
+    max_input_tokens: 400000
 modalities:
     input:
         - text
@@ -5,6 +10,7 @@ modalities:
         - text
 mode: rerank
 model: contextualai/rerank-v2-instruct
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature
@@ -17,6 +23,7 @@ sources:
     - https://docs.contextual.ai/api-reference/rerank/rerank
     - https://docs.contextual.ai/how-to-guides/rerank
     - https://docs.contextual.ai/integration/platforms
+    - https://contextual.ai/pricing
 status: active
 supportedModes:
     - rerank

--- a/providers/google-vertex/dandelin/vilt-b32-finetuned-vqa.yaml
+++ b/providers/google-vertex/dandelin/vilt-b32-finetuned-vqa.yaml
@@ -6,5 +6,17 @@ modalities:
         - text
 mode: unknown
 model: dandelin/vilt-b32-finetuned-vqa
+provisioning: provisioned
+removeParams:
+    - max_tokens
+    - temperature
+    - top_p
+    - "n"
+    - stop
+    - stream
+    - tool_choice
 sources:
     - https://huggingface.co/dandelin/vilt-b32-finetuned-vqa
+status: active
+supportedModes:
+    - unknown

--- a/providers/google-vertex/deepseek-ai/deepseek-ocr-maas.yaml
+++ b/providers/google-vertex/deepseek-ai/deepseek-ocr-maas.yaml
@@ -1,7 +1,7 @@
 costs:
     - input_cost_per_token: 3.e-7
       output_cost_per_token: 0.0000012
-      region: global # docs specify us-central1 but the model is only available via global inference
+      region: us-central1
 features:
     - function_calling
     - structured_output
@@ -23,6 +23,7 @@ params:
       key: max_tokens
       maxValue: 8192
       minValue: 1
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/deepseek/deepseek-ocr
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/deepseek

--- a/providers/google-vertex/deepseek-ai/deepseek-r1-0528-maas.yaml
+++ b/providers/google-vertex/deepseek-ai/deepseek-r1-0528-maas.yaml
@@ -21,6 +21,7 @@ modalities:
         - text
 mode: chat
 model: deepseek-ai/deepseek-r1-0528-maas
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/deepseek
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/deepseek/r1-0528

--- a/providers/google-vertex/deepseek-ai/deepseek-v3-1.yaml
+++ b/providers/google-vertex/deepseek-ai/deepseek-v3-1.yaml
@@ -20,10 +20,9 @@ modalities:
         - text
 mode: chat
 model: deepseek-ai/deepseek-v3-1
-provisioning: provisioned
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/deepseek/deepseek-v31
-    - https://cloud.google.com/vertex-ai/generative-ai/pricing#deepseek-models
 status: active
 supportedModes:
     - chat

--- a/providers/google-vertex/deepseek-ai/deepseek-v3-2.yaml
+++ b/providers/google-vertex/deepseek-ai/deepseek-v3-2.yaml
@@ -22,7 +22,7 @@ params:
       key: max_tokens
       maxValue: 65536
       minValue: 1
-provisioning: provisioned
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/deepseek/deepseek-v32
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/deepseek

--- a/providers/google-vertex/deepseek-ai/deepseek-v3.1-maas.yaml
+++ b/providers/google-vertex/deepseek-ai/deepseek-v3.1-maas.yaml
@@ -4,7 +4,7 @@ costs:
       input_cost_per_token_batches: 3.e-7
       output_cost_per_token: 0.0000017
       output_cost_per_token_batches: 8.5e-7
-      region: us-west2 # docs specify us-central1 but the model is available via us-west2 inference
+      region: us-central1
 features:
     - function_calling
     - tool_choice
@@ -23,6 +23,7 @@ modalities:
         - text
 mode: chat
 model: deepseek-ai/deepseek-v3.1-maas
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/deepseek/deepseek-v31
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/deepseek

--- a/providers/google-vertex/deepseek-ai/deepseek-v3.2-maas.yaml
+++ b/providers/google-vertex/deepseek-ai/deepseek-v3.2-maas.yaml
@@ -7,10 +7,11 @@ costs:
       region: global
 features:
     - function_calling
+    - json_output
+    - prompt_caching
     - structured_output
     - system_messages
     - tool_choice
-    - prompt_caching
 limits:
     context_window: 163840
     max_output_tokens: 65536
@@ -28,10 +29,16 @@ params:
       key: max_tokens
       maxValue: 65536
       minValue: 1
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/deepseek/deepseek-v32
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/deepseek
-    - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/locations
+    - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/use-open-models
+    - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/call-open-model-apis
+    - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/capabilities/function-calling
+    - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/capabilities/structured-output
+    - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/capabilities/thinking
 status: active
 supportedModes:
     - chat
+thinking: true

--- a/providers/google-vertex/deepseek-ai/deepseek-v3.yaml
+++ b/providers/google-vertex/deepseek-ai/deepseek-v3.yaml
@@ -8,8 +8,10 @@ modalities:
         - text
 mode: chat
 model: deepseek-ai/deepseek-v3
+provisioning: provisioned
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/deepseek
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/release-notes
+status: preview
 supportedModes:
     - chat

--- a/providers/google-vertex/elevenlabs/elevenlabs-tts-v2-5.yaml
+++ b/providers/google-vertex/elevenlabs/elevenlabs-tts-v2-5.yaml
@@ -5,6 +5,7 @@ modalities:
         - audio
 mode: text_to_speech
 model: elevenlabs/elevenlabs-tts-v2-5
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature
@@ -13,5 +14,8 @@ removeParams:
     - stop
     - stream
     - tool_choice
+sources:
+    - https://elevenlabs.io/docs/overview/models
+status: active
 supportedModes:
     - text_to_speech

--- a/providers/google-vertex/gemini-2.5-computer-use-preview-10-2025.yaml
+++ b/providers/google-vertex/gemini-2.5-computer-use-preview-10-2025.yaml
@@ -30,9 +30,11 @@ model: gemini-2.5-computer-use-preview-10-2025
 params:
     - key: max_tokens
       maxValue: 64000
+provisioning: serverless
 sources:
     - https://ai.google.dev/gemini-api/docs/models
     - https://ai.google.dev/gemini-api/docs/computer-use
+    - https://ai.google.dev/gemini-api/docs/models/gemini-2.5-computer-use-preview-10-2025
 status: preview
 supportedModes:
     - chat

--- a/providers/google-vertex/gemini-2.5-flash-image.yaml
+++ b/providers/google-vertex/gemini-2.5-flash-image.yaml
@@ -109,6 +109,7 @@ params:
       key: top_k
       maxValue: 64
       minValue: 1
+provisioning: serverless
 removeParams:
     - tool_choice
 sources:

--- a/providers/google-vertex/gemini-2.5-flash-lite-preview-09-2025.yaml
+++ b/providers/google-vertex/gemini-2.5-flash-lite-preview-09-2025.yaml
@@ -4,9 +4,7 @@ costs:
       cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 3.e-7
       input_cost_per_token: 1.e-7
-      input_cost_per_token_batches: 5.e-8
       output_cost_per_token: 4.e-7
-      output_cost_per_token_batches: 2.e-7
       region: global
 features:
     - function_calling
@@ -37,6 +35,7 @@ params:
       maxValue: 65535
     - defaultValue: 1
       key: temperature
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-flash-lite
     - https://ai.google.dev/pricing

--- a/providers/google-vertex/gemini-2.5-flash-lite.yaml
+++ b/providers/google-vertex/gemini-2.5-flash-lite.yaml
@@ -156,8 +156,10 @@ params:
       key: thinking
     - key: "n"
       maxValue: 8
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-flash-lite
+status: active
 supportedModes:
     - chat
 thinking: true

--- a/providers/google-vertex/gemini-2.5-flash-tts.yaml
+++ b/providers/google-vertex/gemini-2.5-flash-tts.yaml
@@ -1,3 +1,9 @@
+costs:
+    - input_cost_per_token: 5.e-7
+      input_cost_per_token_batches: 2.5e-7
+      output_cost_per_audio_token: 0.00001
+      output_cost_per_token_batches: 0.000005
+      region: global
 limits:
     context_window: 8192
     max_input_tokens: 8192
@@ -10,6 +16,7 @@ modalities:
         - audio
 mode: text_to_speech
 model: gemini-2.5-flash-tts
+provisioning: serverless
 removeParams:
     - tool_choice
     - "n"

--- a/providers/google-vertex/gemini-2.5-flash.yaml
+++ b/providers/google-vertex/gemini-2.5-flash.yaml
@@ -224,6 +224,7 @@ features:
     - prompt_caching
     - structured_output
     - code_execution
+    - json_output
 limits:
     context_window: 1048576
     max_input_tokens: 1048576
@@ -252,6 +253,7 @@ params:
       type: string
     - defaultValue: null
       key: thinking
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-flash
     - https://ai.google.dev/pricing

--- a/providers/google-vertex/gemini-2.5-pro-tts.yaml
+++ b/providers/google-vertex/gemini-2.5-pro-tts.yaml
@@ -158,15 +158,16 @@ modalities:
         - audio
 mode: text_to_speech
 model: gemini-2.5-pro-tts
+provisioning: serverless
 removeParams:
     - "n"
     - stop
+    - stream
     - tool_choice
 sources:
     - https://ai.google.dev/gemini-api/docs/speech-generation
     - https://ai.google.dev/gemini-api/docs/models#gemini-2.5-pro-preview-tts
     - https://ai.google.dev/gemini-api/docs/pricing
-    - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/locations
 status: preview
 supportedModes:
     - text_to_speech

--- a/providers/google-vertex/gemini-2.5-pro.yaml
+++ b/providers/google-vertex/gemini-2.5-pro.yaml
@@ -303,6 +303,7 @@ params:
       type: string
     - defaultValue: null
       key: thinking
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-pro
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/context-cache/context-cache-overview

--- a/providers/google-vertex/gemini-3-flash-preview.yaml
+++ b/providers/google-vertex/gemini-3-flash-preview.yaml
@@ -43,9 +43,9 @@ params:
       type: string
     - defaultValue: null
       key: thinking
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/3-flash
-    - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/locations
 status: preview
 supportedModes:
     - chat

--- a/providers/google-vertex/gemini-3-pro-image-preview.yaml
+++ b/providers/google-vertex/gemini-3-pro-image-preview.yaml
@@ -17,11 +17,13 @@ modalities:
     input:
         - text
         - image
+        - pdf
     output:
         - text
         - image
 mode: image
 model: gemini-3-pro-image-preview
+provisioning: serverless
 removeParams:
     - tool_choice
     - thinking

--- a/providers/google-vertex/gemini-3.1-flash-image-preview.yaml
+++ b/providers/google-vertex/gemini-3.1-flash-image-preview.yaml
@@ -27,11 +27,11 @@ params:
       key: temperature
     - defaultValue: 0.95
       key: top_p
+provisioning: serverless
 removeParams:
     - tool_choice
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/3-1-flash-image
-    - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/locations
 status: preview
 supportedModes:
     - chat

--- a/providers/google-vertex/gemini-3.1-flash-lite-preview.yaml
+++ b/providers/google-vertex/gemini-3.1-flash-lite-preview.yaml
@@ -3,7 +3,7 @@ costs:
       cache_read_input_token_cost: 3.e-8
       input_cost_per_audio_token: 5.e-7
       input_cost_per_token: 2.5e-7
-      input_cost_per_token_batches: 1.25e-7
+      input_cost_per_token_batches: 1.3e-7
       output_cost_per_token: 0.0000015
       output_cost_per_token_batches: 7.5e-7
       region: global
@@ -34,6 +34,7 @@ model: gemini-3.1-flash-lite-preview
 params:
     - key: max_tokens
       maxValue: 65535
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/3-1-flash-lite
 status: preview

--- a/providers/google-vertex/gemini-3.1-pro-preview.yaml
+++ b/providers/google-vertex/gemini-3.1-pro-preview.yaml
@@ -42,6 +42,7 @@ model: gemini-3.1-pro-preview
 params:
     - key: max_tokens
       maxValue: 65536
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/3-1-pro
 status: preview

--- a/providers/google-vertex/gemini-embedding-001.yaml
+++ b/providers/google-vertex/gemini-embedding-001.yaml
@@ -90,6 +90,7 @@ costs:
       output_cost_per_token: 0
       region: asia-east1
 limits:
+    context_window: 2048
     max_input_tokens: 2048
     output_vector_size: 3072
 modalities:
@@ -99,6 +100,7 @@ modalities:
         - embedding
 mode: embedding
 model: gemini-embedding-001
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature
@@ -109,8 +111,8 @@ removeParams:
     - tool_choice
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/model-reference/text-embeddings-api
-    - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/locations
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/embeddings/get-text-embeddings
+    - https://ai.google.dev/pricing
 status: active
 supportedModes:
     - embedding

--- a/providers/google-vertex/gemini-embedding-2-preview.yaml
+++ b/providers/google-vertex/gemini-embedding-2-preview.yaml
@@ -1,7 +1,12 @@
 costs:
-    - input_cost_per_token: 2.e-7
+    - input_cost_per_audio_token: 0.0000065
+      input_cost_per_image: 0.00012
+      input_cost_per_image_token: 4.5e-7
+      input_cost_per_token: 2.e-7
+      input_cost_per_video_token: 0.000012
       region: us-central1
 limits:
+    context_window: 8192
     max_input_tokens: 8192
     output_vector_size: 3072
 modalities:
@@ -15,6 +20,7 @@ modalities:
         - embedding
 mode: embedding
 model: gemini-embedding-2-preview
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature
@@ -25,6 +31,7 @@ removeParams:
     - tool_choice
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/embedding-2
+    - https://ai.google.dev/pricing
 status: preview
 supportedModes:
     - embedding

--- a/providers/google-vertex/gemini-live-2.5-flash-native-audio.yaml
+++ b/providers/google-vertex/gemini-live-2.5-flash-native-audio.yaml
@@ -114,6 +114,7 @@ model: gemini-live-2.5-flash-native-audio
 params:
     - key: max_tokens
       maxValue: 64000
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-flash-live-api
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/live-api

--- a/providers/google-vertex/google/automl-e2e.yaml
+++ b/providers/google-vertex/google/automl-e2e.yaml
@@ -1,2 +1,4 @@
 mode: unknown
 model: google/automl-e2e
+supportedModes:
+    - unknown

--- a/providers/google-vertex/google/automl-vision-image-classification.yaml
+++ b/providers/google-vertex/google/automl-vision-image-classification.yaml
@@ -5,6 +5,7 @@ modalities:
         - text
 mode: unknown
 model: google/automl-vision-image-classification
+provisioning: provisioned
 removeParams:
     - max_tokens
     - temperature
@@ -15,3 +16,6 @@ removeParams:
     - tool_choice
 sources:
     - https://docs.cloud.google.com/vertex-ai/docs/image-data/classification/train-model
+status: active
+supportedModes:
+    - unknown

--- a/providers/google-vertex/google/automl-vision-image-object-detection.yaml
+++ b/providers/google-vertex/google/automl-vision-image-object-detection.yaml
@@ -5,6 +5,7 @@ modalities:
         - text
 mode: image
 model: google/automl-vision-image-object-detection
+provisioning: provisioned
 removeParams:
     - max_tokens
     - temperature
@@ -13,5 +14,8 @@ removeParams:
     - stop
     - stream
     - tool_choice
+sources:
+    - https://docs.cloud.google.com/vertex-ai/docs/general/locations
+status: active
 supportedModes:
     - image

--- a/providers/google-vertex/google/bart-large-cnn.yaml
+++ b/providers/google-vertex/google/bart-large-cnn.yaml
@@ -5,5 +5,7 @@ modalities:
         - text
 mode: completion
 model: google/bart-large-cnn
+provisioning: provisioned
+status: active
 supportedModes:
     - completion

--- a/providers/google-vertex/google/bert-base.yaml
+++ b/providers/google-vertex/google/bert-base.yaml
@@ -5,6 +5,7 @@ modalities:
         - embedding
 mode: embedding
 model: google/bert-base
+provisioning: provisioned
 removeParams:
     - max_tokens
     - "n"

--- a/providers/google-vertex/google/chirp-2.yaml
+++ b/providers/google-vertex/google/chirp-2.yaml
@@ -5,6 +5,7 @@ modalities:
         - text
 mode: audio_transcription
 model: google/chirp-2
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature
@@ -16,6 +17,7 @@ removeParams:
 sources:
     - https://docs.cloud.google.com/speech-to-text/v2/docs/transcription-model
     - https://docs.cloud.google.com/speech-to-text/v2/docs/speech-to-text-supported-languages
+    - https://docs.cloud.google.com/speech-to-text/docs/models/chirp-2
 status: active
 supportedModes:
     - audio_transcription

--- a/providers/google-vertex/google/chirp-3.yaml
+++ b/providers/google-vertex/google/chirp-3.yaml
@@ -8,6 +8,7 @@ modalities:
         - text
 mode: audio_transcription
 model: google/chirp-3
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature

--- a/providers/google-vertex/google/cloudnerf-pytorch-zipnerf.yaml
+++ b/providers/google-vertex/google/cloudnerf-pytorch-zipnerf.yaml
@@ -5,5 +5,17 @@ modalities:
         - image
 mode: unknown
 model: cloudnerf-pytorch-zipnerf
+provisioning: provisioned
+removeParams:
+    - max_tokens
+    - temperature
+    - top_p
+    - "n"
+    - stop
+    - stream
+    - tool_choice
 sources:
     - https://console.cloud.google.com/vertex-ai/publishers/google/model-garden/cloudnerf-pytorch-zipnerf
+status: active
+supportedModes:
+    - unknown

--- a/providers/google-vertex/google/codegemma.yaml
+++ b/providers/google-vertex/google/codegemma.yaml
@@ -12,6 +12,9 @@ modalities:
         - code
 mode: completion
 model: google/codegemma
+provisioning: provisioned
+removeParams:
+    - tool_choice
 sources:
     - https://ai.google.dev/gemma/docs/codegemma
 status: active

--- a/providers/google-vertex/google/content-moderation.yaml
+++ b/providers/google-vertex/google/content-moderation.yaml
@@ -1,8 +1,12 @@
+costs:
+    - input_cost_per_image: 0.0015
+      region: global
 modalities:
     input:
         - image
 mode: moderation
 model: google/content-moderation
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature

--- a/providers/google-vertex/google/cxr-foundation.yaml
+++ b/providers/google-vertex/google/cxr-foundation.yaml
@@ -18,5 +18,6 @@ removeParams:
 sources:
     - https://developers.google.com/health-ai-developer-foundations/cxr-foundation
     - https://developers.google.com/health-ai-developer-foundations/cxr-foundation/model-card
+status: active
 supportedModes:
     - embedding

--- a/providers/google-vertex/google/derm-foundation.yaml
+++ b/providers/google-vertex/google/derm-foundation.yaml
@@ -7,6 +7,7 @@ modalities:
         - embedding
 mode: embedding
 model: google/derm-foundation
+provisioning: provisioned
 removeParams:
     - max_tokens
     - temperature

--- a/providers/google-vertex/google/dito.yaml
+++ b/providers/google-vertex/google/dito.yaml
@@ -1,2 +1,4 @@
 mode: unknown
 model: dito
+supportedModes:
+    - unknown

--- a/providers/google-vertex/google/earth-ai-imagery-mammut-eap-10-2025.yaml
+++ b/providers/google-vertex/google/earth-ai-imagery-mammut-eap-10-2025.yaml
@@ -6,8 +6,15 @@ modalities:
         - embedding
 mode: embedding
 model: google/earth-ai-imagery-mammut-eap-10-2025
+provisioning: serverless
 removeParams:
     - max_tokens
+    - temperature
+    - top_p
+    - "n"
+    - stop
+    - stream
+    - tool_choice
 sources:
     - https://ai.google/earth-ai/
     - https://arxiv.org/html/2510.18318v2

--- a/providers/google-vertex/google/earth-ai-imagery-owlvit-eap-10-2025.yaml
+++ b/providers/google-vertex/google/earth-ai-imagery-owlvit-eap-10-2025.yaml
@@ -1,2 +1,6 @@
 mode: unknown
 model: google/earth-ai-imagery-owlvit-eap-10-2025
+provisioning: serverless
+status: preview
+supportedModes:
+    - unknown

--- a/providers/google-vertex/google/embeddinggemma.yaml
+++ b/providers/google-vertex/google/embeddinggemma.yaml
@@ -1,5 +1,6 @@
 limits:
-    max_input_tokens: 1024
+    context_window: 2048
+    max_input_tokens: 2048
     output_vector_size: 768
 modalities:
     input:

--- a/providers/google-vertex/google/face-detector.yaml
+++ b/providers/google-vertex/google/face-detector.yaml
@@ -10,6 +10,7 @@ modalities:
         - text
 mode: unknown
 model: google/face-detector
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature
@@ -21,3 +22,6 @@ removeParams:
 sources:
     - https://docs.cloud.google.com/vision/docs/detecting-faces
     - https://cloud.google.com/vision/pricing
+status: active
+supportedModes:
+    - unknown

--- a/providers/google-vertex/google/functiongemma.yaml
+++ b/providers/google-vertex/google/functiongemma.yaml
@@ -1,5 +1,8 @@
 features:
     - function_calling
+limits:
+    context_window: 32000
+    max_input_tokens: 32000
 modalities:
     input:
         - text
@@ -7,7 +10,10 @@ modalities:
         - text
 mode: chat
 model: google/functiongemma
+provisioning: provisioned
 sources:
     - https://ai.google.dev/gemma/docs/functiongemma
+    - https://ai.google.dev/gemma/docs/functiongemma/model_card
+status: active
 supportedModes:
     - chat

--- a/providers/google-vertex/google/gemini-2.5-computer-use-preview-10-2025.yaml
+++ b/providers/google-vertex/google/gemini-2.5-computer-use-preview-10-2025.yaml
@@ -30,6 +30,7 @@ model: google/gemini-2.5-computer-use-preview-10-2025
 params:
     - key: max_tokens
       maxValue: 64000
+provisioning: serverless
 sources:
     - https://ai.google.dev/gemini-api/docs/models
     - https://ai.google.dev/gemini-api/docs/computer-use

--- a/providers/google-vertex/google/gemini-2.5-flash-image.yaml
+++ b/providers/google-vertex/google/gemini-2.5-flash-image.yaml
@@ -89,6 +89,7 @@ modalities:
     input:
         - text
         - image
+        - pdf
     output:
         - text
         - image
@@ -97,6 +98,7 @@ model: google/gemini-2.5-flash-image
 params:
     - key: max_tokens
       maxValue: 32768
+provisioning: serverless
 removeParams:
     - tool_choice
 sources:

--- a/providers/google-vertex/google/gemini-2.5-flash-lite-preview-09-2025.yaml
+++ b/providers/google-vertex/google/gemini-2.5-flash-lite-preview-09-2025.yaml
@@ -37,6 +37,7 @@ params:
       maxValue: 65535
     - defaultValue: 1
       key: temperature
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-flash-lite
     - https://ai.google.dev/pricing

--- a/providers/google-vertex/google/gemini-2.5-flash-lite.yaml
+++ b/providers/google-vertex/google/gemini-2.5-flash-lite.yaml
@@ -150,6 +150,7 @@ params:
     - defaultValue: 256
       key: max_tokens
       maxValue: 65535
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-flash-lite
 status: active

--- a/providers/google-vertex/google/gemini-2.5-flash-tts.yaml
+++ b/providers/google-vertex/google/gemini-2.5-flash-tts.yaml
@@ -1,3 +1,154 @@
+costs:
+    - input_cost_per_token: 5.e-7
+      input_cost_per_token_batches: 2.5e-7
+      output_cost_per_audio_token: 0.00001
+      output_cost_per_token_batches: 0.000005
+      region: us-west4
+    - input_cost_per_token: 5.e-7
+      input_cost_per_token_batches: 2.5e-7
+      output_cost_per_audio_token: 0.00001
+      output_cost_per_token_batches: 0.000005
+      region: us-west1
+    - input_cost_per_token: 5.e-7
+      input_cost_per_token_batches: 2.5e-7
+      output_cost_per_audio_token: 0.00001
+      output_cost_per_token_batches: 0.000005
+      region: us-south1
+    - input_cost_per_token: 5.e-7
+      input_cost_per_token_batches: 2.5e-7
+      output_cost_per_audio_token: 0.00001
+      output_cost_per_token_batches: 0.000005
+      region: us-east5
+    - input_cost_per_token: 5.e-7
+      input_cost_per_token_batches: 2.5e-7
+      output_cost_per_audio_token: 0.00001
+      output_cost_per_token_batches: 0.000005
+      region: us-east4
+    - input_cost_per_token: 5.e-7
+      input_cost_per_token_batches: 2.5e-7
+      output_cost_per_audio_token: 0.00001
+      output_cost_per_token_batches: 0.000005
+      region: us-east1
+    - input_cost_per_token: 5.e-7
+      input_cost_per_token_batches: 2.5e-7
+      output_cost_per_audio_token: 0.00001
+      output_cost_per_token_batches: 0.000005
+      region: us-central1
+    - input_cost_per_token: 5.e-7
+      input_cost_per_token_batches: 2.5e-7
+      output_cost_per_audio_token: 0.00001
+      output_cost_per_token_batches: 0.000005
+      region: southamerica-east1
+    - input_cost_per_token: 5.e-7
+      input_cost_per_token_batches: 2.5e-7
+      output_cost_per_audio_token: 0.00001
+      output_cost_per_token_batches: 0.000005
+      region: northamerica-northeast1
+    - input_cost_per_token: 5.e-7
+      input_cost_per_token_batches: 2.5e-7
+      output_cost_per_audio_token: 0.00001
+      output_cost_per_token_batches: 0.000005
+      region: me-west1
+    - input_cost_per_token: 5.e-7
+      input_cost_per_token_batches: 2.5e-7
+      output_cost_per_audio_token: 0.00001
+      output_cost_per_token_batches: 0.000005
+      region: me-central2
+    - input_cost_per_token: 5.e-7
+      input_cost_per_token_batches: 2.5e-7
+      output_cost_per_audio_token: 0.00001
+      output_cost_per_token_batches: 0.000005
+      region: me-central1
+    - input_cost_per_token: 5.e-7
+      input_cost_per_token_batches: 2.5e-7
+      output_cost_per_audio_token: 0.00001
+      output_cost_per_token_batches: 0.000005
+      region: global
+    - input_cost_per_token: 5.e-7
+      input_cost_per_token_batches: 2.5e-7
+      output_cost_per_audio_token: 0.00001
+      output_cost_per_token_batches: 0.000005
+      region: europe-west9
+    - input_cost_per_token: 5.e-7
+      input_cost_per_token_batches: 2.5e-7
+      output_cost_per_audio_token: 0.00001
+      output_cost_per_token_batches: 0.000005
+      region: europe-west8
+    - input_cost_per_token: 5.e-7
+      input_cost_per_token_batches: 2.5e-7
+      output_cost_per_audio_token: 0.00001
+      output_cost_per_token_batches: 0.000005
+      region: europe-west6
+    - input_cost_per_token: 5.e-7
+      input_cost_per_token_batches: 2.5e-7
+      output_cost_per_audio_token: 0.00001
+      output_cost_per_token_batches: 0.000005
+      region: europe-west4
+    - input_cost_per_token: 5.e-7
+      input_cost_per_token_batches: 2.5e-7
+      output_cost_per_audio_token: 0.00001
+      output_cost_per_token_batches: 0.000005
+      region: europe-west3
+    - input_cost_per_token: 5.e-7
+      input_cost_per_token_batches: 2.5e-7
+      output_cost_per_audio_token: 0.00001
+      output_cost_per_token_batches: 0.000005
+      region: europe-west2
+    - input_cost_per_token: 5.e-7
+      input_cost_per_token_batches: 2.5e-7
+      output_cost_per_audio_token: 0.00001
+      output_cost_per_token_batches: 0.000005
+      region: europe-west1
+    - input_cost_per_token: 5.e-7
+      input_cost_per_token_batches: 2.5e-7
+      output_cost_per_audio_token: 0.00001
+      output_cost_per_token_batches: 0.000005
+      region: europe-southwest1
+    - input_cost_per_token: 5.e-7
+      input_cost_per_token_batches: 2.5e-7
+      output_cost_per_audio_token: 0.00001
+      output_cost_per_token_batches: 0.000005
+      region: europe-north1
+    - input_cost_per_token: 5.e-7
+      input_cost_per_token_batches: 2.5e-7
+      output_cost_per_audio_token: 0.00001
+      output_cost_per_token_batches: 0.000005
+      region: europe-central2
+    - input_cost_per_token: 5.e-7
+      input_cost_per_token_batches: 2.5e-7
+      output_cost_per_audio_token: 0.00001
+      output_cost_per_token_batches: 0.000005
+      region: australia-southeast1
+    - input_cost_per_token: 5.e-7
+      input_cost_per_token_batches: 2.5e-7
+      output_cost_per_audio_token: 0.00001
+      output_cost_per_token_batches: 0.000005
+      region: asia-southeast1
+    - input_cost_per_token: 5.e-7
+      input_cost_per_token_batches: 2.5e-7
+      output_cost_per_audio_token: 0.00001
+      output_cost_per_token_batches: 0.000005
+      region: asia-south1
+    - input_cost_per_token: 5.e-7
+      input_cost_per_token_batches: 2.5e-7
+      output_cost_per_audio_token: 0.00001
+      output_cost_per_token_batches: 0.000005
+      region: asia-northeast3
+    - input_cost_per_token: 5.e-7
+      input_cost_per_token_batches: 2.5e-7
+      output_cost_per_audio_token: 0.00001
+      output_cost_per_token_batches: 0.000005
+      region: asia-northeast1
+    - input_cost_per_token: 5.e-7
+      input_cost_per_token_batches: 2.5e-7
+      output_cost_per_audio_token: 0.00001
+      output_cost_per_token_batches: 0.000005
+      region: asia-east2
+    - input_cost_per_token: 5.e-7
+      input_cost_per_token_batches: 2.5e-7
+      output_cost_per_audio_token: 0.00001
+      output_cost_per_token_batches: 0.000005
+      region: asia-east1
 limits:
     context_window: 8192
     max_input_tokens: 8192
@@ -10,6 +161,12 @@ modalities:
         - audio
 mode: text_to_speech
 model: google/gemini-2.5-flash-tts
+params:
+    - defaultValue: 256
+      key: max_tokens
+      maxValue: 16384
+      minValue: 1
+provisioning: serverless
 removeParams:
     - tool_choice
     - "n"

--- a/providers/google-vertex/google/gemini-2.5-flash.yaml
+++ b/providers/google-vertex/google/gemini-2.5-flash.yaml
@@ -78,30 +78,6 @@ costs:
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
-      region: me-west1
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
-      input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
-      input_cost_per_token_batches: 1.5e-7
-      output_cost_per_token: 0.0000025
-      output_cost_per_token_batches: 0.00000125
-      region: me-central2
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
-      input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
-      input_cost_per_token_batches: 1.5e-7
-      output_cost_per_token: 0.0000025
-      output_cost_per_token_batches: 0.00000125
-      region: me-central1
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
-      input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
-      input_cost_per_token_batches: 1.5e-7
-      output_cost_per_token: 0.0000025
-      output_cost_per_token_batches: 0.00000125
       region: global
     - cache_read_input_audio_token_cost: 1.e-7
       cache_read_input_token_cost: 3.e-8
@@ -119,14 +95,6 @@ costs:
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: europe-west8
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
-      input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
-      input_cost_per_token_batches: 1.5e-7
-      output_cost_per_token: 0.0000025
-      output_cost_per_token_batches: 0.00000125
-      region: europe-west6
     - cache_read_input_audio_token_cost: 1.e-7
       cache_read_input_token_cost: 3.e-8
       input_cost_per_audio_token: 0.000001
@@ -223,22 +191,6 @@ costs:
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: asia-northeast1
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
-      input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
-      input_cost_per_token_batches: 1.5e-7
-      output_cost_per_token: 0.0000025
-      output_cost_per_token_batches: 0.00000125
-      region: asia-east2
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
-      input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
-      input_cost_per_token_batches: 1.5e-7
-      output_cost_per_token: 0.0000025
-      output_cost_per_token_batches: 0.00000125
-      region: asia-east1
 deprecationDate: "2026-10-16"
 features:
     - function_calling
@@ -262,7 +214,6 @@ modalities:
         - pdf
     output:
         - text
-        - image
 mode: chat
 model: google/gemini-2.5-flash
 params:
@@ -270,9 +221,9 @@ params:
       key: max_tokens
       maxValue: 65535
       minValue: 1
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-flash
-    - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/locations
 status: active
 supportedModes:
     - chat

--- a/providers/google-vertex/google/gemini-2.5-pro-tts.yaml
+++ b/providers/google-vertex/google/gemini-2.5-pro-tts.yaml
@@ -158,6 +158,7 @@ modalities:
         - audio
 mode: text_to_speech
 model: google/gemini-2.5-pro-tts
+provisioning: serverless
 removeParams:
     - "n"
     - stop
@@ -166,7 +167,6 @@ sources:
     - https://ai.google.dev/gemini-api/docs/speech-generation
     - https://ai.google.dev/gemini-api/docs/models#gemini-2.5-pro-preview-tts
     - https://ai.google.dev/gemini-api/docs/pricing
-    - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/locations
 status: preview
 supportedModes:
     - text_to_speech

--- a/providers/google-vertex/google/gemini-2.5-pro.yaml
+++ b/providers/google-vertex/google/gemini-2.5-pro.yaml
@@ -116,7 +116,71 @@ costs:
       input_cost_per_token_batches: 6.25e-7
       output_cost_per_token: 0.00001
       output_cost_per_token_batches: 0.000005
+      region: southamerica-east1
+      tiered_pricing:
+          cache_read:
+              - cost_per_token: 2.5e-7
+                from: 200000
+          input:
+              - cost_per_token: 0.0000025
+                from: 200000
+          output:
+              - cost_per_token: 0.000015
+                from: 200000
+    - cache_read_input_token_cost: 1.3e-7
+      input_cost_per_token: 0.00000125
+      input_cost_per_token_batches: 6.25e-7
+      output_cost_per_token: 0.00001
+      output_cost_per_token_batches: 0.000005
       region: northamerica-northeast1
+      tiered_pricing:
+          cache_read:
+              - cost_per_token: 2.5e-7
+                from: 200000
+          input:
+              - cost_per_token: 0.0000025
+                from: 200000
+          output:
+              - cost_per_token: 0.000015
+                from: 200000
+    - cache_read_input_token_cost: 1.3e-7
+      input_cost_per_token: 0.00000125
+      input_cost_per_token_batches: 6.25e-7
+      output_cost_per_token: 0.00001
+      output_cost_per_token_batches: 0.000005
+      region: me-west1
+      tiered_pricing:
+          cache_read:
+              - cost_per_token: 2.5e-7
+                from: 200000
+          input:
+              - cost_per_token: 0.0000025
+                from: 200000
+          output:
+              - cost_per_token: 0.000015
+                from: 200000
+    - cache_read_input_token_cost: 1.3e-7
+      input_cost_per_token: 0.00000125
+      input_cost_per_token_batches: 6.25e-7
+      output_cost_per_token: 0.00001
+      output_cost_per_token_batches: 0.000005
+      region: me-central2
+      tiered_pricing:
+          cache_read:
+              - cost_per_token: 2.5e-7
+                from: 200000
+          input:
+              - cost_per_token: 0.0000025
+                from: 200000
+          output:
+              - cost_per_token: 0.000015
+                from: 200000
+    - cache_read_input_token_cost: 1.3e-7
+      input_cost_per_token: 0.00000125
+      input_cost_per_token_batches: 6.25e-7
+      output_cost_per_token: 0.00001
+      output_cost_per_token_batches: 0.000005
+      region: me-central1
       tiered_pricing:
           cache_read:
               - cost_per_token: 2.5e-7
@@ -180,7 +244,55 @@ costs:
       input_cost_per_token_batches: 6.25e-7
       output_cost_per_token: 0.00001
       output_cost_per_token_batches: 0.000005
+      region: europe-west6
+      tiered_pricing:
+          cache_read:
+              - cost_per_token: 2.5e-7
+                from: 200000
+          input:
+              - cost_per_token: 0.0000025
+                from: 200000
+          output:
+              - cost_per_token: 0.000015
+                from: 200000
+    - cache_read_input_token_cost: 1.3e-7
+      input_cost_per_token: 0.00000125
+      input_cost_per_token_batches: 6.25e-7
+      output_cost_per_token: 0.00001
+      output_cost_per_token_batches: 0.000005
       region: europe-west4
+      tiered_pricing:
+          cache_read:
+              - cost_per_token: 2.5e-7
+                from: 200000
+          input:
+              - cost_per_token: 0.0000025
+                from: 200000
+          output:
+              - cost_per_token: 0.000015
+                from: 200000
+    - cache_read_input_token_cost: 1.3e-7
+      input_cost_per_token: 0.00000125
+      input_cost_per_token_batches: 6.25e-7
+      output_cost_per_token: 0.00001
+      output_cost_per_token_batches: 0.000005
+      region: europe-west3
+      tiered_pricing:
+          cache_read:
+              - cost_per_token: 2.5e-7
+                from: 200000
+          input:
+              - cost_per_token: 0.0000025
+                from: 200000
+          output:
+              - cost_per_token: 0.000015
+                from: 200000
+    - cache_read_input_token_cost: 1.3e-7
+      input_cost_per_token: 0.00000125
+      input_cost_per_token_batches: 6.25e-7
+      output_cost_per_token: 0.00001
+      output_cost_per_token_batches: 0.000005
+      region: europe-west2
       tiered_pricing:
           cache_read:
               - cost_per_token: 2.5e-7
@@ -260,7 +372,103 @@ costs:
       input_cost_per_token_batches: 6.25e-7
       output_cost_per_token: 0.00001
       output_cost_per_token_batches: 0.000005
+      region: australia-southeast1
+      tiered_pricing:
+          cache_read:
+              - cost_per_token: 2.5e-7
+                from: 200000
+          input:
+              - cost_per_token: 0.0000025
+                from: 200000
+          output:
+              - cost_per_token: 0.000015
+                from: 200000
+    - cache_read_input_token_cost: 1.3e-7
+      input_cost_per_token: 0.00000125
+      input_cost_per_token_batches: 6.25e-7
+      output_cost_per_token: 0.00001
+      output_cost_per_token_batches: 0.000005
+      region: asia-southeast1
+      tiered_pricing:
+          cache_read:
+              - cost_per_token: 2.5e-7
+                from: 200000
+          input:
+              - cost_per_token: 0.0000025
+                from: 200000
+          output:
+              - cost_per_token: 0.000015
+                from: 200000
+    - cache_read_input_token_cost: 1.3e-7
+      input_cost_per_token: 0.00000125
+      input_cost_per_token_batches: 6.25e-7
+      output_cost_per_token: 0.00001
+      output_cost_per_token_batches: 0.000005
+      region: asia-south1
+      tiered_pricing:
+          cache_read:
+              - cost_per_token: 2.5e-7
+                from: 200000
+          input:
+              - cost_per_token: 0.0000025
+                from: 200000
+          output:
+              - cost_per_token: 0.000015
+                from: 200000
+    - cache_read_input_token_cost: 1.3e-7
+      input_cost_per_token: 0.00000125
+      input_cost_per_token_batches: 6.25e-7
+      output_cost_per_token: 0.00001
+      output_cost_per_token_batches: 0.000005
+      region: asia-northeast3
+      tiered_pricing:
+          cache_read:
+              - cost_per_token: 2.5e-7
+                from: 200000
+          input:
+              - cost_per_token: 0.0000025
+                from: 200000
+          output:
+              - cost_per_token: 0.000015
+                from: 200000
+    - cache_read_input_token_cost: 1.3e-7
+      input_cost_per_token: 0.00000125
+      input_cost_per_token_batches: 6.25e-7
+      output_cost_per_token: 0.00001
+      output_cost_per_token_batches: 0.000005
       region: asia-northeast1
+      tiered_pricing:
+          cache_read:
+              - cost_per_token: 2.5e-7
+                from: 200000
+          input:
+              - cost_per_token: 0.0000025
+                from: 200000
+          output:
+              - cost_per_token: 0.000015
+                from: 200000
+    - cache_read_input_token_cost: 1.3e-7
+      input_cost_per_token: 0.00000125
+      input_cost_per_token_batches: 6.25e-7
+      output_cost_per_token: 0.00001
+      output_cost_per_token_batches: 0.000005
+      region: asia-east2
+      tiered_pricing:
+          cache_read:
+              - cost_per_token: 2.5e-7
+                from: 200000
+          input:
+              - cost_per_token: 0.0000025
+                from: 200000
+          output:
+              - cost_per_token: 0.000015
+                from: 200000
+    - cache_read_input_token_cost: 1.3e-7
+      input_cost_per_token: 0.00000125
+      input_cost_per_token_batches: 6.25e-7
+      output_cost_per_token: 0.00001
+      output_cost_per_token_batches: 0.000005
+      region: asia-east1
       tiered_pricing:
           cache_read:
               - cost_per_token: 2.5e-7
@@ -302,10 +510,13 @@ params:
       minValue: 1
     - defaultValue: 1
       key: temperature
-    - defaultValue: 40
+    - defaultValue: 0.95
+      key: top_p
+    - defaultValue: 64
       key: top_k
       maxValue: 100
       minValue: 1
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-pro
 status: active

--- a/providers/google-vertex/google/gemini-3-flash-preview.yaml
+++ b/providers/google-vertex/google/gemini-3-flash-preview.yaml
@@ -42,6 +42,7 @@ params:
       key: top_k
       maxValue: 64
       minValue: 1
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/3-flash
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/locations

--- a/providers/google-vertex/google/gemini-3-pro-image-preview.yaml
+++ b/providers/google-vertex/google/gemini-3-pro-image-preview.yaml
@@ -1,7 +1,9 @@
 costs:
     - input_cost_per_token: 0.000002
+      input_cost_per_token_batches: 0.000001
       output_cost_per_image_token: 0.00012
       output_cost_per_token: 0.000012
+      output_cost_per_token_batches: 0.000006
       region: global
 features:
     - system_messages
@@ -14,11 +16,13 @@ modalities:
     input:
         - text
         - image
+        - pdf
     output:
         - text
         - image
 mode: chat
 model: google/gemini-3-pro-image-preview
+provisioning: serverless
 removeParams:
     - tool_choice
 sources:

--- a/providers/google-vertex/google/gemini-3.1-flash-image-preview.yaml
+++ b/providers/google-vertex/google/gemini-3.1-flash-image-preview.yaml
@@ -27,6 +27,7 @@ params:
       key: temperature
     - defaultValue: 0.95
       key: top_p
+provisioning: serverless
 removeParams:
     - tool_choice
 sources:

--- a/providers/google-vertex/google/gemini-3.1-flash-lite-preview.yaml
+++ b/providers/google-vertex/google/gemini-3.1-flash-lite-preview.yaml
@@ -3,7 +3,7 @@ costs:
       cache_read_input_token_cost: 3.e-8
       input_cost_per_audio_token: 5.e-7
       input_cost_per_token: 2.5e-7
-      input_cost_per_token_batches: 1.25e-7
+      input_cost_per_token_batches: 1.3e-7
       output_cost_per_token: 0.0000015
       output_cost_per_token_batches: 7.5e-7
       region: global
@@ -34,6 +34,7 @@ model: google/gemini-3.1-flash-lite-preview
 params:
     - key: max_tokens
       maxValue: 65535
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/3-1-flash-lite
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/locations

--- a/providers/google-vertex/google/gemini-3.1-pro-preview.yaml
+++ b/providers/google-vertex/google/gemini-3.1-pro-preview.yaml
@@ -42,6 +42,7 @@ model: google/gemini-3.1-pro-preview
 params:
     - key: max_tokens
       maxValue: 65536
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/3-1-pro
 status: preview

--- a/providers/google-vertex/google/gemini-embedding-001.yaml
+++ b/providers/google-vertex/google/gemini-embedding-001.yaml
@@ -100,6 +100,7 @@ modalities:
         - embedding
 mode: embedding
 model: google/gemini-embedding-001
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature

--- a/providers/google-vertex/google/gemini-embedding-2-preview.yaml
+++ b/providers/google-vertex/google/gemini-embedding-2-preview.yaml
@@ -2,6 +2,7 @@ costs:
     - input_cost_per_token: 2.e-7
       region: us-central1
 limits:
+    context_window: 8192
     max_input_tokens: 8192
     output_vector_size: 3072
 modalities:
@@ -15,6 +16,7 @@ modalities:
         - embedding
 mode: embedding
 model: google/gemini-embedding-2-preview
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature
@@ -25,6 +27,7 @@ removeParams:
     - tool_choice
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/embedding-2
+    - https://ai.google.dev/pricing
 status: preview
 supportedModes:
     - embedding

--- a/providers/google-vertex/google/gemini-live-2.5-flash-native-audio.yaml
+++ b/providers/google-vertex/google/gemini-live-2.5-flash-native-audio.yaml
@@ -114,6 +114,7 @@ params:
       key: max_tokens
       maxValue: 64000
       minValue: 1
+provisioning: serverless
 removeParams:
     - "n"
     - top_p

--- a/providers/google-vertex/google/gemma.yaml
+++ b/providers/google-vertex/google/gemma.yaml
@@ -10,7 +10,14 @@ modalities:
         - text
 mode: chat
 model: google/gemma
+params:
+    - key: max_tokens
+      maxValue: 8192
+provisioning: provisioned
+removeParams:
+    - tool_choice
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/open-models/use-gemma
+status: active
 supportedModes:
     - chat

--- a/providers/google-vertex/google/gemma2.yaml
+++ b/providers/google-vertex/google/gemma2.yaml
@@ -5,10 +5,12 @@ modalities:
         - text
 mode: chat
 model: google/gemma2
+provisioning: provisioned
 removeParams:
     - tool_choice
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/open-models/use-gemma
     - https://ai.google.dev/gemma/docs/core/model_card_2
+status: active
 supportedModes:
     - chat

--- a/providers/google-vertex/google/gemma3.yaml
+++ b/providers/google-vertex/google/gemma3.yaml
@@ -10,6 +10,7 @@ modalities:
         - text
 mode: chat
 model: google/gemma3
+provisioning: provisioned
 sources:
     - https://ai.google.dev/gemma/docs/core/model_card_3
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/open-models/use-gemma

--- a/providers/google-vertex/google/gemma3n.yaml
+++ b/providers/google-vertex/google/gemma3n.yaml
@@ -12,6 +12,7 @@ modalities:
         - text
 mode: chat
 model: google/gemma3n
+provisioning: provisioned
 sources:
     - https://ai.google.dev/gemma/docs/gemma-3n
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/open-models/use-gemma

--- a/providers/google-vertex/google/gemma4.yaml
+++ b/providers/google-vertex/google/gemma4.yaml
@@ -1,17 +1,28 @@
+costs:
+    - input_cost_per_token: 1.5e-7
+      output_cost_per_token: 6.e-7
+      region: global
 features:
     - function_calling
     - system_messages
+limits:
+    context_window: 256000
 modalities:
     input:
         - text
         - image
         - audio
+        - video
     output:
         - text
 mode: chat
 model: google/gemma4
+provisioning: serverless
 sources:
     - https://ai.google.dev/gemma/docs/core
+    - https://ai.google.dev/gemma/docs/core/model_card_4
+    - https://ai.google.dev/gemma/docs/capabilities/text/function-calling-gemma4
+    - https://ai.google.dev/gemma/docs/capabilities/thinking
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/open-models/use-gemma
     - https://deepmind.google/models/gemma
 status: active

--- a/providers/google-vertex/google/hear.yaml
+++ b/providers/google-vertex/google/hear.yaml
@@ -1,2 +1,6 @@
 mode: unknown
 model: hear
+provisioning: serverless
+status: active
+supportedModes:
+    - unknown

--- a/providers/google-vertex/google/image-segmentation-001.yaml
+++ b/providers/google-vertex/google/image-segmentation-001.yaml
@@ -5,6 +5,7 @@ modalities:
         - image
 mode: image
 model: image-segmentation-001
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature
@@ -13,5 +14,6 @@ removeParams:
     - stop
     - stream
     - tool_choice
+status: preview
 supportedModes:
     - image

--- a/providers/google-vertex/google/imageclassification-efficientnet.yaml
+++ b/providers/google-vertex/google/imageclassification-efficientnet.yaml
@@ -1,3 +1,4 @@
+isDeprecated: true
 modalities:
     input:
         - image

--- a/providers/google-vertex/google/imageclassification-proprietary-efficientnet.yaml
+++ b/providers/google-vertex/google/imageclassification-proprietary-efficientnet.yaml
@@ -5,6 +5,7 @@ modalities:
         - text
 mode: unknown
 model: google/imageclassification-proprietary-efficientnet
+provisioning: provisioned
 removeParams:
     - max_tokens
     - temperature
@@ -13,3 +14,6 @@ removeParams:
     - stop
     - stream
     - tool_choice
+status: active
+supportedModes:
+    - unknown

--- a/providers/google-vertex/google/imageclassification-proprietary-maxvit.yaml
+++ b/providers/google-vertex/google/imageclassification-proprietary-maxvit.yaml
@@ -5,6 +5,7 @@ modalities:
         - text
 mode: unknown
 model: google/imageclassification-proprietary-maxvit
+provisioning: provisioned
 removeParams:
     - max_tokens
     - temperature
@@ -13,3 +14,6 @@ removeParams:
     - stop
     - stream
     - tool_choice
+status: active
+supportedModes:
+    - unknown

--- a/providers/google-vertex/google/imageclassification-proprietary-vit.yaml
+++ b/providers/google-vertex/google/imageclassification-proprietary-vit.yaml
@@ -1,3 +1,4 @@
+isDeprecated: true
 modalities:
     input:
         - image

--- a/providers/google-vertex/google/imageclassification-vit.yaml
+++ b/providers/google-vertex/google/imageclassification-vit.yaml
@@ -5,6 +5,7 @@ modalities:
         - text
 mode: image
 model: google/imageclassification-vit
+provisioning: provisioned
 removeParams:
     - max_tokens
     - temperature
@@ -13,5 +14,6 @@ removeParams:
     - stop
     - stream
     - tool_choice
+status: active
 supportedModes:
     - image

--- a/providers/google-vertex/google/imagen-3.0-capability-001.yaml
+++ b/providers/google-vertex/google/imagen-3.0-capability-001.yaml
@@ -58,6 +58,7 @@ costs:
     - output_cost_per_image: 0.04
       region: asia-east1
 deprecationDate: "2026-06-30"
+isDeprecated: true
 modalities:
     input:
         - text

--- a/providers/google-vertex/google/imagen-3.0-capability-002.yaml
+++ b/providers/google-vertex/google/imagen-3.0-capability-002.yaml
@@ -1,3 +1,5 @@
+deprecationDate: "2026-06-30"
+isDeprecated: true
 modalities:
     input:
         - text

--- a/providers/google-vertex/google/imagen-4.0-fast-generate-001.yaml
+++ b/providers/google-vertex/google/imagen-4.0-fast-generate-001.yaml
@@ -60,6 +60,7 @@ costs:
     - output_cost_per_image: 0.02
       region: asia-east1
 deprecationDate: "2026-06-30"
+isDeprecated: true
 modalities:
     input:
         - text

--- a/providers/google-vertex/google/imagen-4.0-generate-001.yaml
+++ b/providers/google-vertex/google/imagen-4.0-generate-001.yaml
@@ -59,6 +59,8 @@ costs:
       region: asia-east2
     - output_cost_per_image: 0.04
       region: asia-east1
+deprecationDate: "2026-06-30"
+isDeprecated: true
 modalities:
     input:
         - text

--- a/providers/google-vertex/google/imagen-4.0-ultra-generate-001.yaml
+++ b/providers/google-vertex/google/imagen-4.0-ultra-generate-001.yaml
@@ -72,6 +72,7 @@ params:
       key: "n"
       maxValue: 4
       minValue: 1
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature
@@ -82,7 +83,6 @@ removeParams:
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/imagen/4-0-ultra-generate-001
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/model-versions
-    - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/locations
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/image/generate-images
 status: active
 supportedModes:

--- a/providers/google-vertex/google/imageobjectdetection-proprietary-spinenet.yaml
+++ b/providers/google-vertex/google/imageobjectdetection-proprietary-spinenet.yaml
@@ -5,6 +5,7 @@ modalities:
         - text
 mode: image
 model: google/imageobjectdetection-proprietary-spinenet
+provisioning: provisioned
 removeParams:
     - temperature
     - top_p
@@ -13,5 +14,6 @@ removeParams:
     - stream
     - tool_choice
     - max_tokens
+status: active
 supportedModes:
     - image

--- a/providers/google-vertex/google/imageobjectdetection-proprietary-yolo.yaml
+++ b/providers/google-vertex/google/imageobjectdetection-proprietary-yolo.yaml
@@ -5,6 +5,7 @@ modalities:
         - text
 mode: image
 model: google/imageobjectdetection-proprietary-yolo
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature

--- a/providers/google-vertex/google/imageobjectdetection-yolo.yaml
+++ b/providers/google-vertex/google/imageobjectdetection-yolo.yaml
@@ -5,6 +5,7 @@ modalities:
         - text
 mode: unknown
 model: google/imageobjectdetection-yolo
+provisioning: provisioned
 removeParams:
     - temperature
     - top_p
@@ -13,3 +14,6 @@ removeParams:
     - stream
     - tool_choice
     - max_tokens
+status: active
+supportedModes:
+    - unknown

--- a/providers/google-vertex/google/imagesegmentation-deeplabv3.yaml
+++ b/providers/google-vertex/google/imagesegmentation-deeplabv3.yaml
@@ -5,6 +5,7 @@ modalities:
         - image
 mode: image
 model: google/imagesegmentation-deeplabv3
+provisioning: provisioned
 removeParams:
     - max_tokens
     - temperature

--- a/providers/google-vertex/google/imagewatermarkdetector.yaml
+++ b/providers/google-vertex/google/imagewatermarkdetector.yaml
@@ -5,6 +5,7 @@ modalities:
         - text
 mode: unknown
 model: google/imagewatermarkdetector
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature
@@ -16,3 +17,5 @@ removeParams:
 sources:
     - https://console.cloud.google.com/vertex-ai/publishers/google/model-garden/imagewatermarkdetector
 status: preview
+supportedModes:
+    - unknown

--- a/providers/google-vertex/google/jax-owl-vit-v2.yaml
+++ b/providers/google-vertex/google/jax-owl-vit-v2.yaml
@@ -6,4 +6,17 @@ modalities:
         - text
 mode: unknown
 model: google/jax-owl-vit-v2
+provisioning: provisioned
+removeParams:
+    - max_tokens
+    - temperature
+    - top_p
+    - "n"
+    - stop
+    - stream
+    - tool_choice
+sources:
+    - https://console.cloud.google.com/vertex-ai/publishers/google/model-garden/jax-owl-vit-v2
 status: active
+supportedModes:
+    - unknown

--- a/providers/google-vertex/google/keras-yolov8.yaml
+++ b/providers/google-vertex/google/keras-yolov8.yaml
@@ -5,6 +5,15 @@ modalities:
         - text
 mode: image
 model: google/keras-yolov8
+provisioning: provisioned
+removeParams:
+    - max_tokens
+    - temperature
+    - top_p
+    - "n"
+    - stop
+    - stream
+    - tool_choice
 sources:
     - https://console.cloud.google.com/vertex-ai/publishers/google/model-garden/keras-yolov8
 status: active

--- a/providers/google-vertex/google/label-detector-pali-001.yaml
+++ b/providers/google-vertex/google/label-detector-pali-001.yaml
@@ -5,6 +5,7 @@ modalities:
         - text
 mode: image
 model: google/label-detector-pali-001
+provisioning: serverless
 status: active
 supportedModes:
     - image

--- a/providers/google-vertex/google/language-v1-analyze-entity-sentiment.yaml
+++ b/providers/google-vertex/google/language-v1-analyze-entity-sentiment.yaml
@@ -8,6 +8,7 @@ modalities:
         - text
 mode: unknown
 model: google/language-v1-analyze-entity-sentiment
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature
@@ -19,3 +20,6 @@ removeParams:
 sources:
     - https://cloud.google.com/natural-language/pricing
     - https://docs.cloud.google.com/natural-language/docs/reference/rest/v1/documents/analyzeEntitySentiment
+status: active
+supportedModes:
+    - unknown

--- a/providers/google-vertex/google/language-v1-analyze-sentiment.yaml
+++ b/providers/google-vertex/google/language-v1-analyze-sentiment.yaml
@@ -8,6 +8,7 @@ modalities:
         - text
 mode: unknown
 model: language-v1-analyze-sentiment
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature
@@ -21,3 +22,5 @@ sources:
     - https://docs.cloud.google.com/natural-language/docs/reference/rest/v1/documents/analyzeSentiment
     - https://docs.cloud.google.com/natural-language/docs/basics
 status: active
+supportedModes:
+    - unknown

--- a/providers/google-vertex/google/language-v1-analyze-syntax.yaml
+++ b/providers/google-vertex/google/language-v1-analyze-syntax.yaml
@@ -8,6 +8,7 @@ modalities:
         - text
 mode: unknown
 model: google/language-v1-analyze-syntax
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature
@@ -20,3 +21,5 @@ sources:
     - https://docs.cloud.google.com/natural-language/docs/reference/rest/v1/documents/analyzeSyntax
     - https://cloud.google.com/natural-language/pricing
 status: active
+supportedModes:
+    - unknown

--- a/providers/google-vertex/google/language-v1-classify-text-v1.yaml
+++ b/providers/google-vertex/google/language-v1-classify-text-v1.yaml
@@ -8,6 +8,7 @@ modalities:
         - text
 mode: unknown
 model: language-v1-classify-text-v1
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature
@@ -21,3 +22,5 @@ sources:
     - https://docs.cloud.google.com/natural-language/docs/classifying-text
     - https://docs.cloud.google.com/natural-language/docs/reference/rest/v1/documents/classifyText
 status: active
+supportedModes:
+    - unknown

--- a/providers/google-vertex/google/language-v1-moderate-text.yaml
+++ b/providers/google-vertex/google/language-v1-moderate-text.yaml
@@ -8,6 +8,7 @@ modalities:
         - text
 mode: moderation
 model: language-v1-moderate-text
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature

--- a/providers/google-vertex/google/lyria-002.yaml
+++ b/providers/google-vertex/google/lyria-002.yaml
@@ -1,6 +1,64 @@
 costs:
     - input_cost_per_request: 0.06
+      region: us-west4
+    - input_cost_per_request: 0.06
+      region: us-west1
+    - input_cost_per_request: 0.06
+      region: us-south1
+    - input_cost_per_request: 0.06
+      region: us-east5
+    - input_cost_per_request: 0.06
+      region: us-east4
+    - input_cost_per_request: 0.06
+      region: us-east1
+    - input_cost_per_request: 0.06
       region: us-central1
+    - input_cost_per_request: 0.06
+      region: southamerica-east1
+    - input_cost_per_request: 0.06
+      region: northamerica-northeast1
+    - input_cost_per_request: 0.06
+      region: me-west1
+    - input_cost_per_request: 0.06
+      region: me-central2
+    - input_cost_per_request: 0.06
+      region: me-central1
+    - input_cost_per_request: 0.06
+      region: global
+    - input_cost_per_request: 0.06
+      region: europe-west9
+    - input_cost_per_request: 0.06
+      region: europe-west8
+    - input_cost_per_request: 0.06
+      region: europe-west6
+    - input_cost_per_request: 0.06
+      region: europe-west4
+    - input_cost_per_request: 0.06
+      region: europe-west3
+    - input_cost_per_request: 0.06
+      region: europe-west2
+    - input_cost_per_request: 0.06
+      region: europe-west1
+    - input_cost_per_request: 0.06
+      region: europe-southwest1
+    - input_cost_per_request: 0.06
+      region: europe-north1
+    - input_cost_per_request: 0.06
+      region: europe-central2
+    - input_cost_per_request: 0.06
+      region: australia-southeast1
+    - input_cost_per_request: 0.06
+      region: asia-southeast1
+    - input_cost_per_request: 0.06
+      region: asia-south1
+    - input_cost_per_request: 0.06
+      region: asia-northeast3
+    - input_cost_per_request: 0.06
+      region: asia-northeast1
+    - input_cost_per_request: 0.06
+      region: asia-east2
+    - input_cost_per_request: 0.06
+      region: asia-east1
 modalities:
     input:
         - text
@@ -8,6 +66,7 @@ modalities:
         - audio
 mode: unknown
 model: lyria-002
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature
@@ -19,4 +78,7 @@ removeParams:
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/music/generate-music
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/model-reference/lyria-music-generation
+    - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/locations
 status: active
+supportedModes:
+    - unknown

--- a/providers/google-vertex/google/lyria-3-clip-preview.yaml
+++ b/providers/google-vertex/google/lyria-3-clip-preview.yaml
@@ -6,6 +6,7 @@ modalities:
         - audio
 mode: unknown
 model: lyria-3-clip-preview
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature
@@ -18,3 +19,5 @@ sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/music/generate-music
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/locations
 status: preview
+supportedModes:
+    - unknown

--- a/providers/google-vertex/google/lyria-3-pro-preview.yaml
+++ b/providers/google-vertex/google/lyria-3-pro-preview.yaml
@@ -6,6 +6,7 @@ modalities:
         - audio
 mode: unknown
 model: lyria-3-pro-preview
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature
@@ -19,3 +20,5 @@ sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/lyria/lyria-3
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/music/generate-music
 status: preview
+supportedModes:
+    - unknown

--- a/providers/google-vertex/google/mammut.yaml
+++ b/providers/google-vertex/google/mammut.yaml
@@ -7,6 +7,7 @@ modalities:
         - embedding
 mode: embedding
 model: mammut
+provisioning: provisioned
 removeParams:
     - max_tokens
 sources:

--- a/providers/google-vertex/google/medgemma.yaml
+++ b/providers/google-vertex/google/medgemma.yaml
@@ -11,6 +11,12 @@ modalities:
         - text
 mode: chat
 model: google/medgemma
+params:
+    - key: max_tokens
+      maxValue: 8192
+provisioning: provisioned
+removeParams:
+    - tool_choice
 sources:
     - https://developers.google.com/health-ai-developer-foundations/medgemma
     - https://developers.google.com/health-ai-developer-foundations/medgemma/model-card

--- a/providers/google-vertex/google/medsiglip.yaml
+++ b/providers/google-vertex/google/medsiglip.yaml
@@ -8,6 +8,7 @@ modalities:
         - embedding
 mode: embedding
 model: google/medsiglip
+provisioning: provisioned
 removeParams:
     - max_tokens
     - temperature
@@ -19,5 +20,6 @@ removeParams:
 sources:
     - https://developers.google.com/health-ai-developer-foundations/medsiglip
     - https://developers.google.com/health-ai-developer-foundations/medsiglip/model-card
+status: active
 supportedModes:
     - embedding

--- a/providers/google-vertex/google/multimodalembedding.yaml
+++ b/providers/google-vertex/google/multimodalembedding.yaml
@@ -1,3 +1,120 @@
+costs:
+    - input_cost_per_character: 2.e-7
+      input_cost_per_image: 0.0001
+      input_cost_per_second: 0.0005
+      region: us-west4
+    - input_cost_per_character: 2.e-7
+      input_cost_per_image: 0.0001
+      input_cost_per_second: 0.0005
+      region: us-west1
+    - input_cost_per_character: 2.e-7
+      input_cost_per_image: 0.0001
+      input_cost_per_second: 0.0005
+      region: us-south1
+    - input_cost_per_character: 2.e-7
+      input_cost_per_image: 0.0001
+      input_cost_per_second: 0.0005
+      region: us-east5
+    - input_cost_per_character: 2.e-7
+      input_cost_per_image: 0.0001
+      input_cost_per_second: 0.0005
+      region: us-east4
+    - input_cost_per_character: 2.e-7
+      input_cost_per_image: 0.0001
+      input_cost_per_second: 0.0005
+      region: us-east1
+    - input_cost_per_character: 2.e-7
+      input_cost_per_image: 0.0001
+      input_cost_per_second: 0.0005
+      region: us-central1
+    - input_cost_per_character: 2.e-7
+      input_cost_per_image: 0.0001
+      input_cost_per_second: 0.0005
+      region: southamerica-east1
+    - input_cost_per_character: 2.e-7
+      input_cost_per_image: 0.0001
+      input_cost_per_second: 0.0005
+      region: northamerica-northeast1
+    - input_cost_per_character: 2.e-7
+      input_cost_per_image: 0.0001
+      input_cost_per_second: 0.0005
+      region: me-west1
+    - input_cost_per_character: 2.e-7
+      input_cost_per_image: 0.0001
+      input_cost_per_second: 0.0005
+      region: me-central2
+    - input_cost_per_character: 2.e-7
+      input_cost_per_image: 0.0001
+      input_cost_per_second: 0.0005
+      region: me-central1
+    - input_cost_per_character: 2.e-7
+      input_cost_per_image: 0.0001
+      input_cost_per_second: 0.0005
+      region: europe-west9
+    - input_cost_per_character: 2.e-7
+      input_cost_per_image: 0.0001
+      input_cost_per_second: 0.0005
+      region: europe-west8
+    - input_cost_per_character: 2.e-7
+      input_cost_per_image: 0.0001
+      input_cost_per_second: 0.0005
+      region: europe-west6
+    - input_cost_per_character: 2.e-7
+      input_cost_per_image: 0.0001
+      input_cost_per_second: 0.0005
+      region: europe-west4
+    - input_cost_per_character: 2.e-7
+      input_cost_per_image: 0.0001
+      input_cost_per_second: 0.0005
+      region: europe-west3
+    - input_cost_per_character: 2.e-7
+      input_cost_per_image: 0.0001
+      input_cost_per_second: 0.0005
+      region: europe-west2
+    - input_cost_per_character: 2.e-7
+      input_cost_per_image: 0.0001
+      input_cost_per_second: 0.0005
+      region: europe-west1
+    - input_cost_per_character: 2.e-7
+      input_cost_per_image: 0.0001
+      input_cost_per_second: 0.0005
+      region: europe-southwest1
+    - input_cost_per_character: 2.e-7
+      input_cost_per_image: 0.0001
+      input_cost_per_second: 0.0005
+      region: europe-north1
+    - input_cost_per_character: 2.e-7
+      input_cost_per_image: 0.0001
+      input_cost_per_second: 0.0005
+      region: europe-central2
+    - input_cost_per_character: 2.e-7
+      input_cost_per_image: 0.0001
+      input_cost_per_second: 0.0005
+      region: australia-southeast1
+    - input_cost_per_character: 2.e-7
+      input_cost_per_image: 0.0001
+      input_cost_per_second: 0.0005
+      region: asia-southeast1
+    - input_cost_per_character: 2.e-7
+      input_cost_per_image: 0.0001
+      input_cost_per_second: 0.0005
+      region: asia-south1
+    - input_cost_per_character: 2.e-7
+      input_cost_per_image: 0.0001
+      input_cost_per_second: 0.0005
+      region: asia-northeast3
+    - input_cost_per_character: 2.e-7
+      input_cost_per_image: 0.0001
+      input_cost_per_second: 0.0005
+      region: asia-northeast1
+    - input_cost_per_character: 2.e-7
+      input_cost_per_image: 0.0001
+      input_cost_per_second: 0.0005
+      region: asia-east2
+    - input_cost_per_character: 2.e-7
+      input_cost_per_image: 0.0001
+      input_cost_per_second: 0.0005
+      region: asia-east1
 limits:
     output_vector_size: 1408
 modalities:
@@ -9,6 +126,7 @@ modalities:
         - embedding
 mode: embedding
 model: google/multimodalembedding
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature
@@ -20,5 +138,7 @@ removeParams:
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/embeddings/get-multimodal-embeddings
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/locations-genai
+    - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/model-reference/multimodal-embeddings
+status: active
 supportedModes:
     - embedding

--- a/providers/google-vertex/google/object-detector.yaml
+++ b/providers/google-vertex/google/object-detector.yaml
@@ -8,6 +8,7 @@ modalities:
         - text
 mode: video
 model: google/object-detector
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature
@@ -19,5 +20,6 @@ removeParams:
 sources:
     - https://cloud.google.com/vision-ai/pricing
     - https://cloud.google.com/vision-ai/docs/object-detector-model
+status: active
 supportedModes:
     - video

--- a/providers/google-vertex/google/occupancy-analytics.yaml
+++ b/providers/google-vertex/google/occupancy-analytics.yaml
@@ -5,6 +5,7 @@ modalities:
         - text
 mode: video
 model: google/occupancy-analytics
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature
@@ -16,5 +17,6 @@ removeParams:
 sources:
     - https://cloud.google.com/vision-ai/pricing
     - https://docs.cloud.google.com/vision-ai/docs/overview
+    - https://docs.cloud.google.com/vision-ai/docs/occupancy-analytics-model
 supportedModes:
     - video

--- a/providers/google-vertex/google/owlvit-base-patch32.yaml
+++ b/providers/google-vertex/google/owlvit-base-patch32.yaml
@@ -4,6 +4,7 @@ modalities:
         - text
 mode: unknown
 model: google/owlvit-base-patch32
+provisioning: provisioned
 removeParams:
     - max_tokens
     - temperature
@@ -14,3 +15,6 @@ removeParams:
     - tool_choice
 sources:
     - https://console.cloud.google.com/vertex-ai/publishers/google/model-garden/owlvit-base-patch32
+status: active
+supportedModes:
+    - unknown

--- a/providers/google-vertex/google/paligemma.yaml
+++ b/providers/google-vertex/google/paligemma.yaml
@@ -6,6 +6,7 @@ modalities:
         - text
 mode: chat
 model: google/paligemma
+provisioning: provisioned
 removeParams:
     - "n"
     - stop

--- a/providers/google-vertex/google/path-foundation.yaml
+++ b/providers/google-vertex/google/path-foundation.yaml
@@ -7,6 +7,7 @@ modalities:
         - embedding
 mode: embedding
 model: google/path-foundation
+provisioning: provisioned
 removeParams:
     - max_tokens
     - temperature
@@ -19,5 +20,6 @@ sources:
     - https://developers.google.com/health-ai-developer-foundations/path-foundation
     - https://developers.google.com/health-ai-developer-foundations/path-foundation/model-card
     - https://developers.google.com/health-ai-developer-foundations/path-foundation/serving-api
+status: active
 supportedModes:
     - embedding

--- a/providers/google-vertex/google/people-blur.yaml
+++ b/providers/google-vertex/google/people-blur.yaml
@@ -1,3 +1,12 @@
+costs:
+    - input_cost_per_second: 0.001666666666666667
+      region: us-west1
+    - input_cost_per_second: 0.001666666666666667
+      region: us-east1
+    - input_cost_per_second: 0.001666666666666667
+      region: europe-west1
+    - input_cost_per_second: 0.001666666666666667
+      region: asia-east1
 modalities:
     input:
         - video
@@ -5,6 +14,7 @@ modalities:
         - video
 mode: video
 model: google/people-blur
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature

--- a/providers/google-vertex/google/pic2word.yaml
+++ b/providers/google-vertex/google/pic2word.yaml
@@ -6,5 +6,9 @@ modalities:
         - image
 mode: unknown
 model: google/pic2word
+provisioning: provisioned
 sources:
     - https://console.cloud.google.com/vertex-ai/publishers/google/model-garden/pic2word
+status: active
+supportedModes:
+    - unknown

--- a/providers/google-vertex/google/ppe-detector.yaml
+++ b/providers/google-vertex/google/ppe-detector.yaml
@@ -1,6 +1,8 @@
 costs:
     - input_cost_per_second: 0.00166667
-      region: "*"
+      region: us-central1
+    - input_cost_per_second: 0.00166667
+      region: europe-west4
 modalities:
     input:
         - video
@@ -8,6 +10,7 @@ modalities:
         - text
 mode: video
 model: google/ppe-detector
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature
@@ -19,5 +22,6 @@ removeParams:
 sources:
     - https://docs.cloud.google.com/vision-ai/docs/ppe-detector-model
     - https://cloud.google.com/vision-ai/pricing
+status: active
 supportedModes:
     - video

--- a/providers/google-vertex/google/pretrained-form-parser.yaml
+++ b/providers/google-vertex/google/pretrained-form-parser.yaml
@@ -10,6 +10,7 @@ modalities:
         - text
 mode: unknown
 model: google/pretrained-form-parser
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature
@@ -22,3 +23,5 @@ sources:
     - https://cloud.google.com/document-ai/pricing
     - https://docs.cloud.google.com/document-ai/docs/processors-list
 status: active
+supportedModes:
+    - unknown

--- a/providers/google-vertex/google/pretrained-ocr.yaml
+++ b/providers/google-vertex/google/pretrained-ocr.yaml
@@ -19,6 +19,7 @@ modalities:
         - text
 mode: unknown
 model: pretrained-ocr
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature
@@ -32,3 +33,5 @@ sources:
     - https://cloud.google.com/document-ai/pricing
     - https://docs.cloud.google.com/document-ai/docs/processors-list
 status: active
+supportedModes:
+    - unknown

--- a/providers/google-vertex/google/pt-test.yaml
+++ b/providers/google-vertex/google/pt-test.yaml
@@ -1,2 +1,5 @@
 mode: unknown
 model: google/pt-test
+provisioning: serverless
+supportedModes:
+    - unknown

--- a/providers/google-vertex/google/shieldgemma2.yaml
+++ b/providers/google-vertex/google/shieldgemma2.yaml
@@ -6,6 +6,7 @@ modalities:
         - text
 mode: moderation
 model: google/shieldgemma2
+provisioning: provisioned
 removeParams:
     - "n"
     - stop

--- a/providers/google-vertex/google/t5-1.1.yaml
+++ b/providers/google-vertex/google/t5-1.1.yaml
@@ -5,6 +5,7 @@ modalities:
         - text
 mode: completion
 model: google/t5-1.1
+provisioning: provisioned
 status: active
 supportedModes:
     - completion

--- a/providers/google-vertex/google/t5-flan.yaml
+++ b/providers/google-vertex/google/t5-flan.yaml
@@ -5,6 +5,7 @@ modalities:
         - text
 mode: completion
 model: google/t5-flan
+provisioning: provisioned
 removeParams:
     - "n"
     - stop

--- a/providers/google-vertex/google/tab-net.yaml
+++ b/providers/google-vertex/google/tab-net.yaml
@@ -1,6 +1,17 @@
 mode: unknown
 model: tab-net
+provisioning: provisioned
+removeParams:
+    - max_tokens
+    - temperature
+    - top_p
+    - "n"
+    - stop
+    - stream
+    - tool_choice
 sources:
     - https://docs.cloud.google.com/vertex-ai/docs/tabular-data/tabular-workflows/tabnet
     - https://docs.cloud.google.com/vertex-ai/docs/tabular-data/tabular-workflows/pricing
 status: preview
+supportedModes:
+    - unknown

--- a/providers/google-vertex/google/tag-recognizer.yaml
+++ b/providers/google-vertex/google/tag-recognizer.yaml
@@ -1,2 +1,25 @@
+costs:
+    - input_cost_per_image: 0.000025
+      region: us-central1
+modalities:
+    input:
+        - image
+    output:
+        - text
 mode: unknown
 model: google/tag-recognizer
+provisioning: serverless
+removeParams:
+    - max_tokens
+    - temperature
+    - top_p
+    - "n"
+    - stop
+    - stream
+    - tool_choice
+sources:
+    - https://docs.cloud.google.com/vision-ai/docs/tag-recognizer
+    - https://cloud.google.com/vision-ai/pricing
+status: active
+supportedModes:
+    - unknown

--- a/providers/google-vertex/google/text-detector.yaml
+++ b/providers/google-vertex/google/text-detector.yaml
@@ -1,10 +1,15 @@
+costs:
+    - input_cost_per_image: 0.0015
+      region: global
 modalities:
     input:
         - image
+        - pdf
     output:
         - text
 mode: unknown
 model: google/text-detector
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature
@@ -13,3 +18,9 @@ removeParams:
     - stop
     - stream
     - tool_choice
+sources:
+    - https://cloud.google.com/vision/pricing
+    - https://docs.cloud.google.com/vision/docs/ocr
+status: active
+supportedModes:
+    - unknown

--- a/providers/google-vertex/google/text-embedding-005.yaml
+++ b/providers/google-vertex/google/text-embedding-005.yaml
@@ -9,6 +9,7 @@ modalities:
         - embedding
 mode: embedding
 model: text-embedding-005
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature

--- a/providers/google-vertex/google/text-embedding-large-exp-03-07.yaml
+++ b/providers/google-vertex/google/text-embedding-large-exp-03-07.yaml
@@ -5,6 +5,7 @@ modalities:
         - embedding
 mode: embedding
 model: google/text-embedding-large-exp-03-07
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature

--- a/providers/google-vertex/google/text-multilingual-embedding-002.yaml
+++ b/providers/google-vertex/google/text-multilingual-embedding-002.yaml
@@ -1,3 +1,63 @@
+costs:
+    - input_cost_per_character: 2.5e-8
+      region: us-west4
+    - input_cost_per_character: 2.5e-8
+      region: us-west1
+    - input_cost_per_character: 2.5e-8
+      region: us-south1
+    - input_cost_per_character: 2.5e-8
+      region: us-east5
+    - input_cost_per_character: 2.5e-8
+      region: us-east4
+    - input_cost_per_character: 2.5e-8
+      region: us-east1
+    - input_cost_per_character: 2.5e-8
+      region: us-central1
+    - input_cost_per_character: 2.5e-8
+      region: southamerica-east1
+    - input_cost_per_character: 2.5e-8
+      region: northamerica-northeast1
+    - input_cost_per_character: 2.5e-8
+      region: me-west1
+    - input_cost_per_character: 2.5e-8
+      region: me-central2
+    - input_cost_per_character: 2.5e-8
+      region: me-central1
+    - input_cost_per_character: 2.5e-8
+      region: europe-west9
+    - input_cost_per_character: 2.5e-8
+      region: europe-west8
+    - input_cost_per_character: 2.5e-8
+      region: europe-west6
+    - input_cost_per_character: 2.5e-8
+      region: europe-west4
+    - input_cost_per_character: 2.5e-8
+      region: europe-west3
+    - input_cost_per_character: 2.5e-8
+      region: europe-west2
+    - input_cost_per_character: 2.5e-8
+      region: europe-west1
+    - input_cost_per_character: 2.5e-8
+      region: europe-southwest1
+    - input_cost_per_character: 2.5e-8
+      region: europe-north1
+    - input_cost_per_character: 2.5e-8
+      region: europe-central2
+    - input_cost_per_character: 2.5e-8
+      region: australia-southeast1
+    - input_cost_per_character: 2.5e-8
+      region: asia-southeast1
+    - input_cost_per_character: 2.5e-8
+      region: asia-south1
+    - input_cost_per_character: 2.5e-8
+      region: asia-northeast3
+    - input_cost_per_character: 2.5e-8
+      region: asia-northeast1
+    - input_cost_per_character: 2.5e-8
+      region: asia-east2
+    - input_cost_per_character: 2.5e-8
+      region: asia-east1
+deprecationDate: "2027-04-01"
 limits:
     max_input_tokens: 2048
     output_vector_size: 768
@@ -8,6 +68,7 @@ modalities:
         - embedding
 mode: embedding
 model: text-multilingual-embedding-002
+provisioning: serverless
 removeParams:
     - temperature
     - top_p
@@ -19,5 +80,7 @@ removeParams:
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/embeddings/get-text-embeddings
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/model-reference/text-embeddings-api
+    - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/model-versioning
+status: active
 supportedModes:
     - embedding

--- a/providers/google-vertex/google/text-translation.yaml
+++ b/providers/google-vertex/google/text-translation.yaml
@@ -8,6 +8,7 @@ modalities:
         - text
 mode: unknown
 model: google/text-translation
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature
@@ -19,3 +20,6 @@ removeParams:
 sources:
     - https://cloud.google.com/translate/pricing
     - https://docs.cloud.google.com/translate/docs/reference/rest/v3/projects/translateText
+status: active
+supportedModes:
+    - unknown

--- a/providers/google-vertex/google/tfvision-movinet-var.yaml
+++ b/providers/google-vertex/google/tfvision-movinet-var.yaml
@@ -15,5 +15,6 @@ removeParams:
     - tool_choice
 sources:
     - https://github.com/tensorflow/models/tree/master/official/projects/movinet
+status: active
 supportedModes:
     - video

--- a/providers/google-vertex/google/tfvision-movinet-vcn.yaml
+++ b/providers/google-vertex/google/tfvision-movinet-vcn.yaml
@@ -5,6 +5,7 @@ modalities:
         - text
 mode: unknown
 model: google/tfvision-movinet-vcn
+provisioning: provisioned
 removeParams:
     - max_tokens
     - temperature
@@ -15,3 +16,6 @@ removeParams:
     - tool_choice
 sources:
     - https://github.com/tensorflow/models/tree/master/official/projects/movinet
+status: active
+supportedModes:
+    - unknown

--- a/providers/google-vertex/google/timesfm.yaml
+++ b/providers/google-vertex/google/timesfm.yaml
@@ -1,5 +1,6 @@
 mode: unknown
 model: google/timesfm
+provisioning: provisioned
 removeParams:
     - max_tokens
     - temperature
@@ -11,3 +12,5 @@ removeParams:
 sources:
     - https://research.google/blog/a-decoder-only-foundation-model-for-time-series-forecasting/
 status: active
+supportedModes:
+    - unknown

--- a/providers/google-vertex/google/translate-llm.yaml
+++ b/providers/google-vertex/google/translate-llm.yaml
@@ -8,8 +8,11 @@ modalities:
         - text
 mode: chat
 model: google/translate-llm
+provisioning: serverless
 sources:
     - https://cloud.google.com/translate/pricing
     - https://docs.cloud.google.com/translate/docs/advanced/translate-text-advance
+    - https://docs.cloud.google.com/translate/docs/advanced/compare-models
+status: active
 supportedModes:
     - chat

--- a/providers/google-vertex/google/translategemma.yaml
+++ b/providers/google-vertex/google/translategemma.yaml
@@ -1,14 +1,27 @@
+limits:
+    context_window: 2048
+    max_input_tokens: 2048
+messages:
+    options:
+        - user
+        - assistant
 modalities:
     input:
         - text
+        - image
     output:
         - text
 mode: chat
 model: google/translategemma
+provisioning: provisioned
 removeParams:
     - "n"
     - stop
     - tool_choice
+sources:
+    - https://huggingface.co/google/translategemma-27b-it
+    - https://huggingface.co/google/translategemma-12b-it
+    - https://huggingface.co/google/translategemma-4b-it/discussions/2
 status: active
 supportedModes:
     - chat

--- a/providers/google-vertex/google/vehicle-detector.yaml
+++ b/providers/google-vertex/google/vehicle-detector.yaml
@@ -1,3 +1,8 @@
+costs:
+    - input_cost_per_second: 0.00166667
+      region: us-central1
+    - input_cost_per_second: 0.00166667
+      region: europe-west4
 modalities:
     input:
         - image
@@ -5,6 +10,7 @@ modalities:
         - text
 mode: image
 model: vehicle-detector
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature
@@ -13,5 +19,10 @@ removeParams:
     - stop
     - stream
     - tool_choice
+sources:
+    - https://cloud.google.com/vision-ai/pricing
+    - https://docs.cloud.google.com/vision-ai/docs/person-vehicle-model
+    - https://docs.cloud.google.com/vision-ai/docs/app-supported-regions
+status: preview
 supportedModes:
     - image

--- a/providers/google-vertex/google/veo-2.0-generate-001.yaml
+++ b/providers/google-vertex/google/veo-2.0-generate-001.yaml
@@ -1,34 +1,64 @@
 costs:
-    - region: us-west4
-    - region: us-west1
-    - region: us-south1
-    - region: us-east5
-    - region: us-east4
-    - region: us-east1
-    - region: us-central1
-    - region: southamerica-east1
-    - region: northamerica-northeast1
-    - region: me-west1
-    - region: me-central2
-    - region: me-central1
-    - region: global
-    - region: europe-west9
-    - region: europe-west8
-    - region: europe-west6
-    - region: europe-west4
-    - region: europe-west3
-    - region: europe-west2
-    - region: europe-west1
-    - region: europe-southwest1
-    - region: europe-north1
-    - region: europe-central2
-    - region: australia-southeast1
-    - region: asia-southeast1
-    - region: asia-south1
-    - region: asia-northeast3
-    - region: asia-northeast1
-    - region: asia-east2
-    - region: asia-east1
+    - output_cost_per_second: 0.35
+      region: us-west4
+    - output_cost_per_second: 0.35
+      region: us-west1
+    - output_cost_per_second: 0.35
+      region: us-south1
+    - output_cost_per_second: 0.35
+      region: us-east5
+    - output_cost_per_second: 0.35
+      region: us-east4
+    - output_cost_per_second: 0.35
+      region: us-east1
+    - output_cost_per_second: 0.35
+      region: us-central1
+    - output_cost_per_second: 0.35
+      region: southamerica-east1
+    - output_cost_per_second: 0.35
+      region: northamerica-northeast1
+    - output_cost_per_second: 0.35
+      region: me-west1
+    - output_cost_per_second: 0.35
+      region: me-central2
+    - output_cost_per_second: 0.35
+      region: me-central1
+    - output_cost_per_second: 0.35
+      region: global
+    - output_cost_per_second: 0.35
+      region: europe-west9
+    - output_cost_per_second: 0.35
+      region: europe-west8
+    - output_cost_per_second: 0.35
+      region: europe-west6
+    - output_cost_per_second: 0.35
+      region: europe-west4
+    - output_cost_per_second: 0.35
+      region: europe-west3
+    - output_cost_per_second: 0.35
+      region: europe-west2
+    - output_cost_per_second: 0.35
+      region: europe-west1
+    - output_cost_per_second: 0.35
+      region: europe-southwest1
+    - output_cost_per_second: 0.35
+      region: europe-north1
+    - output_cost_per_second: 0.35
+      region: europe-central2
+    - output_cost_per_second: 0.35
+      region: australia-southeast1
+    - output_cost_per_second: 0.35
+      region: asia-southeast1
+    - output_cost_per_second: 0.35
+      region: asia-south1
+    - output_cost_per_second: 0.35
+      region: asia-northeast3
+    - output_cost_per_second: 0.35
+      region: asia-northeast1
+    - output_cost_per_second: 0.35
+      region: asia-east2
+    - output_cost_per_second: 0.35
+      region: asia-east1
 modalities:
     input:
         - text
@@ -37,6 +67,7 @@ modalities:
         - video
 mode: video
 model: veo-2.0-generate-001
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature
@@ -50,6 +81,7 @@ sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/video/overview
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/locations#available-regions
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/models
+    - https://ai.google.dev/pricing
 status: active
 supportedModes:
     - video

--- a/providers/google-vertex/google/veo-3.0-fast-generate-001.yaml
+++ b/providers/google-vertex/google/veo-3.0-fast-generate-001.yaml
@@ -1,3 +1,124 @@
+costs:
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_4k: 0.3
+      output_cost_per_second_720p: 0.1
+      region: us-west4
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_4k: 0.3
+      output_cost_per_second_720p: 0.1
+      region: us-west1
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_4k: 0.3
+      output_cost_per_second_720p: 0.1
+      region: us-south1
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_4k: 0.3
+      output_cost_per_second_720p: 0.1
+      region: us-east5
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_4k: 0.3
+      output_cost_per_second_720p: 0.1
+      region: us-east4
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_4k: 0.3
+      output_cost_per_second_720p: 0.1
+      region: us-east1
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_4k: 0.3
+      output_cost_per_second_720p: 0.1
+      region: us-central1
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_4k: 0.3
+      output_cost_per_second_720p: 0.1
+      region: southamerica-east1
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_4k: 0.3
+      output_cost_per_second_720p: 0.1
+      region: northamerica-northeast1
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_4k: 0.3
+      output_cost_per_second_720p: 0.1
+      region: me-west1
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_4k: 0.3
+      output_cost_per_second_720p: 0.1
+      region: me-central2
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_4k: 0.3
+      output_cost_per_second_720p: 0.1
+      region: me-central1
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_4k: 0.3
+      output_cost_per_second_720p: 0.1
+      region: global
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_4k: 0.3
+      output_cost_per_second_720p: 0.1
+      region: europe-west9
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_4k: 0.3
+      output_cost_per_second_720p: 0.1
+      region: europe-west8
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_4k: 0.3
+      output_cost_per_second_720p: 0.1
+      region: europe-west6
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_4k: 0.3
+      output_cost_per_second_720p: 0.1
+      region: europe-west4
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_4k: 0.3
+      output_cost_per_second_720p: 0.1
+      region: europe-west3
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_4k: 0.3
+      output_cost_per_second_720p: 0.1
+      region: europe-west2
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_4k: 0.3
+      output_cost_per_second_720p: 0.1
+      region: europe-west1
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_4k: 0.3
+      output_cost_per_second_720p: 0.1
+      region: europe-southwest1
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_4k: 0.3
+      output_cost_per_second_720p: 0.1
+      region: europe-north1
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_4k: 0.3
+      output_cost_per_second_720p: 0.1
+      region: europe-central2
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_4k: 0.3
+      output_cost_per_second_720p: 0.1
+      region: australia-southeast1
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_4k: 0.3
+      output_cost_per_second_720p: 0.1
+      region: asia-southeast1
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_4k: 0.3
+      output_cost_per_second_720p: 0.1
+      region: asia-south1
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_4k: 0.3
+      output_cost_per_second_720p: 0.1
+      region: asia-northeast3
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_4k: 0.3
+      output_cost_per_second_720p: 0.1
+      region: asia-northeast1
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_4k: 0.3
+      output_cost_per_second_720p: 0.1
+      region: asia-east2
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_4k: 0.3
+      output_cost_per_second_720p: 0.1
+      region: asia-east1
 deprecationDate: "2026-06-30"
 modalities:
     input:
@@ -8,6 +129,7 @@ modalities:
         - audio
 mode: video
 model: google/veo-3.0-fast-generate-001
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature
@@ -20,7 +142,7 @@ sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/veo/3-0-fast-generate-001
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/veo/3-0-generate
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/video/generate-videos
-    - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/locations
+    - https://ai.google.dev/pricing
 status: active
 supportedModes:
     - video

--- a/providers/google-vertex/google/veo-3.0-generate-001.yaml
+++ b/providers/google-vertex/google/veo-3.0-generate-001.yaml
@@ -69,6 +69,7 @@ modalities:
         - audio
 mode: video
 model: veo-3.0-generate-001
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature
@@ -79,7 +80,6 @@ removeParams:
     - tool_choice
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/veo/3-0-generate
-    - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/locations
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/video/overview
 status: active
 supportedModes:

--- a/providers/google-vertex/google/veo-3.1-fast-generate-001.yaml
+++ b/providers/google-vertex/google/veo-3.1-fast-generate-001.yaml
@@ -37,6 +37,9 @@ costs:
       region: me-central1
     - output_cost_per_second: 0.15
       output_cost_per_second_4k: 0.35
+      region: global
+    - output_cost_per_second: 0.15
+      output_cost_per_second_4k: 0.35
       region: europe-west9
     - output_cost_per_second: 0.15
       output_cost_per_second_4k: 0.35
@@ -98,6 +101,7 @@ modalities:
         - audio
 mode: video
 model: veo-3.1-fast-generate-001
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature

--- a/providers/google-vertex/google/veo-3.1-generate-001.yaml
+++ b/providers/google-vertex/google/veo-3.1-generate-001.yaml
@@ -9,6 +9,7 @@ modalities:
         - audio
 mode: video
 model: veo-3.1-generate-001
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature
@@ -20,7 +21,7 @@ removeParams:
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/video/generate-videos
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/video/overview
-    - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/locations
+    - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/veo/3-1-generate
 status: active
 supportedModes:
     - video

--- a/providers/google-vertex/google/veo-3.1-lite-generate-001.yaml
+++ b/providers/google-vertex/google/veo-3.1-lite-generate-001.yaml
@@ -39,6 +39,7 @@ modalities:
         - video
 mode: video
 model: veo-3.1-lite-generate-001
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature

--- a/providers/google-vertex/google/video-speech-transcription.yaml
+++ b/providers/google-vertex/google/video-speech-transcription.yaml
@@ -9,6 +9,7 @@ modalities:
         - text
 mode: audio_transcription
 model: google/video-speech-transcription
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature
@@ -19,5 +20,6 @@ removeParams:
     - tool_choice
 sources:
     - https://cloud.google.com/video-intelligence/pricing
+status: active
 supportedModes:
     - audio_transcription

--- a/providers/google-vertex/google/video-text-detection.yaml
+++ b/providers/google-vertex/google/video-text-detection.yaml
@@ -14,6 +14,7 @@ modalities:
         - text
 mode: video
 model: google/video-text-detection
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature

--- a/providers/google-vertex/google/virtual-try-on-001.yaml
+++ b/providers/google-vertex/google/virtual-try-on-001.yaml
@@ -5,6 +5,7 @@ modalities:
         - image
 mode: image
 model: virtual-try-on-001
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature
@@ -16,5 +17,6 @@ removeParams:
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/image/generate-virtual-try-on-images
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/model-reference/imagen-api
+status: active
 supportedModes:
     - image

--- a/providers/google-vertex/google/vit-jax.yaml
+++ b/providers/google-vertex/google/vit-jax.yaml
@@ -5,6 +5,7 @@ modalities:
         - text
 mode: unknown
 model: google/vit-jax
+provisioning: provisioned
 removeParams:
     - max_tokens
     - temperature
@@ -13,3 +14,6 @@ removeParams:
     - stop
     - stream
     - tool_choice
+status: active
+supportedModes:
+    - unknown

--- a/providers/google-vertex/google/weather-next-v2.yaml
+++ b/providers/google-vertex/google/weather-next-v2.yaml
@@ -1,5 +1,6 @@
 mode: unknown
 model: weather-next-v2
+provisioning: provisioned
 removeParams:
     - max_tokens
     - temperature
@@ -13,3 +14,5 @@ sources:
     - https://developers.google.com/weathernext
     - https://developers.google.com/weathernext/guides/access-vmg
 status: preview
+supportedModes:
+    - unknown

--- a/providers/google-vertex/google/weathernext.yaml
+++ b/providers/google-vertex/google/weathernext.yaml
@@ -1,3 +1,17 @@
 mode: unknown
 model: google/weathernext
-status: active
+provisioning: provisioned
+removeParams:
+    - max_tokens
+    - temperature
+    - top_p
+    - "n"
+    - stop
+    - stream
+    - tool_choice
+sources:
+    - https://developers.google.com/weathernext
+    - https://developers.google.com/weathernext/guides/models
+    - https://developers.google.com/weathernext/guides/access-vmg
+    - https://deepmind.google/science/weathernext/
+status: preview

--- a/providers/google-vertex/hidream-ai/hidream-i1.yaml
+++ b/providers/google-vertex/hidream-ai/hidream-i1.yaml
@@ -7,6 +7,7 @@ modalities:
         - image
 mode: image
 model: hidream-ai/hidream-i1
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature
@@ -17,5 +18,6 @@ removeParams:
     - tool_choice
 sources:
     - https://huggingface.co/HiDream-ai/HiDream-I1-Full
+status: active
 supportedModes:
     - image

--- a/providers/google-vertex/ifzhang/bytetrack-multi-object-tracking.yaml
+++ b/providers/google-vertex/ifzhang/bytetrack-multi-object-tracking.yaml
@@ -5,6 +5,7 @@ modalities:
         - video
 mode: video
 model: ifzhang/bytetrack-multi-object-tracking
+provisioning: provisioned
 removeParams:
     - max_tokens
     - temperature
@@ -13,5 +14,6 @@ removeParams:
     - stop
     - stream
     - tool_choice
+status: active
 supportedModes:
     - video

--- a/providers/google-vertex/imagen-3.0-capability-001.yaml
+++ b/providers/google-vertex/imagen-3.0-capability-001.yaml
@@ -60,6 +60,7 @@ costs:
     - output_cost_per_image: 0.04
       region: asia-east1
 deprecationDate: "2026-06-30"
+isDeprecated: true
 modalities:
     input:
         - text

--- a/providers/google-vertex/imagen-3.0-generate-001.yaml
+++ b/providers/google-vertex/imagen-3.0-generate-001.yaml
@@ -72,6 +72,7 @@ params:
       key: "n"
       maxValue: 4
       minValue: 1
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature
@@ -82,7 +83,6 @@ removeParams:
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/imagen/3-0-generate
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/imagen/3-0-generate-001
-    - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/locations
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/image/generate-images
 status: active
 supportedModes:

--- a/providers/google-vertex/imagen-4.0-fast-generate-001.yaml
+++ b/providers/google-vertex/imagen-4.0-fast-generate-001.yaml
@@ -72,6 +72,7 @@ params:
       key: "n"
       maxValue: 4
       minValue: 1
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature
@@ -82,8 +83,8 @@ removeParams:
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/imagen/4-0-fast-generate-001
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/model-reference/imagen-api
-    - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/locations
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/image/generate-images
+    - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/image/overview
 status: active
 supportedModes:
     - image

--- a/providers/google-vertex/instantx/instant-id.yaml
+++ b/providers/google-vertex/instantx/instant-id.yaml
@@ -6,6 +6,7 @@ modalities:
         - image
 mode: image
 model: instantx/instant-id
+provisioning: provisioned
 removeParams:
     - max_tokens
     - temperature
@@ -14,5 +15,6 @@ removeParams:
     - stop
     - stream
     - tool_choice
+status: active
 supportedModes:
     - image

--- a/providers/google-vertex/intfloat/e5.yaml
+++ b/providers/google-vertex/intfloat/e5.yaml
@@ -7,6 +7,7 @@ modalities:
         - embedding
 mode: embedding
 model: intfloat/e5
+provisioning: serverless
 removeParams:
     - temperature
     - top_p

--- a/providers/google-vertex/intfloat/multilingual-e5-large-instruct-maas.yaml
+++ b/providers/google-vertex/intfloat/multilingual-e5-large-instruct-maas.yaml
@@ -8,6 +8,7 @@ modalities:
         - embedding
 mode: embedding
 model: intfloat/multilingual-e5-large-instruct-maas
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature

--- a/providers/google-vertex/jinaai/jina-embeddings-v3.yaml
+++ b/providers/google-vertex/jinaai/jina-embeddings-v3.yaml
@@ -9,6 +9,7 @@ modalities:
         - embedding
 mode: embedding
 model: jinaai/jina-embeddings-v3
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature

--- a/providers/google-vertex/llama-3.1-8b-instruct-maas.yaml
+++ b/providers/google-vertex/llama-3.1-8b-instruct-maas.yaml
@@ -11,6 +11,7 @@ modalities:
         - text
 mode: chat
 model: llama-3.1-8b-instruct-maas
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/llama/llama3-1-8
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/llama/use-llama

--- a/providers/google-vertex/lllyasviel/control-net.yaml
+++ b/providers/google-vertex/lllyasviel/control-net.yaml
@@ -6,6 +6,7 @@ modalities:
         - image
 mode: image
 model: lllyasviel/control-net
+provisioning: provisioned
 removeParams:
     - max_tokens
     - temperature

--- a/providers/google-vertex/meta/codellama-7b-hf.yaml
+++ b/providers/google-vertex/meta/codellama-7b-hf.yaml
@@ -7,6 +7,7 @@ modalities:
         - code
 mode: completion
 model: meta/codellama-7b-hf
+provisioning: provisioned
 removeParams:
     - tool_choice
 status: active

--- a/providers/google-vertex/meta/faster-r-cnn.yaml
+++ b/providers/google-vertex/meta/faster-r-cnn.yaml
@@ -8,6 +8,7 @@ modalities:
         - text
 mode: unknown
 model: meta/faster-r-cnn
+provisioning: provisioned
 removeParams:
     - max_tokens
     - temperature
@@ -16,3 +17,8 @@ removeParams:
     - stop
     - stream
     - tool_choice
+sources:
+    - https://console.cloud.google.com/vertex-ai/publishers/meta/model-garden/faster-r-cnn
+status: active
+supportedModes:
+    - unknown

--- a/providers/google-vertex/meta/imagebind.yaml
+++ b/providers/google-vertex/meta/imagebind.yaml
@@ -7,6 +7,7 @@ modalities:
         - embedding
 mode: embedding
 model: meta/imagebind
+provisioning: provisioned
 removeParams:
     - max_tokens
     - temperature

--- a/providers/google-vertex/meta/llama-2-quantized.yaml
+++ b/providers/google-vertex/meta/llama-2-quantized.yaml
@@ -1,3 +1,5 @@
+limits:
+    context_window: 4096
 modalities:
     input:
         - text
@@ -5,7 +7,11 @@ modalities:
         - text
 mode: chat
 model: meta/llama-2-quantized
+provisioning: provisioned
 removeParams:
     - tool_choice
+sources:
+    - https://console.cloud.google.com/vertex-ai/publishers/meta/model-garden/llama-2-quantized
+    - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/open-models/use-llama
 supportedModes:
     - chat

--- a/providers/google-vertex/meta/llama-3.3-70b-instruct-maas.yaml
+++ b/providers/google-vertex/meta/llama-3.3-70b-instruct-maas.yaml
@@ -25,6 +25,7 @@ params:
       key: max_tokens
       maxValue: 8192
       minValue: 1
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/llama/llama3-3
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/llama

--- a/providers/google-vertex/meta/llama-4-maverick-17b-128e-instruct-maas.yaml
+++ b/providers/google-vertex/meta/llama-4-maverick-17b-128e-instruct-maas.yaml
@@ -22,6 +22,7 @@ model: meta/llama-4-maverick-17b-128e-instruct-maas
 params:
     - key: max_tokens
       maxValue: 8192
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/llama/llama4-maverick
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/llama

--- a/providers/google-vertex/meta/llama-4-scout-17b-16e-instruct-maas.yaml
+++ b/providers/google-vertex/meta/llama-4-scout-17b-16e-instruct-maas.yaml
@@ -25,6 +25,7 @@ params:
       key: max_tokens
       maxValue: 8192
       minValue: 1
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/llama/llama4-scout
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/llama/use-llama

--- a/providers/google-vertex/meta/llama2.yaml
+++ b/providers/google-vertex/meta/llama2.yaml
@@ -7,9 +7,11 @@ modalities:
         - text
 mode: chat
 model: meta/llama2
+provisioning: provisioned
 removeParams:
     - tool_choice
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/llama
+    - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/open-models/use-llama
 supportedModes:
     - chat

--- a/providers/google-vertex/meta/llama3-2.yaml
+++ b/providers/google-vertex/meta/llama3-2.yaml
@@ -5,6 +5,7 @@ modalities:
         - text
 mode: chat
 model: meta/llama3-2
+provisioning: provisioned
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/llama
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/open-models/use-llama

--- a/providers/google-vertex/meta/llama3_1.yaml
+++ b/providers/google-vertex/meta/llama3_1.yaml
@@ -2,6 +2,8 @@ features:
     - function_calling
     - system_messages
     - json_output
+limits:
+    context_window: 128000
 modalities:
     input:
         - text
@@ -9,9 +11,11 @@ modalities:
         - text
 mode: chat
 model: meta/llama3_1
+provisioning: provisioned
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/open-models/use-llama
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/llama
+    - https://huggingface.co/meta-llama/Llama-3.1-405B-Instruct
 status: active
 supportedModes:
     - chat

--- a/providers/google-vertex/meta/llama4.yaml
+++ b/providers/google-vertex/meta/llama4.yaml
@@ -15,6 +15,7 @@ params:
       key: max_tokens
       maxValue: 8192
       minValue: 1
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/llama
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/llama/llama4-maverick

--- a/providers/google-vertex/meta/mask-r-cnn.yaml
+++ b/providers/google-vertex/meta/mask-r-cnn.yaml
@@ -5,6 +5,7 @@ modalities:
         - image
 mode: unknown
 model: meta/mask-r-cnn
+provisioning: provisioned
 removeParams:
     - max_tokens
     - temperature
@@ -13,4 +14,8 @@ removeParams:
     - stop
     - stream
     - tool_choice
+sources:
+    - https://console.cloud.google.com/vertex-ai/publishers/meta/model-garden/mask-r-cnn
 status: active
+supportedModes:
+    - unknown

--- a/providers/google-vertex/meta/nllb.yaml
+++ b/providers/google-vertex/meta/nllb.yaml
@@ -5,6 +5,7 @@ modalities:
         - text
 mode: completion
 model: meta/nllb
+provisioning: provisioned
 removeParams:
     - tool_choice
     - "n"

--- a/providers/google-vertex/meta/prompt-guard.yaml
+++ b/providers/google-vertex/meta/prompt-guard.yaml
@@ -1,3 +1,5 @@
+limits:
+    context_window: 512
 modalities:
     input:
         - text
@@ -5,6 +7,7 @@ modalities:
         - text
 mode: moderation
 model: meta/prompt-guard
+provisioning: provisioned
 removeParams:
     - max_tokens
     - temperature
@@ -15,5 +18,6 @@ removeParams:
     - tool_choice
 sources:
     - https://huggingface.co/meta-llama/Prompt-Guard-86M
+status: active
 supportedModes:
     - moderation

--- a/providers/google-vertex/meta/retinanet.yaml
+++ b/providers/google-vertex/meta/retinanet.yaml
@@ -5,6 +5,7 @@ modalities:
         - text
 mode: unknown
 model: meta/retinanet
+provisioning: provisioned
 removeParams:
     - max_tokens
     - temperature
@@ -13,3 +14,6 @@ removeParams:
     - stop
     - stream
     - tool_choice
+status: active
+supportedModes:
+    - unknown

--- a/providers/google-vertex/meta/roberta-large.yaml
+++ b/providers/google-vertex/meta/roberta-large.yaml
@@ -1,3 +1,6 @@
+limits:
+    context_window: 512
+    max_input_tokens: 512
 modalities:
     input:
         - text
@@ -5,9 +8,13 @@ modalities:
         - text
 mode: unknown
 model: meta/roberta-large
+provisioning: provisioned
 removeParams:
     - tool_choice
     - "n"
     - stop
 sources:
     - https://huggingface.co/FacebookAI/roberta-large
+status: active
+supportedModes:
+    - unknown

--- a/providers/google-vertex/meta/sam3.yaml
+++ b/providers/google-vertex/meta/sam3.yaml
@@ -1,9 +1,23 @@
 modalities:
     input:
+        - text
         - image
+        - video
     output:
         - image
 mode: image
 model: meta/sam3
+provisioning: provisioned
+removeParams:
+    - max_tokens
+    - temperature
+    - top_p
+    - "n"
+    - stop
+    - stream
+    - tool_choice
+sources:
+    - https://github.com/facebookresearch/sam3
+status: active
 supportedModes:
     - image

--- a/providers/google-vertex/meta/segment-anything.yaml
+++ b/providers/google-vertex/meta/segment-anything.yaml
@@ -7,6 +7,7 @@ modalities:
         - image
 mode: image
 model: meta/segment-anything
+provisioning: provisioned
 removeParams:
     - max_tokens
     - temperature
@@ -15,5 +16,6 @@ removeParams:
     - stop
     - stream
     - tool_choice
+status: preview
 supportedModes:
     - image

--- a/providers/google-vertex/meta/xlm-roberta-large.yaml
+++ b/providers/google-vertex/meta/xlm-roberta-large.yaml
@@ -5,6 +5,7 @@ modalities:
         - text
 mode: unknown
 model: meta/xlm-roberta-large
+provisioning: provisioned
 removeParams:
     - max_tokens
     - temperature
@@ -14,3 +15,5 @@ removeParams:
     - stream
     - tool_choice
 status: active
+supportedModes:
+    - unknown

--- a/providers/google-vertex/microsoft/bio-gpt.yaml
+++ b/providers/google-vertex/microsoft/bio-gpt.yaml
@@ -5,6 +5,9 @@ modalities:
         - text
 mode: completion
 model: microsoft/bio-gpt
+provisioning: provisioned
+removeParams:
+    - tool_choice
 sources:
     - https://huggingface.co/microsoft/biogpt
 supportedModes:

--- a/providers/google-vertex/microsoft/phi3.yaml
+++ b/providers/google-vertex/microsoft/phi3.yaml
@@ -5,7 +5,9 @@ modalities:
         - text
 mode: chat
 model: microsoft/phi3
+provisioning: provisioned
 sources:
     - https://console.cloud.google.com/vertex-ai/publishers/microsoft/model-garden/phi3
+status: active
 supportedModes:
     - chat

--- a/providers/google-vertex/microsoft/phi4.yaml
+++ b/providers/google-vertex/microsoft/phi4.yaml
@@ -5,6 +5,7 @@ modalities:
         - text
 mode: chat
 model: microsoft/phi4
+provisioning: provisioned
 sources:
     - https://console.cloud.google.com/vertex-ai/publishers/microsoft/model-garden/phi4
 supportedModes:

--- a/providers/google-vertex/minimaxai/minimax-m2-maas.yaml
+++ b/providers/google-vertex/minimaxai/minimax-m2-maas.yaml
@@ -19,6 +19,10 @@ modalities:
         - text
 mode: chat
 model: minimaxai/minimax-m2-maas
+params:
+    - key: max_tokens
+      maxValue: 196608
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/minimax/minimax-m2
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/minimax

--- a/providers/google-vertex/minimaxai/minimax-m2.yaml
+++ b/providers/google-vertex/minimaxai/minimax-m2.yaml
@@ -16,6 +16,7 @@ model: minimaxai/minimax-m2
 params:
     - key: max_tokens
       maxValue: 196608
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/minimax/minimax-m2
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/minimax

--- a/providers/google-vertex/mistralai/codestral-2.yaml
+++ b/providers/google-vertex/mistralai/codestral-2.yaml
@@ -26,6 +26,7 @@ model: mistralai/codestral-2
 params:
     - key: max_tokens
       maxValue: 128000
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/mistral
     - https://docs.mistral.ai/models/codestral-25-08

--- a/providers/google-vertex/mistralai/mistral-small-2503.yaml
+++ b/providers/google-vertex/mistralai/mistral-small-2503.yaml
@@ -21,6 +21,7 @@ modalities:
         - text
 mode: chat
 model: mistralai/mistral-small-2503
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/mistral
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/mistral/mistral-small-3-1

--- a/providers/google-vertex/mongodb/voyage-3.5-lite.yaml
+++ b/providers/google-vertex/mongodb/voyage-3.5-lite.yaml
@@ -11,6 +11,7 @@ modalities:
         - embedding
 mode: embedding
 model: mongodb/voyage-3.5-lite
+provisioning: provisioned
 removeParams:
     - temperature
     - top_p
@@ -22,5 +23,6 @@ removeParams:
 sources:
     - https://docs.voyageai.com/docs/embeddings
     - https://docs.voyageai.com/docs/pricing
+status: active
 supportedModes:
     - embedding

--- a/providers/google-vertex/mongodb/voyage-4-large.yaml
+++ b/providers/google-vertex/mongodb/voyage-4-large.yaml
@@ -12,6 +12,7 @@ modalities:
         - embedding
 mode: embedding
 model: mongodb/voyage-4-large
+provisioning: provisioned
 removeParams:
     - max_tokens
     - temperature
@@ -23,6 +24,7 @@ removeParams:
 sources:
     - https://docs.voyageai.com/docs/embeddings
     - https://docs.voyageai.com/docs/pricing
+    - https://www.mongodb.com/docs/voyageai/management/gcp-marketplace/
 status: active
 supportedModes:
     - embedding

--- a/providers/google-vertex/mongodb/voyage-4-lite.yaml
+++ b/providers/google-vertex/mongodb/voyage-4-lite.yaml
@@ -8,6 +8,7 @@ modalities:
         - embedding
 mode: embedding
 model: mongodb/voyage-4-lite
+provisioning: provisioned
 removeParams:
     - temperature
     - top_p

--- a/providers/google-vertex/mongodb/voyage-4.yaml
+++ b/providers/google-vertex/mongodb/voyage-4.yaml
@@ -9,6 +9,7 @@ modalities:
         - embedding
 mode: embedding
 model: mongodb/voyage-4
+provisioning: provisioned
 removeParams:
     - max_tokens
     - temperature

--- a/providers/google-vertex/mongodb/voyage-multimodal-3.5.yaml
+++ b/providers/google-vertex/mongodb/voyage-multimodal-3.5.yaml
@@ -10,6 +10,7 @@ modalities:
         - embedding
 mode: embedding
 model: mongodb/voyage-multimodal-3.5
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature

--- a/providers/google-vertex/moonshotai/kimi-k2-5.yaml
+++ b/providers/google-vertex/moonshotai/kimi-k2-5.yaml
@@ -1,10 +1,10 @@
 features:
     - function_calling
-    - structured_output
     - json_output
+    - prompt_caching
+    - structured_output
     - system_messages
     - tool_choice
-    - prompt_caching
 limits:
     context_window: 262144
 modalities:
@@ -25,11 +25,14 @@ params:
       key: top_p
       maxValue: 0.95
       minValue: 0.95
+provisioning: serverless
 removeParams:
     - "n"
 sources:
-    - https://platform.moonshot.ai/docs/api/chat
-    - https://platform.moonshot.ai/docs/pricing/chat
+    - https://platform.kimi.ai/docs/api/chat
+    - https://platform.kimi.ai/docs/pricing/chat-k25
+    - https://platform.kimi.ai/docs/models
+    - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/kimi/kimi-k2-thinking
 status: active
 supportedModes:
     - chat

--- a/providers/google-vertex/moonshotai/kimi-k2-thinking-maas.yaml
+++ b/providers/google-vertex/moonshotai/kimi-k2-thinking-maas.yaml
@@ -26,6 +26,7 @@ params:
       key: max_tokens
       maxValue: 262144
       minValue: 1
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/kimi/kimi-k2-thinking
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/kimi

--- a/providers/google-vertex/moonshotai/kimi-k2.yaml
+++ b/providers/google-vertex/moonshotai/kimi-k2.yaml
@@ -1,3 +1,8 @@
+costs:
+    - cache_read_input_token_cost: 1.5e-7
+      input_cost_per_token: 6.e-7
+      output_cost_per_token: 0.0000025
+      region: global
 features:
     - function_calling
     - structured_output
@@ -18,9 +23,11 @@ model: moonshotai/kimi-k2
 params:
     - key: max_tokens
       maxValue: 262144
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/kimi/kimi-k2-thinking
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/kimi
+    - https://platform.kimi.ai/docs/pricing/chat-k2
 status: active
 supportedModes:
     - chat

--- a/providers/google-vertex/multimodalembedding@001.yaml
+++ b/providers/google-vertex/multimodalembedding@001.yaml
@@ -3,7 +3,42 @@ costs:
       input_cost_per_image: 0.0001
       input_cost_per_token: 8.e-7
       output_cost_per_token: 0
+      region: us-west4
+    - input_cost_per_character: 2.e-7
+      input_cost_per_image: 0.0001
+      input_cost_per_token: 8.e-7
+      output_cost_per_token: 0
+      region: us-west1
+    - input_cost_per_character: 2.e-7
+      input_cost_per_image: 0.0001
+      input_cost_per_token: 8.e-7
+      output_cost_per_token: 0
+      region: us-south1
+    - input_cost_per_character: 2.e-7
+      input_cost_per_image: 0.0001
+      input_cost_per_token: 8.e-7
+      output_cost_per_token: 0
+      region: us-east5
+    - input_cost_per_character: 2.e-7
+      input_cost_per_image: 0.0001
+      input_cost_per_token: 8.e-7
+      output_cost_per_token: 0
+      region: us-east4
+    - input_cost_per_character: 2.e-7
+      input_cost_per_image: 0.0001
+      input_cost_per_token: 8.e-7
+      output_cost_per_token: 0
+      region: us-east1
+    - input_cost_per_character: 2.e-7
+      input_cost_per_image: 0.0001
+      input_cost_per_token: 8.e-7
+      output_cost_per_token: 0
       region: us-central1
+    - input_cost_per_character: 2.e-7
+      input_cost_per_image: 0.0001
+      input_cost_per_token: 8.e-7
+      output_cost_per_token: 0
+      region: southamerica-east1
     - input_cost_per_character: 2.e-7
       input_cost_per_image: 0.0001
       input_cost_per_token: 8.e-7
@@ -13,7 +48,37 @@ costs:
       input_cost_per_image: 0.0001
       input_cost_per_token: 8.e-7
       output_cost_per_token: 0
+      region: me-west1
+    - input_cost_per_character: 2.e-7
+      input_cost_per_image: 0.0001
+      input_cost_per_token: 8.e-7
+      output_cost_per_token: 0
+      region: me-central2
+    - input_cost_per_character: 2.e-7
+      input_cost_per_image: 0.0001
+      input_cost_per_token: 8.e-7
+      output_cost_per_token: 0
+      region: me-central1
+    - input_cost_per_character: 2.e-7
+      input_cost_per_image: 0.0001
+      input_cost_per_token: 8.e-7
+      output_cost_per_token: 0
+      region: global
+    - input_cost_per_character: 2.e-7
+      input_cost_per_image: 0.0001
+      input_cost_per_token: 8.e-7
+      output_cost_per_token: 0
       region: europe-west9
+    - input_cost_per_character: 2.e-7
+      input_cost_per_image: 0.0001
+      input_cost_per_token: 8.e-7
+      output_cost_per_token: 0
+      region: europe-west8
+    - input_cost_per_character: 2.e-7
+      input_cost_per_image: 0.0001
+      input_cost_per_token: 8.e-7
+      output_cost_per_token: 0
+      region: europe-west6
     - input_cost_per_character: 2.e-7
       input_cost_per_image: 0.0001
       input_cost_per_token: 8.e-7
@@ -38,7 +103,32 @@ costs:
       input_cost_per_image: 0.0001
       input_cost_per_token: 8.e-7
       output_cost_per_token: 0
+      region: europe-southwest1
+    - input_cost_per_character: 2.e-7
+      input_cost_per_image: 0.0001
+      input_cost_per_token: 8.e-7
+      output_cost_per_token: 0
+      region: europe-north1
+    - input_cost_per_character: 2.e-7
+      input_cost_per_image: 0.0001
+      input_cost_per_token: 8.e-7
+      output_cost_per_token: 0
+      region: europe-central2
+    - input_cost_per_character: 2.e-7
+      input_cost_per_image: 0.0001
+      input_cost_per_token: 8.e-7
+      output_cost_per_token: 0
+      region: australia-southeast1
+    - input_cost_per_character: 2.e-7
+      input_cost_per_image: 0.0001
+      input_cost_per_token: 8.e-7
+      output_cost_per_token: 0
       region: asia-southeast1
+    - input_cost_per_character: 2.e-7
+      input_cost_per_image: 0.0001
+      input_cost_per_token: 8.e-7
+      output_cost_per_token: 0
+      region: asia-south1
     - input_cost_per_character: 2.e-7
       input_cost_per_image: 0.0001
       input_cost_per_token: 8.e-7
@@ -49,6 +139,16 @@ costs:
       input_cost_per_token: 8.e-7
       output_cost_per_token: 0
       region: asia-northeast1
+    - input_cost_per_character: 2.e-7
+      input_cost_per_image: 0.0001
+      input_cost_per_token: 8.e-7
+      output_cost_per_token: 0
+      region: asia-east2
+    - input_cost_per_character: 2.e-7
+      input_cost_per_image: 0.0001
+      input_cost_per_token: 8.e-7
+      output_cost_per_token: 0
+      region: asia-east1
 limits:
     max_input_tokens: 2048
     output_vector_size: 1408
@@ -61,6 +161,7 @@ modalities:
         - embedding
 mode: embedding
 model: multimodalembedding@001
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature
@@ -72,7 +173,7 @@ removeParams:
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/embeddings/get-multimodal-embeddings
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/model-reference/multimodal-embeddings-api
-    - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/locations
+    - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/locations-genai
 status: active
 supportedModes:
     - embedding

--- a/providers/google-vertex/nvidia/cosmos.yaml
+++ b/providers/google-vertex/nvidia/cosmos.yaml
@@ -7,6 +7,15 @@ modalities:
         - video
 mode: video
 model: nvidia/cosmos
+provisioning: serverless
+removeParams:
+    - max_tokens
+    - temperature
+    - top_p
+    - "n"
+    - stop
+    - stream
+    - tool_choice
 sources:
     - https://www.nvidia.com/en-us/ai/cosmos/
     - https://console.cloud.google.com/vertex-ai/publishers/nvidia/model-garden/cosmos

--- a/providers/google-vertex/nvidia/nemotron-3-super.yaml
+++ b/providers/google-vertex/nvidia/nemotron-3-super.yaml
@@ -1,3 +1,5 @@
+limits:
+    context_window: 1000000
 modalities:
     input:
         - text
@@ -5,6 +7,7 @@ modalities:
         - text
 mode: chat
 model: nvidia/nemotron-3-super
+provisioning: provisioned
 sources:
     - https://research.nvidia.com/labs/nemotron/Nemotron-3-Super/
     - https://console.cloud.google.com/vertex-ai/publishers/nvidia/model-garden/nemotron-3-super

--- a/providers/google-vertex/nvidia/nemotron-nano-12b-v2-vl.yaml
+++ b/providers/google-vertex/nvidia/nemotron-nano-12b-v2-vl.yaml
@@ -1,8 +1,10 @@
+features:
+    - system_messages
 limits:
     context_window: 128000
     max_input_tokens: 128000
-    max_output_tokens: 128000
-    max_tokens: 128000
+    max_output_tokens: 8192
+    max_tokens: 8192
 modalities:
     input:
         - text
@@ -12,8 +14,19 @@ modalities:
         - text
 mode: chat
 model: nvidia/nemotron-nano-12b-v2-vl
+params:
+    - defaultValue: 256
+      key: max_tokens
+      maxValue: 8192
+      minValue: 1
+provisioning: provisioned
+removeParams:
+    - tool_choice
+    - "n"
 sources:
     - https://build.nvidia.com/nvidia/nemotron-nano-12b-v2-vl/modelcard
+    - https://docs.api.nvidia.com/nim/reference/nvidia-nemotron-nano-12b-v2-vl-infer
 status: active
 supportedModes:
     - chat
+thinking: true

--- a/providers/google-vertex/nvidia/nemotron-v3-super-120b.yaml
+++ b/providers/google-vertex/nvidia/nemotron-v3-super-120b.yaml
@@ -1,3 +1,5 @@
+features:
+    - function_calling
 limits:
     context_window: 1000000
     max_input_tokens: 1000000
@@ -18,6 +20,7 @@ params:
     - defaultValue: 32768
       key: max_tokens
       maxValue: 32768
+provisioning: provisioned
 sources:
     - https://docs.api.nvidia.com/nim/reference/nvidia-nemotron-3-super-120b-a12b
     - https://research.nvidia.com/labs/nemotron/Nemotron-3-Super/

--- a/providers/google-vertex/nvidia/nemotron-v3.yaml
+++ b/providers/google-vertex/nvidia/nemotron-v3.yaml
@@ -2,6 +2,8 @@ features:
     - function_calling
     - system_messages
     - tool_choice
+limits:
+    context_window: 1000000
 modalities:
     input:
         - text
@@ -9,9 +11,11 @@ modalities:
         - text
 mode: chat
 model: nvidia/nemotron-v3
+provisioning: provisioned
 sources:
     - https://developer.nvidia.com/nemotron
     - https://developer.nvidia.com/blog/introducing-nemotron-3-super-an-open-hybrid-mamba-transformer-moe-for-agentic-reasoning/
+status: active
 supportedModes:
     - chat
 thinking: true

--- a/providers/google-vertex/openai/clip-vit-base-patch32.yaml
+++ b/providers/google-vertex/openai/clip-vit-base-patch32.yaml
@@ -1,3 +1,6 @@
+limits:
+    max_input_tokens: 77
+    output_vector_size: 512
 modalities:
     input:
         - text
@@ -6,6 +9,7 @@ modalities:
         - embedding
 mode: embedding
 model: openai/clip-vit-base-patch32
+provisioning: provisioned
 removeParams:
     - temperature
     - top_p
@@ -14,6 +18,9 @@ removeParams:
     - stream
     - tool_choice
     - max_tokens
+sources:
+    - https://huggingface.co/openai/clip-vit-base-patch32/blob/main/config.json
+    - https://github.com/openai/CLIP
 status: active
 supportedModes:
     - embedding

--- a/providers/google-vertex/openai/gpt-oss-120b-maas.yaml
+++ b/providers/google-vertex/openai/gpt-oss-120b-maas.yaml
@@ -30,6 +30,7 @@ params:
       key: max_tokens
       maxValue: 131072
       minValue: 1
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/openai/gpt-oss-120b
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/openai

--- a/providers/google-vertex/openai/gpt-oss.yaml
+++ b/providers/google-vertex/openai/gpt-oss.yaml
@@ -8,8 +8,10 @@ modalities:
         - text
 mode: chat
 model: openai/gpt-oss
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/openai/gpt-oss-120b
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/openai/gpt-oss-20b
+status: active
 supportedModes:
     - chat

--- a/providers/google-vertex/openai/openclip.yaml
+++ b/providers/google-vertex/openai/openclip.yaml
@@ -9,6 +9,7 @@ modalities:
         - embedding
 mode: embedding
 model: openai/openclip
+provisioning: provisioned
 removeParams:
     - max_tokens
     - temperature
@@ -17,5 +18,6 @@ removeParams:
     - stop
     - stream
     - tool_choice
+status: preview
 supportedModes:
     - embedding

--- a/providers/google-vertex/openai/whisper-large.yaml
+++ b/providers/google-vertex/openai/whisper-large.yaml
@@ -5,6 +5,7 @@ modalities:
         - text
 mode: audio_transcription
 model: openai/whisper-large
+provisioning: provisioned
 removeParams:
     - temperature
     - top_p
@@ -13,5 +14,6 @@ removeParams:
     - stream
     - tool_choice
     - max_tokens
+status: active
 supportedModes:
     - audio_transcription

--- a/providers/google-vertex/openlm-research/openllama.yaml
+++ b/providers/google-vertex/openlm-research/openllama.yaml
@@ -5,6 +5,7 @@ modalities:
         - text
 mode: completion
 model: openlm-research/openllama
+provisioning: serverless
 removeParams:
     - tool_choice
 supportedModes:

--- a/providers/google-vertex/qodo/qodo-embed-1-7b-v1.yaml
+++ b/providers/google-vertex/qodo/qodo-embed-1-7b-v1.yaml
@@ -9,6 +9,7 @@ modalities:
         - embedding
 mode: embedding
 model: qodo/qodo-embed-1-7b-v1
+provisioning: serverless
 removeParams:
     - temperature
     - top_p
@@ -19,5 +20,6 @@ removeParams:
     - max_tokens
 sources:
     - https://huggingface.co/Qodo/Qodo-Embed-1-7B
+status: active
 supportedModes:
     - embedding

--- a/providers/google-vertex/qwen/qwen2.yaml
+++ b/providers/google-vertex/qwen/qwen2.yaml
@@ -1,7 +1,7 @@
 features:
-    - system_messages
     - function_calling
     - json_output
+    - system_messages
 limits:
     context_window: 32768
 modalities:
@@ -11,6 +11,7 @@ modalities:
         - text
 mode: chat
 model: qwen/qwen2
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/qwen
     - https://console.cloud.google.com/vertex-ai/publishers/qwen/model-garden/qwen2

--- a/providers/google-vertex/qwen/qwen3-235b-a22b-instruct-2507-maas.yaml
+++ b/providers/google-vertex/qwen/qwen3-235b-a22b-instruct-2507-maas.yaml
@@ -25,8 +25,10 @@ modalities:
         - text
 mode: chat
 model: qwen/qwen3-235b-a22b-instruct-2507-maas
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/qwen/qwen3-235b
 status: active
 supportedModes:
     - chat
+thinking: true

--- a/providers/google-vertex/qwen/qwen3-5.yaml
+++ b/providers/google-vertex/qwen/qwen3-5.yaml
@@ -10,9 +10,10 @@ modalities:
         - text
 mode: chat
 model: qwen/qwen3-5
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/qwen
-    - https://cloud.google.com/vertex-ai/generative-ai/pricing
+status: active
 supportedModes:
     - chat
 thinking: true

--- a/providers/google-vertex/qwen/qwen3-coder-480b-a35b-instruct-maas.yaml
+++ b/providers/google-vertex/qwen/qwen3-coder-480b-a35b-instruct-maas.yaml
@@ -35,6 +35,7 @@ params:
       key: max_tokens
       maxValue: 65536
       minValue: 1
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/qwen/qwen3-coder
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/use-open-models

--- a/providers/google-vertex/qwen/qwen3-coder-next.yaml
+++ b/providers/google-vertex/qwen/qwen3-coder-next.yaml
@@ -11,15 +11,20 @@ limits:
 modalities:
     input:
         - text
+        - code
     output:
         - text
+        - code
 mode: chat
 model: qwen/qwen3-coder-next
+params:
+    - key: max_tokens
+      maxValue: 65536
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/qwen
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/qwen/qwen3-coder
     - https://openrouter.ai/qwen/qwen3-coder-next/api
-    - https://qwenlm.github.io/blog/qwen3-coder/
 status: active
 supportedModes:
     - chat

--- a/providers/google-vertex/qwen/qwen3-embedding.yaml
+++ b/providers/google-vertex/qwen/qwen3-embedding.yaml
@@ -13,5 +13,10 @@ removeParams:
     - stop
     - stream
     - tool_choice
+sources:
+    - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/qwen
+    - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/use-open-models
+    - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/embeddings/get-text-embeddings
+status: active
 supportedModes:
     - embedding

--- a/providers/google-vertex/qwen/qwen3-next-80b-a3b-instruct-maas.yaml
+++ b/providers/google-vertex/qwen/qwen3-next-80b-a3b-instruct-maas.yaml
@@ -23,6 +23,7 @@ model: qwen/qwen3-next-80b-a3b-instruct-maas
 params:
     - key: max_tokens
       maxValue: 262144
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/qwen/qwen3-next-instruct
 status: active

--- a/providers/google-vertex/qwen/qwen3-next-80b-a3b-thinking-maas.yaml
+++ b/providers/google-vertex/qwen/qwen3-next-80b-a3b-thinking-maas.yaml
@@ -25,6 +25,7 @@ params:
       key: max_tokens
       maxValue: 262144
       minValue: 1
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/qwen/qwen3-next-thinking
 status: active

--- a/providers/google-vertex/qwen/qwen3-vl.yaml
+++ b/providers/google-vertex/qwen/qwen3-vl.yaml
@@ -11,6 +11,7 @@ modalities:
         - text
 mode: chat
 model: qwen/qwen3-vl
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/qwen
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/models

--- a/providers/google-vertex/qwen/qwen3.yaml
+++ b/providers/google-vertex/qwen/qwen3.yaml
@@ -1,9 +1,9 @@
 features:
     - function_calling
+    - json_output
     - structured_output
     - system_messages
     - tool_choice
-    - json_output
 limits:
     context_window: 262144
     max_input_tokens: 262144
@@ -19,6 +19,7 @@ model: qwen/qwen3
 params:
     - key: max_tokens
       maxValue: 16384
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/qwen
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/qwen/qwen3-235b

--- a/providers/google-vertex/runwayml/stable-diffusion-inpainting.yaml
+++ b/providers/google-vertex/runwayml/stable-diffusion-inpainting.yaml
@@ -6,6 +6,7 @@ modalities:
         - image
 mode: image
 model: runwayml/stable-diffusion-inpainting
+provisioning: provisioned
 removeParams:
     - max_tokens
     - temperature
@@ -14,5 +15,6 @@ removeParams:
     - stop
     - stream
     - tool_choice
+status: active
 supportedModes:
     - image

--- a/providers/google-vertex/salesforce/blip-image-captioning-base.yaml
+++ b/providers/google-vertex/salesforce/blip-image-captioning-base.yaml
@@ -6,6 +6,7 @@ modalities:
         - text
 mode: chat
 model: salesforce/blip-image-captioning-base
+provisioning: provisioned
 removeParams:
     - tool_choice
     - "n"

--- a/providers/google-vertex/salesforce/blip-vqa-base.yaml
+++ b/providers/google-vertex/salesforce/blip-vqa-base.yaml
@@ -6,6 +6,10 @@ modalities:
         - text
 mode: chat
 model: salesforce/blip-vqa-base
+provisioning: provisioned
+removeParams:
+    - tool_choice
+    - "n"
 sources:
     - https://huggingface.co/Salesforce/blip-vqa-base
 status: active

--- a/providers/google-vertex/salesforce/blip2-opt-2.7-b.yaml
+++ b/providers/google-vertex/salesforce/blip2-opt-2.7-b.yaml
@@ -6,6 +6,7 @@ modalities:
         - text
 mode: chat
 model: salesforce/blip2-opt-2.7-b
+provisioning: provisioned
 removeParams:
     - "n"
     - tool_choice

--- a/providers/google-vertex/sesame/csm.yaml
+++ b/providers/google-vertex/sesame/csm.yaml
@@ -6,9 +6,11 @@ modalities:
         - audio
 mode: text_to_speech
 model: sesame/csm
+provisioning: provisioned
 removeParams:
     - tool_choice
 sources:
     - https://huggingface.co/sesame/csm-1b
+status: active
 supportedModes:
     - text_to_speech

--- a/providers/google-vertex/stability-ai/stable-diffusion-2-1.yaml
+++ b/providers/google-vertex/stability-ai/stable-diffusion-2-1.yaml
@@ -4,10 +4,12 @@ messages:
 modalities:
     input:
         - text
+        - image
     output:
         - image
 mode: image
 model: stability-ai/stable-diffusion-2-1
+provisioning: provisioned
 removeParams:
     - max_tokens
     - temperature
@@ -16,5 +18,6 @@ removeParams:
     - stop
     - stream
     - tool_choice
+status: active
 supportedModes:
     - image

--- a/providers/google-vertex/stability-ai/stable-diffusion-4x-upscaler.yaml
+++ b/providers/google-vertex/stability-ai/stable-diffusion-4x-upscaler.yaml
@@ -6,6 +6,7 @@ modalities:
         - image
 mode: image
 model: stability-ai/stable-diffusion-4x-upscaler
+provisioning: provisioned
 removeParams:
     - temperature
     - top_p

--- a/providers/google-vertex/stability-ai/stable-diffusion-xl-base.yaml
+++ b/providers/google-vertex/stability-ai/stable-diffusion-xl-base.yaml
@@ -5,6 +5,7 @@ modalities:
         - image
 mode: image
 model: stability-ai/stable-diffusion-xl-base
+provisioning: provisioned
 removeParams:
     - temperature
     - top_p

--- a/providers/google-vertex/stability-ai/stable-diffusion-xl-lcm.yaml
+++ b/providers/google-vertex/stability-ai/stable-diffusion-xl-lcm.yaml
@@ -5,6 +5,7 @@ modalities:
         - image
 mode: image
 model: stability-ai/stable-diffusion-xl-lcm
+provisioning: provisioned
 removeParams:
     - temperature
     - top_p
@@ -13,5 +14,6 @@ removeParams:
     - stream
     - tool_choice
     - max_tokens
+status: active
 supportedModes:
     - image

--- a/providers/google-vertex/text-embedding-004.yaml
+++ b/providers/google-vertex/text-embedding-004.yaml
@@ -2,7 +2,7 @@ costs:
     - input_cost_per_character: 2.5e-8
       input_cost_per_token: 1.e-7
       output_cost_per_token: 0
-      region: "*"
+      region: global
 deprecationDate: "2027-04-01"
 limits:
     max_input_tokens: 2048
@@ -14,6 +14,7 @@ modalities:
         - embedding
 mode: embedding
 model: text-embedding-004
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature

--- a/providers/google-vertex/text-embedding-005.yaml
+++ b/providers/google-vertex/text-embedding-005.yaml
@@ -14,6 +14,7 @@ modalities:
         - embedding
 mode: embedding
 model: text-embedding-005
+provisioning: serverless
 removeParams:
     - temperature
     - top_p

--- a/providers/google-vertex/text-multilingual-embedding-002.yaml
+++ b/providers/google-vertex/text-multilingual-embedding-002.yaml
@@ -2,16 +2,16 @@ costs:
     - input_cost_per_character: 2.5e-8
       input_cost_per_token: 1.e-7
       output_cost_per_token: 0
-      region: "*"
+      region: global
 limits:
     max_input_tokens: 2048
-    max_tokens: 4096
     output_vector_size: 768
 modalities:
     input:
         - text
 mode: embedding
 model: text-multilingual-embedding-002
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature
@@ -23,7 +23,6 @@ removeParams:
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/embeddings/get-text-embeddings
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/model-reference/text-embeddings-api
-    - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/locations
 status: active
 supportedModes:
     - embedding

--- a/providers/google-vertex/thudm/cogvideox.yaml
+++ b/providers/google-vertex/thudm/cogvideox.yaml
@@ -5,6 +5,15 @@ modalities:
         - video
 mode: video
 model: thudm/cogvideox
+provisioning: provisioned
+removeParams:
+    - max_tokens
+    - temperature
+    - top_p
+    - "n"
+    - stop
+    - stream
+    - tool_choice
 status: active
 supportedModes:
     - video

--- a/providers/google-vertex/tiiuae/falcon-instruct-7b-peft.yaml
+++ b/providers/google-vertex/tiiuae/falcon-instruct-7b-peft.yaml
@@ -5,5 +5,6 @@ modalities:
         - text
 mode: chat
 model: tiiuae/falcon-instruct-7b-peft
+provisioning: provisioned
 supportedModes:
     - chat

--- a/providers/google-vertex/timbrooks/instruct-pix2pix.yaml
+++ b/providers/google-vertex/timbrooks/instruct-pix2pix.yaml
@@ -6,11 +6,13 @@ modalities:
         - image
 mode: image
 model: timbrooks/instruct-pix2pix
+provisioning: serverless
 removeParams:
     - tool_choice
     - stop
     - "n"
 sources:
     - https://console.cloud.google.com/vertex-ai/publishers/timbrooks/model-garden/instruct-pix2pix
+status: active
 supportedModes:
     - image

--- a/providers/google-vertex/virtueai/virtueguard-text-lite.yaml
+++ b/providers/google-vertex/virtueai/virtueguard-text-lite.yaml
@@ -5,5 +5,9 @@ modalities:
         - text
 mode: moderation
 model: virtueai/virtueguard-text-lite
+provisioning: provisioned
+sources:
+    - https://www.virtueai.com/virtueguard
+status: active
 supportedModes:
     - moderation

--- a/providers/google-vertex/wan-ai/wan2-1.yaml
+++ b/providers/google-vertex/wan-ai/wan2-1.yaml
@@ -1,10 +1,12 @@
 modalities:
     input:
         - text
+        - image
     output:
         - video
 mode: video
 model: wan-ai/wan2-1
+provisioning: provisioned
 removeParams:
     - max_tokens
     - temperature

--- a/providers/google-vertex/wan-ai/wan2-2.yaml
+++ b/providers/google-vertex/wan-ai/wan2-2.yaml
@@ -6,6 +6,17 @@ modalities:
         - video
 mode: video
 model: wan-ai/wan2-2
+provisioning: provisioned
+removeParams:
+    - max_tokens
+    - temperature
+    - top_p
+    - "n"
+    - stop
+    - stream
+    - tool_choice
+sources:
+    - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/release-notes
 status: active
 supportedModes:
     - video

--- a/providers/google-vertex/writer/palmyra-x4.yaml
+++ b/providers/google-vertex/writer/palmyra-x4.yaml
@@ -12,6 +12,7 @@ modalities:
         - text
 mode: chat
 model: writer/palmyra-x4
+provisioning: provisioned
 sources:
     - https://dev.writer.com/home/models
     - https://dev.writer.com/api-guides/models

--- a/providers/google-vertex/zai-org/glm-4.5.yaml
+++ b/providers/google-vertex/zai-org/glm-4.5.yaml
@@ -8,6 +8,7 @@ modalities:
         - text
 mode: chat
 model: zai-org/glm-4.5
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/zaiorg
 status: active

--- a/providers/google-vertex/zai-org/glm-4.7-maas.yaml
+++ b/providers/google-vertex/zai-org/glm-4.7-maas.yaml
@@ -24,6 +24,7 @@ model: zai-org/glm-4.7-maas
 params:
     - key: max_tokens
       maxValue: 128000
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/zaiorg/glm-47
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/zaiorg

--- a/providers/google-vertex/zai-org/glm-4.7.yaml
+++ b/providers/google-vertex/zai-org/glm-4.7.yaml
@@ -20,10 +20,9 @@ model: zai-org/glm-4.7
 params:
     - key: max_tokens
       maxValue: 128000
-provisioning: provisioned
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/zaiorg/glm-47
-    - https://cloud.google.com/vertex-ai/generative-ai/pricing#glm-models
 status: active
 supportedModes:
     - chat

--- a/providers/google-vertex/zai-org/glm-5-maas.yaml
+++ b/providers/google-vertex/zai-org/glm-5-maas.yaml
@@ -5,6 +5,7 @@ costs:
       region: global
 features:
     - function_calling
+    - json_output
     - prompt_caching
     - structured_output
     - system_messages
@@ -24,10 +25,12 @@ model: zai-org/glm-5-maas
 params:
     - key: max_tokens
       maxValue: 128000
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/zaiorg/glm-5
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/capabilities/thinking
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/zaiorg
+    - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/capabilities/structured-output
 status: active
 supportedModes:
     - chat

--- a/providers/google-vertex/zai-org/glm-5.yaml
+++ b/providers/google-vertex/zai-org/glm-5.yaml
@@ -16,10 +16,10 @@ model: zai-org/glm-5
 params:
     - key: max_tokens
       maxValue: 128000
-provisioning: provisioned
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/zaiorg/glm-5
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/zaiorg
-status: active
+status: preview
 supportedModes:
     - chat

--- a/providers/google-vertex/zai-org/glm-image.yaml
+++ b/providers/google-vertex/zai-org/glm-image.yaml
@@ -5,5 +5,15 @@ modalities:
         - image
 mode: image
 model: zai-org/glm-image
+removeParams:
+    - max_tokens
+    - temperature
+    - top_p
+    - "n"
+    - stop
+    - stream
+    - tool_choice
+sources:
+    - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/zaiorg
 supportedModes:
     - image

--- a/providers/google-vertex/zai-org/glm-ocr.yaml
+++ b/providers/google-vertex/zai-org/glm-ocr.yaml
@@ -10,7 +10,9 @@ modalities:
         - text
 mode: chat
 model: zai-org/glm-ocr
+provisioning: serverless
 sources:
     - https://huggingface.co/zai-org/glm-ocr
+    - https://docs.z.ai/guides/vlm/glm-ocr
 supportedModes:
     - chat


### PR DESCRIPTION
Auto-generated by poc-agent for provider `google-vertex`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches a large number of `providers/google-vertex` model definitions, which could affect model selection, routing (via `provisioning`), and cost/limit calculations if consumers rely on these fields.
> 
> **Overview**
> Updates the Google Vertex model YAML catalog with **normalized metadata across many models**, including adding `provisioning` (`serverless` vs `provisioned`), filling in/adjusting `status`, `supportedModes`, `sources`, and expanding `removeParams` where appropriate.
> 
> Refreshes model capability and billing metadata by adding/adjusting `features`, `limits` (notably some `max_tokens`/context window changes such as `claude-sonnet-4-6@default` to 128k output), and large region-specific `costs` tables for several Gemini/Claude/Veo/embedding and vision models; also marks some models as deprecated via `status`, `isDeprecated`, and `deprecationDate`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 476bb7fdecb892ad6038365b38f30930a2d2ae72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->