### PR TITLE
feat(sambanova): update model YAMLs [bot]

### DIFF
--- a/providers/sambanova/DeepSeek-V3.1-cb.yaml
+++ b/providers/sambanova/DeepSeek-V3.1-cb.yaml
@@ -24,7 +24,9 @@ modalities:
         - text
 mode: chat
 model: DeepSeek-V3.1-cb
+provisioning: serverless
 sources:
     - https://docs.sambanova.ai/docs/api-reference/chat-completions/create-chat-based-completion
+status: active
 supportedModes:
     - chat

--- a/providers/sambanova/DeepSeek-V3.1.yaml
+++ b/providers/sambanova/DeepSeek-V3.1.yaml
@@ -17,9 +17,12 @@ modalities:
         - text
 mode: chat
 model: DeepSeek-V3.1
+provisioning: serverless
 sources:
     - https://sambanova.ai/blog/deepseek-v3.1-is-live-on-sambacloud
     - https://docs.sambanova.ai/docs/en/features/function-calling
+    - https://docs.sambanova.ai/docs/en/build/reasoning
+    - https://docs.sambanova.ai/docs/api-reference/chat-completions/create-chat-based-completion
 status: active
 supportedModes:
     - chat

--- a/providers/sambanova/DeepSeek-V3.2.yaml
+++ b/providers/sambanova/DeepSeek-V3.2.yaml
@@ -22,6 +22,7 @@ modalities:
         - text
 mode: chat
 model: DeepSeek-V3.2
+provisioning: serverless
 sources:
     - https://docs.sambanova.ai/docs/en/features/function-calling
 status: preview

--- a/providers/sambanova/Llama-4-Maverick-17B-128E-Instruct.yaml
+++ b/providers/sambanova/Llama-4-Maverick-17B-128E-Instruct.yaml
@@ -9,8 +9,6 @@ features:
     - json_output
 limits:
     context_window: 128000
-    max_output_tokens: 4096
-    max_tokens: 4096
 modalities:
     input:
         - text
@@ -19,6 +17,7 @@ modalities:
         - text
 mode: chat
 model: Llama-4-Maverick-17B-128E-Instruct
+provisioning: serverless
 sources:
     - https://docs.sambanova.ai/docs/en/features/function-calling
     - https://docs.sambanova.ai/docs/en/features/vision

--- a/providers/sambanova/Meta-Llama-3.3-70B-Instruct.yaml
+++ b/providers/sambanova/Meta-Llama-3.3-70B-Instruct.yaml
@@ -16,9 +16,9 @@ modalities:
         - text
 mode: chat
 model: Meta-Llama-3.3-70B-Instruct
+provisioning: serverless
 sources:
     - https://docs.sambanova.ai/docs/en/features/function-calling
-    - https://community.sambanova.ai/t/context-lengths-up-to-128k-for-meta-llama-3-3-70b-instruct-now-available/950
 status: active
 supportedModes:
     - chat

--- a/providers/sambanova/MiniMax-M2.5.yaml
+++ b/providers/sambanova/MiniMax-M2.5.yaml
@@ -7,6 +7,7 @@ features:
     - tool_choice
     - system_messages
     - json_output
+    - structured_output
 limits:
     context_window: 160000
 modalities:
@@ -16,9 +17,11 @@ modalities:
         - text
 mode: chat
 model: MiniMax-M2.5
+provisioning: serverless
 sources:
     - https://cloud.sambanova.ai/playground?model=MiniMax-M2.5
     - https://docs.sambanova.ai/docs/en/features/function-calling
+    - https://sambanova-systems.mintlify.dev/docs/api-reference/chat-completions/create-chat-based-completion.md
 status: active
 supportedModes:
     - chat

--- a/providers/sambanova/Whisper-Large-v3.yaml
+++ b/providers/sambanova/Whisper-Large-v3.yaml
@@ -1,6 +1,8 @@
 costs:
     - input_cost_per_second: 0.00002778
       region: "*"
+deprecationDate: "2026-03-09"
+isDeprecated: true
 modalities:
     input:
         - audio

--- a/providers/sambanova/gpt-oss-120b.yaml
+++ b/providers/sambanova/gpt-oss-120b.yaml
@@ -7,14 +7,20 @@ features:
     - tool_choice
 limits:
     context_window: 128000
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: chat
 model: gpt-oss-120b
 params:
     - key: reasoning_effort
       type: string
+provisioning: serverless
 sources:
-    - https://sambanova.ai/blog/start-building-with-lightning-fast-gpt-oss-120b-on-sambacloud
-status: preview
+    - https://docs.sambanova.ai/docs/en/features/function-calling
+status: active
 supportedModes:
     - chat
 thinking: true


### PR DESCRIPTION
Auto-generated by poc-agent for provider `sambanova`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates model registry YAMLs (provisioning/status/features/limits) that may change which SambaNova models are exposed as active/preview and how they’re provisioned. Also marks `Whisper-Large-v3` deprecated with a date, which could affect downstream selection/availability logic if consumed automatically.
> 
> **Overview**
> Refreshes SambaNova provider model YAML metadata by standardizing `provisioning: serverless` across several chat models and updating documentation `sources` links.
> 
> Adjusts model lifecycle/config flags: promotes `gpt-oss-120b` to `status: active` and adds explicit `modalities`, adds `structured_output` support for `MiniMax-M2.5`, removes `max_tokens`/`max_output_tokens` limits from `Llama-4-Maverick-17B-128E-Instruct`, and marks `Whisper-Large-v3` as deprecated with a `deprecationDate`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62c2b568c98c792d83d1eb8119762d4b1d21284d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->