### PR TITLE
feat(google-gemini): update model YAMLs [bot]

### DIFF
--- a/providers/google-gemini/deep-research-pro-preview-12-2025.yaml
+++ b/providers/google-gemini/deep-research-pro-preview-12-2025.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       cache_storage_cost_per_token_per_hour: 0.0000045
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
@@ -8,7 +8,7 @@ costs:
       region: "*"
       tiered_pricing:
           cache_read:
-              - cost_per_token: 4.e-7
+              - cost_per_token: 4e-7
                 from: 200000
           input:
               - cost_per_token: 0.000004

--- a/providers/google-gemini/gemini-1.5-flash-001.yaml
+++ b/providers/google-gemini/gemini-1.5-flash-001.yaml
@@ -2,14 +2,14 @@ costs:
     - cache_creation_input_token_cost: 0.000001
       cache_read_input_token_cost: 1.875e-8
       input_cost_per_token: 7.5e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       region: "*"
       tiered_pricing:
           input:
               - cost_per_token: 1.5e-7
                 from: 128000
           output:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 128000
 features:
     - function_calling

--- a/providers/google-gemini/gemini-1.5-flash-002.yaml
+++ b/providers/google-gemini/gemini-1.5-flash-002.yaml
@@ -2,14 +2,14 @@ costs:
     - cache_creation_input_token_cost: 0.000001
       cache_read_input_token_cost: 1.875e-8
       input_cost_per_token: 7.5e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       region: "*"
       tiered_pricing:
           input:
               - cost_per_token: 1.5e-7
                 from: 128000
           output:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 128000
 features:
     - function_calling

--- a/providers/google-gemini/gemini-1.5-flash-latest.yaml
+++ b/providers/google-gemini/gemini-1.5-flash-latest.yaml
@@ -1,13 +1,13 @@
 costs:
     - input_cost_per_token: 7.5e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       region: "*"
       tiered_pricing:
           input:
               - cost_per_token: 1.5e-7
                 from: 128000
           output:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 128000
 features:
     - function_calling

--- a/providers/google-gemini/gemini-1.5-flash.yaml
+++ b/providers/google-gemini/gemini-1.5-flash.yaml
@@ -1,13 +1,13 @@
 costs:
     - input_cost_per_token: 7.5e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       region: "*"
       tiered_pricing:
           input:
               - cost_per_token: 1.5e-7
                 from: 128000
           output:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 128000
 features:
     - function_calling

--- a/providers/google-gemini/gemini-2.0-flash-001.yaml
+++ b/providers/google-gemini/gemini-2.0-flash-001.yaml
@@ -2,12 +2,12 @@ costs:
     - cache_read_input_audio_token_cost: 1.75e-7
       cache_read_input_token_cost: 2.5e-8
       cache_storage_cost_per_token_per_hour: 0.000001
-      input_cost_per_audio_token: 7.e-7
-      input_cost_per_token: 1.e-7
-      input_cost_per_token_batches: 5.e-8
+      input_cost_per_audio_token: 7e-7
+      input_cost_per_token: 1e-7
+      input_cost_per_token_batches: 5e-8
       output_cost_per_image_1k: 0.039
-      output_cost_per_token: 4.e-7
-      output_cost_per_token_batches: 2.e-7
+      output_cost_per_token: 4e-7
+      output_cost_per_token_batches: 2e-7
       region: "*"
 features:
     - function_calling

--- a/providers/google-gemini/gemini-2.0-flash-lite-001.yaml
+++ b/providers/google-gemini/gemini-2.0-flash-lite-001.yaml
@@ -1,7 +1,7 @@
 costs:
     - input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: "*"
 features:

--- a/providers/google-gemini/gemini-2.0-flash-lite.yaml
+++ b/providers/google-gemini/gemini-2.0-flash-lite.yaml
@@ -1,7 +1,7 @@
 costs:
     - input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: "*"
 features:

--- a/providers/google-gemini/gemini-2.0-flash.yaml
+++ b/providers/google-gemini/gemini-2.0-flash.yaml
@@ -2,12 +2,12 @@ costs:
     - cache_read_input_audio_token_cost: 1.75e-7
       cache_read_input_token_cost: 2.5e-8
       cache_storage_cost_per_token_per_hour: 0.000001
-      input_cost_per_audio_token: 7.e-7
-      input_cost_per_token: 1.e-7
-      input_cost_per_token_batches: 5.e-8
+      input_cost_per_audio_token: 7e-7
+      input_cost_per_token: 1e-7
+      input_cost_per_token_batches: 5e-8
       output_cost_per_image_1k: 0.039
-      output_cost_per_token: 4.e-7
-      output_cost_per_token_batches: 2.e-7
+      output_cost_per_token: 4e-7
+      output_cost_per_token_batches: 2e-7
       region: "*"
 features:
     - function_calling

--- a/providers/google-gemini/gemini-2.5-flash-image.yaml
+++ b/providers/google-gemini/gemini-2.5-flash-image.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_token_cost: 3.e-8
+    - cache_read_input_token_cost: 3e-8
       cache_storage_cost_per_token_per_hour: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_image_1k: 0.039
       output_cost_per_image_token: 0.00003

--- a/providers/google-gemini/gemini-2.5-flash-lite-preview-09-2025.yaml
+++ b/providers/google-gemini/gemini-2.5-flash-lite-preview-09-2025.yaml
@@ -1,12 +1,12 @@
 costs:
-    - cache_read_input_audio_token_cost: 3.e-8
-      cache_read_input_token_cost: 1.e-8
+    - cache_read_input_audio_token_cost: 3e-8
+      cache_read_input_token_cost: 1e-8
       cache_storage_cost_per_token_per_hour: 0.000001
-      input_cost_per_audio_token: 3.e-7
-      input_cost_per_token: 1.e-7
-      input_cost_per_token_batches: 5.e-8
-      output_cost_per_token: 4.e-7
-      output_cost_per_token_batches: 2.e-7
+      input_cost_per_audio_token: 3e-7
+      input_cost_per_token: 1e-7
+      input_cost_per_token_batches: 5e-8
+      output_cost_per_token: 4e-7
+      output_cost_per_token_batches: 2e-7
       region: "*"
 features:
     - function_calling

--- a/providers/google-gemini/gemini-2.5-flash-lite.yaml
+++ b/providers/google-gemini/gemini-2.5-flash-lite.yaml
@@ -1,12 +1,12 @@
 costs:
-    - cache_read_input_audio_token_cost: 3.e-8
-      cache_read_input_token_cost: 1.e-8
+    - cache_read_input_audio_token_cost: 3e-8
+      cache_read_input_token_cost: 1e-8
       cache_storage_cost_per_token_per_hour: 0.000001
-      input_cost_per_audio_token: 3.e-7
-      input_cost_per_token: 1.e-7
-      input_cost_per_token_batches: 5.e-8
-      output_cost_per_token: 4.e-7
-      output_cost_per_token_batches: 2.e-7
+      input_cost_per_audio_token: 3e-7
+      input_cost_per_token: 1e-7
+      input_cost_per_token_batches: 5e-8
+      output_cost_per_token: 4e-7
+      output_cost_per_token_batches: 2e-7
       region: "*"
 deprecationDate: "2026-07-22"
 features:

--- a/providers/google-gemini/gemini-2.5-flash-native-audio-latest.yaml
+++ b/providers/google-gemini/gemini-2.5-flash-native-audio-latest.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_audio_token: 0.000003
-      input_cost_per_token: 5.e-7
+      input_cost_per_token: 5e-7
       input_cost_per_video_token: 0.000003
       output_cost_per_audio_token: 0.000012
       output_cost_per_token: 0.000002

--- a/providers/google-gemini/gemini-2.5-flash-native-audio-preview-09-2025.yaml
+++ b/providers/google-gemini/gemini-2.5-flash-native-audio-preview-09-2025.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_audio_token: 0.000003
-      input_cost_per_token: 5.e-7
+      input_cost_per_token: 5e-7
       input_cost_per_video_token: 0.000003
       output_cost_per_audio_token: 0.000012
       output_cost_per_token: 0.000002

--- a/providers/google-gemini/gemini-2.5-flash-native-audio-preview-12-2025.yaml
+++ b/providers/google-gemini/gemini-2.5-flash-native-audio-preview-12-2025.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_audio_token: 0.000003
-      input_cost_per_token: 5.e-7
+      input_cost_per_token: 5e-7
       input_cost_per_video_token: 0.000003
       output_cost_per_audio_token: 0.000012
       output_cost_per_token: 0.000002

--- a/providers/google-gemini/gemini-2.5-flash-preview-09-2025.yaml
+++ b/providers/google-gemini/gemini-2.5-flash-preview-09-2025.yaml
@@ -1,9 +1,9 @@
 costs:
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125

--- a/providers/google-gemini/gemini-2.5-flash-preview-tts.yaml
+++ b/providers/google-gemini/gemini-2.5-flash-preview-tts.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
       input_cost_per_token_batches: 2.5e-7
       output_cost_per_audio_token: 0.00001
       output_cost_per_token_batches: 0.000005

--- a/providers/google-gemini/gemini-2.5-flash.yaml
+++ b/providers/google-gemini/gemini-2.5-flash.yaml
@@ -1,9 +1,9 @@
 costs:
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125

--- a/providers/google-gemini/gemini-2.5-pro-preview-tts.yaml
+++ b/providers/google-gemini/gemini-2.5-pro-preview-tts.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: "*"

--- a/providers/google-gemini/gemini-3-flash-preview.yaml
+++ b/providers/google-gemini/gemini-3-flash-preview.yaml
@@ -1,9 +1,9 @@
 costs:
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 5.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 5e-8
       cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 5.e-7
+      input_cost_per_token: 5e-7
       input_cost_per_token_batches: 2.5e-7
       output_cost_per_token: 0.000003
       output_cost_per_token_batches: 0.0000015

--- a/providers/google-gemini/gemini-3-pro-preview.yaml
+++ b/providers/google-gemini/gemini-3-pro-preview.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       cache_storage_cost_per_token_per_hour: 0.0000045
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
@@ -8,7 +8,7 @@ costs:
       region: "*"
       tiered_pricing:
           cache_read:
-              - cost_per_token: 4.e-7
+              - cost_per_token: 4e-7
                 from: 200000
           input:
               - cost_per_token: 0.000004

--- a/providers/google-gemini/gemini-3.1-flash-image-preview.yaml
+++ b/providers/google-gemini/gemini-3.1-flash-image-preview.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
       input_cost_per_token_batches: 2.5e-7
       output_cost_per_image: 0.067
       output_cost_per_token: 0.000003

--- a/providers/google-gemini/gemini-3.1-flash-lite-preview.yaml
+++ b/providers/google-gemini/gemini-3.1-flash-lite-preview.yaml
@@ -1,8 +1,8 @@
 costs:
-    - cache_read_input_audio_token_cost: 5.e-8
+    - cache_read_input_audio_token_cost: 5e-8
       cache_read_input_token_cost: 2.5e-8
       cache_storage_cost_per_token_per_hour: 0.000001
-      input_cost_per_audio_token: 5.e-7
+      input_cost_per_audio_token: 5e-7
       input_cost_per_token: 2.5e-7
       input_cost_per_token_batches: 1.25e-7
       output_cost_per_token: 0.0000015

--- a/providers/google-gemini/gemini-3.1-pro-preview-customtools.yaml
+++ b/providers/google-gemini/gemini-3.1-pro-preview-customtools.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       cache_storage_cost_per_token_per_hour: 0.0000045
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
@@ -8,7 +8,7 @@ costs:
       region: "*"
       tiered_pricing:
           cache_read:
-              - cost_per_token: 4.e-7
+              - cost_per_token: 4e-7
                 from: 200000
           input:
               - cost_per_token: 0.000004

--- a/providers/google-gemini/gemini-3.1-pro-preview.yaml
+++ b/providers/google-gemini/gemini-3.1-pro-preview.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       cache_storage_cost_per_token_per_hour: 0.0000045
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
@@ -8,7 +8,7 @@ costs:
       region: "*"
       tiered_pricing:
           cache_read:
-              - cost_per_token: 4.e-7
+              - cost_per_token: 4e-7
                 from: 200000
           input:
               - cost_per_token: 0.000004

--- a/providers/google-gemini/gemini-embedding-2-preview.yaml
+++ b/providers/google-gemini/gemini-embedding-2-preview.yaml
@@ -3,7 +3,7 @@ costs:
       input_cost_per_image: 0.00012
       input_cost_per_image_token: 4.5e-7
       input_cost_per_second: 0.00016
-      input_cost_per_token: 2.e-7
+      input_cost_per_token: 2e-7
       input_cost_per_video_token: 0.000012
       region: "*"
 limits:

--- a/providers/google-gemini/gemini-flash-latest.yaml
+++ b/providers/google-gemini/gemini-flash-latest.yaml
@@ -1,9 +1,9 @@
 costs:
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 5.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 5e-8
       cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 5.e-7
+      input_cost_per_token: 5e-7
       input_cost_per_token_batches: 2.5e-7
       output_cost_per_token: 0.000003
       output_cost_per_token_batches: 0.0000015

--- a/providers/google-gemini/gemini-flash-lite-latest.yaml
+++ b/providers/google-gemini/gemini-flash-lite-latest.yaml
@@ -1,12 +1,12 @@
 costs:
-    - cache_read_input_audio_token_cost: 3.e-8
-      cache_read_input_token_cost: 1.e-8
+    - cache_read_input_audio_token_cost: 3e-8
+      cache_read_input_token_cost: 1e-8
       cache_storage_cost_per_token_per_hour: 0.000001
-      input_cost_per_audio_token: 3.e-7
-      input_cost_per_token: 1.e-7
-      input_cost_per_token_batches: 5.e-8
-      output_cost_per_token: 4.e-7
-      output_cost_per_token_batches: 2.e-7
+      input_cost_per_audio_token: 3e-7
+      input_cost_per_token: 1e-7
+      input_cost_per_token_batches: 5e-8
+      output_cost_per_token: 4e-7
+      output_cost_per_token_batches: 2e-7
       region: "*"
 features:
     - function_calling
@@ -35,8 +35,10 @@ model: gemini-flash-lite-latest
 params:
     - key: max_tokens
       maxValue: 65536
+provisioning: serverless
 sources:
     - https://ai.google.dev/gemini-api/docs/models/gemini-2.5-flash-lite
+status: active
 supportedModes:
     - chat
 thinking: true

--- a/providers/google-gemini/gemini-pro-latest.yaml
+++ b/providers/google-gemini/gemini-pro-latest.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       cache_storage_cost_per_token_per_hour: 0.0000045
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
@@ -8,7 +8,7 @@ costs:
       region: "*"
       tiered_pricing:
           cache_read:
-              - cost_per_token: 4.e-7
+              - cost_per_token: 4e-7
                 from: 200000
           input:
               - cost_per_token: 0.000004

--- a/providers/google-gemini/gemini-robotics-er-1.5-preview.yaml
+++ b/providers/google-gemini/gemini-robotics-er-1.5-preview.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000025
       region: "*"
 features:

--- a/providers/google-gemini/gemini-robotics-er-1.6-preview.yaml
+++ b/providers/google-gemini/gemini-robotics-er-1.6-preview.yaml
@@ -1,7 +1,7 @@
 costs:
     - input_cost_per_audio_token: 0.000002
       input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 0.000005
       output_cost_per_token_batches: 0.0000025
       region: "*"


### PR DESCRIPTION
Auto-generated by poc-agent for provider `google-gemini`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk data-only changes to provider model YAMLs; main risk is unintended cost/metadata parsing differences if downstream tooling treats `3.e-7` differently from `3e-7`.
> 
> **Overview**
> Updates many `google-gemini` model YAMLs to **normalize scientific-notation cost fields** (e.g., `3.e-7` -> `3e-7`) across cache/input/output pricing entries.
> 
> Additionally updates `gemini-flash-lite-latest.yaml` metadata by adding `provisioning: serverless` and `status: active`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3dc76ac7103650863952173b309d6d0c94c47cc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->