### PR TITLE
feat(google-vertex): update model YAMLs [bot]

### DIFF
--- a/providers/google-vertex/anthropic/claude-3-5-haiku.yaml
+++ b/providers/google-vertex/anthropic/claude-3-5-haiku.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_creation_input_token_cost: 0.000001
-      cache_read_input_token_cost: 8.e-8
-      input_cost_per_token: 8.e-7
+      cache_read_input_token_cost: 8e-8
+      input_cost_per_token: 8e-7
       output_cost_per_token: 0.000004
       region: "*"
 features:

--- a/providers/google-vertex/anthropic/claude-3-5-haiku@20241022.yaml
+++ b/providers/google-vertex/anthropic/claude-3-5-haiku@20241022.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_creation_input_token_cost: 0.000001
-      cache_read_input_token_cost: 8.e-8
-      input_cost_per_token: 8.e-7
+      cache_read_input_token_cost: 8e-8
+      input_cost_per_token: 8e-7
       output_cost_per_token: 0.000004
       region: "*"
 features:

--- a/providers/google-vertex/anthropic/claude-3-5-sonnet-v2.yaml
+++ b/providers/google-vertex/anthropic/claude-3-5-sonnet-v2.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: "*"

--- a/providers/google-vertex/anthropic/claude-3-5-sonnet-v2@20241022.yaml
+++ b/providers/google-vertex/anthropic/claude-3-5-sonnet-v2@20241022.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: "*"

--- a/providers/google-vertex/anthropic/claude-3-5-sonnet.yaml
+++ b/providers/google-vertex/anthropic/claude-3-5-sonnet.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: "*"

--- a/providers/google-vertex/anthropic/claude-3-5-sonnet@20240620.yaml
+++ b/providers/google-vertex/anthropic/claude-3-5-sonnet@20240620.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: "*"

--- a/providers/google-vertex/anthropic/claude-3-7-sonnet@20250219.yaml
+++ b/providers/google-vertex/anthropic/claude-3-7-sonnet@20250219.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: "*"

--- a/providers/google-vertex/anthropic/claude-3-haiku.yaml
+++ b/providers/google-vertex/anthropic/claude-3-haiku.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_creation_input_token_cost: 3.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_creation_input_token_cost: 3e-7
+      cache_read_input_token_cost: 3e-8
       input_cost_per_token: 2.5e-7
       output_cost_per_token: 0.00000125
       region: "*"

--- a/providers/google-vertex/anthropic/claude-3-haiku@20240307.yaml
+++ b/providers/google-vertex/anthropic/claude-3-haiku@20240307.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_creation_input_token_cost: 3.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_creation_input_token_cost: 3e-7
+      cache_read_input_token_cost: 3e-8
       input_cost_per_token: 2.5e-7
       output_cost_per_token: 0.00000125
       region: "*"

--- a/providers/google-vertex/anthropic/claude-3-sonnet.yaml
+++ b/providers/google-vertex/anthropic/claude-3-sonnet.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: "*"

--- a/providers/google-vertex/anthropic/claude-3-sonnet@20240229.yaml
+++ b/providers/google-vertex/anthropic/claude-3-sonnet@20240229.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: "*"

--- a/providers/google-vertex/anthropic/claude-haiku-4-5.yaml
+++ b/providers/google-vertex/anthropic/claude-haiku-4-5.yaml
@@ -7,9 +7,9 @@ costs:
       output_cost_per_token_batches: 0.00000275
       region: us-east5
     - cache_creation_input_token_cost: 0.00000125
-      cache_read_input_token_cost: 1.e-7
+      cache_read_input_token_cost: 1e-7
       input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 0.000005
       output_cost_per_token_batches: 0.0000025
       region: global

--- a/providers/google-vertex/anthropic/claude-haiku-4-5@20251001.yaml
+++ b/providers/google-vertex/anthropic/claude-haiku-4-5@20251001.yaml
@@ -7,9 +7,9 @@ costs:
       output_cost_per_token_batches: 0.00000275
       region: us-east5
     - cache_creation_input_token_cost: 0.00000125
-      cache_read_input_token_cost: 1.e-7
+      cache_read_input_token_cost: 1e-7
       input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 0.000005
       output_cost_per_token_batches: 0.0000025
       region: global

--- a/providers/google-vertex/anthropic/claude-opus-4-5.yaml
+++ b/providers/google-vertex/anthropic/claude-opus-4-5.yaml
@@ -7,7 +7,7 @@ costs:
       output_cost_per_token_batches: 0.00001375
       region: us-east5
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025

--- a/providers/google-vertex/anthropic/claude-opus-4-5@20251101.yaml
+++ b/providers/google-vertex/anthropic/claude-opus-4-5@20251101.yaml
@@ -5,7 +5,7 @@ costs:
       output_cost_per_token: 0.0000275
       region: us-east5
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       output_cost_per_token: 0.000025
       region: global

--- a/providers/google-vertex/anthropic/claude-opus-4-6.yaml
+++ b/providers/google-vertex/anthropic/claude-opus-4-6.yaml
@@ -5,7 +5,7 @@ costs:
       output_cost_per_token: 0.0000275
       region: us-east5
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       output_cost_per_token: 0.000025
       region: global

--- a/providers/google-vertex/anthropic/claude-opus-4-6@default.yaml
+++ b/providers/google-vertex/anthropic/claude-opus-4-6@default.yaml
@@ -7,7 +7,7 @@ costs:
       output_cost_per_token_batches: 0.00001375
       region: us-east5
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025

--- a/providers/google-vertex/anthropic/claude-opus-4-7.yaml
+++ b/providers/google-vertex/anthropic/claude-opus-4-7.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025

--- a/providers/google-vertex/anthropic/claude-sonnet-4-5.yaml
+++ b/providers/google-vertex/anthropic/claude-sonnet-4-5.yaml
@@ -18,7 +18,7 @@ costs:
               - cost_per_token: 0.00002475
                 from: 200000
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
@@ -26,7 +26,7 @@ costs:
       region: global
       tiered_pricing:
           cache_read:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 200000
           cache_write:
               - cost_per_token: 0.0000075

--- a/providers/google-vertex/anthropic/claude-sonnet-4-5@20250929.yaml
+++ b/providers/google-vertex/anthropic/claude-sonnet-4-5@20250929.yaml
@@ -18,7 +18,7 @@ costs:
               - cost_per_token: 0.00002475
                 from: 200000
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
@@ -26,7 +26,7 @@ costs:
       region: global
       tiered_pricing:
           cache_read:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 200000
           cache_write:
               - cost_per_token: 0.0000075

--- a/providers/google-vertex/anthropic/claude-sonnet-4-6.yaml
+++ b/providers/google-vertex/anthropic/claude-sonnet-4-6.yaml
@@ -5,7 +5,7 @@ costs:
       output_cost_per_token: 0.0000165
       region: us-east5
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: global

--- a/providers/google-vertex/anthropic/claude-sonnet-4-6@default.yaml
+++ b/providers/google-vertex/anthropic/claude-sonnet-4-6@default.yaml
@@ -7,7 +7,7 @@ costs:
       output_cost_per_token_batches: 0.00000825
       region: us-east5
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015

--- a/providers/google-vertex/anthropic/claude-sonnet-4.yaml
+++ b/providers/google-vertex/anthropic/claude-sonnet-4.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
@@ -8,7 +8,7 @@ costs:
       region: us-east5
       tiered_pricing:
           cache_read:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 200000
           cache_write:
               - cost_per_token: 0.0000075
@@ -20,7 +20,7 @@ costs:
               - cost_per_token: 0.0000225
                 from: 200000
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
@@ -28,7 +28,7 @@ costs:
       region: global
       tiered_pricing:
           cache_read:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 200000
           cache_write:
               - cost_per_token: 0.0000075
@@ -40,7 +40,7 @@ costs:
               - cost_per_token: 0.0000225
                 from: 200000
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
@@ -48,7 +48,7 @@ costs:
       region: europe-west1
       tiered_pricing:
           cache_read:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 200000
           cache_write:
               - cost_per_token: 0.0000075

--- a/providers/google-vertex/anthropic/claude-sonnet-4@20250514.yaml
+++ b/providers/google-vertex/anthropic/claude-sonnet-4@20250514.yaml
@@ -1,21 +1,21 @@
 costs:
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: us-east5
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: global
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: europe-west1
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: asia-east1

--- a/providers/google-vertex/csm/cube.yaml
+++ b/providers/google-vertex/csm/cube.yaml
@@ -5,6 +5,7 @@ modalities:
         - image
 mode: image
 model: csm/cube
+provisioning: provisioned
 sources:
     - https://console.cloud.google.com/vertex-ai/publishers/sesame/model-garden/csm
 supportedModes:

--- a/providers/google-vertex/deepseek-ai/deepseek-ocr-2.yaml
+++ b/providers/google-vertex/deepseek-ai/deepseek-ocr-2.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 3.e-7
+    - input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000012
       region: us-central1
 features:

--- a/providers/google-vertex/deepseek-ai/deepseek-ocr-maas.yaml
+++ b/providers/google-vertex/deepseek-ai/deepseek-ocr-maas.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 3.e-7
+    - input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000012
       region: global # docs specify us-central1 but the model is only available via global inference
 features:

--- a/providers/google-vertex/deepseek-ai/deepseek-v3-1.yaml
+++ b/providers/google-vertex/deepseek-ai/deepseek-v3-1.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_token_cost: 6.e-8
-      input_cost_per_token: 6.e-7
-      input_cost_per_token_batches: 3.e-7
+    - cache_read_input_token_cost: 6e-8
+      input_cost_per_token: 6e-7
+      input_cost_per_token_batches: 3e-7
       output_cost_per_token: 0.0000017
       output_cost_per_token_batches: 8.5e-7
       region: us-central1

--- a/providers/google-vertex/deepseek-ai/deepseek-v3.1-maas.yaml
+++ b/providers/google-vertex/deepseek-ai/deepseek-v3.1-maas.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_token_cost: 6.e-8
-      input_cost_per_token: 6.e-7
-      input_cost_per_token_batches: 3.e-7
+    - cache_read_input_token_cost: 6e-8
+      input_cost_per_token: 6e-7
+      input_cost_per_token_batches: 3e-7
       output_cost_per_token: 0.0000017
       output_cost_per_token_batches: 8.5e-7
       region: us-west2 # docs specify us-central1 but the model is available via us-west2 inference

--- a/providers/google-vertex/gemini-1.0-pro-001.yaml
+++ b/providers/google-vertex/gemini-1.0-pro-001.yaml
@@ -1,7 +1,7 @@
 costs:
     - input_cost_per_character: 1.25e-7
       input_cost_per_image: 0.0025
-      input_cost_per_token: 5.e-7
+      input_cost_per_token: 5e-7
       output_cost_per_token: 0.0000015
       region: "*"
 features:

--- a/providers/google-vertex/gemini-1.0-pro-002.yaml
+++ b/providers/google-vertex/gemini-1.0-pro-002.yaml
@@ -1,7 +1,7 @@
 costs:
     - input_cost_per_character: 1.25e-7
       input_cost_per_image: 0.0025
-      input_cost_per_token: 5.e-7
+      input_cost_per_token: 5e-7
       output_cost_per_token: 0.0000015
       region: "*"
 features:

--- a/providers/google-vertex/gemini-1.0-pro-vision-001.yaml
+++ b/providers/google-vertex/gemini-1.0-pro-vision-001.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_image: 0.0025
-      input_cost_per_token: 5.e-7
+      input_cost_per_token: 5e-7
       output_cost_per_token: 0.0000015
       region: "*"
 features:

--- a/providers/google-vertex/gemini-1.0-pro-vision.yaml
+++ b/providers/google-vertex/gemini-1.0-pro-vision.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_image: 0.0025
-      input_cost_per_token: 5.e-7
+      input_cost_per_token: 5e-7
       output_cost_per_token: 0.0000015
       region: "*"
 features:

--- a/providers/google-vertex/gemini-1.0-pro.yaml
+++ b/providers/google-vertex/gemini-1.0-pro.yaml
@@ -1,7 +1,7 @@
 costs:
     - input_cost_per_character: 1.25e-7
       input_cost_per_image: 0.0025
-      input_cost_per_token: 5.e-7
+      input_cost_per_token: 5e-7
       output_cost_per_token: 0.0000015
       region: "*"
 features:

--- a/providers/google-vertex/gemini-1.0-ultra-001.yaml
+++ b/providers/google-vertex/gemini-1.0-ultra-001.yaml
@@ -1,7 +1,7 @@
 costs:
     - input_cost_per_character: 1.25e-7
       input_cost_per_image: 0.0025
-      input_cost_per_token: 5.e-7
+      input_cost_per_token: 5e-7
       output_cost_per_token: 0.0000015
       region: "*"
 features:

--- a/providers/google-vertex/gemini-1.0-ultra.yaml
+++ b/providers/google-vertex/gemini-1.0-ultra.yaml
@@ -1,7 +1,7 @@
 costs:
     - input_cost_per_character: 1.25e-7
       input_cost_per_image: 0.0025
-      input_cost_per_token: 5.e-7
+      input_cost_per_token: 5e-7
       output_cost_per_token: 0.0000015
       region: "*"
 features:

--- a/providers/google-vertex/gemini-1.5-flash-001.yaml
+++ b/providers/google-vertex/gemini-1.5-flash-001.yaml
@@ -2,14 +2,14 @@ costs:
     - input_cost_per_character: 1.875e-8
       input_cost_per_image: 0.00002
       input_cost_per_token: 7.5e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       region: "*"
       tiered_pricing:
           input:
               - cost_per_token: 0.000001
                 from: 128000
           output:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 128000
 features:
     - function_calling

--- a/providers/google-vertex/gemini-1.5-flash-002.yaml
+++ b/providers/google-vertex/gemini-1.5-flash-002.yaml
@@ -2,14 +2,14 @@ costs:
     - input_cost_per_character: 1.875e-8
       input_cost_per_image: 0.00002
       input_cost_per_token: 7.5e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       region: "*"
       tiered_pricing:
           input:
               - cost_per_token: 0.000001
                 from: 128000
           output:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 128000
 features:
     - function_calling

--- a/providers/google-vertex/gemini-1.5-flash.yaml
+++ b/providers/google-vertex/gemini-1.5-flash.yaml
@@ -2,14 +2,14 @@ costs:
     - input_cost_per_character: 1.875e-8
       input_cost_per_image: 0.00002
       input_cost_per_token: 7.5e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       region: "*"
       tiered_pricing:
           input:
               - cost_per_token: 0.000001
                 from: 128000
           output:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 128000
 features:
     - function_calling

--- a/providers/google-vertex/gemini-2.0-flash-001.yaml
+++ b/providers/google-vertex/gemini-2.0-flash-001.yaml
@@ -5,8 +5,8 @@ costs:
       input_cost_per_token: 1.5e-7
       input_cost_per_token_batches: 7.5e-8
       input_cost_per_video_token: 0.000003
-      output_cost_per_token: 6.e-7
-      output_cost_per_token_batches: 3.e-7
+      output_cost_per_token: 6e-7
+      output_cost_per_token_batches: 3e-7
       region: us-west4
     - cache_creation_input_token_cost: 1.5e-7
       cache_read_input_token_cost: 3.75e-8
@@ -14,8 +14,8 @@ costs:
       input_cost_per_token: 1.5e-7
       input_cost_per_token_batches: 7.5e-8
       input_cost_per_video_token: 0.000003
-      output_cost_per_token: 6.e-7
-      output_cost_per_token_batches: 3.e-7
+      output_cost_per_token: 6e-7
+      output_cost_per_token_batches: 3e-7
       region: us-west1
     - cache_creation_input_token_cost: 1.5e-7
       cache_read_input_token_cost: 3.75e-8
@@ -23,8 +23,8 @@ costs:
       input_cost_per_token: 1.5e-7
       input_cost_per_token_batches: 7.5e-8
       input_cost_per_video_token: 0.000003
-      output_cost_per_token: 6.e-7
-      output_cost_per_token_batches: 3.e-7
+      output_cost_per_token: 6e-7
+      output_cost_per_token_batches: 3e-7
       region: us-south1
     - cache_creation_input_token_cost: 1.5e-7
       cache_read_input_token_cost: 3.75e-8
@@ -32,8 +32,8 @@ costs:
       input_cost_per_token: 1.5e-7
       input_cost_per_token_batches: 7.5e-8
       input_cost_per_video_token: 0.000003
-      output_cost_per_token: 6.e-7
-      output_cost_per_token_batches: 3.e-7
+      output_cost_per_token: 6e-7
+      output_cost_per_token_batches: 3e-7
       region: us-east5
     - cache_creation_input_token_cost: 1.5e-7
       cache_read_input_token_cost: 3.75e-8
@@ -41,8 +41,8 @@ costs:
       input_cost_per_token: 1.5e-7
       input_cost_per_token_batches: 7.5e-8
       input_cost_per_video_token: 0.000003
-      output_cost_per_token: 6.e-7
-      output_cost_per_token_batches: 3.e-7
+      output_cost_per_token: 6e-7
+      output_cost_per_token_batches: 3e-7
       region: us-east4
     - cache_creation_input_token_cost: 1.5e-7
       cache_read_input_token_cost: 3.75e-8
@@ -50,8 +50,8 @@ costs:
       input_cost_per_token: 1.5e-7
       input_cost_per_token_batches: 7.5e-8
       input_cost_per_video_token: 0.000003
-      output_cost_per_token: 6.e-7
-      output_cost_per_token_batches: 3.e-7
+      output_cost_per_token: 6e-7
+      output_cost_per_token_batches: 3e-7
       region: us-east1
     - cache_creation_input_token_cost: 1.5e-7
       cache_read_input_token_cost: 3.75e-8
@@ -59,8 +59,8 @@ costs:
       input_cost_per_token: 1.5e-7
       input_cost_per_token_batches: 7.5e-8
       input_cost_per_video_token: 0.000003
-      output_cost_per_token: 6.e-7
-      output_cost_per_token_batches: 3.e-7
+      output_cost_per_token: 6e-7
+      output_cost_per_token_batches: 3e-7
       region: us-central1
     - cache_creation_input_token_cost: 1.5e-7
       cache_read_input_token_cost: 3.75e-8
@@ -68,8 +68,8 @@ costs:
       input_cost_per_token: 1.5e-7
       input_cost_per_token_batches: 7.5e-8
       input_cost_per_video_token: 0.000003
-      output_cost_per_token: 6.e-7
-      output_cost_per_token_batches: 3.e-7
+      output_cost_per_token: 6e-7
+      output_cost_per_token_batches: 3e-7
       region: global
     - cache_creation_input_token_cost: 1.5e-7
       cache_read_input_token_cost: 3.75e-8
@@ -77,8 +77,8 @@ costs:
       input_cost_per_token: 1.5e-7
       input_cost_per_token_batches: 7.5e-8
       input_cost_per_video_token: 0.000003
-      output_cost_per_token: 6.e-7
-      output_cost_per_token_batches: 3.e-7
+      output_cost_per_token: 6e-7
+      output_cost_per_token_batches: 3e-7
       region: europe-west9
     - cache_creation_input_token_cost: 1.5e-7
       cache_read_input_token_cost: 3.75e-8
@@ -86,8 +86,8 @@ costs:
       input_cost_per_token: 1.5e-7
       input_cost_per_token_batches: 7.5e-8
       input_cost_per_video_token: 0.000003
-      output_cost_per_token: 6.e-7
-      output_cost_per_token_batches: 3.e-7
+      output_cost_per_token: 6e-7
+      output_cost_per_token_batches: 3e-7
       region: europe-west8
     - cache_creation_input_token_cost: 1.5e-7
       cache_read_input_token_cost: 3.75e-8
@@ -95,8 +95,8 @@ costs:
       input_cost_per_token: 1.5e-7
       input_cost_per_token_batches: 7.5e-8
       input_cost_per_video_token: 0.000003
-      output_cost_per_token: 6.e-7
-      output_cost_per_token_batches: 3.e-7
+      output_cost_per_token: 6e-7
+      output_cost_per_token_batches: 3e-7
       region: europe-west4
     - cache_creation_input_token_cost: 1.5e-7
       cache_read_input_token_cost: 3.75e-8
@@ -104,8 +104,8 @@ costs:
       input_cost_per_token: 1.5e-7
       input_cost_per_token_batches: 7.5e-8
       input_cost_per_video_token: 0.000003
-      output_cost_per_token: 6.e-7
-      output_cost_per_token_batches: 3.e-7
+      output_cost_per_token: 6e-7
+      output_cost_per_token_batches: 3e-7
       region: europe-west1
     - cache_creation_input_token_cost: 1.5e-7
       cache_read_input_token_cost: 3.75e-8
@@ -113,8 +113,8 @@ costs:
       input_cost_per_token: 1.5e-7
       input_cost_per_token_batches: 7.5e-8
       input_cost_per_video_token: 0.000003
-      output_cost_per_token: 6.e-7
-      output_cost_per_token_batches: 3.e-7
+      output_cost_per_token: 6e-7
+      output_cost_per_token_batches: 3e-7
       region: europe-southwest1
     - cache_creation_input_token_cost: 1.5e-7
       cache_read_input_token_cost: 3.75e-8
@@ -122,8 +122,8 @@ costs:
       input_cost_per_token: 1.5e-7
       input_cost_per_token_batches: 7.5e-8
       input_cost_per_video_token: 0.000003
-      output_cost_per_token: 6.e-7
-      output_cost_per_token_batches: 3.e-7
+      output_cost_per_token: 6e-7
+      output_cost_per_token_batches: 3e-7
       region: europe-north1
     - cache_creation_input_token_cost: 1.5e-7
       cache_read_input_token_cost: 3.75e-8
@@ -131,8 +131,8 @@ costs:
       input_cost_per_token: 1.5e-7
       input_cost_per_token_batches: 7.5e-8
       input_cost_per_video_token: 0.000003
-      output_cost_per_token: 6.e-7
-      output_cost_per_token_batches: 3.e-7
+      output_cost_per_token: 6e-7
+      output_cost_per_token_batches: 3e-7
       region: europe-central2
 deprecationDate: "2026-06-01"
 features:

--- a/providers/google-vertex/gemini-2.0-flash-lite-001.yaml
+++ b/providers/google-vertex/gemini-2.0-flash-lite-001.yaml
@@ -2,181 +2,181 @@ costs:
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: us-west4
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: us-west1
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: us-south1
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: us-east5
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: us-east4
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: us-east1
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: us-central1
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: southamerica-east1
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: northamerica-northeast1
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: me-west1
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: me-central2
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: me-central1
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: global
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: europe-west9
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: europe-west8
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: europe-west6
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: europe-west4
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: europe-west3
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: europe-west2
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: europe-west1
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: europe-southwest1
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: europe-north1
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: europe-central2
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: australia-southeast1
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: asia-southeast1
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: asia-south1
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: asia-northeast3
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: asia-northeast1
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: asia-east2
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: asia-east1
 deprecationDate: "2026-06-01"

--- a/providers/google-vertex/gemini-2.0-flash-lite.yaml
+++ b/providers/google-vertex/gemini-2.0-flash-lite.yaml
@@ -2,91 +2,91 @@ costs:
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: us-west4
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: us-west1
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: us-south1
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: us-east5
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: us-east4
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: us-east1
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: us-central1
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: global
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: europe-west9
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: europe-west8
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: europe-west4
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: europe-west1
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: europe-southwest1
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: europe-north1
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: europe-central2
 deprecationDate: "2026-06-01"

--- a/providers/google-vertex/gemini-2.0-flash.yaml
+++ b/providers/google-vertex/gemini-2.0-flash.yaml
@@ -5,8 +5,8 @@ costs:
       input_cost_per_token: 1.5e-7
       input_cost_per_token_batches: 7.5e-8
       input_cost_per_video_token: 0.000003
-      output_cost_per_token: 6.e-7
-      output_cost_per_token_batches: 3.e-7
+      output_cost_per_token: 6e-7
+      output_cost_per_token_batches: 3e-7
       region: us-west4
     - cache_read_input_audio_token_cost: 2.5e-7
       cache_read_input_token_cost: 3.75e-8
@@ -14,8 +14,8 @@ costs:
       input_cost_per_token: 1.5e-7
       input_cost_per_token_batches: 7.5e-8
       input_cost_per_video_token: 0.000003
-      output_cost_per_token: 6.e-7
-      output_cost_per_token_batches: 3.e-7
+      output_cost_per_token: 6e-7
+      output_cost_per_token_batches: 3e-7
       region: us-west1
     - cache_read_input_audio_token_cost: 2.5e-7
       cache_read_input_token_cost: 3.75e-8
@@ -23,8 +23,8 @@ costs:
       input_cost_per_token: 1.5e-7
       input_cost_per_token_batches: 7.5e-8
       input_cost_per_video_token: 0.000003
-      output_cost_per_token: 6.e-7
-      output_cost_per_token_batches: 3.e-7
+      output_cost_per_token: 6e-7
+      output_cost_per_token_batches: 3e-7
       region: us-south1
     - cache_read_input_audio_token_cost: 2.5e-7
       cache_read_input_token_cost: 3.75e-8
@@ -32,8 +32,8 @@ costs:
       input_cost_per_token: 1.5e-7
       input_cost_per_token_batches: 7.5e-8
       input_cost_per_video_token: 0.000003
-      output_cost_per_token: 6.e-7
-      output_cost_per_token_batches: 3.e-7
+      output_cost_per_token: 6e-7
+      output_cost_per_token_batches: 3e-7
       region: us-east5
     - cache_read_input_audio_token_cost: 2.5e-7
       cache_read_input_token_cost: 3.75e-8
@@ -41,8 +41,8 @@ costs:
       input_cost_per_token: 1.5e-7
       input_cost_per_token_batches: 7.5e-8
       input_cost_per_video_token: 0.000003
-      output_cost_per_token: 6.e-7
-      output_cost_per_token_batches: 3.e-7
+      output_cost_per_token: 6e-7
+      output_cost_per_token_batches: 3e-7
       region: us-east4
     - cache_read_input_audio_token_cost: 2.5e-7
       cache_read_input_token_cost: 3.75e-8
@@ -50,8 +50,8 @@ costs:
       input_cost_per_token: 1.5e-7
       input_cost_per_token_batches: 7.5e-8
       input_cost_per_video_token: 0.000003
-      output_cost_per_token: 6.e-7
-      output_cost_per_token_batches: 3.e-7
+      output_cost_per_token: 6e-7
+      output_cost_per_token_batches: 3e-7
       region: us-east1
     - cache_read_input_audio_token_cost: 2.5e-7
       cache_read_input_token_cost: 3.75e-8
@@ -59,8 +59,8 @@ costs:
       input_cost_per_token: 1.5e-7
       input_cost_per_token_batches: 7.5e-8
       input_cost_per_video_token: 0.000003
-      output_cost_per_token: 6.e-7
-      output_cost_per_token_batches: 3.e-7
+      output_cost_per_token: 6e-7
+      output_cost_per_token_batches: 3e-7
       region: us-central1
     - cache_read_input_audio_token_cost: 2.5e-7
       cache_read_input_token_cost: 3.75e-8
@@ -68,8 +68,8 @@ costs:
       input_cost_per_token: 1.5e-7
       input_cost_per_token_batches: 7.5e-8
       input_cost_per_video_token: 0.000003
-      output_cost_per_token: 6.e-7
-      output_cost_per_token_batches: 3.e-7
+      output_cost_per_token: 6e-7
+      output_cost_per_token_batches: 3e-7
       region: global
     - cache_read_input_audio_token_cost: 2.5e-7
       cache_read_input_token_cost: 3.75e-8
@@ -77,8 +77,8 @@ costs:
       input_cost_per_token: 1.5e-7
       input_cost_per_token_batches: 7.5e-8
       input_cost_per_video_token: 0.000003
-      output_cost_per_token: 6.e-7
-      output_cost_per_token_batches: 3.e-7
+      output_cost_per_token: 6e-7
+      output_cost_per_token_batches: 3e-7
       region: europe-west9
     - cache_read_input_audio_token_cost: 2.5e-7
       cache_read_input_token_cost: 3.75e-8
@@ -86,8 +86,8 @@ costs:
       input_cost_per_token: 1.5e-7
       input_cost_per_token_batches: 7.5e-8
       input_cost_per_video_token: 0.000003
-      output_cost_per_token: 6.e-7
-      output_cost_per_token_batches: 3.e-7
+      output_cost_per_token: 6e-7
+      output_cost_per_token_batches: 3e-7
       region: europe-west8
     - cache_read_input_audio_token_cost: 2.5e-7
       cache_read_input_token_cost: 3.75e-8
@@ -95,8 +95,8 @@ costs:
       input_cost_per_token: 1.5e-7
       input_cost_per_token_batches: 7.5e-8
       input_cost_per_video_token: 0.000003
-      output_cost_per_token: 6.e-7
-      output_cost_per_token_batches: 3.e-7
+      output_cost_per_token: 6e-7
+      output_cost_per_token_batches: 3e-7
       region: europe-west4
     - cache_read_input_audio_token_cost: 2.5e-7
       cache_read_input_token_cost: 3.75e-8
@@ -104,8 +104,8 @@ costs:
       input_cost_per_token: 1.5e-7
       input_cost_per_token_batches: 7.5e-8
       input_cost_per_video_token: 0.000003
-      output_cost_per_token: 6.e-7
-      output_cost_per_token_batches: 3.e-7
+      output_cost_per_token: 6e-7
+      output_cost_per_token_batches: 3e-7
       region: europe-west1
     - cache_read_input_audio_token_cost: 2.5e-7
       cache_read_input_token_cost: 3.75e-8
@@ -113,8 +113,8 @@ costs:
       input_cost_per_token: 1.5e-7
       input_cost_per_token_batches: 7.5e-8
       input_cost_per_video_token: 0.000003
-      output_cost_per_token: 6.e-7
-      output_cost_per_token_batches: 3.e-7
+      output_cost_per_token: 6e-7
+      output_cost_per_token_batches: 3e-7
       region: europe-southwest1
     - cache_read_input_audio_token_cost: 2.5e-7
       cache_read_input_token_cost: 3.75e-8
@@ -122,8 +122,8 @@ costs:
       input_cost_per_token: 1.5e-7
       input_cost_per_token_batches: 7.5e-8
       input_cost_per_video_token: 0.000003
-      output_cost_per_token: 6.e-7
-      output_cost_per_token_batches: 3.e-7
+      output_cost_per_token: 6e-7
+      output_cost_per_token_batches: 3e-7
       region: europe-north1
     - cache_read_input_audio_token_cost: 2.5e-7
       cache_read_input_token_cost: 3.75e-8
@@ -131,8 +131,8 @@ costs:
       input_cost_per_token: 1.5e-7
       input_cost_per_token_batches: 7.5e-8
       input_cost_per_video_token: 0.000003
-      output_cost_per_token: 6.e-7
-      output_cost_per_token_batches: 3.e-7
+      output_cost_per_token: 6e-7
+      output_cost_per_token_batches: 3e-7
       region: europe-central2
 deprecationDate: "2026-06-01"
 features:

--- a/providers/google-vertex/gemini-2.5-flash-image.yaml
+++ b/providers/google-vertex/gemini-2.5-flash-image.yaml
@@ -1,83 +1,83 @@
 costs:
-    - input_cost_per_token: 3.e-7
+    - input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_image_token: 0.00003
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: us-west4
-    - input_cost_per_token: 3.e-7
+    - input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_image_token: 0.00003
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: us-west1
-    - input_cost_per_token: 3.e-7
+    - input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_image_token: 0.00003
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: us-south1
-    - input_cost_per_token: 3.e-7
+    - input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_image_token: 0.00003
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: us-east5
-    - input_cost_per_token: 3.e-7
+    - input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_image_token: 0.00003
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: us-east4
-    - input_cost_per_token: 3.e-7
+    - input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_image_token: 0.00003
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: us-east1
-    - input_cost_per_token: 3.e-7
+    - input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_image_token: 0.00003
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: us-central1
-    - input_cost_per_token: 3.e-7
+    - input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_image_token: 0.00003
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: global
-    - input_cost_per_token: 3.e-7
+    - input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_image_token: 0.00003
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: europe-west8
-    - input_cost_per_token: 3.e-7
+    - input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_image_token: 0.00003
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: europe-west4
-    - input_cost_per_token: 3.e-7
+    - input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_image_token: 0.00003
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: europe-west1
-    - input_cost_per_token: 3.e-7
+    - input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_image_token: 0.00003
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: europe-southwest1
-    - input_cost_per_token: 3.e-7
+    - input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_image_token: 0.00003
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: europe-north1
-    - input_cost_per_token: 3.e-7
+    - input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_image_token: 0.00003
       output_cost_per_token: 0.0000025

--- a/providers/google-vertex/gemini-2.5-flash-lite-preview-09-2025.yaml
+++ b/providers/google-vertex/gemini-2.5-flash-lite-preview-09-2025.yaml
@@ -1,12 +1,12 @@
 costs:
-    - cache_read_input_audio_token_cost: 3.e-8
-      cache_read_input_token_cost: 1.e-8
+    - cache_read_input_audio_token_cost: 3e-8
+      cache_read_input_token_cost: 1e-8
       cache_storage_cost_per_token_per_hour: 0.000001
-      input_cost_per_audio_token: 3.e-7
-      input_cost_per_token: 1.e-7
-      input_cost_per_token_batches: 5.e-8
-      output_cost_per_token: 4.e-7
-      output_cost_per_token_batches: 2.e-7
+      input_cost_per_audio_token: 3e-7
+      input_cost_per_token: 1e-7
+      input_cost_per_token_batches: 5e-8
+      output_cost_per_token: 4e-7
+      output_cost_per_token_batches: 2e-7
       region: global
 features:
     - function_calling

--- a/providers/google-vertex/gemini-2.5-flash-lite.yaml
+++ b/providers/google-vertex/gemini-2.5-flash-lite.yaml
@@ -1,123 +1,123 @@
 costs:
-    - cache_read_input_audio_token_cost: 3.e-8
-      cache_read_input_token_cost: 1.e-8
-      input_cost_per_audio_token: 3.e-7
-      input_cost_per_token: 1.e-7
-      input_cost_per_token_batches: 5.e-8
-      output_cost_per_token: 4.e-7
-      output_cost_per_token_batches: 2.e-7
+    - cache_read_input_audio_token_cost: 3e-8
+      cache_read_input_token_cost: 1e-8
+      input_cost_per_audio_token: 3e-7
+      input_cost_per_token: 1e-7
+      input_cost_per_token_batches: 5e-8
+      output_cost_per_token: 4e-7
+      output_cost_per_token_batches: 2e-7
       region: us-west4
-    - cache_read_input_audio_token_cost: 3.e-8
-      cache_read_input_token_cost: 1.e-8
-      input_cost_per_audio_token: 3.e-7
-      input_cost_per_token: 1.e-7
-      input_cost_per_token_batches: 5.e-8
-      output_cost_per_token: 4.e-7
-      output_cost_per_token_batches: 2.e-7
+    - cache_read_input_audio_token_cost: 3e-8
+      cache_read_input_token_cost: 1e-8
+      input_cost_per_audio_token: 3e-7
+      input_cost_per_token: 1e-7
+      input_cost_per_token_batches: 5e-8
+      output_cost_per_token: 4e-7
+      output_cost_per_token_batches: 2e-7
       region: us-west1
-    - cache_read_input_audio_token_cost: 3.e-8
-      cache_read_input_token_cost: 1.e-8
-      input_cost_per_audio_token: 3.e-7
-      input_cost_per_token: 1.e-7
-      input_cost_per_token_batches: 5.e-8
-      output_cost_per_token: 4.e-7
-      output_cost_per_token_batches: 2.e-7
+    - cache_read_input_audio_token_cost: 3e-8
+      cache_read_input_token_cost: 1e-8
+      input_cost_per_audio_token: 3e-7
+      input_cost_per_token: 1e-7
+      input_cost_per_token_batches: 5e-8
+      output_cost_per_token: 4e-7
+      output_cost_per_token_batches: 2e-7
       region: us-south1
-    - cache_read_input_audio_token_cost: 3.e-8
-      cache_read_input_token_cost: 1.e-8
-      input_cost_per_audio_token: 3.e-7
-      input_cost_per_token: 1.e-7
-      input_cost_per_token_batches: 5.e-8
-      output_cost_per_token: 4.e-7
-      output_cost_per_token_batches: 2.e-7
+    - cache_read_input_audio_token_cost: 3e-8
+      cache_read_input_token_cost: 1e-8
+      input_cost_per_audio_token: 3e-7
+      input_cost_per_token: 1e-7
+      input_cost_per_token_batches: 5e-8
+      output_cost_per_token: 4e-7
+      output_cost_per_token_batches: 2e-7
       region: us-east5
-    - cache_read_input_audio_token_cost: 3.e-8
-      cache_read_input_token_cost: 1.e-8
-      input_cost_per_audio_token: 3.e-7
-      input_cost_per_token: 1.e-7
-      input_cost_per_token_batches: 5.e-8
-      output_cost_per_token: 4.e-7
-      output_cost_per_token_batches: 2.e-7
+    - cache_read_input_audio_token_cost: 3e-8
+      cache_read_input_token_cost: 1e-8
+      input_cost_per_audio_token: 3e-7
+      input_cost_per_token: 1e-7
+      input_cost_per_token_batches: 5e-8
+      output_cost_per_token: 4e-7
+      output_cost_per_token_batches: 2e-7
       region: us-east4
-    - cache_read_input_audio_token_cost: 3.e-8
-      cache_read_input_token_cost: 1.e-8
-      input_cost_per_audio_token: 3.e-7
-      input_cost_per_token: 1.e-7
-      input_cost_per_token_batches: 5.e-8
-      output_cost_per_token: 4.e-7
-      output_cost_per_token_batches: 2.e-7
+    - cache_read_input_audio_token_cost: 3e-8
+      cache_read_input_token_cost: 1e-8
+      input_cost_per_audio_token: 3e-7
+      input_cost_per_token: 1e-7
+      input_cost_per_token_batches: 5e-8
+      output_cost_per_token: 4e-7
+      output_cost_per_token_batches: 2e-7
       region: us-east1
-    - cache_read_input_audio_token_cost: 3.e-8
-      cache_read_input_token_cost: 1.e-8
-      input_cost_per_audio_token: 3.e-7
-      input_cost_per_token: 1.e-7
-      input_cost_per_token_batches: 5.e-8
-      output_cost_per_token: 4.e-7
-      output_cost_per_token_batches: 2.e-7
+    - cache_read_input_audio_token_cost: 3e-8
+      cache_read_input_token_cost: 1e-8
+      input_cost_per_audio_token: 3e-7
+      input_cost_per_token: 1e-7
+      input_cost_per_token_batches: 5e-8
+      output_cost_per_token: 4e-7
+      output_cost_per_token_batches: 2e-7
       region: us-central1
-    - cache_read_input_audio_token_cost: 3.e-8
-      cache_read_input_token_cost: 1.e-8
-      input_cost_per_audio_token: 3.e-7
-      input_cost_per_token: 1.e-7
-      input_cost_per_token_batches: 5.e-8
-      output_cost_per_token: 4.e-7
-      output_cost_per_token_batches: 2.e-7
+    - cache_read_input_audio_token_cost: 3e-8
+      cache_read_input_token_cost: 1e-8
+      input_cost_per_audio_token: 3e-7
+      input_cost_per_token: 1e-7
+      input_cost_per_token_batches: 5e-8
+      output_cost_per_token: 4e-7
+      output_cost_per_token_batches: 2e-7
       region: global
-    - cache_read_input_audio_token_cost: 3.e-8
-      cache_read_input_token_cost: 1.e-8
-      input_cost_per_audio_token: 3.e-7
-      input_cost_per_token: 1.e-7
-      input_cost_per_token_batches: 5.e-8
-      output_cost_per_token: 4.e-7
-      output_cost_per_token_batches: 2.e-7
+    - cache_read_input_audio_token_cost: 3e-8
+      cache_read_input_token_cost: 1e-8
+      input_cost_per_audio_token: 3e-7
+      input_cost_per_token: 1e-7
+      input_cost_per_token_batches: 5e-8
+      output_cost_per_token: 4e-7
+      output_cost_per_token_batches: 2e-7
       region: europe-west9
-    - cache_read_input_audio_token_cost: 3.e-8
-      cache_read_input_token_cost: 1.e-8
-      input_cost_per_audio_token: 3.e-7
-      input_cost_per_token: 1.e-7
-      input_cost_per_token_batches: 5.e-8
-      output_cost_per_token: 4.e-7
-      output_cost_per_token_batches: 2.e-7
+    - cache_read_input_audio_token_cost: 3e-8
+      cache_read_input_token_cost: 1e-8
+      input_cost_per_audio_token: 3e-7
+      input_cost_per_token: 1e-7
+      input_cost_per_token_batches: 5e-8
+      output_cost_per_token: 4e-7
+      output_cost_per_token_batches: 2e-7
       region: europe-west8
-    - cache_read_input_audio_token_cost: 3.e-8
-      cache_read_input_token_cost: 1.e-8
-      input_cost_per_audio_token: 3.e-7
-      input_cost_per_token: 1.e-7
-      input_cost_per_token_batches: 5.e-8
-      output_cost_per_token: 4.e-7
-      output_cost_per_token_batches: 2.e-7
+    - cache_read_input_audio_token_cost: 3e-8
+      cache_read_input_token_cost: 1e-8
+      input_cost_per_audio_token: 3e-7
+      input_cost_per_token: 1e-7
+      input_cost_per_token_batches: 5e-8
+      output_cost_per_token: 4e-7
+      output_cost_per_token_batches: 2e-7
       region: europe-west4
-    - cache_read_input_audio_token_cost: 3.e-8
-      cache_read_input_token_cost: 1.e-8
-      input_cost_per_audio_token: 3.e-7
-      input_cost_per_token: 1.e-7
-      input_cost_per_token_batches: 5.e-8
-      output_cost_per_token: 4.e-7
-      output_cost_per_token_batches: 2.e-7
+    - cache_read_input_audio_token_cost: 3e-8
+      cache_read_input_token_cost: 1e-8
+      input_cost_per_audio_token: 3e-7
+      input_cost_per_token: 1e-7
+      input_cost_per_token_batches: 5e-8
+      output_cost_per_token: 4e-7
+      output_cost_per_token_batches: 2e-7
       region: europe-west1
-    - cache_read_input_audio_token_cost: 3.e-8
-      cache_read_input_token_cost: 1.e-8
-      input_cost_per_audio_token: 3.e-7
-      input_cost_per_token: 1.e-7
-      input_cost_per_token_batches: 5.e-8
-      output_cost_per_token: 4.e-7
-      output_cost_per_token_batches: 2.e-7
+    - cache_read_input_audio_token_cost: 3e-8
+      cache_read_input_token_cost: 1e-8
+      input_cost_per_audio_token: 3e-7
+      input_cost_per_token: 1e-7
+      input_cost_per_token_batches: 5e-8
+      output_cost_per_token: 4e-7
+      output_cost_per_token_batches: 2e-7
       region: europe-southwest1
-    - cache_read_input_audio_token_cost: 3.e-8
-      cache_read_input_token_cost: 1.e-8
-      input_cost_per_audio_token: 3.e-7
-      input_cost_per_token: 1.e-7
-      input_cost_per_token_batches: 5.e-8
-      output_cost_per_token: 4.e-7
-      output_cost_per_token_batches: 2.e-7
+    - cache_read_input_audio_token_cost: 3e-8
+      cache_read_input_token_cost: 1e-8
+      input_cost_per_audio_token: 3e-7
+      input_cost_per_token: 1e-7
+      input_cost_per_token_batches: 5e-8
+      output_cost_per_token: 4e-7
+      output_cost_per_token_batches: 2e-7
       region: europe-north1
-    - cache_read_input_audio_token_cost: 3.e-8
-      cache_read_input_token_cost: 1.e-8
-      input_cost_per_audio_token: 3.e-7
-      input_cost_per_token: 1.e-7
-      input_cost_per_token_batches: 5.e-8
-      output_cost_per_token: 4.e-7
-      output_cost_per_token_batches: 2.e-7
+    - cache_read_input_audio_token_cost: 3e-8
+      cache_read_input_token_cost: 1e-8
+      input_cost_per_audio_token: 3e-7
+      input_cost_per_token: 1e-7
+      input_cost_per_token_batches: 5e-8
+      output_cost_per_token: 4e-7
+      output_cost_per_token_batches: 2e-7
       region: europe-central2
 deprecationDate: "2026-10-16"
 features:

--- a/providers/google-vertex/gemini-2.5-flash-preview-09-2025.yaml
+++ b/providers/google-vertex/gemini-2.5-flash-preview-09-2025.yaml
@@ -1,8 +1,8 @@
 costs:
-    - cache_read_input_token_cost: 3.e-8
+    - cache_read_input_token_cost: 3e-8
       cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000025
       region: global
 features:

--- a/providers/google-vertex/gemini-2.5-flash.yaml
+++ b/providers/google-vertex/gemini-2.5-flash.yaml
@@ -1,216 +1,216 @@
 costs:
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: us-west4
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: us-west1
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: us-south1
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: us-east5
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: us-east4
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: us-east1
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: us-central1
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: southamerica-east1
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: northamerica-northeast1
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: global
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: europe-west9
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: europe-west8
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: europe-west4
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: europe-west3
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: europe-west2
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: europe-west1
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: europe-southwest1
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: europe-north1
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: europe-central2
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: australia-southeast1
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: asia-southeast1
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: asia-south1
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: asia-northeast3
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125

--- a/providers/google-vertex/gemini-2.5-pro-tts.yaml
+++ b/providers/google-vertex/gemini-2.5-pro-tts.yaml
@@ -1,151 +1,151 @@
 costs:
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: us-west4
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: us-west1
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: us-south1
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: us-east5
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: us-east4
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: us-east1
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: us-central1
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: southamerica-east1
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: northamerica-northeast1
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: me-west1
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: me-central2
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: me-central1
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: global
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: europe-west9
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: europe-west8
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: europe-west6
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: europe-west4
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: europe-west3
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: europe-west2
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: europe-west1
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: europe-southwest1
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: europe-north1
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: europe-central2
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: australia-southeast1
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: asia-southeast1
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: asia-south1
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: asia-northeast3
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: asia-northeast1
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: asia-east2
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: asia-east1

--- a/providers/google-vertex/gemini-3-flash-preview.yaml
+++ b/providers/google-vertex/gemini-3-flash-preview.yaml
@@ -1,8 +1,8 @@
 costs:
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 5.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 5e-8
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 5.e-7
+      input_cost_per_token: 5e-7
       input_cost_per_token_batches: 2.5e-7
       output_cost_per_token: 0.000003
       output_cost_per_token_batches: 0.0000015

--- a/providers/google-vertex/gemini-3-pro-preview.yaml
+++ b/providers/google-vertex/gemini-3-pro-preview.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000012
@@ -7,7 +7,7 @@ costs:
       region: us-west4
       tiered_pricing:
           cache_read:
-              - cost_per_token: 4.e-7
+              - cost_per_token: 4e-7
                 from: 200000
           input:
               - cost_per_token: 0.000004
@@ -15,7 +15,7 @@ costs:
           output:
               - cost_per_token: 0.000018
                 from: 200000
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000012
@@ -23,7 +23,7 @@ costs:
       region: us-west1
       tiered_pricing:
           cache_read:
-              - cost_per_token: 4.e-7
+              - cost_per_token: 4e-7
                 from: 200000
           input:
               - cost_per_token: 0.000004
@@ -31,7 +31,7 @@ costs:
           output:
               - cost_per_token: 0.000018
                 from: 200000
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000012
@@ -39,7 +39,7 @@ costs:
       region: us-south1
       tiered_pricing:
           cache_read:
-              - cost_per_token: 4.e-7
+              - cost_per_token: 4e-7
                 from: 200000
           input:
               - cost_per_token: 0.000004
@@ -47,7 +47,7 @@ costs:
           output:
               - cost_per_token: 0.000018
                 from: 200000
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000012
@@ -55,7 +55,7 @@ costs:
       region: us-east5
       tiered_pricing:
           cache_read:
-              - cost_per_token: 4.e-7
+              - cost_per_token: 4e-7
                 from: 200000
           input:
               - cost_per_token: 0.000004
@@ -63,7 +63,7 @@ costs:
           output:
               - cost_per_token: 0.000018
                 from: 200000
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000012
@@ -71,7 +71,7 @@ costs:
       region: us-east4
       tiered_pricing:
           cache_read:
-              - cost_per_token: 4.e-7
+              - cost_per_token: 4e-7
                 from: 200000
           input:
               - cost_per_token: 0.000004
@@ -79,7 +79,7 @@ costs:
           output:
               - cost_per_token: 0.000018
                 from: 200000
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000012
@@ -87,7 +87,7 @@ costs:
       region: us-east1
       tiered_pricing:
           cache_read:
-              - cost_per_token: 4.e-7
+              - cost_per_token: 4e-7
                 from: 200000
           input:
               - cost_per_token: 0.000004
@@ -95,7 +95,7 @@ costs:
           output:
               - cost_per_token: 0.000018
                 from: 200000
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000012
@@ -103,7 +103,7 @@ costs:
       region: us-central1
       tiered_pricing:
           cache_read:
-              - cost_per_token: 4.e-7
+              - cost_per_token: 4e-7
                 from: 200000
           input:
               - cost_per_token: 0.000004
@@ -111,7 +111,7 @@ costs:
           output:
               - cost_per_token: 0.000018
                 from: 200000
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000012
@@ -119,7 +119,7 @@ costs:
       region: southamerica-east1
       tiered_pricing:
           cache_read:
-              - cost_per_token: 4.e-7
+              - cost_per_token: 4e-7
                 from: 200000
           input:
               - cost_per_token: 0.000004
@@ -127,7 +127,7 @@ costs:
           output:
               - cost_per_token: 0.000018
                 from: 200000
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000012
@@ -135,7 +135,7 @@ costs:
       region: northamerica-northeast1
       tiered_pricing:
           cache_read:
-              - cost_per_token: 4.e-7
+              - cost_per_token: 4e-7
                 from: 200000
           input:
               - cost_per_token: 0.000004
@@ -143,7 +143,7 @@ costs:
           output:
               - cost_per_token: 0.000018
                 from: 200000
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000012
@@ -151,7 +151,7 @@ costs:
       region: me-west1
       tiered_pricing:
           cache_read:
-              - cost_per_token: 4.e-7
+              - cost_per_token: 4e-7
                 from: 200000
           input:
               - cost_per_token: 0.000004
@@ -159,7 +159,7 @@ costs:
           output:
               - cost_per_token: 0.000018
                 from: 200000
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000012
@@ -167,7 +167,7 @@ costs:
       region: me-central2
       tiered_pricing:
           cache_read:
-              - cost_per_token: 4.e-7
+              - cost_per_token: 4e-7
                 from: 200000
           input:
               - cost_per_token: 0.000004
@@ -175,7 +175,7 @@ costs:
           output:
               - cost_per_token: 0.000018
                 from: 200000
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000012
@@ -183,7 +183,7 @@ costs:
       region: me-central1
       tiered_pricing:
           cache_read:
-              - cost_per_token: 4.e-7
+              - cost_per_token: 4e-7
                 from: 200000
           input:
               - cost_per_token: 0.000004
@@ -191,7 +191,7 @@ costs:
           output:
               - cost_per_token: 0.000018
                 from: 200000
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000012
@@ -199,7 +199,7 @@ costs:
       region: global
       tiered_pricing:
           cache_read:
-              - cost_per_token: 4.e-7
+              - cost_per_token: 4e-7
                 from: 200000
           input:
               - cost_per_token: 0.000004
@@ -207,7 +207,7 @@ costs:
           output:
               - cost_per_token: 0.000018
                 from: 200000
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000012
@@ -215,7 +215,7 @@ costs:
       region: europe-west9
       tiered_pricing:
           cache_read:
-              - cost_per_token: 4.e-7
+              - cost_per_token: 4e-7
                 from: 200000
           input:
               - cost_per_token: 0.000004
@@ -223,7 +223,7 @@ costs:
           output:
               - cost_per_token: 0.000018
                 from: 200000
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000012
@@ -231,7 +231,7 @@ costs:
       region: europe-west8
       tiered_pricing:
           cache_read:
-              - cost_per_token: 4.e-7
+              - cost_per_token: 4e-7
                 from: 200000
           input:
               - cost_per_token: 0.000004
@@ -239,7 +239,7 @@ costs:
           output:
               - cost_per_token: 0.000018
                 from: 200000
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000012
@@ -247,7 +247,7 @@ costs:
       region: europe-west6
       tiered_pricing:
           cache_read:
-              - cost_per_token: 4.e-7
+              - cost_per_token: 4e-7
                 from: 200000
           input:
               - cost_per_token: 0.000004
@@ -255,7 +255,7 @@ costs:
           output:
               - cost_per_token: 0.000018
                 from: 200000
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000012
@@ -263,7 +263,7 @@ costs:
       region: europe-west4
       tiered_pricing:
           cache_read:
-              - cost_per_token: 4.e-7
+              - cost_per_token: 4e-7
                 from: 200000
           input:
               - cost_per_token: 0.000004
@@ -271,7 +271,7 @@ costs:
           output:
               - cost_per_token: 0.000018
                 from: 200000
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000012
@@ -279,7 +279,7 @@ costs:
       region: europe-west3
       tiered_pricing:
           cache_read:
-              - cost_per_token: 4.e-7
+              - cost_per_token: 4e-7
                 from: 200000
           input:
               - cost_per_token: 0.000004
@@ -287,7 +287,7 @@ costs:
           output:
               - cost_per_token: 0.000018
                 from: 200000
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000012
@@ -295,7 +295,7 @@ costs:
       region: europe-west2
       tiered_pricing:
           cache_read:
-              - cost_per_token: 4.e-7
+              - cost_per_token: 4e-7
                 from: 200000
           input:
               - cost_per_token: 0.000004
@@ -303,7 +303,7 @@ costs:
           output:
               - cost_per_token: 0.000018
                 from: 200000
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000012
@@ -311,7 +311,7 @@ costs:
       region: europe-west1
       tiered_pricing:
           cache_read:
-              - cost_per_token: 4.e-7
+              - cost_per_token: 4e-7
                 from: 200000
           input:
               - cost_per_token: 0.000004
@@ -319,7 +319,7 @@ costs:
           output:
               - cost_per_token: 0.000018
                 from: 200000
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000012
@@ -327,7 +327,7 @@ costs:
       region: europe-southwest1
       tiered_pricing:
           cache_read:
-              - cost_per_token: 4.e-7
+              - cost_per_token: 4e-7
                 from: 200000
           input:
               - cost_per_token: 0.000004
@@ -335,7 +335,7 @@ costs:
           output:
               - cost_per_token: 0.000018
                 from: 200000
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000012
@@ -343,7 +343,7 @@ costs:
       region: europe-north1
       tiered_pricing:
           cache_read:
-              - cost_per_token: 4.e-7
+              - cost_per_token: 4e-7
                 from: 200000
           input:
               - cost_per_token: 0.000004
@@ -351,7 +351,7 @@ costs:
           output:
               - cost_per_token: 0.000018
                 from: 200000
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000012
@@ -359,7 +359,7 @@ costs:
       region: europe-central2
       tiered_pricing:
           cache_read:
-              - cost_per_token: 4.e-7
+              - cost_per_token: 4e-7
                 from: 200000
           input:
               - cost_per_token: 0.000004
@@ -367,7 +367,7 @@ costs:
           output:
               - cost_per_token: 0.000018
                 from: 200000
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000012
@@ -375,7 +375,7 @@ costs:
       region: australia-southeast1
       tiered_pricing:
           cache_read:
-              - cost_per_token: 4.e-7
+              - cost_per_token: 4e-7
                 from: 200000
           input:
               - cost_per_token: 0.000004
@@ -383,7 +383,7 @@ costs:
           output:
               - cost_per_token: 0.000018
                 from: 200000
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000012
@@ -391,7 +391,7 @@ costs:
       region: asia-southeast1
       tiered_pricing:
           cache_read:
-              - cost_per_token: 4.e-7
+              - cost_per_token: 4e-7
                 from: 200000
           input:
               - cost_per_token: 0.000004
@@ -399,7 +399,7 @@ costs:
           output:
               - cost_per_token: 0.000018
                 from: 200000
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000012
@@ -407,7 +407,7 @@ costs:
       region: asia-south1
       tiered_pricing:
           cache_read:
-              - cost_per_token: 4.e-7
+              - cost_per_token: 4e-7
                 from: 200000
           input:
               - cost_per_token: 0.000004
@@ -415,7 +415,7 @@ costs:
           output:
               - cost_per_token: 0.000018
                 from: 200000
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000012
@@ -423,7 +423,7 @@ costs:
       region: asia-northeast3
       tiered_pricing:
           cache_read:
-              - cost_per_token: 4.e-7
+              - cost_per_token: 4e-7
                 from: 200000
           input:
               - cost_per_token: 0.000004
@@ -431,7 +431,7 @@ costs:
           output:
               - cost_per_token: 0.000018
                 from: 200000
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000012
@@ -439,7 +439,7 @@ costs:
       region: asia-northeast1
       tiered_pricing:
           cache_read:
-              - cost_per_token: 4.e-7
+              - cost_per_token: 4e-7
                 from: 200000
           input:
               - cost_per_token: 0.000004
@@ -447,7 +447,7 @@ costs:
           output:
               - cost_per_token: 0.000018
                 from: 200000
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000012
@@ -455,7 +455,7 @@ costs:
       region: asia-east2
       tiered_pricing:
           cache_read:
-              - cost_per_token: 4.e-7
+              - cost_per_token: 4e-7
                 from: 200000
           input:
               - cost_per_token: 0.000004
@@ -463,7 +463,7 @@ costs:
           output:
               - cost_per_token: 0.000018
                 from: 200000
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000012
@@ -471,7 +471,7 @@ costs:
       region: asia-east1
       tiered_pricing:
           cache_read:
-              - cost_per_token: 4.e-7
+              - cost_per_token: 4e-7
                 from: 200000
           input:
               - cost_per_token: 0.000004

--- a/providers/google-vertex/gemini-3.1-flash-image-preview.yaml
+++ b/providers/google-vertex/gemini-3.1-flash-image-preview.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
       input_cost_per_token_batches: 2.5e-7
       output_cost_per_image_token: 0.00006
       output_cost_per_token: 0.000003

--- a/providers/google-vertex/gemini-3.1-flash-lite-preview.yaml
+++ b/providers/google-vertex/gemini-3.1-flash-lite-preview.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_audio_token_cost: 5.e-8
-      cache_read_input_token_cost: 3.e-8
-      input_cost_per_audio_token: 5.e-7
+    - cache_read_input_audio_token_cost: 5e-8
+      cache_read_input_token_cost: 3e-8
+      input_cost_per_audio_token: 5e-7
       input_cost_per_token: 2.5e-7
       input_cost_per_token_batches: 1.25e-7
       output_cost_per_token: 0.0000015

--- a/providers/google-vertex/gemini-3.1-pro-preview.yaml
+++ b/providers/google-vertex/gemini-3.1-pro-preview.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000012
@@ -7,7 +7,7 @@ costs:
       region: global
       tiered_pricing:
           cache_read:
-              - cost_per_token: 4.e-7
+              - cost_per_token: 4e-7
                 from: 200000
           input:
               - cost_per_token: 0.000004

--- a/providers/google-vertex/gemini-embedding-2-preview.yaml
+++ b/providers/google-vertex/gemini-embedding-2-preview.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 2.e-7
+    - input_cost_per_token: 2e-7
       region: us-central1
 limits:
     max_input_tokens: 8192

--- a/providers/google-vertex/gemini-live-2.5-flash-native-audio.yaml
+++ b/providers/google-vertex/gemini-live-2.5-flash-native-audio.yaml
@@ -1,91 +1,91 @@
 costs:
     - input_cost_per_audio_token: 0.000003
       input_cost_per_image_token: 0.000003
-      input_cost_per_token: 5.e-7
+      input_cost_per_token: 5e-7
       input_cost_per_video_token: 0.000003
       output_cost_per_audio_token: 0.000012
       output_cost_per_token: 0.000002
       region: us-west4
     - input_cost_per_audio_token: 0.000003
       input_cost_per_image_token: 0.000003
-      input_cost_per_token: 5.e-7
+      input_cost_per_token: 5e-7
       input_cost_per_video_token: 0.000003
       output_cost_per_audio_token: 0.000012
       output_cost_per_token: 0.000002
       region: us-west1
     - input_cost_per_audio_token: 0.000003
       input_cost_per_image_token: 0.000003
-      input_cost_per_token: 5.e-7
+      input_cost_per_token: 5e-7
       input_cost_per_video_token: 0.000003
       output_cost_per_audio_token: 0.000012
       output_cost_per_token: 0.000002
       region: us-south1
     - input_cost_per_audio_token: 0.000003
       input_cost_per_image_token: 0.000003
-      input_cost_per_token: 5.e-7
+      input_cost_per_token: 5e-7
       input_cost_per_video_token: 0.000003
       output_cost_per_audio_token: 0.000012
       output_cost_per_token: 0.000002
       region: us-east5
     - input_cost_per_audio_token: 0.000003
       input_cost_per_image_token: 0.000003
-      input_cost_per_token: 5.e-7
+      input_cost_per_token: 5e-7
       input_cost_per_video_token: 0.000003
       output_cost_per_audio_token: 0.000012
       output_cost_per_token: 0.000002
       region: us-east4
     - input_cost_per_audio_token: 0.000003
       input_cost_per_image_token: 0.000003
-      input_cost_per_token: 5.e-7
+      input_cost_per_token: 5e-7
       input_cost_per_video_token: 0.000003
       output_cost_per_audio_token: 0.000012
       output_cost_per_token: 0.000002
       region: us-east1
     - input_cost_per_audio_token: 0.000003
       input_cost_per_image_token: 0.000003
-      input_cost_per_token: 5.e-7
+      input_cost_per_token: 5e-7
       input_cost_per_video_token: 0.000003
       output_cost_per_audio_token: 0.000012
       output_cost_per_token: 0.000002
       region: us-central1
     - input_cost_per_audio_token: 0.000003
       input_cost_per_image_token: 0.000003
-      input_cost_per_token: 5.e-7
+      input_cost_per_token: 5e-7
       input_cost_per_video_token: 0.000003
       output_cost_per_audio_token: 0.000012
       output_cost_per_token: 0.000002
       region: europe-west8
     - input_cost_per_audio_token: 0.000003
       input_cost_per_image_token: 0.000003
-      input_cost_per_token: 5.e-7
+      input_cost_per_token: 5e-7
       input_cost_per_video_token: 0.000003
       output_cost_per_audio_token: 0.000012
       output_cost_per_token: 0.000002
       region: europe-west4
     - input_cost_per_audio_token: 0.000003
       input_cost_per_image_token: 0.000003
-      input_cost_per_token: 5.e-7
+      input_cost_per_token: 5e-7
       input_cost_per_video_token: 0.000003
       output_cost_per_audio_token: 0.000012
       output_cost_per_token: 0.000002
       region: europe-west1
     - input_cost_per_audio_token: 0.000003
       input_cost_per_image_token: 0.000003
-      input_cost_per_token: 5.e-7
+      input_cost_per_token: 5e-7
       input_cost_per_video_token: 0.000003
       output_cost_per_audio_token: 0.000012
       output_cost_per_token: 0.000002
       region: europe-southwest1
     - input_cost_per_audio_token: 0.000003
       input_cost_per_image_token: 0.000003
-      input_cost_per_token: 5.e-7
+      input_cost_per_token: 5e-7
       input_cost_per_video_token: 0.000003
       output_cost_per_audio_token: 0.000012
       output_cost_per_token: 0.000002
       region: europe-north1
     - input_cost_per_audio_token: 0.000003
       input_cost_per_image_token: 0.000003
-      input_cost_per_token: 5.e-7
+      input_cost_per_token: 5e-7
       input_cost_per_video_token: 0.000003
       output_cost_per_audio_token: 0.000012
       output_cost_per_token: 0.000002

--- a/providers/google-vertex/gemini-pro-vision.yaml
+++ b/providers/google-vertex/gemini-pro-vision.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_image: 0.0025
-      input_cost_per_token: 5.e-7
+      input_cost_per_token: 5e-7
       output_cost_per_token: 0.0000015
       region: "*"
 features:

--- a/providers/google-vertex/gemini-pro.yaml
+++ b/providers/google-vertex/gemini-pro.yaml
@@ -1,7 +1,7 @@
 costs:
     - input_cost_per_character: 1.25e-7
       input_cost_per_image: 0.0025
-      input_cost_per_token: 5.e-7
+      input_cost_per_token: 5e-7
       output_cost_per_token: 0.0000015
       region: "*"
 features:

--- a/providers/google-vertex/google/gemini-2.0-flash-lite-001.yaml
+++ b/providers/google-vertex/google/gemini-2.0-flash-lite-001.yaml
@@ -2,91 +2,91 @@ costs:
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: us-west4
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: us-west1
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: us-south1
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: us-east5
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: us-east4
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: us-east1
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: us-central1
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: global
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: europe-west9
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: europe-west8
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: europe-west4
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: europe-west1
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: europe-southwest1
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: europe-north1
     - input_cost_per_audio_token: 7.5e-8
       input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: europe-central2
 deprecationDate: "2026-06-01"

--- a/providers/google-vertex/google/gemini-2.5-flash-image.yaml
+++ b/providers/google-vertex/google/gemini-2.5-flash-image.yaml
@@ -1,77 +1,77 @@
 costs:
-    - input_cost_per_token: 3.e-7
+    - input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_image_token: 0.00003
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: us-west4
-    - input_cost_per_token: 3.e-7
+    - input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_image_token: 0.00003
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: us-west1
-    - input_cost_per_token: 3.e-7
+    - input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_image_token: 0.00003
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: us-south1
-    - input_cost_per_token: 3.e-7
+    - input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_image_token: 0.00003
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: us-east5
-    - input_cost_per_token: 3.e-7
+    - input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_image_token: 0.00003
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: us-east4
-    - input_cost_per_token: 3.e-7
+    - input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_image_token: 0.00003
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: us-east1
-    - input_cost_per_token: 3.e-7
+    - input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_image_token: 0.00003
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: us-central1
-    - input_cost_per_token: 3.e-7
+    - input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_image_token: 0.00003
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: europe-west8
-    - input_cost_per_token: 3.e-7
+    - input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_image_token: 0.00003
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: europe-west4
-    - input_cost_per_token: 3.e-7
+    - input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_image_token: 0.00003
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: europe-west1
-    - input_cost_per_token: 3.e-7
+    - input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_image_token: 0.00003
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: europe-southwest1
-    - input_cost_per_token: 3.e-7
+    - input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_image_token: 0.00003
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: europe-north1
-    - input_cost_per_token: 3.e-7
+    - input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_image_token: 0.00003
       output_cost_per_token: 0.0000025

--- a/providers/google-vertex/google/gemini-2.5-flash-lite-preview-09-2025.yaml
+++ b/providers/google-vertex/google/gemini-2.5-flash-lite-preview-09-2025.yaml
@@ -1,12 +1,12 @@
 costs:
-    - cache_read_input_audio_token_cost: 3.e-8
-      cache_read_input_token_cost: 1.e-8
+    - cache_read_input_audio_token_cost: 3e-8
+      cache_read_input_token_cost: 1e-8
       cache_storage_cost_per_token_per_hour: 0.000001
-      input_cost_per_audio_token: 3.e-7
-      input_cost_per_token: 1.e-7
-      input_cost_per_token_batches: 5.e-8
-      output_cost_per_token: 4.e-7
-      output_cost_per_token_batches: 2.e-7
+      input_cost_per_audio_token: 3e-7
+      input_cost_per_token: 1e-7
+      input_cost_per_token_batches: 5e-8
+      output_cost_per_token: 4e-7
+      output_cost_per_token_batches: 2e-7
       region: global
 features:
     - function_calling

--- a/providers/google-vertex/google/gemini-2.5-flash-lite.yaml
+++ b/providers/google-vertex/google/gemini-2.5-flash-lite.yaml
@@ -1,123 +1,123 @@
 costs:
-    - cache_read_input_audio_token_cost: 3.e-8
-      cache_read_input_token_cost: 1.e-8
-      input_cost_per_audio_token: 3.e-7
-      input_cost_per_token: 1.e-7
-      input_cost_per_token_batches: 5.e-8
-      output_cost_per_token: 4.e-7
-      output_cost_per_token_batches: 2.e-7
+    - cache_read_input_audio_token_cost: 3e-8
+      cache_read_input_token_cost: 1e-8
+      input_cost_per_audio_token: 3e-7
+      input_cost_per_token: 1e-7
+      input_cost_per_token_batches: 5e-8
+      output_cost_per_token: 4e-7
+      output_cost_per_token_batches: 2e-7
       region: us-west4
-    - cache_read_input_audio_token_cost: 3.e-8
-      cache_read_input_token_cost: 1.e-8
-      input_cost_per_audio_token: 3.e-7
-      input_cost_per_token: 1.e-7
-      input_cost_per_token_batches: 5.e-8
-      output_cost_per_token: 4.e-7
-      output_cost_per_token_batches: 2.e-7
+    - cache_read_input_audio_token_cost: 3e-8
+      cache_read_input_token_cost: 1e-8
+      input_cost_per_audio_token: 3e-7
+      input_cost_per_token: 1e-7
+      input_cost_per_token_batches: 5e-8
+      output_cost_per_token: 4e-7
+      output_cost_per_token_batches: 2e-7
       region: us-west1
-    - cache_read_input_audio_token_cost: 3.e-8
-      cache_read_input_token_cost: 1.e-8
-      input_cost_per_audio_token: 3.e-7
-      input_cost_per_token: 1.e-7
-      input_cost_per_token_batches: 5.e-8
-      output_cost_per_token: 4.e-7
-      output_cost_per_token_batches: 2.e-7
+    - cache_read_input_audio_token_cost: 3e-8
+      cache_read_input_token_cost: 1e-8
+      input_cost_per_audio_token: 3e-7
+      input_cost_per_token: 1e-7
+      input_cost_per_token_batches: 5e-8
+      output_cost_per_token: 4e-7
+      output_cost_per_token_batches: 2e-7
       region: us-south1
-    - cache_read_input_audio_token_cost: 3.e-8
-      cache_read_input_token_cost: 1.e-8
-      input_cost_per_audio_token: 3.e-7
-      input_cost_per_token: 1.e-7
-      input_cost_per_token_batches: 5.e-8
-      output_cost_per_token: 4.e-7
-      output_cost_per_token_batches: 2.e-7
+    - cache_read_input_audio_token_cost: 3e-8
+      cache_read_input_token_cost: 1e-8
+      input_cost_per_audio_token: 3e-7
+      input_cost_per_token: 1e-7
+      input_cost_per_token_batches: 5e-8
+      output_cost_per_token: 4e-7
+      output_cost_per_token_batches: 2e-7
       region: us-east5
-    - cache_read_input_audio_token_cost: 3.e-8
-      cache_read_input_token_cost: 1.e-8
-      input_cost_per_audio_token: 3.e-7
-      input_cost_per_token: 1.e-7
-      input_cost_per_token_batches: 5.e-8
-      output_cost_per_token: 4.e-7
-      output_cost_per_token_batches: 2.e-7
+    - cache_read_input_audio_token_cost: 3e-8
+      cache_read_input_token_cost: 1e-8
+      input_cost_per_audio_token: 3e-7
+      input_cost_per_token: 1e-7
+      input_cost_per_token_batches: 5e-8
+      output_cost_per_token: 4e-7
+      output_cost_per_token_batches: 2e-7
       region: us-east4
-    - cache_read_input_audio_token_cost: 3.e-8
-      cache_read_input_token_cost: 1.e-8
-      input_cost_per_audio_token: 3.e-7
-      input_cost_per_token: 1.e-7
-      input_cost_per_token_batches: 5.e-8
-      output_cost_per_token: 4.e-7
-      output_cost_per_token_batches: 2.e-7
+    - cache_read_input_audio_token_cost: 3e-8
+      cache_read_input_token_cost: 1e-8
+      input_cost_per_audio_token: 3e-7
+      input_cost_per_token: 1e-7
+      input_cost_per_token_batches: 5e-8
+      output_cost_per_token: 4e-7
+      output_cost_per_token_batches: 2e-7
       region: us-east1
-    - cache_read_input_audio_token_cost: 3.e-8
-      cache_read_input_token_cost: 1.e-8
-      input_cost_per_audio_token: 3.e-7
-      input_cost_per_token: 1.e-7
-      input_cost_per_token_batches: 5.e-8
-      output_cost_per_token: 4.e-7
-      output_cost_per_token_batches: 2.e-7
+    - cache_read_input_audio_token_cost: 3e-8
+      cache_read_input_token_cost: 1e-8
+      input_cost_per_audio_token: 3e-7
+      input_cost_per_token: 1e-7
+      input_cost_per_token_batches: 5e-8
+      output_cost_per_token: 4e-7
+      output_cost_per_token_batches: 2e-7
       region: us-central1
-    - cache_read_input_audio_token_cost: 3.e-8
-      cache_read_input_token_cost: 1.e-8
-      input_cost_per_audio_token: 3.e-7
-      input_cost_per_token: 1.e-7
-      input_cost_per_token_batches: 5.e-8
-      output_cost_per_token: 4.e-7
-      output_cost_per_token_batches: 2.e-7
+    - cache_read_input_audio_token_cost: 3e-8
+      cache_read_input_token_cost: 1e-8
+      input_cost_per_audio_token: 3e-7
+      input_cost_per_token: 1e-7
+      input_cost_per_token_batches: 5e-8
+      output_cost_per_token: 4e-7
+      output_cost_per_token_batches: 2e-7
       region: global
-    - cache_read_input_audio_token_cost: 3.e-8
-      cache_read_input_token_cost: 1.e-8
-      input_cost_per_audio_token: 3.e-7
-      input_cost_per_token: 1.e-7
-      input_cost_per_token_batches: 5.e-8
-      output_cost_per_token: 4.e-7
-      output_cost_per_token_batches: 2.e-7
+    - cache_read_input_audio_token_cost: 3e-8
+      cache_read_input_token_cost: 1e-8
+      input_cost_per_audio_token: 3e-7
+      input_cost_per_token: 1e-7
+      input_cost_per_token_batches: 5e-8
+      output_cost_per_token: 4e-7
+      output_cost_per_token_batches: 2e-7
       region: europe-west9
-    - cache_read_input_audio_token_cost: 3.e-8
-      cache_read_input_token_cost: 1.e-8
-      input_cost_per_audio_token: 3.e-7
-      input_cost_per_token: 1.e-7
-      input_cost_per_token_batches: 5.e-8
-      output_cost_per_token: 4.e-7
-      output_cost_per_token_batches: 2.e-7
+    - cache_read_input_audio_token_cost: 3e-8
+      cache_read_input_token_cost: 1e-8
+      input_cost_per_audio_token: 3e-7
+      input_cost_per_token: 1e-7
+      input_cost_per_token_batches: 5e-8
+      output_cost_per_token: 4e-7
+      output_cost_per_token_batches: 2e-7
       region: europe-west8
-    - cache_read_input_audio_token_cost: 3.e-8
-      cache_read_input_token_cost: 1.e-8
-      input_cost_per_audio_token: 3.e-7
-      input_cost_per_token: 1.e-7
-      input_cost_per_token_batches: 5.e-8
-      output_cost_per_token: 4.e-7
-      output_cost_per_token_batches: 2.e-7
+    - cache_read_input_audio_token_cost: 3e-8
+      cache_read_input_token_cost: 1e-8
+      input_cost_per_audio_token: 3e-7
+      input_cost_per_token: 1e-7
+      input_cost_per_token_batches: 5e-8
+      output_cost_per_token: 4e-7
+      output_cost_per_token_batches: 2e-7
       region: europe-west4
-    - cache_read_input_audio_token_cost: 3.e-8
-      cache_read_input_token_cost: 1.e-8
-      input_cost_per_audio_token: 3.e-7
-      input_cost_per_token: 1.e-7
-      input_cost_per_token_batches: 5.e-8
-      output_cost_per_token: 4.e-7
-      output_cost_per_token_batches: 2.e-7
+    - cache_read_input_audio_token_cost: 3e-8
+      cache_read_input_token_cost: 1e-8
+      input_cost_per_audio_token: 3e-7
+      input_cost_per_token: 1e-7
+      input_cost_per_token_batches: 5e-8
+      output_cost_per_token: 4e-7
+      output_cost_per_token_batches: 2e-7
       region: europe-west1
-    - cache_read_input_audio_token_cost: 3.e-8
-      cache_read_input_token_cost: 1.e-8
-      input_cost_per_audio_token: 3.e-7
-      input_cost_per_token: 1.e-7
-      input_cost_per_token_batches: 5.e-8
-      output_cost_per_token: 4.e-7
-      output_cost_per_token_batches: 2.e-7
+    - cache_read_input_audio_token_cost: 3e-8
+      cache_read_input_token_cost: 1e-8
+      input_cost_per_audio_token: 3e-7
+      input_cost_per_token: 1e-7
+      input_cost_per_token_batches: 5e-8
+      output_cost_per_token: 4e-7
+      output_cost_per_token_batches: 2e-7
       region: europe-southwest1
-    - cache_read_input_audio_token_cost: 3.e-8
-      cache_read_input_token_cost: 1.e-8
-      input_cost_per_audio_token: 3.e-7
-      input_cost_per_token: 1.e-7
-      input_cost_per_token_batches: 5.e-8
-      output_cost_per_token: 4.e-7
-      output_cost_per_token_batches: 2.e-7
+    - cache_read_input_audio_token_cost: 3e-8
+      cache_read_input_token_cost: 1e-8
+      input_cost_per_audio_token: 3e-7
+      input_cost_per_token: 1e-7
+      input_cost_per_token_batches: 5e-8
+      output_cost_per_token: 4e-7
+      output_cost_per_token_batches: 2e-7
       region: europe-north1
-    - cache_read_input_audio_token_cost: 3.e-8
-      cache_read_input_token_cost: 1.e-8
-      input_cost_per_audio_token: 3.e-7
-      input_cost_per_token: 1.e-7
-      input_cost_per_token_batches: 5.e-8
-      output_cost_per_token: 4.e-7
-      output_cost_per_token_batches: 2.e-7
+    - cache_read_input_audio_token_cost: 3e-8
+      cache_read_input_token_cost: 1e-8
+      input_cost_per_audio_token: 3e-7
+      input_cost_per_token: 1e-7
+      input_cost_per_token_batches: 5e-8
+      output_cost_per_token: 4e-7
+      output_cost_per_token_batches: 2e-7
       region: europe-central2
 features:
     - function_calling

--- a/providers/google-vertex/google/gemini-2.5-flash-preview-09-2025.yaml
+++ b/providers/google-vertex/google/gemini-2.5-flash-preview-09-2025.yaml
@@ -1,8 +1,8 @@
 costs:
-    - cache_read_input_token_cost: 3.e-8
+    - cache_read_input_token_cost: 3e-8
       cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000025
       region: global
 features:

--- a/providers/google-vertex/google/gemini-2.5-flash.yaml
+++ b/providers/google-vertex/google/gemini-2.5-flash.yaml
@@ -1,240 +1,240 @@
 costs:
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: us-west4
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: us-west1
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: us-south1
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: us-east5
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: us-east4
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: us-east1
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: us-central1
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: southamerica-east1
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: northamerica-northeast1
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: me-west1
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: me-central2
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: me-central1
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: global
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: europe-west9
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: europe-west8
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: europe-west6
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: europe-west4
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: europe-west3
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: europe-west2
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: europe-west1
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: europe-southwest1
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: europe-north1
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: europe-central2
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: australia-southeast1
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: asia-southeast1
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: asia-south1
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: asia-northeast3
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: asia-northeast1
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: asia-east2
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125

--- a/providers/google-vertex/google/gemini-2.5-pro-tts.yaml
+++ b/providers/google-vertex/google/gemini-2.5-pro-tts.yaml
@@ -1,151 +1,151 @@
 costs:
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: us-west4
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: us-west1
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: us-south1
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: us-east5
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: us-east4
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: us-east1
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: us-central1
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: southamerica-east1
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: northamerica-northeast1
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: me-west1
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: me-central2
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: me-central1
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: global
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: europe-west9
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: europe-west8
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: europe-west6
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: europe-west4
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: europe-west3
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: europe-west2
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: europe-west1
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: europe-southwest1
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: europe-north1
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: europe-central2
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: australia-southeast1
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: asia-southeast1
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: asia-south1
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: asia-northeast3
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: asia-northeast1
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: asia-east2
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: asia-east1

--- a/providers/google-vertex/google/gemini-3-flash-preview.yaml
+++ b/providers/google-vertex/google/gemini-3-flash-preview.yaml
@@ -1,8 +1,8 @@
 costs:
-    - cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 5.e-8
+    - cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 5e-8
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 5.e-7
+      input_cost_per_token: 5e-7
       input_cost_per_token_batches: 2.5e-7
       output_cost_per_token: 0.000003
       output_cost_per_token_batches: 0.0000015

--- a/providers/google-vertex/google/gemini-3.1-flash-image-preview.yaml
+++ b/providers/google-vertex/google/gemini-3.1-flash-image-preview.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
       input_cost_per_token_batches: 2.5e-7
       output_cost_per_image_token: 0.00006
       output_cost_per_token: 0.000003

--- a/providers/google-vertex/google/gemini-3.1-flash-lite-preview.yaml
+++ b/providers/google-vertex/google/gemini-3.1-flash-lite-preview.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_audio_token_cost: 5.e-8
-      cache_read_input_token_cost: 3.e-8
-      input_cost_per_audio_token: 5.e-7
+    - cache_read_input_audio_token_cost: 5e-8
+      cache_read_input_token_cost: 3e-8
+      input_cost_per_audio_token: 5e-7
       input_cost_per_token: 2.5e-7
       input_cost_per_token_batches: 1.25e-7
       output_cost_per_token: 0.0000015

--- a/providers/google-vertex/google/gemini-3.1-flash-tts-preview.yaml
+++ b/providers/google-vertex/google/gemini-3.1-flash-tts-preview.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token_batches: 0.00001
       region: global

--- a/providers/google-vertex/google/gemini-3.1-pro-preview.yaml
+++ b/providers/google-vertex/google/gemini-3.1-pro-preview.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000012
@@ -7,7 +7,7 @@ costs:
       region: global
       tiered_pricing:
           cache_read:
-              - cost_per_token: 4.e-7
+              - cost_per_token: 4e-7
                 from: 200000
           input:
               - cost_per_token: 0.000004

--- a/providers/google-vertex/google/gemini-embedding-2-preview.yaml
+++ b/providers/google-vertex/google/gemini-embedding-2-preview.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 2.e-7
+    - input_cost_per_token: 2e-7
       region: us-central1
 limits:
     max_input_tokens: 8192

--- a/providers/google-vertex/google/gemini-live-2.5-flash-native-audio.yaml
+++ b/providers/google-vertex/google/gemini-live-2.5-flash-native-audio.yaml
@@ -1,91 +1,91 @@
 costs:
     - input_cost_per_audio_token: 0.000003
       input_cost_per_image_token: 0.000003
-      input_cost_per_token: 5.e-7
+      input_cost_per_token: 5e-7
       input_cost_per_video_token: 0.000003
       output_cost_per_audio_token: 0.000012
       output_cost_per_token: 0.000002
       region: us-west4
     - input_cost_per_audio_token: 0.000003
       input_cost_per_image_token: 0.000003
-      input_cost_per_token: 5.e-7
+      input_cost_per_token: 5e-7
       input_cost_per_video_token: 0.000003
       output_cost_per_audio_token: 0.000012
       output_cost_per_token: 0.000002
       region: us-west1
     - input_cost_per_audio_token: 0.000003
       input_cost_per_image_token: 0.000003
-      input_cost_per_token: 5.e-7
+      input_cost_per_token: 5e-7
       input_cost_per_video_token: 0.000003
       output_cost_per_audio_token: 0.000012
       output_cost_per_token: 0.000002
       region: us-south1
     - input_cost_per_audio_token: 0.000003
       input_cost_per_image_token: 0.000003
-      input_cost_per_token: 5.e-7
+      input_cost_per_token: 5e-7
       input_cost_per_video_token: 0.000003
       output_cost_per_audio_token: 0.000012
       output_cost_per_token: 0.000002
       region: us-east5
     - input_cost_per_audio_token: 0.000003
       input_cost_per_image_token: 0.000003
-      input_cost_per_token: 5.e-7
+      input_cost_per_token: 5e-7
       input_cost_per_video_token: 0.000003
       output_cost_per_audio_token: 0.000012
       output_cost_per_token: 0.000002
       region: us-east4
     - input_cost_per_audio_token: 0.000003
       input_cost_per_image_token: 0.000003
-      input_cost_per_token: 5.e-7
+      input_cost_per_token: 5e-7
       input_cost_per_video_token: 0.000003
       output_cost_per_audio_token: 0.000012
       output_cost_per_token: 0.000002
       region: us-east1
     - input_cost_per_audio_token: 0.000003
       input_cost_per_image_token: 0.000003
-      input_cost_per_token: 5.e-7
+      input_cost_per_token: 5e-7
       input_cost_per_video_token: 0.000003
       output_cost_per_audio_token: 0.000012
       output_cost_per_token: 0.000002
       region: us-central1
     - input_cost_per_audio_token: 0.000003
       input_cost_per_image_token: 0.000003
-      input_cost_per_token: 5.e-7
+      input_cost_per_token: 5e-7
       input_cost_per_video_token: 0.000003
       output_cost_per_audio_token: 0.000012
       output_cost_per_token: 0.000002
       region: europe-west8
     - input_cost_per_audio_token: 0.000003
       input_cost_per_image_token: 0.000003
-      input_cost_per_token: 5.e-7
+      input_cost_per_token: 5e-7
       input_cost_per_video_token: 0.000003
       output_cost_per_audio_token: 0.000012
       output_cost_per_token: 0.000002
       region: europe-west4
     - input_cost_per_audio_token: 0.000003
       input_cost_per_image_token: 0.000003
-      input_cost_per_token: 5.e-7
+      input_cost_per_token: 5e-7
       input_cost_per_video_token: 0.000003
       output_cost_per_audio_token: 0.000012
       output_cost_per_token: 0.000002
       region: europe-west1
     - input_cost_per_audio_token: 0.000003
       input_cost_per_image_token: 0.000003
-      input_cost_per_token: 5.e-7
+      input_cost_per_token: 5e-7
       input_cost_per_video_token: 0.000003
       output_cost_per_audio_token: 0.000012
       output_cost_per_token: 0.000002
       region: europe-southwest1
     - input_cost_per_audio_token: 0.000003
       input_cost_per_image_token: 0.000003
-      input_cost_per_token: 5.e-7
+      input_cost_per_token: 5e-7
       input_cost_per_video_token: 0.000003
       output_cost_per_audio_token: 0.000012
       output_cost_per_token: 0.000002
       region: europe-north1
     - input_cost_per_audio_token: 0.000003
       input_cost_per_image_token: 0.000003
-      input_cost_per_token: 5.e-7
+      input_cost_per_token: 5e-7
       input_cost_per_video_token: 0.000003
       output_cost_per_audio_token: 0.000012
       output_cost_per_token: 0.000002

--- a/providers/google-vertex/google/gemma-4-26b-a4b-it-maas.yaml
+++ b/providers/google-vertex/google/gemma-4-26b-a4b-it-maas.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: global
 features:
     - function_calling

--- a/providers/google-vertex/google/language-v1-analyze-syntax.yaml
+++ b/providers/google-vertex/google/language-v1-analyze-syntax.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_character: 5.e-7
+    - input_cost_per_character: 5e-7
       region: "*"
 modalities:
     input:

--- a/providers/google-vertex/google/medasr.yaml
+++ b/providers/google-vertex/google/medasr.yaml
@@ -5,6 +5,7 @@ modalities:
         - text
 mode: audio_transcription
 model: google/medasr
+provisioning: provisioned
 removeParams:
     - max_tokens
     - temperature

--- a/providers/google-vertex/google/resnet50.yaml
+++ b/providers/google-vertex/google/resnet50.yaml
@@ -5,6 +5,7 @@ modalities:
         - text
 mode: unknown
 model: google/resnet50
+provisioning: provisioned
 removeParams:
     - temperature
     - top_p
@@ -13,3 +14,6 @@ removeParams:
     - stream
     - tool_choice
     - max_tokens
+status: active
+supportedModes:
+    - unknown

--- a/providers/google-vertex/google/tfvision-yolov7.yaml
+++ b/providers/google-vertex/google/tfvision-yolov7.yaml
@@ -5,6 +5,7 @@ modalities:
         - text
 mode: unknown
 model: google/tfvision-yolov7
+provisioning: provisioned
 removeParams:
     - max_tokens
     - temperature
@@ -13,3 +14,8 @@ removeParams:
     - stop
     - stream
     - tool_choice
+sources:
+    - https://console.cloud.google.com/vertex-ai/publishers/google/model-garden/tfvision-yolov7
+status: preview
+supportedModes:
+    - unknown

--- a/providers/google-vertex/google/txgemma.yaml
+++ b/providers/google-vertex/google/txgemma.yaml
@@ -5,6 +5,7 @@ modalities:
         - text
 mode: chat
 model: google/txgemma
+provisioning: provisioned
 sources:
     - https://developers.google.com/health-ai-developer-foundations/txgemma
     - https://developers.google.com/health-ai-developer-foundations/txgemma/model-card

--- a/providers/google-vertex/jamba-1.5-mini.yaml
+++ b/providers/google-vertex/jamba-1.5-mini.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 4.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 4e-7
       region: "*"
 features:
     - tool_choice

--- a/providers/google-vertex/liuhaotian/pytorch-llava.yaml
+++ b/providers/google-vertex/liuhaotian/pytorch-llava.yaml
@@ -6,5 +6,6 @@ modalities:
         - text
 mode: chat
 model: liuhaotian/pytorch-llava
+provisioning: provisioned
 supportedModes:
     - chat

--- a/providers/google-vertex/lmsys/lmsys-vicuna-7b.yaml
+++ b/providers/google-vertex/lmsys/lmsys-vicuna-7b.yaml
@@ -5,5 +5,6 @@ modalities:
         - text
 mode: chat
 model: lmsys/lmsys-vicuna-7b
+provisioning: provisioned
 supportedModes:
     - chat

--- a/providers/google-vertex/medlm-medium.yaml
+++ b/providers/google-vertex/medlm-medium.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_character: 5.e-7
+    - input_cost_per_character: 5e-7
       region: "*"
 features:
     - tool_choice

--- a/providers/google-vertex/meta/llama-4-scout-17b-16e-instruct-maas.yaml
+++ b/providers/google-vertex/meta/llama-4-scout-17b-16e-instruct-maas.yaml
@@ -1,7 +1,7 @@
 costs:
     - input_cost_per_token: 2.5e-7
       input_cost_per_token_batches: 1.25e-7
-      output_cost_per_token: 7.e-7
+      output_cost_per_token: 7e-7
       output_cost_per_token_batches: 3.5e-7
       region: us-east5
 features:

--- a/providers/google-vertex/minimaxai/minimax-m2-maas.yaml
+++ b/providers/google-vertex/minimaxai/minimax-m2-maas.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 3.e-8
-      input_cost_per_token: 3.e-7
+    - cache_read_input_token_cost: 3e-8
+      input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000012
       region: global
 features:

--- a/providers/google-vertex/mistral-ai/mixtral.yaml
+++ b/providers/google-vertex/mistral-ai/mixtral.yaml
@@ -1,3 +1,5 @@
+deprecationDate: "2024-11-30"
+isDeprecated: true
 mode: chat
 model: mistral-ai/mixtral
 supportedModes:

--- a/providers/google-vertex/mistralai/codestral-2.yaml
+++ b/providers/google-vertex/mistralai/codestral-2.yaml
@@ -1,9 +1,9 @@
 costs:
-    - input_cost_per_token: 3.e-7
-      output_cost_per_token: 9.e-7
+    - input_cost_per_token: 3e-7
+      output_cost_per_token: 9e-7
       region: us-central1
-    - input_cost_per_token: 3.e-7
-      output_cost_per_token: 9.e-7
+    - input_cost_per_token: 3e-7
+      output_cost_per_token: 9e-7
       region: europe-west4
 features:
     - function_calling

--- a/providers/google-vertex/mistralai/codestral-2@001.yaml
+++ b/providers/google-vertex/mistralai/codestral-2@001.yaml
@@ -1,9 +1,9 @@
 costs:
-    - input_cost_per_token: 3.e-7
-      output_cost_per_token: 9.e-7
+    - input_cost_per_token: 3e-7
+      output_cost_per_token: 9e-7
       region: us-central1
-    - input_cost_per_token: 3.e-7
-      output_cost_per_token: 9.e-7
+    - input_cost_per_token: 3e-7
+      output_cost_per_token: 9e-7
       region: europe-west4
 features:
     - function_calling

--- a/providers/google-vertex/mistralai/mistral-large-3.yaml
+++ b/providers/google-vertex/mistralai/mistral-large-3.yaml
@@ -1,8 +1,8 @@
 costs:
-    - input_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
       output_cost_per_token: 0.0000015
       region: us-central1
-    - input_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
       output_cost_per_token: 0.0000015
       region: europe-west4
 features:

--- a/providers/google-vertex/mistralai/mistral-medium-3.yaml
+++ b/providers/google-vertex/mistralai/mistral-medium-3.yaml
@@ -1,8 +1,8 @@
 costs:
-    - input_cost_per_token: 4.e-7
+    - input_cost_per_token: 4e-7
       output_cost_per_token: 0.000002
       region: us-central1
-    - input_cost_per_token: 4.e-7
+    - input_cost_per_token: 4e-7
       output_cost_per_token: 0.000002
       region: europe-west4
 features:
@@ -21,6 +21,7 @@ modalities:
         - text
 mode: chat
 model: mistralai/mistral-medium-3
+provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/mistral
     - https://docs.mistral.ai/models/mistral-medium-3-25-05

--- a/providers/google-vertex/mistralai/mistral-medium-3@001.yaml
+++ b/providers/google-vertex/mistralai/mistral-medium-3@001.yaml
@@ -1,8 +1,8 @@
 costs:
-    - input_cost_per_token: 4.e-7
+    - input_cost_per_token: 4e-7
       output_cost_per_token: 0.000002
       region: us-central1
-    - input_cost_per_token: 4.e-7
+    - input_cost_per_token: 4e-7
       output_cost_per_token: 0.000002
       region: europe-west4
 features:

--- a/providers/google-vertex/mistralai/mistral-ocr-2505.yaml
+++ b/providers/google-vertex/mistralai/mistral-ocr-2505.yaml
@@ -1,9 +1,9 @@
 costs:
-    - input_cost_per_token: 5.e-10
-      output_cost_per_token: 5.e-10
+    - input_cost_per_token: 5e-10
+      output_cost_per_token: 5e-10
       region: us-central1
-    - input_cost_per_token: 5.e-10
-      output_cost_per_token: 5.e-10
+    - input_cost_per_token: 5e-10
+      output_cost_per_token: 5e-10
       region: europe-west4
 deprecationDate: "2026-02-27"
 features:

--- a/providers/google-vertex/mistralai/mistral-small-2503.yaml
+++ b/providers/google-vertex/mistralai/mistral-small-2503.yaml
@@ -1,9 +1,9 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 3.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 3e-7
       region: us-central1
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 3.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 3e-7
       region: europe-west4
 features:
     - function_calling

--- a/providers/google-vertex/mongodb/voyage-3.5-lite.yaml
+++ b/providers/google-vertex/mongodb/voyage-3.5-lite.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 2.e-8
+    - input_cost_per_token: 2e-8
       region: us-central1
 limits:
     max_input_tokens: 32000

--- a/providers/google-vertex/moonshotai/kimi-k2-thinking-maas.yaml
+++ b/providers/google-vertex/moonshotai/kimi-k2-thinking-maas.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_read_input_token_cost: 1.5e-7
-      input_cost_per_token: 6.e-7
+      input_cost_per_token: 6e-7
       output_cost_per_token: 0.0000025
       region: global
 features:

--- a/providers/google-vertex/multimodalembedding@001.yaml
+++ b/providers/google-vertex/multimodalembedding@001.yaml
@@ -1,52 +1,52 @@
 costs:
-    - input_cost_per_character: 2.e-7
+    - input_cost_per_character: 2e-7
       input_cost_per_image: 0.0001
-      input_cost_per_token: 8.e-7
+      input_cost_per_token: 8e-7
       output_cost_per_token: 0
       region: us-central1
-    - input_cost_per_character: 2.e-7
+    - input_cost_per_character: 2e-7
       input_cost_per_image: 0.0001
-      input_cost_per_token: 8.e-7
+      input_cost_per_token: 8e-7
       output_cost_per_token: 0
       region: northamerica-northeast1
-    - input_cost_per_character: 2.e-7
+    - input_cost_per_character: 2e-7
       input_cost_per_image: 0.0001
-      input_cost_per_token: 8.e-7
+      input_cost_per_token: 8e-7
       output_cost_per_token: 0
       region: europe-west9
-    - input_cost_per_character: 2.e-7
+    - input_cost_per_character: 2e-7
       input_cost_per_image: 0.0001
-      input_cost_per_token: 8.e-7
+      input_cost_per_token: 8e-7
       output_cost_per_token: 0
       region: europe-west4
-    - input_cost_per_character: 2.e-7
+    - input_cost_per_character: 2e-7
       input_cost_per_image: 0.0001
-      input_cost_per_token: 8.e-7
+      input_cost_per_token: 8e-7
       output_cost_per_token: 0
       region: europe-west3
-    - input_cost_per_character: 2.e-7
+    - input_cost_per_character: 2e-7
       input_cost_per_image: 0.0001
-      input_cost_per_token: 8.e-7
+      input_cost_per_token: 8e-7
       output_cost_per_token: 0
       region: europe-west2
-    - input_cost_per_character: 2.e-7
+    - input_cost_per_character: 2e-7
       input_cost_per_image: 0.0001
-      input_cost_per_token: 8.e-7
+      input_cost_per_token: 8e-7
       output_cost_per_token: 0
       region: europe-west1
-    - input_cost_per_character: 2.e-7
+    - input_cost_per_character: 2e-7
       input_cost_per_image: 0.0001
-      input_cost_per_token: 8.e-7
+      input_cost_per_token: 8e-7
       output_cost_per_token: 0
       region: asia-southeast1
-    - input_cost_per_character: 2.e-7
+    - input_cost_per_character: 2e-7
       input_cost_per_image: 0.0001
-      input_cost_per_token: 8.e-7
+      input_cost_per_token: 8e-7
       output_cost_per_token: 0
       region: asia-northeast3
-    - input_cost_per_character: 2.e-7
+    - input_cost_per_character: 2e-7
       input_cost_per_image: 0.0001
-      input_cost_per_token: 8.e-7
+      input_cost_per_token: 8e-7
       output_cost_per_token: 0
       region: asia-northeast1
 limits:

--- a/providers/google-vertex/openai/gpt-oss-120b-maas.yaml
+++ b/providers/google-vertex/openai/gpt-oss-120b-maas.yaml
@@ -1,10 +1,10 @@
 costs:
-    - input_cost_per_token: 9.e-8
+    - input_cost_per_token: 9e-8
       input_cost_per_token_batches: 4.5e-8
       output_cost_per_token: 3.6e-7
       output_cost_per_token_batches: 1.8e-7
       region: us-central1
-    - input_cost_per_token: 9.e-8
+    - input_cost_per_token: 9e-8
       input_cost_per_token_batches: 4.5e-8
       output_cost_per_token: 3.6e-7
       output_cost_per_token_batches: 1.8e-7

--- a/providers/google-vertex/openai/gpt-oss-20b-maas.yaml
+++ b/providers/google-vertex/openai/gpt-oss-20b-maas.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 7.e-9
-      input_cost_per_token: 7.e-8
+    - cache_read_input_token_cost: 7e-9
+      input_cost_per_token: 7e-8
       input_cost_per_token_batches: 3.5e-8
       output_cost_per_token: 2.5e-7
       output_cost_per_token_batches: 1.25e-7

--- a/providers/google-vertex/qwen/qwen3-coder-480b-a35b-instruct-maas.yaml
+++ b/providers/google-vertex/qwen/qwen3-coder-480b-a35b-instruct-maas.yaml
@@ -3,13 +3,13 @@ costs:
       input_cost_per_token: 2.2e-7
       input_cost_per_token_batches: 1.1e-7
       output_cost_per_token: 0.0000018
-      output_cost_per_token_batches: 9.e-7
+      output_cost_per_token_batches: 9e-7
       region: us-south1
     - cache_read_input_token_cost: 2.2e-8
       input_cost_per_token: 2.2e-7
       input_cost_per_token_batches: 1.1e-7
       output_cost_per_token: 0.0000018
-      output_cost_per_token_batches: 9.e-7
+      output_cost_per_token_batches: 9e-7
       region: global
 features:
     - function_calling

--- a/providers/google-vertex/qwen/qwen3-coder.yaml
+++ b/providers/google-vertex/qwen/qwen3-coder.yaml
@@ -3,13 +3,13 @@ costs:
       input_cost_per_token: 2.2e-7
       input_cost_per_token_batches: 1.1e-7
       output_cost_per_token: 0.0000018
-      output_cost_per_token_batches: 9.e-7
+      output_cost_per_token_batches: 9e-7
       region: us-south1
     - cache_read_input_token_cost: 2.2e-8
       input_cost_per_token: 2.2e-7
       input_cost_per_token_batches: 1.1e-7
       output_cost_per_token: 0.0000018
-      output_cost_per_token_batches: 9.e-7
+      output_cost_per_token_batches: 9e-7
       region: global
 features:
     - function_calling

--- a/providers/google-vertex/qwen/qwq.yaml
+++ b/providers/google-vertex/qwen/qwq.yaml
@@ -2,6 +2,11 @@ features:
     - system_messages
     - function_calling
     - json_output
+limits:
+    context_window: 131072
+    max_input_tokens: 131072
+    max_output_tokens: 32768
+    max_tokens: 32768
 modalities:
     input:
         - text
@@ -9,9 +14,12 @@ modalities:
         - text
 mode: chat
 model: qwen/qwq
+provisioning: serverless
 sources:
     - https://huggingface.co/Qwen/QwQ-32B
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/qwen/qwen3-235b
 supportedModes:
     - chat
 thinking: true
+
+# costs not found in official docs — QwQ-32B is not listed on the current Vertex AI pricing page or model documentation

--- a/providers/google-vertex/text-embedding-004.yaml
+++ b/providers/google-vertex/text-embedding-004.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_character: 2.5e-8
-      input_cost_per_token: 1.e-7
+      input_cost_per_token: 1e-7
       output_cost_per_token: 0
       region: "*"
 deprecationDate: "2027-04-01"

--- a/providers/google-vertex/text-embedding-005.yaml
+++ b/providers/google-vertex/text-embedding-005.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_character: 2.5e-8
-      input_cost_per_token: 1.e-7
+      input_cost_per_token: 1e-7
       output_cost_per_token: 0
       region: "*"
 limits:

--- a/providers/google-vertex/text-multilingual-embedding-002.yaml
+++ b/providers/google-vertex/text-multilingual-embedding-002.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_character: 2.5e-8
-      input_cost_per_token: 1.e-7
+      input_cost_per_token: 1e-7
       output_cost_per_token: 0
       region: "*"
 limits:

--- a/providers/google-vertex/textembedding-gecko-multilingual.yaml
+++ b/providers/google-vertex/textembedding-gecko-multilingual.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_character: 2.5e-8
-      input_cost_per_token: 1.e-7
+      input_cost_per_token: 1e-7
       output_cost_per_token: 0
       region: "*"
 isDeprecated: true

--- a/providers/google-vertex/textembedding-gecko-multilingual@001.yaml
+++ b/providers/google-vertex/textembedding-gecko-multilingual@001.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_character: 2.5e-8
-      input_cost_per_token: 1.e-7
+      input_cost_per_token: 1e-7
       output_cost_per_token: 0
       region: "*"
 isDeprecated: true

--- a/providers/google-vertex/textembedding-gecko.yaml
+++ b/providers/google-vertex/textembedding-gecko.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_character: 2.5e-8
-      input_cost_per_token: 1.e-7
+      input_cost_per_token: 1e-7
       output_cost_per_token: 0
       region: "*"
 isDeprecated: true

--- a/providers/google-vertex/textembedding-gecko@001.yaml
+++ b/providers/google-vertex/textembedding-gecko@001.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_character: 2.5e-8
-      input_cost_per_token: 1.e-7
+      input_cost_per_token: 1e-7
       output_cost_per_token: 0
       region: "*"
 isDeprecated: true

--- a/providers/google-vertex/textembedding-gecko@003.yaml
+++ b/providers/google-vertex/textembedding-gecko@003.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_character: 2.5e-8
-      input_cost_per_token: 1.e-7
+      input_cost_per_token: 1e-7
       output_cost_per_token: 0
       region: "*"
 isDeprecated: true

--- a/providers/google-vertex/xai/grok-4.1-fast-non-reasoning.yaml
+++ b/providers/google-vertex/xai/grok-4.1-fast-non-reasoning.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_token_cost: 5.e-8
-      input_cost_per_token: 2.e-7
-      output_cost_per_token: 5.e-7
+    - cache_read_input_token_cost: 5e-8
+      input_cost_per_token: 2e-7
+      output_cost_per_token: 5e-7
       region: global
 features:
     - function_calling

--- a/providers/google-vertex/xai/grok-4.1-fast-reasoning.yaml
+++ b/providers/google-vertex/xai/grok-4.1-fast-reasoning.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_token_cost: 5.e-8
-      input_cost_per_token: 2.e-7
-      output_cost_per_token: 5.e-7
+    - cache_read_input_token_cost: 5e-8
+      input_cost_per_token: 2e-7
+      output_cost_per_token: 5e-7
       region: global
 features:
     - function_calling

--- a/providers/google-vertex/xai/grok-4.20-non-reasoning.yaml
+++ b/providers/google-vertex/xai/grok-4.20-non-reasoning.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000006
       region: global

--- a/providers/google-vertex/xai/grok-4.20-reasoning.yaml
+++ b/providers/google-vertex/xai/grok-4.20-reasoning.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000006
       region: global

--- a/providers/google-vertex/zai-org/glm-4.7-maas.yaml
+++ b/providers/google-vertex/zai-org/glm-4.7-maas.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_read_input_token_cost: 1.1e-7
-      input_cost_per_token: 6.e-7
+      input_cost_per_token: 6e-7
       output_cost_per_token: 0.0000022
       region: global
 features:

--- a/providers/google-vertex/zai-org/glm-4.7.yaml
+++ b/providers/google-vertex/zai-org/glm-4.7.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 6.e-7
+    - input_cost_per_token: 6e-7
       output_cost_per_token: 0.0000022
       region: global
 features:

--- a/providers/google-vertex/zai-org/glm-5-maas.yaml
+++ b/providers/google-vertex/zai-org/glm-5-maas.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 1.e-7
+    - cache_read_input_token_cost: 1e-7
       input_cost_per_token: 0.000001
       output_cost_per_token: 0.0000032
       region: global


### PR DESCRIPTION
Auto-generated by poc-agent for provider `google-vertex`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly config-only edits to model YAMLs (pricing numeric formatting and metadata fields). Low risk, but could affect downstream parsing/validation of model configs if strict about numeric formats or new keys like `provisioning`/`limits`.
> 
> **Overview**
> **Updates Google Vertex model catalog YAMLs** with normalized pricing numbers and refreshed metadata.
> 
> Most changes reformat scientific-notation cost fields (e.g., `3.e-7` → `3e-7`) across many models, without changing the underlying values.
> 
> Separately adds/updates model metadata in a few places: introduces `provisioning: provisioned/serverless` on several model entries (e.g., `csm/cube`, `google/medasr`, `google/resnet50`, `qwen/qwq`), adds missing `limits` for `qwen/qwq`, and marks `mistral-ai/mixtral` as deprecated with a `deprecationDate`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5e30b9b2a9c20cf8683881edde6651ce92a2e4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->