### PR TITLE
feat(groq): update model YAMLs [bot]

### DIFF
--- a/providers/groq/allam-2-7b.yaml
+++ b/providers/groq/allam-2-7b.yaml
@@ -12,6 +12,7 @@ modalities:
         - text
 mode: chat
 model: allam-2-7b
+provisioning: serverless
 sources:
     - https://console.groq.com/docs/model/allam-2-7b
 supportedModes:

--- a/providers/groq/canopylabs/orpheus-arabic-saudi.yaml
+++ b/providers/groq/canopylabs/orpheus-arabic-saudi.yaml
@@ -6,10 +6,13 @@ limits:
     max_output_tokens: 50000
     max_tokens: 50000
 modalities:
+    input:
+        - text
     output:
         - audio
 mode: text_to_speech
 model: canopylabs/orpheus-arabic-saudi
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature

--- a/providers/groq/canopylabs/orpheus-v1-english.yaml
+++ b/providers/groq/canopylabs/orpheus-v1-english.yaml
@@ -12,6 +12,7 @@ modalities:
         - audio
 mode: text_to_speech
 model: canopylabs/orpheus-v1-english
+provisioning: serverless
 removeParams:
     - max_tokens
     - temperature

--- a/providers/groq/groq/compound-mini.yaml
+++ b/providers/groq/groq/compound-mini.yaml
@@ -15,6 +15,7 @@ model: groq/compound-mini
 params:
     - key: max_tokens
       maxValue: 8192
+provisioning: serverless
 sources:
     - https://console.groq.com/docs/compound
 status: active

--- a/providers/groq/groq/compound.yaml
+++ b/providers/groq/groq/compound.yaml
@@ -17,6 +17,7 @@ params:
       key: max_tokens
       maxValue: 8192
       minValue: 1
+provisioning: serverless
 removeParams:
     - stop
 sources:

--- a/providers/groq/llama-3.1-8b-instant.yaml
+++ b/providers/groq/llama-3.1-8b-instant.yaml
@@ -27,8 +27,10 @@ params:
     - defaultValue: null
       key: response_format
       type: string
+provisioning: serverless
 sources:
     - https://console.groq.com/docs/tool-use
+    - https://console.groq.com/docs/api-reference#chat-create
 status: active
 supportedModes:
     - chat

--- a/providers/groq/llama-3.3-70b-versatile.yaml
+++ b/providers/groq/llama-3.3-70b-versatile.yaml
@@ -30,6 +30,7 @@ params:
     - defaultValue: null
       key: response_format
       type: string
+provisioning: serverless
 sources:
     - https://console.groq.com/docs/tool-use
     - https://console.groq.com/docs/structured-outputs

--- a/providers/groq/meta-llama/llama-4-scout-17b-16e-instruct.yaml
+++ b/providers/groq/meta-llama/llama-4-scout-17b-16e-instruct.yaml
@@ -28,12 +28,15 @@ params:
       key: max_tokens
       maxValue: 8192
       minValue: 1
+provisioning: serverless
 sources:
     - https://console.groq.com/docs/tool-use
     - https://console.groq.com/docs/vision
     - https://console.groq.com/docs/structured-outputs
     - https://console.groq.com/docs/batch
     - https://console.groq.com/docs/api-reference#chat-create
+    - https://console.groq.com/docs/prompt-caching
+    - https://console.groq.com/docs/reasoning
 status: preview
 supportedModes:
     - chat

--- a/providers/groq/meta-llama/llama-prompt-guard-2-86m.yaml
+++ b/providers/groq/meta-llama/llama-prompt-guard-2-86m.yaml
@@ -18,6 +18,7 @@ params:
       key: max_tokens
       maxValue: 512
       minValue: 1
+provisioning: serverless
 status: preview
 supportedModes:
     - moderation

--- a/providers/groq/openai/gpt-oss-120b.yaml
+++ b/providers/groq/openai/gpt-oss-120b.yaml
@@ -5,7 +5,6 @@ costs:
       region: "*"
 features:
     - function_calling
-    - parallel_function_calling
     - tool_choice
     - structured_output
     - prompt_caching
@@ -29,8 +28,10 @@ params:
       maxValue: 65536
       minValue: 1
     - key: reasoning_effort
+provisioning: serverless
 sources:
     - https://console.groq.com/docs/model/openai/gpt-oss-120b
+status: active
 supportedModes:
     - chat
 thinking: true

--- a/providers/groq/openai/gpt-oss-20b.yaml
+++ b/providers/groq/openai/gpt-oss-20b.yaml
@@ -24,9 +24,11 @@ model: openai/gpt-oss-20b
 params:
     - key: max_tokens
       maxValue: 65536
+provisioning: serverless
 sources:
     - https://console.groq.com/docs/tool-use
     - https://console.groq.com/docs/structured-outputs
+    - https://console.groq.com/docs/prompt-caching
 status: active
 supportedModes:
     - chat

--- a/providers/groq/openai/gpt-oss-safeguard-20b.yaml
+++ b/providers/groq/openai/gpt-oss-safeguard-20b.yaml
@@ -26,6 +26,7 @@ params:
       key: max_tokens
       maxValue: 65536
       minValue: 1
+provisioning: serverless
 sources:
     - https://console.groq.com/docs/model/openai/gpt-oss-safeguard-20b
 status: preview

--- a/providers/groq/qwen/qwen3-32b.yaml
+++ b/providers/groq/qwen/qwen3-32b.yaml
@@ -24,6 +24,7 @@ params:
       minValue: 1
     - defaultValue: default
       key: reasoning_effort
+provisioning: serverless
 sources:
     - https://console.groq.com/docs/model/qwen/qwen3-32b
     - https://console.groq.com/docs/reasoning

--- a/providers/groq/whisper-large-v3-turbo.yaml
+++ b/providers/groq/whisper-large-v3-turbo.yaml
@@ -13,6 +13,7 @@ modalities:
         - text
 mode: audio_transcription
 model: whisper-large-v3-turbo
+provisioning: serverless
 removeParams:
     - max_tokens
     - top_p

--- a/providers/groq/whisper-large-v3.yaml
+++ b/providers/groq/whisper-large-v3.yaml
@@ -18,6 +18,7 @@ params:
       key: temperature
       maxValue: 1
       minValue: 0
+provisioning: serverless
 removeParams:
     - max_tokens
     - top_p
@@ -27,5 +28,5 @@ sources:
     - https://console.groq.com/docs/speech-to-text
 status: active
 supportedModes:
-    - audio_translation
     - audio_transcription
+    - audio_translation


### PR DESCRIPTION
Auto-generated by poc-agent for provider `groq`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only updates, but they may change how the model catalog is interpreted (e.g., provisioning type, supported modes, and enabled features).
> 
> **Overview**
> Updates Groq provider model definitions to consistently include `provisioning: serverless` across chat, TTS, transcription, and moderation models.
> 
> Refreshes a few model metadata details: adds missing `modalities.input` for `canopylabs/orpheus-arabic-saudi`, adds/updates Groq documentation `sources` for several models, marks `openai/gpt-oss-120b` as `status: active` while dropping `parallel_function_calling`, and ensures `whisper-large-v3` lists `audio_translation` in `supportedModes`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0744a3130a54602a2d5cd6a0cce544732414a8f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->