### PR TITLE
feat(openrouter): update model YAMLs [bot]

### DIFF
--- a/providers/openrouter/aion-1.0-mini.yaml
+++ b/providers/openrouter/aion-1.0-mini.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 7.e-7
+    - input_cost_per_token: 7e-7
       output_cost_per_token: 0.0000014
       region: "*"
 features:

--- a/providers/openrouter/aion-labs/aion-1.0-mini.yaml
+++ b/providers/openrouter/aion-labs/aion-1.0-mini.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 7.e-7
+    - input_cost_per_token: 7e-7
       output_cost_per_token: 0.0000014
       region: "*"
 limits:

--- a/providers/openrouter/aion-labs/aion-2.0.yaml
+++ b/providers/openrouter/aion-labs/aion-2.0.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
-      input_cost_per_token: 8.e-7
+    - cache_read_input_token_cost: 2e-7
+      input_cost_per_token: 8e-7
       output_cost_per_token: 0.0000016
       region: "*"
 features:

--- a/providers/openrouter/aion-labs/aion-rp-llama-3.1-8b.yaml
+++ b/providers/openrouter/aion-labs/aion-rp-llama-3.1-8b.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 8.e-7
+    - input_cost_per_token: 8e-7
       output_cost_per_token: 0.0000016
       region: "*"
 limits:

--- a/providers/openrouter/aion-rp-llama-3.1-8b.yaml
+++ b/providers/openrouter/aion-rp-llama-3.1-8b.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 8.e-7
+    - input_cost_per_token: 8e-7
       output_cost_per_token: 0.0000016
       region: "*"
 features:

--- a/providers/openrouter/alfredpros/codellama-7b-instruct-solidity.yaml
+++ b/providers/openrouter/alfredpros/codellama-7b-instruct-solidity.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 8.e-7
+    - input_cost_per_token: 8e-7
       output_cost_per_token: 0.0000012
       region: "*"
 limits:

--- a/providers/openrouter/alibaba/tongyi-deepresearch-30b-a3b.yaml
+++ b/providers/openrouter/alibaba/tongyi-deepresearch-30b-a3b.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 9.e-8
+    - input_cost_per_token: 9e-8
       output_cost_per_token: 4.5e-7
       region: "*"
 features:

--- a/providers/openrouter/allenai/olmo-2-0325-32b-instruct.yaml
+++ b/providers/openrouter/allenai/olmo-2-0325-32b-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 5.e-8
-      output_cost_per_token: 2.e-7
+    - input_cost_per_token: 5e-8
+      output_cost_per_token: 2e-7
       region: "*"
 isDeprecated: true
 limits:

--- a/providers/openrouter/allenai/olmo-3-32b-think.yaml
+++ b/providers/openrouter/allenai/olmo-3-32b-think.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 5.e-7
+      output_cost_per_token: 5e-7
       region: "*"
 deprecationDate: "2026-04-06"
 features:

--- a/providers/openrouter/allenai/olmo-3.1-32b-instruct.yaml
+++ b/providers/openrouter/allenai/olmo-3.1-32b-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 6.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 6e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/allenai/olmo-3.1-32b-think.yaml
+++ b/providers/openrouter/allenai/olmo-3.1-32b-think.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 5.e-7
+      output_cost_per_token: 5e-7
       region: "*"
 deprecationDate: "2026-04-06"
 features:

--- a/providers/openrouter/amazon/nova-2-lite-v1.yaml
+++ b/providers/openrouter/amazon/nova-2-lite-v1.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 3.e-7
+    - input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000025
       region: "*"
 features:

--- a/providers/openrouter/amazon/nova-lite-v1.yaml
+++ b/providers/openrouter/amazon/nova-lite-v1.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 6.e-8
+    - input_cost_per_token: 6e-8
       output_cost_per_token: 2.4e-7
       region: "*"
 features:

--- a/providers/openrouter/amazon/nova-pro-v1.yaml
+++ b/providers/openrouter/amazon/nova-pro-v1.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 8.e-7
+    - input_cost_per_token: 8e-7
       output_cost_per_token: 0.0000032
       region: "*"
 features:

--- a/providers/openrouter/anthropic/claude-3-5-haiku-20241022.yaml
+++ b/providers/openrouter/anthropic/claude-3-5-haiku-20241022.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_creation_input_token_cost: 0.000001
-      cache_read_input_token_cost: 8.e-8
-      input_cost_per_token: 8.e-7
+      cache_read_input_token_cost: 8e-8
+      input_cost_per_token: 8e-7
       output_cost_per_token: 0.000004
       region: "*"
 features:

--- a/providers/openrouter/anthropic/claude-3-5-haiku.yaml
+++ b/providers/openrouter/anthropic/claude-3-5-haiku.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_creation_input_token_cost: 0.000001
-      cache_read_input_token_cost: 8.e-8
-      input_cost_per_token: 8.e-7
+      cache_read_input_token_cost: 8e-8
+      input_cost_per_token: 8e-7
       output_cost_per_token: 0.000004
       region: "*"
 features:

--- a/providers/openrouter/anthropic/claude-3-haiku.yaml
+++ b/providers/openrouter/anthropic/claude-3-haiku.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_creation_input_token_cost: 3.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_creation_input_token_cost: 3e-7
+      cache_read_input_token_cost: 3e-8
       input_cost_per_token: 2.5e-7
       output_cost_per_token: 0.00000125
       region: "*"

--- a/providers/openrouter/anthropic/claude-3.5-haiku.yaml
+++ b/providers/openrouter/anthropic/claude-3.5-haiku.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_creation_input_token_cost: 0.000001
-      cache_read_input_token_cost: 8.e-8
-      input_cost_per_token: 8.e-7
+      cache_read_input_token_cost: 8e-8
+      input_cost_per_token: 8e-7
       output_cost_per_token: 0.000004
       region: "*"
 features:

--- a/providers/openrouter/anthropic/claude-3.5-sonnet.yaml
+++ b/providers/openrouter/anthropic/claude-3.5-sonnet.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 0.0000075
-      cache_read_input_token_cost: 6.e-7
+      cache_read_input_token_cost: 6e-7
       input_cost_per_token: 0.000006
       output_cost_per_token: 0.00003
       region: "*"

--- a/providers/openrouter/anthropic/claude-3.5-sonnet:beta.yaml
+++ b/providers/openrouter/anthropic/claude-3.5-sonnet:beta.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 0.0000075
-      cache_read_input_token_cost: 6.e-7
+      cache_read_input_token_cost: 6e-7
       input_cost_per_token: 0.000006
       output_cost_per_token: 0.00003
       region: "*"

--- a/providers/openrouter/anthropic/claude-3.7-sonnet.yaml
+++ b/providers/openrouter/anthropic/claude-3.7-sonnet.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: "*"

--- a/providers/openrouter/anthropic/claude-haiku-4.5.yaml
+++ b/providers/openrouter/anthropic/claude-haiku-4.5.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 0.00000125
-      cache_read_input_token_cost: 1.e-7
+      cache_read_input_token_cost: 1e-7
       input_cost_per_token: 0.000001
       output_cost_per_token: 0.000005
       region: "*"

--- a/providers/openrouter/anthropic/claude-opus-4.5.yaml
+++ b/providers/openrouter/anthropic/claude-opus-4.5.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       output_cost_per_token: 0.000025
       region: "*"

--- a/providers/openrouter/anthropic/claude-opus-4.6.yaml
+++ b/providers/openrouter/anthropic/claude-opus-4.6.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       output_cost_per_token: 0.000025
       region: "*"

--- a/providers/openrouter/anthropic/claude-opus-4.7.yaml
+++ b/providers/openrouter/anthropic/claude-opus-4.7.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       output_cost_per_token: 0.000025
       region: "*"

--- a/providers/openrouter/anthropic/claude-sonnet-4.5.yaml
+++ b/providers/openrouter/anthropic/claude-sonnet-4.5.yaml
@@ -1,12 +1,12 @@
 costs:
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: "*"
       tiered_pricing:
           cache_read:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 200000
           cache_write:
               - cost_per_token: 0.0000075

--- a/providers/openrouter/anthropic/claude-sonnet-4.6.yaml
+++ b/providers/openrouter/anthropic/claude-sonnet-4.6.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: "*"

--- a/providers/openrouter/anthropic/claude-sonnet-4.yaml
+++ b/providers/openrouter/anthropic/claude-sonnet-4.yaml
@@ -1,12 +1,12 @@
 costs:
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: "*"
       tiered_pricing:
           cache_read:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 200000
           cache_write:
               - cost_per_token: 0.0000075

--- a/providers/openrouter/arcee-ai/coder-large.yaml
+++ b/providers/openrouter/arcee-ai/coder-large.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 5.e-7
-      output_cost_per_token: 8.e-7
+    - input_cost_per_token: 5e-7
+      output_cost_per_token: 8e-7
       region: "*"
 limits:
     context_window: 32768

--- a/providers/openrouter/arcee-ai/maestro-reasoning.yaml
+++ b/providers/openrouter/arcee-ai/maestro-reasoning.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 9.e-7
+    - input_cost_per_token: 9e-7
       output_cost_per_token: 0.0000033
       region: "*"
 limits:

--- a/providers/openrouter/baidu/ernie-4.5-21b-a3b-thinking.yaml
+++ b/providers/openrouter/baidu/ernie-4.5-21b-a3b-thinking.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 7.e-8
+    - input_cost_per_token: 7e-8
       output_cost_per_token: 2.8e-7
       region: "*"
 limits:

--- a/providers/openrouter/baidu/ernie-4.5-21b-a3b.yaml
+++ b/providers/openrouter/baidu/ernie-4.5-21b-a3b.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 7.e-8
+    - input_cost_per_token: 7e-8
       output_cost_per_token: 2.8e-7
       region: "*"
 features:

--- a/providers/openrouter/bytedance-seed/seed-1.6-flash.yaml
+++ b/providers/openrouter/bytedance-seed/seed-1.6-flash.yaml
@@ -1,13 +1,13 @@
 costs:
     - input_cost_per_token: 7.5e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       region: "*"
       tiered_pricing:
           input:
-              - cost_per_token: 1.e-7
+              - cost_per_token: 1e-7
                 from: 128000
           output:
-              - cost_per_token: 8.e-7
+              - cost_per_token: 8e-7
                 from: 128000
 features:
     - function_calling

--- a/providers/openrouter/bytedance-seed/seed-1.6.yaml
+++ b/providers/openrouter/bytedance-seed/seed-1.6.yaml
@@ -4,7 +4,7 @@ costs:
       region: "*"
       tiered_pricing:
           input:
-              - cost_per_token: 5.e-7
+              - cost_per_token: 5e-7
                 from: 128000
           output:
               - cost_per_token: 0.000004

--- a/providers/openrouter/bytedance-seed/seed-2.0-lite.yaml
+++ b/providers/openrouter/bytedance-seed/seed-2.0-lite.yaml
@@ -4,7 +4,7 @@ costs:
       region: "*"
       tiered_pricing:
           input:
-              - cost_per_token: 5.e-7
+              - cost_per_token: 5e-7
                 from: 128000
           output:
               - cost_per_token: 0.000004

--- a/providers/openrouter/bytedance-seed/seed-2.0-mini.yaml
+++ b/providers/openrouter/bytedance-seed/seed-2.0-mini.yaml
@@ -1,13 +1,13 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 4.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 4e-7
       region: "*"
       tiered_pricing:
           input:
-              - cost_per_token: 2.e-7
+              - cost_per_token: 2e-7
                 from: 128000
           output:
-              - cost_per_token: 8.e-7
+              - cost_per_token: 8e-7
                 from: 128000
 features:
     - function_calling

--- a/providers/openrouter/bytedance/ui-tars-1.5-7b.yaml
+++ b/providers/openrouter/bytedance/ui-tars-1.5-7b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 2.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 2e-7
       region: "*"
 limits:
     context_window: 128000

--- a/providers/openrouter/claude-3-haiku.yaml
+++ b/providers/openrouter/claude-3-haiku.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_creation_input_token_cost: 3.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_creation_input_token_cost: 3e-7
+      cache_read_input_token_cost: 3e-8
       input_cost_per_token: 2.5e-7
       output_cost_per_token: 0.00000125
       region: "*"

--- a/providers/openrouter/claude-3-haiku:beta.yaml
+++ b/providers/openrouter/claude-3-haiku:beta.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_creation_input_token_cost: 3.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_creation_input_token_cost: 3e-7
+      cache_read_input_token_cost: 3e-8
       input_cost_per_token: 2.5e-7
       output_cost_per_token: 0.00000125
       region: "*"

--- a/providers/openrouter/claude-3.5-haiku-20241022.yaml
+++ b/providers/openrouter/claude-3.5-haiku-20241022.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_creation_input_token_cost: 0.000001
-      cache_read_input_token_cost: 8.e-8
-      input_cost_per_token: 8.e-7
+      cache_read_input_token_cost: 8e-8
+      input_cost_per_token: 8e-7
       output_cost_per_token: 0.000004
       region: "*"
 features:

--- a/providers/openrouter/claude-3.5-haiku.yaml
+++ b/providers/openrouter/claude-3.5-haiku.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_creation_input_token_cost: 0.000001
-      cache_read_input_token_cost: 8.e-8
-      input_cost_per_token: 8.e-7
+      cache_read_input_token_cost: 8e-8
+      input_cost_per_token: 8e-7
       output_cost_per_token: 0.000004
       region: "*"
 features:

--- a/providers/openrouter/claude-3.5-haiku:beta.yaml
+++ b/providers/openrouter/claude-3.5-haiku:beta.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_creation_input_token_cost: 0.000001
-      cache_read_input_token_cost: 8.e-8
-      input_cost_per_token: 8.e-7
+      cache_read_input_token_cost: 8e-8
+      input_cost_per_token: 8e-7
       output_cost_per_token: 0.000004
       region: "*"
 features:

--- a/providers/openrouter/claude-3.5-sonnet.yaml
+++ b/providers/openrouter/claude-3.5-sonnet.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 0.0000075
-      cache_read_input_token_cost: 6.e-7
+      cache_read_input_token_cost: 6e-7
       input_cost_per_token: 0.000006
       output_cost_per_token: 0.00003
       region: "*"

--- a/providers/openrouter/claude-3.5-sonnet:beta.yaml
+++ b/providers/openrouter/claude-3.5-sonnet:beta.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 0.0000075
-      cache_read_input_token_cost: 6.e-7
+      cache_read_input_token_cost: 6e-7
       input_cost_per_token: 0.000006
       output_cost_per_token: 0.00003
       region: "*"

--- a/providers/openrouter/claude-3.7-sonnet:beta.yaml
+++ b/providers/openrouter/claude-3.7-sonnet:beta.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: "*"

--- a/providers/openrouter/claude-3.7-sonnet:thinking.yaml
+++ b/providers/openrouter/claude-3.7-sonnet:thinking.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 0.000006
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: "*"

--- a/providers/openrouter/claude-sonnet-4.yaml
+++ b/providers/openrouter/claude-sonnet-4.yaml
@@ -1,12 +1,12 @@
 costs:
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: "*"
       tiered_pricing:
           cache_read:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 200000
           cache_write:
               - cost_per_token: 0.0000075

--- a/providers/openrouter/cognitivecomputations/dolphin-mixtral-8x7b.yaml
+++ b/providers/openrouter/cognitivecomputations/dolphin-mixtral-8x7b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 5.e-7
-      output_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
+      output_cost_per_token: 5e-7
       region: "*"
 limits:
     context_window: 32768

--- a/providers/openrouter/cohere/command-r-08-2024.yaml
+++ b/providers/openrouter/cohere/command-r-08-2024.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/command-r-03-2024.yaml
+++ b/providers/openrouter/command-r-03-2024.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
       output_cost_per_token: 0.0000015
       region: "*"
 features:

--- a/providers/openrouter/command-r-08-2024.yaml
+++ b/providers/openrouter/command-r-08-2024.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/databricks/dbrx-instruct.yaml
+++ b/providers/openrouter/databricks/dbrx-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 6.e-7
-      output_cost_per_token: 6.e-7
+    - input_cost_per_token: 6e-7
+      output_cost_per_token: 6e-7
       region: "*"
 limits:
     context_window: 32768

--- a/providers/openrouter/deepseek-chat-v3-0324.yaml
+++ b/providers/openrouter/deepseek-chat-v3-0324.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_read_input_token_cost: 1.35e-7
-      input_cost_per_token: 2.e-7
+      input_cost_per_token: 2e-7
       output_cost_per_token: 7.7e-7
       region: "*"
 features:

--- a/providers/openrouter/deepseek-r1-distill-llama-70b.yaml
+++ b/providers/openrouter/deepseek-r1-distill-llama-70b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 7.e-7
-      output_cost_per_token: 8.e-7
+    - input_cost_per_token: 7e-7
+      output_cost_per_token: 8e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/deepseek-r1.yaml
+++ b/providers/openrouter/deepseek-r1.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 7.e-7
+    - input_cost_per_token: 7e-7
       output_cost_per_token: 0.0000025
       region: "*"
 features:

--- a/providers/openrouter/deepseek-r1t2-chimera.yaml
+++ b/providers/openrouter/deepseek-r1t2-chimera.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_read_input_token_cost: 1.5e-7
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000011
       region: "*"
 features:

--- a/providers/openrouter/deepseek/deepseek-chat-v3-0324.yaml
+++ b/providers/openrouter/deepseek/deepseek-chat-v3-0324.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_read_input_token_cost: 1.35e-7
-      input_cost_per_token: 2.e-7
+      input_cost_per_token: 2e-7
       output_cost_per_token: 7.7e-7
       region: "*"
 features:

--- a/providers/openrouter/deepseek/deepseek-r1-distill-llama-70b.yaml
+++ b/providers/openrouter/deepseek/deepseek-r1-distill-llama-70b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 7.e-7
-      output_cost_per_token: 8.e-7
+    - input_cost_per_token: 7e-7
+      output_cost_per_token: 8e-7
       region: "*"
 features:
     - json_output

--- a/providers/openrouter/deepseek/deepseek-r1.yaml
+++ b/providers/openrouter/deepseek/deepseek-r1.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 7.e-7
+    - input_cost_per_token: 7e-7
       output_cost_per_token: 0.0000025
       region: "*"
 features:

--- a/providers/openrouter/deepseek/deepseek-v3.2-speciale.yaml
+++ b/providers/openrouter/deepseek/deepseek-v3.2-speciale.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
-      input_cost_per_token: 4.e-7
+    - cache_read_input_token_cost: 2e-7
+      input_cost_per_token: 4e-7
       output_cost_per_token: 0.0000012
       region: "*"
 features:

--- a/providers/openrouter/devstral-medium.yaml
+++ b/providers/openrouter/devstral-medium.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 4.e-8
-      input_cost_per_token: 4.e-7
+    - cache_read_input_token_cost: 4e-8
+      input_cost_per_token: 4e-7
       output_cost_per_token: 0.000002
       region: "*"
 features:

--- a/providers/openrouter/devstral-small.yaml
+++ b/providers/openrouter/devstral-small.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_token_cost: 1.e-8
-      input_cost_per_token: 1.e-7
-      output_cost_per_token: 3.e-7
+    - cache_read_input_token_cost: 1e-8
+      input_cost_per_token: 1e-7
+      output_cost_per_token: 3e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/fireworks/firellava-13b.yaml
+++ b/providers/openrouter/fireworks/firellava-13b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 2.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 2e-7
       region: "*"
 limits:
     context_window: 4096

--- a/providers/openrouter/gemini-2.5-flash-lite.yaml
+++ b/providers/openrouter/gemini-2.5-flash-lite.yaml
@@ -1,14 +1,14 @@
 costs:
-    - cache_read_input_audio_token_cost: 3.e-8
-      cache_read_input_token_cost: 1.e-8
+    - cache_read_input_audio_token_cost: 3e-8
+      cache_read_input_token_cost: 1e-8
       cache_storage_cost_per_token_per_hour: 0.000001
-      input_cost_per_audio_token: 3.e-7
-      input_cost_per_image_token: 1.e-7
-      input_cost_per_token: 1.e-7
-      input_cost_per_token_batches: 5.e-8
-      input_cost_per_video_token: 1.e-7
-      output_cost_per_token: 4.e-7
-      output_cost_per_token_batches: 2.e-7
+      input_cost_per_audio_token: 3e-7
+      input_cost_per_image_token: 1e-7
+      input_cost_per_token: 1e-7
+      input_cost_per_token_batches: 5e-8
+      input_cost_per_video_token: 1e-7
+      output_cost_per_token: 4e-7
+      output_cost_per_token_batches: 2e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/gemini-2.5-flash.yaml
+++ b/providers/openrouter/gemini-2.5-flash.yaml
@@ -1,10 +1,10 @@
 costs:
     - cache_creation_input_token_cost: 8.33e-8
-      cache_read_input_token_cost: 3.e-8
+      cache_read_input_token_cost: 3e-8
       input_cost_per_audio_token: 0.000001
-      input_cost_per_image_token: 3.e-7
-      input_cost_per_token: 3.e-7
-      input_cost_per_video_token: 3.e-7
+      input_cost_per_image_token: 3e-7
+      input_cost_per_token: 3e-7
+      input_cost_per_video_token: 3e-7
       output_cost_per_token: 0.0000025
       region: "*"
 features:

--- a/providers/openrouter/gemma-2-9b-it.yaml
+++ b/providers/openrouter/gemma-2-9b-it.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 3.e-8
-      output_cost_per_token: 9.e-8
+    - input_cost_per_token: 3e-8
+      output_cost_per_token: 9e-8
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/gemma-3-12b-it.yaml
+++ b/providers/openrouter/gemma-3-12b-it.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 4.e-8
+    - input_cost_per_token: 4e-8
       output_cost_per_token: 1.3e-7
       region: "*"
 features:

--- a/providers/openrouter/gemma-3-27b-it.yaml
+++ b/providers/openrouter/gemma-3-27b-it.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 8.e-8
+    - input_cost_per_token: 8e-8
       output_cost_per_token: 1.6e-7
       region: "*"
 features:

--- a/providers/openrouter/gemma-3-4b-it.yaml
+++ b/providers/openrouter/gemma-3-4b-it.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 4.e-8
-      output_cost_per_token: 8.e-8
+    - input_cost_per_token: 4e-8
+      output_cost_per_token: 8e-8
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/gemma-3n-e4b-it.yaml
+++ b/providers/openrouter/gemma-3n-e4b-it.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-8
-      output_cost_per_token: 4.e-8
+    - input_cost_per_token: 2e-8
+      output_cost_per_token: 4e-8
       region: "*"
 limits:
     context_window: 32768

--- a/providers/openrouter/glm-4-32b.yaml
+++ b/providers/openrouter/glm-4-32b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 1.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 1e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/glm-4.5.yaml
+++ b/providers/openrouter/glm-4.5.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_read_input_token_cost: 1.1e-7
-      input_cost_per_token: 6.e-7
+      input_cost_per_token: 6e-7
       output_cost_per_token: 0.0000022
       region: "*"
 features:

--- a/providers/openrouter/google/gemini-2.0-flash-001.yaml
+++ b/providers/openrouter/google/gemini-2.0-flash-001.yaml
@@ -2,9 +2,9 @@ costs:
     - cache_creation_input_token_cost: 8.333333333333334e-8
       cache_read_input_token_cost: 2.5e-8
       cache_storage_cost_per_token_per_hour: 0.000001
-      input_cost_per_audio_token: 7.e-7
-      input_cost_per_token: 1.e-7
-      output_cost_per_token: 4.e-7
+      input_cost_per_audio_token: 7e-7
+      input_cost_per_token: 1e-7
+      output_cost_per_token: 4e-7
       region: "*"
 deprecationDate: "2026-06-01"
 features:

--- a/providers/openrouter/google/gemini-2.5-flash-image.yaml
+++ b/providers/openrouter/google/gemini-2.5-flash-image.yaml
@@ -1,8 +1,8 @@
 costs:
     - cache_creation_input_token_cost: 8.33e-8
-      cache_read_input_token_cost: 3.e-8
+      cache_read_input_token_cost: 3e-8
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       output_cost_per_image_token: 0.00003
       output_cost_per_token: 0.0000025
       region: "*"

--- a/providers/openrouter/google/gemini-2.5-flash-lite-preview-09-2025.yaml
+++ b/providers/openrouter/google/gemini-2.5-flash-lite-preview-09-2025.yaml
@@ -1,9 +1,9 @@
 costs:
-    - cache_read_input_token_cost: 1.e-8
+    - cache_read_input_token_cost: 1e-8
       cache_storage_cost_per_token_per_hour: 0.000001
-      input_cost_per_audio_token: 3.e-7
-      input_cost_per_token: 1.e-7
-      output_cost_per_token: 4.e-7
+      input_cost_per_audio_token: 3e-7
+      input_cost_per_token: 1e-7
+      output_cost_per_token: 4e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/google/gemini-2.5-flash-lite.yaml
+++ b/providers/openrouter/google/gemini-2.5-flash-lite.yaml
@@ -1,7 +1,7 @@
 costs:
-    - input_cost_per_audio_token: 3.e-7
-      input_cost_per_token: 1.e-7
-      output_cost_per_token: 4.e-7
+    - input_cost_per_audio_token: 3e-7
+      input_cost_per_token: 1e-7
+      output_cost_per_token: 4e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/google/gemini-2.5-flash.yaml
+++ b/providers/openrouter/google/gemini-2.5-flash.yaml
@@ -1,8 +1,8 @@
 costs:
-    - cache_creation_input_token_cost: 8.e-8
-      cache_read_input_token_cost: 3.e-8
+    - cache_creation_input_token_cost: 8e-8
+      cache_read_input_token_cost: 3e-8
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000025
       region: "*"
 features:

--- a/providers/openrouter/google/gemini-3-flash-preview.yaml
+++ b/providers/openrouter/google/gemini-3-flash-preview.yaml
@@ -1,8 +1,8 @@
 costs:
     - cache_creation_input_token_cost: 8.333333333333334e-8
-      cache_read_input_token_cost: 5.e-8
+      cache_read_input_token_cost: 5e-8
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 5.e-7
+      input_cost_per_token: 5e-7
       output_cost_per_token: 0.000003
       region: "*"
 features:

--- a/providers/openrouter/google/gemini-3.1-flash-image-preview.yaml
+++ b/providers/openrouter/google/gemini-3.1-flash-image-preview.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
       output_cost_per_image_token: 0.00006
       output_cost_per_token: 0.000003
       region: "*"

--- a/providers/openrouter/google/gemini-3.1-flash-lite-preview.yaml
+++ b/providers/openrouter/google/gemini-3.1-flash-lite-preview.yaml
@@ -1,8 +1,8 @@
 costs:
     - cache_creation_input_token_cost: 8.333333333333334e-8
-      cache_read_input_audio_token_cost: 5.e-8
+      cache_read_input_audio_token_cost: 5e-8
       cache_read_input_token_cost: 2.5e-8
-      input_cost_per_audio_token: 5.e-7
+      input_cost_per_audio_token: 5e-7
       input_cost_per_token: 2.5e-7
       output_cost_per_token: 0.0000015
       region: "*"

--- a/providers/openrouter/google/gemini-3.1-pro-preview-customtools.yaml
+++ b/providers/openrouter/google/gemini-3.1-pro-preview-customtools.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 3.75e-7
-      cache_read_input_token_cost: 2.e-7
+      cache_read_input_token_cost: 2e-7
       cache_storage_cost_per_token_per_hour: 0.0000045
       input_cost_per_audio_token: 0.000002
       input_cost_per_token: 0.000002
@@ -8,7 +8,7 @@ costs:
       region: "*"
       tiered_pricing:
           cache_read:
-              - cost_per_token: 4.e-7
+              - cost_per_token: 4e-7
                 from: 200000
           input:
               - cost_per_token: 0.000004

--- a/providers/openrouter/google/gemini-3.1-pro-preview.yaml
+++ b/providers/openrouter/google/gemini-3.1-pro-preview.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       cache_storage_cost_per_token_per_hour: 0.0000045
       input_cost_per_audio_token: 0.000002
       input_cost_per_token: 0.000002
@@ -7,7 +7,7 @@ costs:
       region: "*"
       tiered_pricing:
           cache_read:
-              - cost_per_token: 4.e-7
+              - cost_per_token: 4e-7
                 from: 200000
           input:
               - cost_per_token: 0.000004

--- a/providers/openrouter/google/gemma-3-12b-it.yaml
+++ b/providers/openrouter/google/gemma-3-12b-it.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 4.e-8
+    - input_cost_per_token: 4e-8
       output_cost_per_token: 1.3e-7
       region: "*"
 features:

--- a/providers/openrouter/google/gemma-3-27b-it.yaml
+++ b/providers/openrouter/google/gemma-3-27b-it.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 8.e-8
+    - input_cost_per_token: 8e-8
       output_cost_per_token: 1.6e-7
       region: "*"
 features:

--- a/providers/openrouter/google/gemma-3-4b-it.yaml
+++ b/providers/openrouter/google/gemma-3-4b-it.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 4.e-8
-      output_cost_per_token: 8.e-8
+    - input_cost_per_token: 4e-8
+      output_cost_per_token: 8e-8
       region: "*"
 features:
     - json_output

--- a/providers/openrouter/google/gemma-3n-e4b-it.yaml
+++ b/providers/openrouter/google/gemma-3n-e4b-it.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-8
-      output_cost_per_token: 4.e-8
+    - input_cost_per_token: 2e-8
+      output_cost_per_token: 4e-8
       region: "*"
 limits:
     context_window: 32768

--- a/providers/openrouter/google/gemma-4-26b-a4b-it.yaml
+++ b/providers/openrouter/google/gemma-4-26b-a4b-it.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 1.3e-7
-      output_cost_per_token: 4.e-7
+      output_cost_per_token: 4e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/google/gemma-4-31b-it.yaml
+++ b/providers/openrouter/google/gemma-4-31b-it.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 1.4e-7
-      output_cost_per_token: 4.e-7
+      output_cost_per_token: 4e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/google/palm-2-chat-bison.yaml
+++ b/providers/openrouter/google/palm-2-chat-bison.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 5.e-7
-      output_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
+      output_cost_per_token: 5e-7
       region: "*"
 limits:
     context_window: 9216

--- a/providers/openrouter/google/palm-2-codechat-bison.yaml
+++ b/providers/openrouter/google/palm-2-codechat-bison.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 5.e-7
-      output_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
+      output_cost_per_token: 5e-7
       region: "*"
 limits:
     context_window: 7168

--- a/providers/openrouter/gpt-3.5-turbo.yaml
+++ b/providers/openrouter/gpt-3.5-turbo.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
       output_cost_per_token: 0.0000015
       region: "*"
 features:

--- a/providers/openrouter/gpt-4.1-mini.yaml
+++ b/providers/openrouter/gpt-4.1-mini.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 1.e-7
-      input_cost_per_token: 4.e-7
+    - cache_read_input_token_cost: 1e-7
+      input_cost_per_token: 4e-7
       output_cost_per_token: 0.0000016
       region: "*"
 features:

--- a/providers/openrouter/gpt-4.1-nano.yaml
+++ b/providers/openrouter/gpt-4.1-nano.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_read_input_token_cost: 2.5e-8
-      input_cost_per_token: 1.e-7
-      output_cost_per_token: 4.e-7
+      input_cost_per_token: 1e-7
+      output_cost_per_token: 4e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/gpt-4.1.yaml
+++ b/providers/openrouter/gpt-4.1.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 5.e-7
+    - cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000008
       region: "*"

--- a/providers/openrouter/gpt-4o-mini-2024-07-18.yaml
+++ b/providers/openrouter/gpt-4o-mini-2024-07-18.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_read_input_token_cost: 7.5e-8
       input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/gpt-4o-mini.yaml
+++ b/providers/openrouter/gpt-4o-mini.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_read_input_token_cost: 7.5e-8
       input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/gpt-oss-20b.yaml
+++ b/providers/openrouter/gpt-oss-20b.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_read_input_token_cost: 1.5e-8
-      input_cost_per_token: 3.e-8
+      input_cost_per_token: 3e-8
       output_cost_per_token: 1.1e-7
       region: "*"
 features:

--- a/providers/openrouter/grok-3-mini-beta.yaml
+++ b/providers/openrouter/grok-3-mini-beta.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_read_input_token_cost: 7.5e-8
-      input_cost_per_token: 3.e-7
-      output_cost_per_token: 5.e-7
+      input_cost_per_token: 3e-7
+      output_cost_per_token: 5e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/grok-3-mini.yaml
+++ b/providers/openrouter/grok-3-mini.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_read_input_token_cost: 7.5e-8
-      input_cost_per_token: 3.e-7
-      output_cost_per_token: 5.e-7
+      input_cost_per_token: 3e-7
+      output_cost_per_token: 5e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/gryphe/mythomax-l2-13b.yaml
+++ b/providers/openrouter/gryphe/mythomax-l2-13b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 6.e-8
-      output_cost_per_token: 6.e-8
+    - input_cost_per_token: 6e-8
+      output_cost_per_token: 6e-8
       region: "*"
 features:
     - json_output

--- a/providers/openrouter/hermes-3-llama-3.1-70b.yaml
+++ b/providers/openrouter/hermes-3-llama-3.1-70b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 3.e-7
-      output_cost_per_token: 3.e-7
+    - input_cost_per_token: 3e-7
+      output_cost_per_token: 3e-7
       region: "*"
 limits:
     context_window: 131072

--- a/providers/openrouter/kwaipilot/kat-coder-pro-v2.yaml
+++ b/providers/openrouter/kwaipilot/kat-coder-pro-v2.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 6.e-8
-      input_cost_per_token: 3.e-7
+    - cache_read_input_token_cost: 6e-8
+      input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000012
       region: "*"
 features:

--- a/providers/openrouter/liquid/lfm-2-24b-a2b.yaml
+++ b/providers/openrouter/liquid/lfm-2-24b-a2b.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 3.e-8
+    - input_cost_per_token: 3e-8
       output_cost_per_token: 1.2e-7
       region: "*"
 limits:

--- a/providers/openrouter/liquid/lfm-2.2-6b.yaml
+++ b/providers/openrouter/liquid/lfm-2.2-6b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 1.e-8
-      output_cost_per_token: 2.e-8
+    - input_cost_per_token: 1e-8
+      output_cost_per_token: 2e-8
       region: "*"
 limits:
     context_window: 32768

--- a/providers/openrouter/liquid/lfm2-8b-a1b.yaml
+++ b/providers/openrouter/liquid/lfm2-8b-a1b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 1.e-8
-      output_cost_per_token: 2.e-8
+    - input_cost_per_token: 1e-8
+      output_cost_per_token: 2e-8
       region: "*"
 limits:
     context_window: 8192

--- a/providers/openrouter/llama-3-8b-instruct.yaml
+++ b/providers/openrouter/llama-3-8b-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 3.e-8
-      output_cost_per_token: 4.e-8
+    - input_cost_per_token: 3e-8
+      output_cost_per_token: 4e-8
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/llama-3.1-70b-instruct.yaml
+++ b/providers/openrouter/llama-3.1-70b-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 4.e-7
-      output_cost_per_token: 4.e-7
+    - input_cost_per_token: 4e-7
+      output_cost_per_token: 4e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/llama-3.1-8b-instruct.yaml
+++ b/providers/openrouter/llama-3.1-8b-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-8
-      output_cost_per_token: 5.e-8
+    - input_cost_per_token: 2e-8
+      output_cost_per_token: 5e-8
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/llama-3.1-nemotron-ultra-253b-v1.yaml
+++ b/providers/openrouter/llama-3.1-nemotron-ultra-253b-v1.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 6.e-7
+    - input_cost_per_token: 6e-7
       output_cost_per_token: 0.0000018
       region: "*"
 features:

--- a/providers/openrouter/llama-3.2-1b-instruct.yaml
+++ b/providers/openrouter/llama-3.2-1b-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 2.7e-8
-      output_cost_per_token: 2.e-7
+      output_cost_per_token: 2e-7
       region: "*"
 limits:
     context_window: 60000

--- a/providers/openrouter/llama-3.3-70b-instruct.yaml
+++ b/providers/openrouter/llama-3.3-70b-instruct.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 1.e-7
+    - input_cost_per_token: 1e-7
       output_cost_per_token: 3.2e-7
       region: "*"
 features:

--- a/providers/openrouter/llama-4-maverick.yaml
+++ b/providers/openrouter/llama-4-maverick.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/llama-4-scout.yaml
+++ b/providers/openrouter/llama-4-scout.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 8.e-8
-      output_cost_per_token: 3.e-7
+    - input_cost_per_token: 8e-8
+      output_cost_per_token: 3e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/llama-guard-3-8b.yaml
+++ b/providers/openrouter/llama-guard-3-8b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-8
-      output_cost_per_token: 6.e-8
+    - input_cost_per_token: 2e-8
+      output_cost_per_token: 6e-8
       region: "*"
 limits:
     context_window: 131072

--- a/providers/openrouter/llemma_7b.yaml
+++ b/providers/openrouter/llemma_7b.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 8.e-7
+    - input_cost_per_token: 8e-7
       output_cost_per_token: 0.0000012
       region: "*"
 limits:

--- a/providers/openrouter/maestro-reasoning.yaml
+++ b/providers/openrouter/maestro-reasoning.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 9.e-7
+    - input_cost_per_token: 9e-7
       output_cost_per_token: 0.0000033
       region: "*"
 features:

--- a/providers/openrouter/magistral-small-2506.yaml
+++ b/providers/openrouter/magistral-small-2506.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
       output_cost_per_token: 0.0000015
       region: "*"
 deprecationDate: "2025-10-31"

--- a/providers/openrouter/meituan/longcat-flash-chat.yaml
+++ b/providers/openrouter/meituan/longcat-flash-chat.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 8.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 8e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/meta-llama/codellama-34b-instruct.yaml
+++ b/providers/openrouter/meta-llama/codellama-34b-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 5.e-7
-      output_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
+      output_cost_per_token: 5e-7
       region: "*"
 limits:
     context_window: 8192

--- a/providers/openrouter/meta-llama/llama-2-13b-chat.yaml
+++ b/providers/openrouter/meta-llama/llama-2-13b-chat.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 2.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 2e-7
       region: "*"
 limits:
     context_window: 4096

--- a/providers/openrouter/meta-llama/llama-3-8b-instruct.yaml
+++ b/providers/openrouter/meta-llama/llama-3-8b-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 3.e-8
-      output_cost_per_token: 4.e-8
+    - input_cost_per_token: 3e-8
+      output_cost_per_token: 4e-8
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/meta-llama/llama-3.1-70b-instruct.yaml
+++ b/providers/openrouter/meta-llama/llama-3.1-70b-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 4.e-7
-      output_cost_per_token: 4.e-7
+    - input_cost_per_token: 4e-7
+      output_cost_per_token: 4e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/meta-llama/llama-3.1-8b-instruct.yaml
+++ b/providers/openrouter/meta-llama/llama-3.1-8b-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-8
-      output_cost_per_token: 5.e-8
+    - input_cost_per_token: 2e-8
+      output_cost_per_token: 5e-8
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/meta-llama/llama-3.2-1b-instruct.yaml
+++ b/providers/openrouter/meta-llama/llama-3.2-1b-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 2.7e-8
-      output_cost_per_token: 2.e-7
+      output_cost_per_token: 2e-7
       region: "*"
 limits:
     context_window: 60000

--- a/providers/openrouter/meta-llama/llama-3.3-70b-instruct.yaml
+++ b/providers/openrouter/meta-llama/llama-3.3-70b-instruct.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 1.e-7
+    - input_cost_per_token: 1e-7
       output_cost_per_token: 3.2e-7
       region: "*"
 features:

--- a/providers/openrouter/meta-llama/llama-4-maverick.yaml
+++ b/providers/openrouter/meta-llama/llama-4-maverick.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/meta-llama/llama-4-scout.yaml
+++ b/providers/openrouter/meta-llama/llama-4-scout.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 8.e-8
-      output_cost_per_token: 3.e-7
+    - input_cost_per_token: 8e-8
+      output_cost_per_token: 3e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/meta-llama/llama-guard-3-8b.yaml
+++ b/providers/openrouter/meta-llama/llama-guard-3-8b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-8
-      output_cost_per_token: 6.e-8
+    - input_cost_per_token: 2e-8
+      output_cost_per_token: 6e-8
       region: "*"
 limits:
     context_window: 131072

--- a/providers/openrouter/minimax-01.yaml
+++ b/providers/openrouter/minimax-01.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 2.e-7
+    - input_cost_per_token: 2e-7
       output_cost_per_token: 0.0000011
       region: "*"
 features:

--- a/providers/openrouter/minimax-m1.yaml
+++ b/providers/openrouter/minimax-m1.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 4.e-7
+    - input_cost_per_token: 4e-7
       output_cost_per_token: 0.0000022
       region: "*"
       tiered_pricing:

--- a/providers/openrouter/minimax/minimax-01.yaml
+++ b/providers/openrouter/minimax/minimax-01.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 2.e-7
+    - input_cost_per_token: 2e-7
       output_cost_per_token: 0.0000011
       region: "*"
 limits:

--- a/providers/openrouter/minimax/minimax-m1.yaml
+++ b/providers/openrouter/minimax/minimax-m1.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 4.e-7
+    - input_cost_per_token: 4e-7
       output_cost_per_token: 0.0000022
       region: "*"
       tiered_pricing:

--- a/providers/openrouter/minimax/minimax-m2-her.yaml
+++ b/providers/openrouter/minimax/minimax-m2-her.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_creation_input_token_cost: 3.75e-7
-      cache_read_input_token_cost: 3.e-8
-      input_cost_per_token: 3.e-7
+      cache_read_input_token_cost: 3e-8
+      input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000012
       region: "*"
 features:

--- a/providers/openrouter/minimax/minimax-m2.7.yaml
+++ b/providers/openrouter/minimax/minimax-m2.7.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 6.e-8
-      input_cost_per_token: 3.e-7
+    - cache_read_input_token_cost: 6e-8
+      input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000012
       region: "*"
 features:

--- a/providers/openrouter/minimax/minimax-m2.yaml
+++ b/providers/openrouter/minimax/minimax-m2.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 3.e-8
+    - cache_read_input_token_cost: 3e-8
       input_cost_per_token: 2.55e-7
       output_cost_per_token: 0.000001
       region: "*"

--- a/providers/openrouter/mistral-large-2407.yaml
+++ b/providers/openrouter/mistral-large-2407.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000006
       region: "*"

--- a/providers/openrouter/mistral-large-2411.yaml
+++ b/providers/openrouter/mistral-large-2411.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000006
       region: "*"

--- a/providers/openrouter/mistral-large.yaml
+++ b/providers/openrouter/mistral-large.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000006
       region: "*"

--- a/providers/openrouter/mistral-medium-3.yaml
+++ b/providers/openrouter/mistral-medium-3.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 4.e-8
-      input_cost_per_token: 4.e-7
+    - cache_read_input_token_cost: 4e-8
+      input_cost_per_token: 4e-7
       output_cost_per_token: 0.000002
       region: "*"
 features:

--- a/providers/openrouter/mistral-nemo.yaml
+++ b/providers/openrouter/mistral-nemo.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-8
-      output_cost_per_token: 4.e-8
+    - input_cost_per_token: 2e-8
+      output_cost_per_token: 4e-8
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/mistral-saba.yaml
+++ b/providers/openrouter/mistral-saba.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 6.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 6e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/mistral-small-24b-instruct-2501.yaml
+++ b/providers/openrouter/mistral-small-24b-instruct-2501.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 5.e-8
-      output_cost_per_token: 8.e-8
+    - input_cost_per_token: 5e-8
+      output_cost_per_token: 8e-8
       region: "*"
 limits:
     context_window: 32768

--- a/providers/openrouter/mistral-small-3.1-24b-instruct.yaml
+++ b/providers/openrouter/mistral-small-3.1-24b-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_read_input_token_cost: 1.5e-8
-      input_cost_per_token: 3.e-8
+      input_cost_per_token: 3e-8
       output_cost_per_token: 1.1e-7
       region: "*"
 features:

--- a/providers/openrouter/mistral-small-3.2-24b-instruct.yaml
+++ b/providers/openrouter/mistral-small-3.2-24b-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 7.5e-8
-      output_cost_per_token: 2.e-7
+      output_cost_per_token: 2e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/mistral-small.yaml
+++ b/providers/openrouter/mistral-small.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 3.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 3e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/mistralai/codestral-2508.yaml
+++ b/providers/openrouter/mistralai/codestral-2508.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_token_cost: 3.e-8
-      input_cost_per_token: 3.e-7
-      output_cost_per_token: 9.e-7
+    - cache_read_input_token_cost: 3e-8
+      input_cost_per_token: 3e-7
+      output_cost_per_token: 9e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/mistralai/devstral-2512.yaml
+++ b/providers/openrouter/mistralai/devstral-2512.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 4.e-8
-      input_cost_per_token: 4.e-7
+    - cache_read_input_token_cost: 4e-8
+      input_cost_per_token: 4e-7
       output_cost_per_token: 0.000002
       region: "*"
 features:

--- a/providers/openrouter/mistralai/devstral-medium.yaml
+++ b/providers/openrouter/mistralai/devstral-medium.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 4.e-8
-      input_cost_per_token: 4.e-7
+    - cache_read_input_token_cost: 4e-8
+      input_cost_per_token: 4e-7
       output_cost_per_token: 0.000002
       region: "*"
 features:

--- a/providers/openrouter/mistralai/devstral-small.yaml
+++ b/providers/openrouter/mistralai/devstral-small.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_token_cost: 1.e-8
-      input_cost_per_token: 1.e-7
-      output_cost_per_token: 3.e-7
+    - cache_read_input_token_cost: 1e-8
+      input_cost_per_token: 1e-7
+      output_cost_per_token: 3e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/mistralai/ministral-14b-2512.yaml
+++ b/providers/openrouter/mistralai/ministral-14b-2512.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_token_cost: 2.e-8
-      input_cost_per_token: 2.e-7
-      output_cost_per_token: 2.e-7
+    - cache_read_input_token_cost: 2e-8
+      input_cost_per_token: 2e-7
+      output_cost_per_token: 2e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/mistralai/ministral-3b-2512.yaml
+++ b/providers/openrouter/mistralai/ministral-3b-2512.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_token_cost: 1.e-8
-      input_cost_per_token: 1.e-7
-      output_cost_per_token: 1.e-7
+    - cache_read_input_token_cost: 1e-8
+      input_cost_per_token: 1e-7
+      output_cost_per_token: 1e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/mistralai/mistral-large-2407.yaml
+++ b/providers/openrouter/mistralai/mistral-large-2407.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000006
       region: "*"

--- a/providers/openrouter/mistralai/mistral-large-2411.yaml
+++ b/providers/openrouter/mistralai/mistral-large-2411.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000006
       region: "*"

--- a/providers/openrouter/mistralai/mistral-large-2512.yaml
+++ b/providers/openrouter/mistralai/mistral-large-2512.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 5.e-8
-      input_cost_per_token: 5.e-7
+    - cache_read_input_token_cost: 5e-8
+      input_cost_per_token: 5e-7
       output_cost_per_token: 0.0000015
       region: "*"
 features:

--- a/providers/openrouter/mistralai/mistral-large.yaml
+++ b/providers/openrouter/mistralai/mistral-large.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000006
       region: "*"

--- a/providers/openrouter/mistralai/mistral-medium-3.1.yaml
+++ b/providers/openrouter/mistralai/mistral-medium-3.1.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 4.e-8
-      input_cost_per_token: 4.e-7
+    - cache_read_input_token_cost: 4e-8
+      input_cost_per_token: 4e-7
       output_cost_per_token: 0.000002
       region: "*"
 features:

--- a/providers/openrouter/mistralai/mistral-medium-3.yaml
+++ b/providers/openrouter/mistralai/mistral-medium-3.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 4.e-8
-      input_cost_per_token: 4.e-7
+    - cache_read_input_token_cost: 4e-8
+      input_cost_per_token: 4e-7
       output_cost_per_token: 0.000002
       region: "*"
 features:

--- a/providers/openrouter/mistralai/mistral-nemo.yaml
+++ b/providers/openrouter/mistralai/mistral-nemo.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-8
-      output_cost_per_token: 4.e-8
+    - input_cost_per_token: 2e-8
+      output_cost_per_token: 4e-8
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/mistralai/mistral-saba.yaml
+++ b/providers/openrouter/mistralai/mistral-saba.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_token_cost: 2.e-8
-      input_cost_per_token: 2.e-7
-      output_cost_per_token: 6.e-7
+    - cache_read_input_token_cost: 2e-8
+      input_cost_per_token: 2e-7
+      output_cost_per_token: 6e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/mistralai/mistral-small-24b-instruct-2501.yaml
+++ b/providers/openrouter/mistralai/mistral-small-24b-instruct-2501.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 5.e-8
-      output_cost_per_token: 8.e-8
+    - input_cost_per_token: 5e-8
+      output_cost_per_token: 8e-8
       region: "*"
 features:
     - json_output

--- a/providers/openrouter/mistralai/mistral-small-2603.yaml
+++ b/providers/openrouter/mistralai/mistral-small-2603.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_read_input_token_cost: 1.5e-8
       input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/mistralai/mistral-small-3.1-24b-instruct.yaml
+++ b/providers/openrouter/mistralai/mistral-small-3.1-24b-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_read_input_token_cost: 1.5e-8
-      input_cost_per_token: 3.e-8
+      input_cost_per_token: 3e-8
       output_cost_per_token: 1.1e-7
       region: "*"
 features:

--- a/providers/openrouter/mistralai/mistral-small-3.2-24b-instruct.yaml
+++ b/providers/openrouter/mistralai/mistral-small-3.2-24b-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 7.5e-8
-      output_cost_per_token: 2.e-7
+      output_cost_per_token: 2e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/mistralai/mistral-small-creative.yaml
+++ b/providers/openrouter/mistralai/mistral-small-creative.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_token_cost: 1.e-8
-      input_cost_per_token: 1.e-7
-      output_cost_per_token: 3.e-7
+    - cache_read_input_token_cost: 1e-8
+      input_cost_per_token: 1e-7
+      output_cost_per_token: 3e-7
       region: "*"
 deprecationDate: "2026-04-30"
 features:

--- a/providers/openrouter/mistralai/mixtral-8x22b-instruct.yaml
+++ b/providers/openrouter/mistralai/mixtral-8x22b-instruct.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000006
       region: "*"

--- a/providers/openrouter/mistralai/pixtral-12b.yaml
+++ b/providers/openrouter/mistralai/pixtral-12b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 1.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 1e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/mistralai/pixtral-large-2411.yaml
+++ b/providers/openrouter/mistralai/pixtral-large-2411.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000006
       region: "*"

--- a/providers/openrouter/mistralai/voxtral-small-24b-2507.yaml
+++ b/providers/openrouter/mistralai/voxtral-small-24b-2507.yaml
@@ -1,8 +1,8 @@
 costs:
-    - cache_read_input_token_cost: 1.e-8
+    - cache_read_input_token_cost: 1e-8
       input_cost_per_second: 0.0001
-      input_cost_per_token: 1.e-7
-      output_cost_per_token: 3.e-7
+      input_cost_per_token: 1e-7
+      output_cost_per_token: 3e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/mixtral-8x22b-instruct.yaml
+++ b/providers/openrouter/mixtral-8x22b-instruct.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000006
       region: "*"

--- a/providers/openrouter/moonshotai/kimi-k2-0905.yaml
+++ b/providers/openrouter/moonshotai/kimi-k2-0905.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_read_input_token_cost: 1.5e-7
-      input_cost_per_token: 4.e-7
+      input_cost_per_token: 4e-7
       output_cost_per_token: 0.000002
       region: "*"
 features:

--- a/providers/openrouter/moonshotai/kimi-k2-0905:exacto.yaml
+++ b/providers/openrouter/moonshotai/kimi-k2-0905:exacto.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_read_input_token_cost: 1.5e-7
-      input_cost_per_token: 4.e-7
+      input_cost_per_token: 4e-7
       output_cost_per_token: 0.000002
       region: "*"
 features:

--- a/providers/openrouter/moonshotai/kimi-k2.6.yaml
+++ b/providers/openrouter/moonshotai/kimi-k2.6.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
-      input_cost_per_token: 6.e-7
+    - cache_read_input_token_cost: 2e-7
+      input_cost_per_token: 6e-7
       output_cost_per_token: 0.0000028
       region: "*"
 features:
@@ -20,4 +20,10 @@ modalities:
         - text
 mode: chat
 model: moonshotai/kimi-k2.6
+provisioning: serverless
+sources:
+    - https://openrouter.ai/moonshotai/kimi-k2.6
+status: active
+supportedModes:
+    - chat
 thinking: true

--- a/providers/openrouter/morph-v3-fast.yaml
+++ b/providers/openrouter/morph-v3-fast.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 8.e-7
+    - input_cost_per_token: 8e-7
       output_cost_per_token: 0.0000012
       region: "*"
 limits:

--- a/providers/openrouter/morph-v3-large.yaml
+++ b/providers/openrouter/morph-v3-large.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 9.e-7
+    - input_cost_per_token: 9e-7
       output_cost_per_token: 0.0000019
       region: "*"
 limits:

--- a/providers/openrouter/morph/morph-v3-fast.yaml
+++ b/providers/openrouter/morph/morph-v3-fast.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 8.e-7
+    - input_cost_per_token: 8e-7
       output_cost_per_token: 0.0000012
       region: "*"
 limits:

--- a/providers/openrouter/morph/morph-v3-large.yaml
+++ b/providers/openrouter/morph/morph-v3-large.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 9.e-7
+    - input_cost_per_token: 9e-7
       output_cost_per_token: 0.0000019
       region: "*"
 limits:

--- a/providers/openrouter/mythomax-l2-13b.yaml
+++ b/providers/openrouter/mythomax-l2-13b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 6.e-8
-      output_cost_per_token: 6.e-8
+    - input_cost_per_token: 6e-8
+      output_cost_per_token: 6e-8
       region: "*"
 features:
     - structured_output

--- a/providers/openrouter/nex-agi/deepseek-v3.1-nex-n1.yaml
+++ b/providers/openrouter/nex-agi/deepseek-v3.1-nex-n1.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 1.35e-7
-      output_cost_per_token: 5.e-7
+      output_cost_per_token: 5e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/nousresearch/hermes-3-llama-3.1-70b.yaml
+++ b/providers/openrouter/nousresearch/hermes-3-llama-3.1-70b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 3.e-7
-      output_cost_per_token: 3.e-7
+    - input_cost_per_token: 3e-7
+      output_cost_per_token: 3e-7
       region: "*"
 features:
     - json_output

--- a/providers/openrouter/nousresearch/hermes-4-70b.yaml
+++ b/providers/openrouter/nousresearch/hermes-4-70b.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 1.3e-7
-      output_cost_per_token: 4.e-7
+      output_cost_per_token: 4e-7
       region: "*"
 features:
     - json_output

--- a/providers/openrouter/nousresearch/nous-hermes-llama2-13b.yaml
+++ b/providers/openrouter/nousresearch/nous-hermes-llama2-13b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 2.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 2e-7
       region: "*"
 limits:
     context_window: 4096

--- a/providers/openrouter/nova-lite-v1.yaml
+++ b/providers/openrouter/nova-lite-v1.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 6.e-8
+    - input_cost_per_token: 6e-8
       output_cost_per_token: 2.4e-7
       region: "*"
 features:

--- a/providers/openrouter/nova-pro-v1.yaml
+++ b/providers/openrouter/nova-pro-v1.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 8.e-7
+    - input_cost_per_token: 8e-7
       output_cost_per_token: 0.0000032
       region: "*"
 features:

--- a/providers/openrouter/nvidia/llama-3.3-nemotron-super-49b-v1.5.yaml
+++ b/providers/openrouter/nvidia/llama-3.3-nemotron-super-49b-v1.5.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 4.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 4e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/nvidia/nemotron-3-nano-30b-a3b.yaml
+++ b/providers/openrouter/nvidia/nemotron-3-nano-30b-a3b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 5.e-8
-      output_cost_per_token: 2.e-7
+    - input_cost_per_token: 5e-8
+      output_cost_per_token: 2e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/nvidia/nemotron-3-super-120b-a12b.yaml
+++ b/providers/openrouter/nvidia/nemotron-3-super-120b-a12b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 5.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 5e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/nvidia/nemotron-nano-12b-v2-vl.yaml
+++ b/providers/openrouter/nvidia/nemotron-nano-12b-v2-vl.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 6.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 6e-7
       region: "*"
 limits:
     context_window: 131072

--- a/providers/openrouter/nvidia/nemotron-nano-9b-v2.yaml
+++ b/providers/openrouter/nvidia/nemotron-nano-9b-v2.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 4.e-8
+    - input_cost_per_token: 4e-8
       output_cost_per_token: 1.6e-7
       region: "*"
 features:

--- a/providers/openrouter/o3.yaml
+++ b/providers/openrouter/o3.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 5.e-7
+    - cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000008
       region: "*"

--- a/providers/openrouter/openai/gpt-3.5-turbo.yaml
+++ b/providers/openrouter/openai/gpt-3.5-turbo.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
       output_cost_per_token: 0.0000015
       region: "*"
 features:

--- a/providers/openrouter/openai/gpt-4.1-2025-04-14.yaml
+++ b/providers/openrouter/openai/gpt-4.1-2025-04-14.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 5.e-7
+    - cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000008
       region: "*"

--- a/providers/openrouter/openai/gpt-4.1-mini-2025-04-14.yaml
+++ b/providers/openrouter/openai/gpt-4.1-mini-2025-04-14.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 1.e-7
-      input_cost_per_token: 4.e-7
+    - cache_read_input_token_cost: 1e-7
+      input_cost_per_token: 4e-7
       output_cost_per_token: 0.0000016
       region: "*"
 features:

--- a/providers/openrouter/openai/gpt-4.1-mini.yaml
+++ b/providers/openrouter/openai/gpt-4.1-mini.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 1.e-7
-      input_cost_per_token: 4.e-7
+    - cache_read_input_token_cost: 1e-7
+      input_cost_per_token: 4e-7
       output_cost_per_token: 0.0000016
       region: "*"
 features:

--- a/providers/openrouter/openai/gpt-4.1-nano-2025-04-14.yaml
+++ b/providers/openrouter/openai/gpt-4.1-nano-2025-04-14.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_read_input_token_cost: 2.5e-8
-      input_cost_per_token: 1.e-7
-      output_cost_per_token: 4.e-7
+      input_cost_per_token: 1e-7
+      output_cost_per_token: 4e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/openai/gpt-4.1-nano.yaml
+++ b/providers/openrouter/openai/gpt-4.1-nano.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_read_input_token_cost: 2.5e-8
-      input_cost_per_token: 1.e-7
-      output_cost_per_token: 4.e-7
+      input_cost_per_token: 1e-7
+      output_cost_per_token: 4e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/openai/gpt-4.1.yaml
+++ b/providers/openrouter/openai/gpt-4.1.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 5.e-7
+    - cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000008
       region: "*"

--- a/providers/openrouter/openai/gpt-4o-mini-2024-07-18.yaml
+++ b/providers/openrouter/openai/gpt-4o-mini-2024-07-18.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_read_input_token_cost: 7.5e-8
       input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/openai/gpt-4o-mini-search-preview.yaml
+++ b/providers/openrouter/openai/gpt-4o-mini-search-preview.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: "*"
 features:
     - structured_output

--- a/providers/openrouter/openai/gpt-4o-mini.yaml
+++ b/providers/openrouter/openai/gpt-4o-mini.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_read_input_token_cost: 7.5e-8
       input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/openai/gpt-5-nano.yaml
+++ b/providers/openrouter/openai/gpt-5-nano.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_token_cost: 5.e-9
-      input_cost_per_token: 5.e-8
-      output_cost_per_token: 4.e-7
+    - cache_read_input_token_cost: 5e-9
+      input_cost_per_token: 5e-8
+      output_cost_per_token: 4e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/openai/gpt-5.4-nano.yaml
+++ b/providers/openrouter/openai/gpt-5.4-nano.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 2.e-8
-      input_cost_per_token: 2.e-7
+    - cache_read_input_token_cost: 2e-8
+      input_cost_per_token: 2e-7
       output_cost_per_token: 0.00000125
       region: "*"
 features:

--- a/providers/openrouter/openai/gpt-5.yaml
+++ b/providers/openrouter/openai/gpt-5.yaml
@@ -27,6 +27,7 @@ params:
     - defaultValue: medium
       key: reasoning_effort
       type: string
+provisioning: serverless
 sources:
     - https://openrouter.ai/openai/gpt-5/api
 supportedModes:

--- a/providers/openrouter/openai/gpt-audio-mini.yaml
+++ b/providers/openrouter/openai/gpt-audio-mini.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_audio_token: 6.e-7
-      input_cost_per_token: 6.e-7
+    - input_cost_per_audio_token: 6e-7
+      input_cost_per_token: 6e-7
       output_cost_per_audio_token: 0.0000024
       output_cost_per_token: 0.0000024
       region: "*"

--- a/providers/openrouter/openai/gpt-oss-20b.yaml
+++ b/providers/openrouter/openai/gpt-oss-20b.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_read_input_token_cost: 1.5e-8
-      input_cost_per_token: 3.e-8
+      input_cost_per_token: 3e-8
       output_cost_per_token: 1.1e-7
       region: "*"
 features:

--- a/providers/openrouter/openai/gpt-oss-safeguard-20b.yaml
+++ b/providers/openrouter/openai/gpt-oss-safeguard-20b.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_read_input_token_cost: 3.7e-8
       input_cost_per_token: 7.5e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/openai/o3.yaml
+++ b/providers/openrouter/openai/o3.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 5.e-7
+    - cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000008
       region: "*"

--- a/providers/openrouter/openai/o4-mini-deep-research.yaml
+++ b/providers/openrouter/openai/o4-mini-deep-research.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 5.e-7
+    - cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000008
       region: "*"

--- a/providers/openrouter/pixtral-12b.yaml
+++ b/providers/openrouter/pixtral-12b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 1.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 1e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/pixtral-large-2411.yaml
+++ b/providers/openrouter/pixtral-large-2411.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000006
       region: "*"

--- a/providers/openrouter/prime-intellect/intellect-3.yaml
+++ b/providers/openrouter/prime-intellect/intellect-3.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 2.e-7
+    - input_cost_per_token: 2e-7
       output_cost_per_token: 0.0000011
       region: "*"
 features:

--- a/providers/openrouter/qwen-2.5-7b-instruct.yaml
+++ b/providers/openrouter/qwen-2.5-7b-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 4.e-8
-      output_cost_per_token: 1.e-7
+    - input_cost_per_token: 4e-8
+      output_cost_per_token: 1e-7
       region: "*"
 features:
     - json_output

--- a/providers/openrouter/qwen-2.5-vl-7b-instruct.yaml
+++ b/providers/openrouter/qwen-2.5-vl-7b-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 2.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 2e-7
       region: "*"
 limits:
     context_window: 32768

--- a/providers/openrouter/qwen/qwen-2.5-7b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen-2.5-7b-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 4.e-8
-      output_cost_per_token: 1.e-7
+    - input_cost_per_token: 4e-8
+      output_cost_per_token: 1e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/qwen/qwen-2.5-vl-7b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen-2.5-vl-7b-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 2.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 2e-7
       region: "*"
 limits:
     context_window: 32768

--- a/providers/openrouter/qwen/qwen2.5-vl-32b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen2.5-vl-32b-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 6.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 6e-7
       region: "*"
 features:
     - json_output

--- a/providers/openrouter/qwen/qwen2.5-vl-72b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen2.5-vl-72b-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 8.e-7
-      output_cost_per_token: 8.e-7
+    - input_cost_per_token: 8e-7
+      output_cost_per_token: 8e-7
       region: "*"
 features:
     - json_output

--- a/providers/openrouter/qwen/qwen3-14b.yaml
+++ b/providers/openrouter/qwen/qwen3-14b.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 6.e-8
+    - input_cost_per_token: 6e-8
       output_cost_per_token: 2.4e-7
       region: "*"
 features:

--- a/providers/openrouter/qwen/qwen3-235b-a22b-2507.yaml
+++ b/providers/openrouter/qwen/qwen3-235b-a22b-2507.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 7.1e-8
-      output_cost_per_token: 1.e-7
+      output_cost_per_token: 1e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/qwen/qwen3-30b-a3b-instruct-2507.yaml
+++ b/providers/openrouter/qwen/qwen3-30b-a3b-instruct-2507.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 9.e-8
-      output_cost_per_token: 3.e-7
+    - input_cost_per_token: 9e-8
+      output_cost_per_token: 3e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/qwen/qwen3-30b-a3b-thinking-2507.yaml
+++ b/providers/openrouter/qwen/qwen3-30b-a3b-thinking-2507.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 8.e-8
-      output_cost_per_token: 4.e-7
+    - input_cost_per_token: 8e-8
+      output_cost_per_token: 4e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/qwen/qwen3-30b-a3b.yaml
+++ b/providers/openrouter/qwen/qwen3-30b-a3b.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 8.e-8
+    - input_cost_per_token: 8e-8
       output_cost_per_token: 2.8e-7
       region: "*"
 features:

--- a/providers/openrouter/qwen/qwen3-32b.yaml
+++ b/providers/openrouter/qwen/qwen3-32b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 4.e-8
-      input_cost_per_token: 8.e-8
+    - cache_read_input_token_cost: 4e-8
+      input_cost_per_token: 8e-8
       output_cost_per_token: 2.4e-7
       region: "*"
 features:

--- a/providers/openrouter/qwen/qwen3-8b.yaml
+++ b/providers/openrouter/qwen/qwen3-8b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 5.e-8
-      output_cost_per_token: 4.e-7
+    - input_cost_per_token: 5e-8
+      output_cost_per_token: 4e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/qwen/qwen3-coder-30b-a3b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen3-coder-30b-a3b-instruct.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 7.e-8
+    - input_cost_per_token: 7e-8
       output_cost_per_token: 2.7e-7
       region: "*"
 features:

--- a/providers/openrouter/qwen/qwen3-coder-next.yaml
+++ b/providers/openrouter/qwen/qwen3-coder-next.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 6.e-8
+    - cache_read_input_token_cost: 6e-8
       input_cost_per_token: 1.2e-7
       output_cost_per_token: 7.5e-7
       region: "*"

--- a/providers/openrouter/qwen/qwen3-next-80b-a3b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen3-next-80b-a3b-instruct.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 9.e-8
+    - input_cost_per_token: 9e-8
       output_cost_per_token: 0.0000011
       region: "*"
 features:

--- a/providers/openrouter/qwen/qwen3-vl-235b-a22b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen3-vl-235b-a22b-instruct.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 2.e-7
+    - input_cost_per_token: 2e-7
       output_cost_per_token: 8.8e-7
       region: "*"
 features:

--- a/providers/openrouter/qwen/qwen3-vl-8b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen3-vl-8b-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 8.e-8
-      output_cost_per_token: 5.e-7
+    - input_cost_per_token: 8e-8
+      output_cost_per_token: 5e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/qwen/qwen3.5-9b.yaml
+++ b/providers/openrouter/qwen/qwen3.5-9b.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-8
+    - input_cost_per_token: 5e-8
       output_cost_per_token: 1.5e-7
       region: "*"
 features:

--- a/providers/openrouter/qwen2.5-vl-32b-instruct.yaml
+++ b/providers/openrouter/qwen2.5-vl-32b-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 6.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 6e-7
       region: "*"
 features:
     - system_messages

--- a/providers/openrouter/qwen2.5-vl-72b-instruct.yaml
+++ b/providers/openrouter/qwen2.5-vl-72b-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 8.e-7
-      output_cost_per_token: 8.e-7
+    - input_cost_per_token: 8e-7
+      output_cost_per_token: 8e-7
       region: "*"
 limits:
     context_window: 32768

--- a/providers/openrouter/qwen3-14b.yaml
+++ b/providers/openrouter/qwen3-14b.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 6.e-8
+    - input_cost_per_token: 6e-8
       output_cost_per_token: 2.4e-7
       region: "*"
 features:

--- a/providers/openrouter/qwen3-235b-a22b-2507.yaml
+++ b/providers/openrouter/qwen3-235b-a22b-2507.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 7.1e-8
-      output_cost_per_token: 1.e-7
+      output_cost_per_token: 1e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/qwen3-30b-a3b-instruct-2507.yaml
+++ b/providers/openrouter/qwen3-30b-a3b-instruct-2507.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 9.e-8
-      output_cost_per_token: 3.e-7
+    - input_cost_per_token: 9e-8
+      output_cost_per_token: 3e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/qwen3-30b-a3b.yaml
+++ b/providers/openrouter/qwen3-30b-a3b.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 8.e-8
+    - input_cost_per_token: 8e-8
       output_cost_per_token: 2.8e-7
       region: "*"
 features:

--- a/providers/openrouter/qwen3-32b.yaml
+++ b/providers/openrouter/qwen3-32b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 4.e-8
-      input_cost_per_token: 8.e-8
+    - cache_read_input_token_cost: 4e-8
+      input_cost_per_token: 8e-8
       output_cost_per_token: 2.4e-7
       region: "*"
 features:

--- a/providers/openrouter/qwen3-8b.yaml
+++ b/providers/openrouter/qwen3-8b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 5.e-8
-      output_cost_per_token: 4.e-7
+    - input_cost_per_token: 5e-8
+      output_cost_per_token: 4e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/reka-flash-3.yaml
+++ b/providers/openrouter/reka-flash-3.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_image: 0.01
-      input_cost_per_token: 8.e-7
+      input_cost_per_token: 8e-7
       output_cost_per_token: 0.000002
       region: "*"
 features:

--- a/providers/openrouter/reka/reka-edge.yaml
+++ b/providers/openrouter/reka/reka-edge.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 1.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 1e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/rekaai/reka-edge.yaml
+++ b/providers/openrouter/rekaai/reka-edge.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 1.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 1e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/rekaai/reka-flash-3.yaml
+++ b/providers/openrouter/rekaai/reka-flash-3.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 2.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 2e-7
       region: "*"
 limits:
     context_window: 65536

--- a/providers/openrouter/sao10k/l3-lunaris-8b.yaml
+++ b/providers/openrouter/sao10k/l3-lunaris-8b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 4.e-8
-      output_cost_per_token: 5.e-8
+    - input_cost_per_token: 4e-8
+      output_cost_per_token: 5e-8
       region: "*"
 features:
     - json_output

--- a/providers/openrouter/stepfun/step-3.5-flash.yaml
+++ b/providers/openrouter/stepfun/step-3.5-flash.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 3.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 3e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/thedrummer/cydonia-24b-v4.1.yaml
+++ b/providers/openrouter/thedrummer/cydonia-24b-v4.1.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 3.e-7
-      output_cost_per_token: 5.e-7
+    - input_cost_per_token: 3e-7
+      output_cost_per_token: 5e-7
       region: "*"
 limits:
     context_window: 131072

--- a/providers/openrouter/thedrummer/skyfall-36b-v2.yaml
+++ b/providers/openrouter/thedrummer/skyfall-36b-v2.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 5.5e-7
-      output_cost_per_token: 8.e-7
+      output_cost_per_token: 8e-7
       region: "*"
 limits:
     context_window: 32768

--- a/providers/openrouter/thedrummer/unslopnemo-12b.yaml
+++ b/providers/openrouter/thedrummer/unslopnemo-12b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 4.e-7
-      output_cost_per_token: 4.e-7
+    - input_cost_per_token: 4e-7
+      output_cost_per_token: 4e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/tngtech/deepseek-r1t2-chimera.yaml
+++ b/providers/openrouter/tngtech/deepseek-r1t2-chimera.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_read_input_token_cost: 1.5e-7
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000011
       region: "*"
 features:
@@ -20,7 +20,9 @@ modalities:
         - text
 mode: chat
 model: tngtech/deepseek-r1t2-chimera
+provisioning: serverless
 sources:
+    - https://openrouter.ai/tngtech/deepseek-r1t2-chimera
     - https://openrouter.ai/tngtech/deepseek-r1t2-chimera/api
 status: active
 supportedModes:

--- a/providers/openrouter/ui-tars-1.5-7b.yaml
+++ b/providers/openrouter/ui-tars-1.5-7b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 2.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 2e-7
       region: "*"
 limits:
     context_window: 128000

--- a/providers/openrouter/unslopnemo-12b.yaml
+++ b/providers/openrouter/unslopnemo-12b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 4.e-7
-      output_cost_per_token: 4.e-7
+    - input_cost_per_token: 4e-7
+      output_cost_per_token: 4e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/upstage/solar-pro-3.yaml
+++ b/providers/openrouter/upstage/solar-pro-3.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_read_input_token_cost: 1.5e-8
       input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/writer/palmyra-x5.yaml
+++ b/providers/openrouter/writer/palmyra-x5.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 6.e-7
+    - input_cost_per_token: 6e-7
       output_cost_per_token: 0.000006
       region: "*"
 limits:

--- a/providers/openrouter/x-ai/grok-3-mini-beta.yaml
+++ b/providers/openrouter/x-ai/grok-3-mini-beta.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_read_input_token_cost: 7.5e-8
-      input_cost_per_token: 3.e-7
-      output_cost_per_token: 5.e-7
+      input_cost_per_token: 3e-7
+      output_cost_per_token: 5e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/x-ai/grok-3-mini.yaml
+++ b/providers/openrouter/x-ai/grok-3-mini.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_read_input_token_cost: 7.5e-8
-      input_cost_per_token: 3.e-7
-      output_cost_per_token: 5.e-7
+      input_cost_per_token: 3e-7
+      output_cost_per_token: 5e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/x-ai/grok-4-fast.yaml
+++ b/providers/openrouter/x-ai/grok-4-fast.yaml
@@ -1,11 +1,11 @@
 costs:
-    - cache_read_input_token_cost: 5.e-8
-      input_cost_per_token: 2.e-7
-      output_cost_per_token: 5.e-7
+    - cache_read_input_token_cost: 5e-8
+      input_cost_per_token: 2e-7
+      output_cost_per_token: 5e-7
       region: "*"
       tiered_pricing:
           input:
-              - cost_per_token: 4.e-7
+              - cost_per_token: 4e-7
                 from: 128000
           output:
               - cost_per_token: 0.000001

--- a/providers/openrouter/x-ai/grok-4.1-fast.yaml
+++ b/providers/openrouter/x-ai/grok-4.1-fast.yaml
@@ -1,11 +1,11 @@
 costs:
-    - cache_read_input_token_cost: 5.e-8
-      input_cost_per_token: 2.e-7
-      output_cost_per_token: 5.e-7
+    - cache_read_input_token_cost: 5e-8
+      input_cost_per_token: 2e-7
+      output_cost_per_token: 5e-7
       region: "*"
       tiered_pricing:
           input:
-              - cost_per_token: 4.e-7
+              - cost_per_token: 4e-7
                 from: 128000
           output:
               - cost_per_token: 0.000001

--- a/providers/openrouter/x-ai/grok-4.20-beta.yaml
+++ b/providers/openrouter/x-ai/grok-4.20-beta.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000006
       region: "*"

--- a/providers/openrouter/x-ai/grok-4.20-multi-agent-beta.yaml
+++ b/providers/openrouter/x-ai/grok-4.20-multi-agent-beta.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000006
       region: "*"

--- a/providers/openrouter/x-ai/grok-4.20-multi-agent.yaml
+++ b/providers/openrouter/x-ai/grok-4.20-multi-agent.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000006
@@ -7,7 +7,7 @@ costs:
       region: "*"
       tiered_pricing:
           cache_read:
-              - cost_per_token: 4.e-7
+              - cost_per_token: 4e-7
                 from: 200000
           input:
               - cost_per_token: 0.000004

--- a/providers/openrouter/x-ai/grok-4.20.yaml
+++ b/providers/openrouter/x-ai/grok-4.20.yaml
@@ -1,11 +1,11 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000006
       region: "*"
       tiered_pricing:
           cache_read:
-              - cost_per_token: 4.e-7
+              - cost_per_token: 4e-7
                 from: 200000
           input:
               - cost_per_token: 0.000004

--- a/providers/openrouter/x-ai/grok-code-fast-1.yaml
+++ b/providers/openrouter/x-ai/grok-code-fast-1.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 2.e-8
-      input_cost_per_token: 2.e-7
+    - cache_read_input_token_cost: 2e-8
+      input_cost_per_token: 2e-7
       output_cost_per_token: 0.0000015
       region: "*"
 features:

--- a/providers/openrouter/xiaomi/mimo-v2-flash.yaml
+++ b/providers/openrouter/xiaomi/mimo-v2-flash.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_read_input_token_cost: 4.5e-8
-      input_cost_per_token: 9.e-8
+      input_cost_per_token: 9e-8
       output_cost_per_token: 2.9e-7
       region: "*"
 features:

--- a/providers/openrouter/xiaomi/mimo-v2-omni.yaml
+++ b/providers/openrouter/xiaomi/mimo-v2-omni.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 8.e-8
-      input_cost_per_token: 4.e-7
+    - cache_read_input_token_cost: 8e-8
+      input_cost_per_token: 4e-7
       output_cost_per_token: 0.000002
       region: "*"
 features:

--- a/providers/openrouter/xiaomi/mimo-v2-pro.yaml
+++ b/providers/openrouter/xiaomi/mimo-v2-pro.yaml
@@ -1,11 +1,11 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000001
       output_cost_per_token: 0.000003
       region: "*"
       tiered_pricing:
           cache_read:
-              - cost_per_token: 4.e-7
+              - cost_per_token: 4e-7
                 from: 256000
           input:
               - cost_per_token: 0.000002

--- a/providers/openrouter/z-ai/glm-4-32b.yaml
+++ b/providers/openrouter/z-ai/glm-4-32b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 1.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 1e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/z-ai/glm-4.5.yaml
+++ b/providers/openrouter/z-ai/glm-4.5.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_read_input_token_cost: 1.1e-7
-      input_cost_per_token: 6.e-7
+      input_cost_per_token: 6e-7
       output_cost_per_token: 0.0000022
       region: "*"
 features:

--- a/providers/openrouter/z-ai/glm-4.5v.yaml
+++ b/providers/openrouter/z-ai/glm-4.5v.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_read_input_token_cost: 1.1e-7
-      input_cost_per_token: 6.e-7
+      input_cost_per_token: 6e-7
       output_cost_per_token: 0.0000018
       region: "*"
 features:

--- a/providers/openrouter/z-ai/glm-4.6v.yaml
+++ b/providers/openrouter/z-ai/glm-4.6v.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 3.e-7
-      output_cost_per_token: 9.e-7
+    - input_cost_per_token: 3e-7
+      output_cost_per_token: 9e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/z-ai/glm-4.7-flash.yaml
+++ b/providers/openrouter/z-ai/glm-4.7-flash.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_token_cost: 1.e-8
-      input_cost_per_token: 6.e-8
-      output_cost_per_token: 4.e-7
+    - cache_read_input_token_cost: 1e-8
+      input_cost_per_token: 6e-8
+      output_cost_per_token: 4e-7
       region: "*"
 features:
     - function_calling


### PR DESCRIPTION
Auto-generated by poc-agent for provider `openrouter`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly mechanical YAML updates to model catalog data (pricing numeric formatting and a few metadata fields). Risk is low, but incorrect cost values/metadata could affect billing display or model routing if consumed directly.
> 
> **Overview**
> Updates many OpenRouter model YAMLs by **normalizing cost fields** (e.g., `7.e-7` → `7e-7`, similar fixes across cache/input/output token pricing and tiered pricing).
> 
> Also refreshes **model metadata** for a small set of entries, adding/adjusting fields like `provisioning: serverless`, additional `sources` URLs, and `status`/`supportedModes` where applicable (e.g., `moonshotai/kimi-k2.6`, `tngtech/deepseek-r1t2-chimera`, `openai/gpt-5`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4788df47c7f761176db5e578dba406440c1e89c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->