### PR TITLE
notation change

### DIFF
--- a/providers/ai21/jamba-1.5-mini.yaml
+++ b/providers/ai21/jamba-1.5-mini.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 4.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 4e-7
       region: "*"
 features:
     - tool_choice

--- a/providers/ai21/jamba-1.5-mini@001.yaml
+++ b/providers/ai21/jamba-1.5-mini@001.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 4.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 4e-7
       region: "*"
 features:
     - tool_choice

--- a/providers/ai21/jamba-1.5.yaml
+++ b/providers/ai21/jamba-1.5.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 4.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 4e-7
       region: "*"
 features:
     - tool_choice

--- a/providers/ai21/jamba-mini-1.6.yaml
+++ b/providers/ai21/jamba-mini-1.6.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 4.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 4e-7
       region: "*"
 features:
     - tool_choice

--- a/providers/ai21/jamba-mini-1.7.yaml
+++ b/providers/ai21/jamba-mini-1.7.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 4.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 4e-7
       region: "*"
 features:
     - tool_choice

--- a/providers/anthropic/claude-3-5-haiku-20241022.yaml
+++ b/providers/anthropic/claude-3-5-haiku-20241022.yaml
@@ -1,8 +1,8 @@
 costs:
     - cache_creation_input_token_cost: 0.000001
-      cache_read_input_token_cost: 8.e-8
-      input_cost_per_token: 8.e-7
-      input_cost_per_token_batches: 4.e-7
+      cache_read_input_token_cost: 8e-8
+      input_cost_per_token: 8e-7
+      input_cost_per_token_batches: 4e-7
       output_cost_per_token: 0.000004
       output_cost_per_token_batches: 0.000002
       region: "*"

--- a/providers/anthropic/claude-3-5-sonnet-20240620.yaml
+++ b/providers/anthropic/claude-3-5-sonnet-20240620.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: "*"

--- a/providers/anthropic/claude-3-5-sonnet-20241022.yaml
+++ b/providers/anthropic/claude-3-5-sonnet-20241022.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: "*"

--- a/providers/anthropic/claude-3-5-sonnet-latest.yaml
+++ b/providers/anthropic/claude-3-5-sonnet-latest.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: "*"

--- a/providers/anthropic/claude-3-7-sonnet-latest.yaml
+++ b/providers/anthropic/claude-3-7-sonnet-latest.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015

--- a/providers/anthropic/claude-3-haiku-20240307.yaml
+++ b/providers/anthropic/claude-3-haiku-20240307.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_creation_input_token_cost: 3.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_creation_input_token_cost: 3e-7
+      cache_read_input_token_cost: 3e-8
       input_cost_per_token: 2.5e-7
       input_cost_per_token_batches: 1.25e-7
       output_cost_per_token: 0.00000125

--- a/providers/anthropic/claude-4-sonnet-20250514.yaml
+++ b/providers/anthropic/claude-4-sonnet-20250514.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015

--- a/providers/anthropic/claude-haiku-4-5-20251001.yaml
+++ b/providers/anthropic/claude-haiku-4-5-20251001.yaml
@@ -1,8 +1,8 @@
 costs:
     - cache_creation_input_token_cost: 0.00000125
-      cache_read_input_token_cost: 1.e-7
+      cache_read_input_token_cost: 1e-7
       input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 0.000005
       output_cost_per_token_batches: 0.0000025
       region: "*"

--- a/providers/anthropic/claude-haiku-4-5.yaml
+++ b/providers/anthropic/claude-haiku-4-5.yaml
@@ -1,8 +1,8 @@
 costs:
     - cache_creation_input_token_cost: 0.00000125
-      cache_read_input_token_cost: 1.e-7
+      cache_read_input_token_cost: 1e-7
       input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 0.000005
       output_cost_per_token_batches: 0.0000025
       region: "*"

--- a/providers/anthropic/claude-opus-4-5-20251101.yaml
+++ b/providers/anthropic/claude-opus-4-5-20251101.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025

--- a/providers/anthropic/claude-opus-4-5.yaml
+++ b/providers/anthropic/claude-opus-4-5.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025

--- a/providers/anthropic/claude-opus-4-6.yaml
+++ b/providers/anthropic/claude-opus-4-6.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025

--- a/providers/anthropic/claude-opus-4-7.yaml
+++ b/providers/anthropic/claude-opus-4-7.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025

--- a/providers/anthropic/claude-sonnet-4-20250514.yaml
+++ b/providers/anthropic/claude-sonnet-4-20250514.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015

--- a/providers/anthropic/claude-sonnet-4-5-20250929.yaml
+++ b/providers/anthropic/claude-sonnet-4-5-20250929.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
@@ -8,7 +8,7 @@ costs:
       region: "*"
       tiered_pricing:
           cache_read:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 200000
           cache_write:
               - cost_per_token: 0.0000075

--- a/providers/anthropic/claude-sonnet-4-5.yaml
+++ b/providers/anthropic/claude-sonnet-4-5.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015

--- a/providers/anthropic/claude-sonnet-4-6.yaml
+++ b/providers/anthropic/claude-sonnet-4-6.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015

--- a/providers/aws-bedrock/ai21.jamba-1-5-mini-v1:0.yaml
+++ b/providers/aws-bedrock/ai21.jamba-1-5-mini-v1:0.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 4.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 4e-7
       region: us-east-1
 features:
     - system_messages

--- a/providers/aws-bedrock/ai21.jamba-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/ai21.jamba-instruct-v1:0.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 5.e-7
-      output_cost_per_token: 7.e-7
+    - input_cost_per_token: 5e-7
+      output_cost_per_token: 7e-7
       region: us-east-1
 isDeprecated: true
 limits:

--- a/providers/aws-bedrock/amazon.nova-lite-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.nova-lite-v1:0.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 6.e-8
-      input_cost_per_token_batches: 3.e-8
+    - input_cost_per_token: 6e-8
+      input_cost_per_token_batches: 3e-8
       output_cost_per_token: 2.4e-7
       output_cost_per_token_batches: 1.2e-7
       region: us-west-2
@@ -12,26 +12,26 @@ costs:
       output_cost_per_token: 2.88e-7
       output_cost_per_token_batches: 1.44e-7
       region: us-gov-west-1
-    - input_cost_per_token: 6.e-8
-      input_cost_per_token_batches: 3.e-8
+    - input_cost_per_token: 6e-8
+      input_cost_per_token_batches: 3e-8
       output_cost_per_token: 2.4e-7
       output_cost_per_token_batches: 1.2e-7
       region: us-east-2
-    - cache_creation_input_token_cost: 6.e-8
+    - cache_creation_input_token_cost: 6e-8
       cache_read_input_token_cost: 1.5e-8
-      input_cost_per_token: 6.e-8
-      input_cost_per_token_batches: 3.e-8
+      input_cost_per_token: 6e-8
+      input_cost_per_token_batches: 3e-8
       output_cost_per_token: 2.4e-7
       output_cost_per_token_batches: 1.2e-7
       region: us-east-1
-    - input_cost_per_token: 6.e-8
-      input_cost_per_token_batches: 3.e-8
+    - input_cost_per_token: 6e-8
+      input_cost_per_token_batches: 3e-8
       output_cost_per_token: 2.4e-7
       output_cost_per_token_batches: 1.2e-7
       region: me-central-1
     - input_cost_per_token: 7.5e-8
       input_cost_per_token_batches: 3.75e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: il-central-1
     - input_cost_per_token: 8.8e-8

--- a/providers/aws-bedrock/amazon.nova-micro-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.nova-micro-v1:0.yaml
@@ -7,7 +7,7 @@ costs:
       input_cost_per_token: 3.5e-8
       input_cost_per_token_batches: 1.75e-8
       output_cost_per_token: 1.4e-7
-      output_cost_per_token_batches: 7.e-8
+      output_cost_per_token_batches: 7e-8
       region: us-east-1
     - input_cost_per_token: 4.9e-8
       output_cost_per_token: 1.96e-7

--- a/providers/aws-bedrock/amazon.nova-pro-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.nova-pro-v1:0.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 8.e-7
-      input_cost_per_token_batches: 4.e-7
+    - input_cost_per_token: 8e-7
+      input_cost_per_token_batches: 4e-7
       output_cost_per_token: 0.0000032
       output_cost_per_token_batches: 0.0000016
       region: us-west-2
@@ -12,24 +12,24 @@ costs:
       output_cost_per_token: 0.00000384
       output_cost_per_token_batches: 0.00000192
       region: us-gov-west-1
-    - input_cost_per_token: 8.e-7
-      input_cost_per_token_batches: 4.e-7
+    - input_cost_per_token: 8e-7
+      input_cost_per_token_batches: 4e-7
       output_cost_per_token: 0.0000032
       output_cost_per_token_batches: 0.0000016
       region: us-east-2
-    - cache_read_input_token_cost: 2.e-7
-      input_cost_per_token: 8.e-7
-      input_cost_per_token_batches: 4.e-7
+    - cache_read_input_token_cost: 2e-7
+      input_cost_per_token: 8e-7
+      input_cost_per_token_batches: 4e-7
       output_cost_per_token: 0.0000032
       output_cost_per_token_batches: 0.0000016
       region: us-east-1
-    - input_cost_per_token: 8.e-7
-      input_cost_per_token_batches: 4.e-7
+    - input_cost_per_token: 8e-7
+      input_cost_per_token_batches: 4e-7
       output_cost_per_token: 0.0000032
       output_cost_per_token_batches: 0.0000016
       region: me-central-1
     - input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 0.000004
       output_cost_per_token_batches: 0.000002
       region: il-central-1

--- a/providers/aws-bedrock/amazon.nova-sonic-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.nova-sonic-v1:0.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_audio_token: 0.0000034
-      input_cost_per_token: 6.e-8
+      input_cost_per_token: 6e-8
       output_cost_per_audio_token: 0.0000136
       output_cost_per_token: 2.4e-7
       region: us-east-1

--- a/providers/aws-bedrock/amazon.titan-embed-g1-text-02.yaml
+++ b/providers/aws-bedrock/amazon.titan-embed-g1-text-02.yaml
@@ -1,7 +1,7 @@
 costs:
-    - input_cost_per_token: 1.e-7
+    - input_cost_per_token: 1e-7
       region: us-west-2
-    - input_cost_per_token: 1.e-7
+    - input_cost_per_token: 1e-7
       region: us-east-1
 isDeprecated: true
 modalities:

--- a/providers/aws-bedrock/amazon.titan-embed-image-v1.yaml
+++ b/providers/aws-bedrock/amazon.titan-embed-image-v1.yaml
@@ -1,43 +1,43 @@
 costs:
     - input_cost_per_image: 0.00006
-      input_cost_per_token: 8.e-7
-      input_cost_per_token_batches: 4.e-7
+      input_cost_per_token: 8e-7
+      input_cost_per_token_batches: 4e-7
       region: us-west-2
     - input_cost_per_image: 0.00006
-      input_cost_per_token: 8.e-7
-      input_cost_per_token_batches: 4.e-7
+      input_cost_per_token: 8e-7
+      input_cost_per_token_batches: 4e-7
       region: us-east-1
     - input_cost_per_image: 0.0001
       input_cost_per_token: 0.0000012
-      input_cost_per_token_batches: 6.e-7
+      input_cost_per_token_batches: 6e-7
       region: sa-east-1
     - input_cost_per_image: 0.00008
       input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       region: eu-west-3
     - input_cost_per_image: 0.0001
       input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       region: eu-west-2
     - input_cost_per_image: 0.00007
       input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       region: eu-west-1
     - input_cost_per_image: 0.0001
       input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       region: eu-central-1
     - input_cost_per_image: 0.0001
-      input_cost_per_token: 9.e-7
+      input_cost_per_token: 9e-7
       input_cost_per_token_batches: 4.5e-7
       region: ca-central-1
     - input_cost_per_image: 0.00008
       input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       region: ap-southeast-2
     - input_cost_per_image: 0.00007
       input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       region: ap-south-1
 limits:
     max_input_tokens: 256

--- a/providers/aws-bedrock/amazon.titan-embed-text-v1.yaml
+++ b/providers/aws-bedrock/amazon.titan-embed-text-v1.yaml
@@ -1,15 +1,15 @@
 costs:
-    - input_cost_per_token: 1.e-7
+    - input_cost_per_token: 1e-7
       region: us-west-2
-    - input_cost_per_token: 1.e-7
+    - input_cost_per_token: 1e-7
       region: us-east-1
-    - input_cost_per_token: 1.e-7
+    - input_cost_per_token: 1e-7
       region: eu-west-1
-    - input_cost_per_token: 2.e-7
+    - input_cost_per_token: 2e-7
       region: eu-central-1
     - input_cost_per_token: 1.2e-7
       region: ap-south-1
-    - input_cost_per_token: 2.e-7
+    - input_cost_per_token: 2e-7
       region: ap-northeast-1
 limits:
     max_input_tokens: 8192

--- a/providers/aws-bedrock/amazon.titan-embed-text-v2:0.yaml
+++ b/providers/aws-bedrock/amazon.titan-embed-text-v2:0.yaml
@@ -1,25 +1,25 @@
 costs:
-    - input_cost_per_token: 2.e-8
-      input_cost_per_token_batches: 1.e-8
+    - input_cost_per_token: 2e-8
+      input_cost_per_token_batches: 1e-8
       region: us-west-2
     - input_cost_per_token: 2.4e-8
       region: us-west-1
     - input_cost_per_token: 1.1e-7
       region: us-gov-west-1
-    - input_cost_per_token: 3.e-8
+    - input_cost_per_token: 3e-8
       region: us-gov-east-1
-    - input_cost_per_token: 2.e-8
+    - input_cost_per_token: 2e-8
       region: us-east-2
-    - input_cost_per_token: 2.e-8
-      input_cost_per_token_batches: 1.e-8
+    - input_cost_per_token: 2e-8
+      input_cost_per_token_batches: 1e-8
       region: us-east-1
-    - input_cost_per_token: 2.e-7
-      input_cost_per_token_batches: 1.e-7
+    - input_cost_per_token: 2e-7
+      input_cost_per_token_batches: 1e-7
       region: sa-east-1
-    - input_cost_per_token: 3.e-8
+    - input_cost_per_token: 3e-8
       region: eu-west-3
-    - input_cost_per_token: 1.e-7
-      input_cost_per_token_batches: 5.e-8
+    - input_cost_per_token: 1e-7
+      input_cost_per_token_batches: 5e-8
       region: eu-west-2
     - input_cost_per_token: 2.6e-8
       region: eu-west-1
@@ -34,11 +34,11 @@ costs:
       region: eu-north-1
     - input_cost_per_token: 2.7e-8
       region: eu-central-2
-    - input_cost_per_token: 2.e-7
-      input_cost_per_token_batches: 1.e-7
+    - input_cost_per_token: 2e-7
+      input_cost_per_token_batches: 1e-7
       region: eu-central-1
-    - input_cost_per_token: 1.e-7
-      input_cost_per_token_batches: 5.e-8
+    - input_cost_per_token: 1e-7
+      input_cost_per_token_batches: 5e-8
       region: ca-central-1
     - input_cost_per_token: 2.6e-8
       region: ap-southeast-2

--- a/providers/aws-bedrock/amazon.titan-text-express-v1.yaml
+++ b/providers/aws-bedrock/amazon.titan-text-express-v1.yaml
@@ -1,30 +1,30 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 6.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 6e-7
       region: us-west-2
-    - input_cost_per_token: 8.e-7
+    - input_cost_per_token: 8e-7
       output_cost_per_token: 0.0000016
       region: us-gov-west-1
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 6.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 6e-7
       region: us-east-1
-    - input_cost_per_token: 4.e-7
+    - input_cost_per_token: 4e-7
       output_cost_per_token: 0.0000011
       region: sa-east-1
     - input_cost_per_token: 2.5e-7
       output_cost_per_token: 7.88e-7
       region: eu-west-3
-    - input_cost_per_token: 3.e-7
-      output_cost_per_token: 9.e-7
+    - input_cost_per_token: 3e-7
+      output_cost_per_token: 9e-7
       region: eu-west-2
     - input_cost_per_token: 0.000001
       output_cost_per_token: 0.0000017
       region: eu-west-1
-    - input_cost_per_token: 3.e-7
+    - input_cost_per_token: 3e-7
       output_cost_per_token: 8.63e-7
       region: eu-central-1
-    - input_cost_per_token: 3.e-7
-      output_cost_per_token: 8.e-7
+    - input_cost_per_token: 3e-7
+      output_cost_per_token: 8e-7
       region: ca-central-1
     - input_cost_per_token: 2.5e-7
       output_cost_per_token: 7.88e-7

--- a/providers/aws-bedrock/amazon.titan-text-lite-v1.yaml
+++ b/providers/aws-bedrock/amazon.titan-text-lite-v1.yaml
@@ -1,30 +1,30 @@
 costs:
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 2.e-7
+      output_cost_per_token: 2e-7
       region: us-west-2
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 2.e-7
+      output_cost_per_token: 2e-7
       region: us-east-1
-    - input_cost_per_token: 3.e-7
-      output_cost_per_token: 4.e-7
+    - input_cost_per_token: 3e-7
+      output_cost_per_token: 4e-7
       region: sa-east-1
-    - input_cost_per_token: 2.e-7
+    - input_cost_per_token: 2e-7
       output_cost_per_token: 2.5e-7
       region: eu-west-3
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 3.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 3e-7
       region: eu-west-2
-    - input_cost_per_token: 3.e-7
-      output_cost_per_token: 4.e-7
+    - input_cost_per_token: 3e-7
+      output_cost_per_token: 4e-7
       region: eu-west-1
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 3.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 3e-7
       region: ca-central-1
-    - input_cost_per_token: 2.e-7
+    - input_cost_per_token: 2e-7
       output_cost_per_token: 2.5e-7
       region: ap-southeast-2
-    - input_cost_per_token: 4.e-7
-      output_cost_per_token: 5.e-7
+    - input_cost_per_token: 4e-7
+      output_cost_per_token: 5e-7
       region: ap-south-1
 isDeprecated: true
 mode: chat

--- a/providers/aws-bedrock/amazon.titan-text-premier-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.titan-text-premier-v1:0.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
       output_cost_per_token: 0.0000015
       region: us-east-1
 isDeprecated: true

--- a/providers/aws-bedrock/amazon.titan-tg1-large.yaml
+++ b/providers/aws-bedrock/amazon.titan-tg1-large.yaml
@@ -1,9 +1,9 @@
 costs:
-    - input_cost_per_token: 3.e-7
-      output_cost_per_token: 4.e-7
+    - input_cost_per_token: 3e-7
+      output_cost_per_token: 4e-7
       region: us-west-2
-    - input_cost_per_token: 3.e-7
-      output_cost_per_token: 4.e-7
+    - input_cost_per_token: 3e-7
+      output_cost_per_token: 4e-7
       region: us-east-1
 limits:
     context_window: 8000

--- a/providers/aws-bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0.yaml
+++ b/providers/aws-bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0.yaml
@@ -1,48 +1,48 @@
 costs:
     - cache_creation_input_token_cost: 0.0000075
-      cache_read_input_token_cost: 6.e-7
+      cache_read_input_token_cost: 6e-7
       input_cost_per_token: 0.000006
       input_cost_per_token_batches: 0.000003
       output_cost_per_token: 0.00003
       output_cost_per_token_batches: 0.000015
       region: us-west-2
     - cache_creation_input_token_cost: 0.0000075
-      cache_read_input_token_cost: 6.e-7
+      cache_read_input_token_cost: 6e-7
       input_cost_per_token: 0.000006
       input_cost_per_token_batches: 0.000003
       output_cost_per_token: 0.00003
       output_cost_per_token_batches: 0.000015
       region: us-east-2
     - cache_creation_input_token_cost: 0.0000075
-      cache_read_input_token_cost: 6.e-7
+      cache_read_input_token_cost: 6e-7
       input_cost_per_token: 0.000006
       input_cost_per_token_batches: 0.000003
       output_cost_per_token: 0.00003
       output_cost_per_token_batches: 0.000015
       region: us-east-1
     - cache_creation_input_token_cost: 0.0000075
-      cache_read_input_token_cost: 6.e-7
+      cache_read_input_token_cost: 6e-7
       input_cost_per_token: 0.000006
       input_cost_per_token_batches: 0.000003
       output_cost_per_token: 0.00003
       output_cost_per_token_batches: 0.000015
       region: eu-west-3
     - cache_creation_input_token_cost: 0.0000075
-      cache_read_input_token_cost: 6.e-7
+      cache_read_input_token_cost: 6e-7
       input_cost_per_token: 0.000006
       input_cost_per_token_batches: 0.000003
       output_cost_per_token: 0.00003
       output_cost_per_token_batches: 0.000015
       region: eu-west-1
     - cache_creation_input_token_cost: 0.0000075
-      cache_read_input_token_cost: 6.e-7
+      cache_read_input_token_cost: 6e-7
       input_cost_per_token: 0.000006
       input_cost_per_token_batches: 0.000003
       output_cost_per_token: 0.00003
       output_cost_per_token_batches: 0.000015
       region: eu-central-2
     - cache_creation_input_token_cost: 0.0000075
-      cache_read_input_token_cost: 6.e-7
+      cache_read_input_token_cost: 6e-7
       input_cost_per_token: 0.000006
       input_cost_per_token_batches: 0.000003
       output_cost_per_token: 0.00003

--- a/providers/aws-bedrock/anthropic.claude-instant-v1.yaml
+++ b/providers/aws-bedrock/anthropic.claude-instant-v1.yaml
@@ -5,13 +5,13 @@ costs:
     - input_cost_per_token: 0.00000326
       output_cost_per_token: 0.00001102
       region: us-east-1
-    - input_cost_per_token: 8.e-7
+    - input_cost_per_token: 8e-7
       output_cost_per_token: 0.0000024
       region: eu-central-1
-    - input_cost_per_token: 8.e-7
+    - input_cost_per_token: 8e-7
       output_cost_per_token: 0.0000024
       region: ap-southeast-1
-    - input_cost_per_token: 8.e-7
+    - input_cost_per_token: 8e-7
       output_cost_per_token: 0.0000024
       region: ap-northeast-1
 isDeprecated: true

--- a/providers/aws-bedrock/anthropic.claude-sonnet-4-6.yaml
+++ b/providers/aws-bedrock/anthropic.claude-sonnet-4-6.yaml
@@ -1,223 +1,223 @@
 costs:
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: us-west-2
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: us-west-1
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: us-east-2
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: us-east-1
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: sa-east-1
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: mx-central-1
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: me-south-1
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: me-central-1
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: il-central-1
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: eu-west-3
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: eu-west-2
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: eu-west-1
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: eu-south-2
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: eu-south-1
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: eu-north-1
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: eu-central-2
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: eu-central-1
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ca-west-1
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ca-central-1
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ap-southeast-7
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ap-southeast-5
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ap-southeast-4
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ap-southeast-3
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ap-southeast-2
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ap-southeast-1
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ap-south-2
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ap-south-1
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ap-northeast-3
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ap-northeast-2
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ap-northeast-1
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ap-east-2
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015

--- a/providers/aws-bedrock/apac.amazon.nova-lite-v1:0.yaml
+++ b/providers/aws-bedrock/apac.amazon.nova-lite-v1:0.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_read_input_token_cost: 1.5e-8
-      input_cost_per_token: 6.e-8
+      input_cost_per_token: 6e-8
       output_cost_per_token: 2.4e-7
       region: me-central-1
     - cache_read_input_token_cost: 1.8e-8

--- a/providers/aws-bedrock/apac.amazon.nova-pro-v1:0.yaml
+++ b/providers/aws-bedrock/apac.amazon.nova-pro-v1:0.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
-      input_cost_per_token: 8.e-7
+    - cache_read_input_token_cost: 2e-7
+      input_cost_per_token: 8e-7
       output_cost_per_token: 0.0000032
       region: me-central-1
     - region: ap-southeast-7

--- a/providers/aws-bedrock/apac.anthropic.claude-3-7-sonnet-20250219-v1:0.yaml
+++ b/providers/aws-bedrock/apac.anthropic.claude-3-7-sonnet-20250219-v1:0.yaml
@@ -1,48 +1,48 @@
 costs:
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ap-southeast-2
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ap-southeast-1
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ap-south-2
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ap-south-1
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ap-northeast-3
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ap-northeast-2
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015

--- a/providers/aws-bedrock/apac.anthropic.claude-sonnet-4-20250514-v1:0.yaml
+++ b/providers/aws-bedrock/apac.anthropic.claude-sonnet-4-20250514-v1:0.yaml
@@ -1,78 +1,78 @@
 costs:
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: me-central-1
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: ap-southeast-7
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: ap-southeast-5
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: ap-southeast-4
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: ap-southeast-3
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ap-southeast-2
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ap-southeast-1
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ap-south-2
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ap-south-1
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: ap-northeast-3
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ap-northeast-2
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ap-northeast-1
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: ap-east-2

--- a/providers/aws-bedrock/cohere.command-light-text-v14.yaml
+++ b/providers/aws-bedrock/cohere.command-light-text-v14.yaml
@@ -1,9 +1,9 @@
 costs:
-    - input_cost_per_token: 3.e-7
-      output_cost_per_token: 6.e-7
+    - input_cost_per_token: 3e-7
+      output_cost_per_token: 6e-7
       region: us-west-2
-    - input_cost_per_token: 3.e-7
-      output_cost_per_token: 6.e-7
+    - input_cost_per_token: 3e-7
+      output_cost_per_token: 6e-7
       region: us-east-1
 isDeprecated: true
 limits:

--- a/providers/aws-bedrock/cohere.command-r-v1:0.yaml
+++ b/providers/aws-bedrock/cohere.command-r-v1:0.yaml
@@ -1,8 +1,8 @@
 costs:
-    - input_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
       output_cost_per_token: 0.0000015
       region: us-west-2
-    - input_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
       output_cost_per_token: 0.0000015
       region: us-east-1
 deprecationDate: "2026-02-19"

--- a/providers/aws-bedrock/cohere.embed-english-v3.yaml
+++ b/providers/aws-bedrock/cohere.embed-english-v3.yaml
@@ -1,39 +1,39 @@
 costs:
     - input_cost_per_image: 0.0001
-      input_cost_per_token: 1.e-7
+      input_cost_per_token: 1e-7
       region: us-west-2
     - input_cost_per_image: 0.0001
-      input_cost_per_token: 1.e-7
+      input_cost_per_token: 1e-7
       region: us-east-1
     - input_cost_per_image: 0.0001
-      input_cost_per_token: 1.e-7
+      input_cost_per_token: 1e-7
       region: sa-east-1
     - input_cost_per_image: 0.0001
-      input_cost_per_token: 1.e-7
+      input_cost_per_token: 1e-7
       region: eu-west-3
     - input_cost_per_image: 0.0001
-      input_cost_per_token: 1.e-7
+      input_cost_per_token: 1e-7
       region: eu-west-2
     - input_cost_per_image: 0.0001
-      input_cost_per_token: 1.e-7
+      input_cost_per_token: 1e-7
       region: eu-west-1
     - input_cost_per_image: 0.0001
-      input_cost_per_token: 1.e-7
+      input_cost_per_token: 1e-7
       region: eu-central-1
     - input_cost_per_image: 0.0001
-      input_cost_per_token: 1.e-7
+      input_cost_per_token: 1e-7
       region: ca-central-1
     - input_cost_per_image: 0.0001
-      input_cost_per_token: 1.e-7
+      input_cost_per_token: 1e-7
       region: ap-southeast-2
     - input_cost_per_image: 0.0001
-      input_cost_per_token: 1.e-7
+      input_cost_per_token: 1e-7
       region: ap-southeast-1
     - input_cost_per_image: 0.0001
-      input_cost_per_token: 1.e-7
+      input_cost_per_token: 1e-7
       region: ap-south-1
     - input_cost_per_image: 0.0001
-      input_cost_per_token: 1.e-7
+      input_cost_per_token: 1e-7
       region: ap-northeast-1
 limits:
     max_input_tokens: 512

--- a/providers/aws-bedrock/cohere.embed-multilingual-v3.yaml
+++ b/providers/aws-bedrock/cohere.embed-multilingual-v3.yaml
@@ -1,39 +1,39 @@
 costs:
     - input_cost_per_image: 0.0001
-      input_cost_per_token: 1.e-7
+      input_cost_per_token: 1e-7
       region: us-west-2
     - input_cost_per_image: 0.0001
-      input_cost_per_token: 1.e-7
+      input_cost_per_token: 1e-7
       region: us-east-1
     - input_cost_per_image: 0.0001
-      input_cost_per_token: 1.e-7
+      input_cost_per_token: 1e-7
       region: sa-east-1
     - input_cost_per_image: 0.0001
-      input_cost_per_token: 1.e-7
+      input_cost_per_token: 1e-7
       region: eu-west-3
     - input_cost_per_image: 0.0001
-      input_cost_per_token: 1.e-7
+      input_cost_per_token: 1e-7
       region: eu-west-2
     - input_cost_per_image: 0.0001
-      input_cost_per_token: 1.e-7
+      input_cost_per_token: 1e-7
       region: eu-west-1
     - input_cost_per_image: 0.0001
-      input_cost_per_token: 1.e-7
+      input_cost_per_token: 1e-7
       region: eu-central-1
     - input_cost_per_image: 0.0001
-      input_cost_per_token: 1.e-7
+      input_cost_per_token: 1e-7
       region: ca-central-1
     - input_cost_per_image: 0.0001
-      input_cost_per_token: 1.e-7
+      input_cost_per_token: 1e-7
       region: ap-southeast-2
     - input_cost_per_image: 0.0001
-      input_cost_per_token: 1.e-7
+      input_cost_per_token: 1e-7
       region: ap-southeast-1
     - input_cost_per_image: 0.0001
-      input_cost_per_token: 1.e-7
+      input_cost_per_token: 1e-7
       region: ap-south-1
     - input_cost_per_image: 0.0001
-      input_cost_per_token: 1.e-7
+      input_cost_per_token: 1e-7
       region: ap-northeast-1
 limits:
     max_input_tokens: 512

--- a/providers/aws-bedrock/deepseek.v3-v1:0.yaml
+++ b/providers/aws-bedrock/deepseek.v3-v1:0.yaml
@@ -5,13 +5,13 @@ costs:
     - input_cost_per_token: 5.8e-7
       output_cost_per_token: 0.00000168
       region: us-east-2
-    - input_cost_per_token: 9.e-7
+    - input_cost_per_token: 9e-7
       output_cost_per_token: 0.0000026069
       region: eu-west-2
     - input_cost_per_token: 5.8e-7
       output_cost_per_token: 0.00000168
       region: eu-north-1
-    - input_cost_per_token: 6.e-7
+    - input_cost_per_token: 6e-7
       output_cost_per_token: 0.00000174
       region: ap-southeast-3
     - input_cost_per_token: 5.974e-7

--- a/providers/aws-bedrock/eu.amazon.nova-lite-v1:0.yaml
+++ b/providers/aws-bedrock/eu.amazon.nova-lite-v1:0.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_read_input_token_cost: 1.87e-8
       input_cost_per_token: 7.5e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       region: il-central-1
     - cache_read_input_token_cost: 2.2e-8
       input_cost_per_token: 8.8e-8

--- a/providers/aws-bedrock/eu.amazon.nova-micro-v1:0.yaml
+++ b/providers/aws-bedrock/eu.amazon.nova-micro-v1:0.yaml
@@ -11,11 +11,11 @@ costs:
       output_cost_per_token: 2.08e-7
       output_cost_per_token_batches: 1.04e-7
       region: eu-west-3
-    - cache_read_input_token_cost: 1.e-8
-      input_cost_per_token: 4.e-8
-      input_cost_per_token_batches: 2.e-8
+    - cache_read_input_token_cost: 1e-8
+      input_cost_per_token: 4e-8
+      input_cost_per_token_batches: 2e-8
       output_cost_per_token: 1.6e-7
-      output_cost_per_token_batches: 8.e-8
+      output_cost_per_token_batches: 8e-8
       region: eu-west-1
     - cache_read_input_token_cost: 9.7e-9
       input_cost_per_token: 3.9e-8

--- a/providers/aws-bedrock/eu.amazon.nova-pro-v1:0.yaml
+++ b/providers/aws-bedrock/eu.amazon.nova-pro-v1:0.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_read_input_token_cost: 2.5e-7
       input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 0.000004
       output_cost_per_token_batches: 0.000002
       region: il-central-1

--- a/providers/aws-bedrock/eu.anthropic.claude-3-7-sonnet-20250219-v1:0.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-3-7-sonnet-20250219-v1:0.yaml
@@ -1,27 +1,27 @@
 costs:
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: eu-west-3
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: eu-west-1
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: eu-north-1
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015

--- a/providers/aws-bedrock/eu.anthropic.claude-sonnet-4-20250514-v1:0.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-sonnet-4-20250514-v1:0.yaml
@@ -1,13 +1,13 @@
 costs:
     - region: il-central-1
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: eu-west-3
       tiered_pricing:
           cache_read:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 200001
           cache_write:
               - cost_per_token: 0.0000075
@@ -19,13 +19,13 @@ costs:
               - cost_per_token: 0.0000225
                 from: 200001
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: eu-west-1
       tiered_pricing:
           cache_read:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 200001
           cache_write:
               - cost_per_token: 0.0000075
@@ -37,13 +37,13 @@ costs:
               - cost_per_token: 0.0000225
                 from: 200001
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: eu-south-2
       tiered_pricing:
           cache_read:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 200001
           cache_write:
               - cost_per_token: 0.0000075
@@ -55,13 +55,13 @@ costs:
               - cost_per_token: 0.0000225
                 from: 200001
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: eu-south-1
       tiered_pricing:
           cache_read:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 200001
           cache_write:
               - cost_per_token: 0.0000075
@@ -73,13 +73,13 @@ costs:
               - cost_per_token: 0.0000225
                 from: 200001
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: eu-north-1
       tiered_pricing:
           cache_read:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 200001
           cache_write:
               - cost_per_token: 0.0000075
@@ -91,13 +91,13 @@ costs:
               - cost_per_token: 0.0000225
                 from: 200001
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: eu-central-1
       tiered_pricing:
           cache_read:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 200001
           cache_write:
               - cost_per_token: 0.0000075

--- a/providers/aws-bedrock/eu.meta.llama3-2-3b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/eu.meta.llama3-2-3b-instruct-v1:0.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 2.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 2e-7
       region: eu-west-3
     - input_cost_per_token: 1.7e-7
       output_cost_per_token: 1.7e-7

--- a/providers/aws-bedrock/global.amazon.nova-2-lite-v1:0.yaml
+++ b/providers/aws-bedrock/global.amazon.nova-2-lite-v1:0.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_read_input_token_cost: 7.5e-8
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000025
       region: us-west-2
     - cache_read_input_token_cost: 9.75e-8
@@ -8,15 +8,15 @@ costs:
       output_cost_per_token: 0.00000321
       region: us-west-1
     - cache_read_input_token_cost: 7.5e-8
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000025
       region: us-east-2
     - cache_read_input_token_cost: 7.5e-8
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000025
       region: us-east-1
-    - cache_read_input_token_cost: 8.e-8
-      input_cost_per_token: 3.e-7
+    - cache_read_input_token_cost: 8e-8
+      input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000025
       region: me-central-1
     - cache_read_input_token_cost: 9.5e-8
@@ -55,7 +55,7 @@ costs:
       input_cost_per_token: 3.4e-7
       output_cost_per_token: 0.00000281
       region: ca-west-1
-    - cache_read_input_token_cost: 8.e-8
+    - cache_read_input_token_cost: 8e-8
       input_cost_per_token: 3.2e-7
       output_cost_per_token: 0.00000267
       region: ca-central-1
@@ -71,11 +71,11 @@ costs:
       input_cost_per_token: 3.3e-7
       output_cost_per_token: 0.00000271
       region: ap-southeast-4
-    - cache_read_input_token_cost: 8.e-8
+    - cache_read_input_token_cost: 8e-8
       input_cost_per_token: 3.2e-7
       output_cost_per_token: 0.00000264
       region: ap-southeast-3
-    - cache_read_input_token_cost: 8.e-8
+    - cache_read_input_token_cost: 8e-8
       input_cost_per_token: 3.2e-7
       output_cost_per_token: 0.00000263
       region: ap-southeast-2
@@ -87,15 +87,15 @@ costs:
       input_cost_per_token: 3.5e-7
       output_cost_per_token: 0.00000295
       region: ap-south-1
-    - cache_read_input_token_cost: 9.e-8
+    - cache_read_input_token_cost: 9e-8
       input_cost_per_token: 3.6e-7
       output_cost_per_token: 0.00000296
       region: ap-northeast-2
-    - cache_read_input_token_cost: 9.e-8
+    - cache_read_input_token_cost: 9e-8
       input_cost_per_token: 3.6e-7
       output_cost_per_token: 0.00000301
       region: ap-northeast-1
-    - cache_read_input_token_cost: 9.e-8
+    - cache_read_input_token_cost: 9e-8
       input_cost_per_token: 3.6e-7
       output_cost_per_token: 0.00000301
       region: ap-east-2

--- a/providers/aws-bedrock/global.anthropic.claude-haiku-4-5-20251001-v1:0.yaml
+++ b/providers/aws-bedrock/global.anthropic.claude-haiku-4-5-20251001-v1:0.yaml
@@ -1,225 +1,225 @@
 costs:
     - cache_creation_input_token_cost: 0.00000125
-      cache_read_input_token_cost: 1.e-7
+      cache_read_input_token_cost: 1e-7
       input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 0.000005
       output_cost_per_token_batches: 0.0000025
       region: us-west-2
     - cache_creation_input_token_cost: 0.00000125
-      cache_read_input_token_cost: 1.e-7
+      cache_read_input_token_cost: 1e-7
       input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 0.000005
       output_cost_per_token_batches: 0.0000025
       region: us-west-1
     - cache_creation_input_token_cost: 0.00000125
-      cache_read_input_token_cost: 1.e-7
+      cache_read_input_token_cost: 1e-7
       input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 0.000005
       output_cost_per_token_batches: 0.0000025
       region: us-east-2
     - cache_creation_input_token_cost: 0.00000125
-      cache_read_input_token_cost: 1.e-7
+      cache_read_input_token_cost: 1e-7
       input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 0.000005
       output_cost_per_token_batches: 0.0000025
       region: us-east-1
     - cache_creation_input_token_cost: 0.00000125
-      cache_read_input_token_cost: 1.e-7
+      cache_read_input_token_cost: 1e-7
       input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 0.000005
       output_cost_per_token_batches: 0.0000025
       region: sa-east-1
     - cache_creation_input_token_cost: 0.00000125
-      cache_read_input_token_cost: 1.e-7
+      cache_read_input_token_cost: 1e-7
       input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 0.000005
       output_cost_per_token_batches: 0.0000025
       region: mx-central-1
     - cache_creation_input_token_cost: 0.00000125
-      cache_read_input_token_cost: 1.e-7
+      cache_read_input_token_cost: 1e-7
       input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 0.000005
       output_cost_per_token_batches: 0.0000025
       region: me-south-1
     - cache_creation_input_token_cost: 0.00000125
-      cache_read_input_token_cost: 1.e-7
+      cache_read_input_token_cost: 1e-7
       input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 0.000005
       output_cost_per_token_batches: 0.0000025
       region: me-central-1
     - cache_creation_input_token_cost: 0.00000125
-      cache_read_input_token_cost: 1.e-7
+      cache_read_input_token_cost: 1e-7
       input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 0.000005
       output_cost_per_token_batches: 0.0000025
       region: il-central-1
     - cache_creation_input_token_cost: 0.00000125
-      cache_read_input_token_cost: 1.e-7
+      cache_read_input_token_cost: 1e-7
       input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 0.000005
       output_cost_per_token_batches: 0.0000025
       region: eu-west-3
     - cache_creation_input_token_cost: 0.00000125
-      cache_read_input_token_cost: 1.e-7
+      cache_read_input_token_cost: 1e-7
       input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 0.000005
       output_cost_per_token_batches: 0.0000025
       region: eu-west-2
     - cache_creation_input_token_cost: 0.00000125
-      cache_read_input_token_cost: 1.e-7
+      cache_read_input_token_cost: 1e-7
       input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 0.000005
       output_cost_per_token_batches: 0.0000025
       region: eu-west-1
     - cache_creation_input_token_cost: 0.00000125
-      cache_read_input_token_cost: 1.e-7
+      cache_read_input_token_cost: 1e-7
       input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 0.000005
       output_cost_per_token_batches: 0.0000025
       region: eu-south-2
     - cache_creation_input_token_cost: 0.00000125
-      cache_read_input_token_cost: 1.e-7
+      cache_read_input_token_cost: 1e-7
       input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 0.000005
       output_cost_per_token_batches: 0.0000025
       region: eu-south-1
     - cache_creation_input_token_cost: 0.00000125
-      cache_read_input_token_cost: 1.e-7
+      cache_read_input_token_cost: 1e-7
       input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 0.000005
       output_cost_per_token_batches: 0.0000025
       region: eu-north-1
     - cache_creation_input_token_cost: 0.00000125
-      cache_read_input_token_cost: 1.e-7
+      cache_read_input_token_cost: 1e-7
       input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 0.000005
       output_cost_per_token_batches: 0.0000025
       region: eu-central-2
     - cache_creation_input_token_cost: 0.00000125
-      cache_read_input_token_cost: 1.e-7
+      cache_read_input_token_cost: 1e-7
       input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 0.000005
       output_cost_per_token_batches: 0.0000025
       region: eu-central-1
     - cache_creation_input_token_cost: 0.00000125
-      cache_read_input_token_cost: 1.e-7
+      cache_read_input_token_cost: 1e-7
       input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 0.000005
       output_cost_per_token_batches: 0.0000025
       region: ca-west-1
     - cache_creation_input_token_cost: 0.00000125
-      cache_read_input_token_cost: 1.e-7
+      cache_read_input_token_cost: 1e-7
       input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 0.000005
       output_cost_per_token_batches: 0.0000025
       region: ca-central-1
     - cache_creation_input_token_cost: 0.00000125
-      cache_read_input_token_cost: 1.e-7
+      cache_read_input_token_cost: 1e-7
       input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 0.000005
       output_cost_per_token_batches: 0.0000025
       region: ap-southeast-7
     - cache_creation_input_token_cost: 0.00000125
-      cache_read_input_token_cost: 1.e-7
+      cache_read_input_token_cost: 1e-7
       input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 0.000005
       output_cost_per_token_batches: 0.0000025
       region: ap-southeast-5
     - cache_creation_input_token_cost: 0.00000125
-      cache_read_input_token_cost: 1.e-7
+      cache_read_input_token_cost: 1e-7
       input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 0.000005
       output_cost_per_token_batches: 0.0000025
       region: ap-southeast-4
     - cache_creation_input_token_cost: 0.00000125
-      cache_read_input_token_cost: 1.e-7
+      cache_read_input_token_cost: 1e-7
       input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 0.000005
       output_cost_per_token_batches: 0.0000025
       region: ap-southeast-3
     - cache_creation_input_token_cost: 0.00000125
-      cache_read_input_token_cost: 1.e-7
+      cache_read_input_token_cost: 1e-7
       input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 0.000005
       output_cost_per_token_batches: 0.0000025
       region: ap-southeast-2
     - cache_creation_input_token_cost: 0.00000125
-      cache_read_input_token_cost: 1.e-7
+      cache_read_input_token_cost: 1e-7
       input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 0.000005
       output_cost_per_token_batches: 0.0000025
       region: ap-southeast-1
     - cache_creation_input_token_cost: 0.00000125
-      cache_read_input_token_cost: 1.e-7
+      cache_read_input_token_cost: 1e-7
       input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 0.000005
       output_cost_per_token_batches: 0.0000025
       region: ap-south-2
     - cache_creation_input_token_cost: 0.00000125
-      cache_read_input_token_cost: 1.e-7
+      cache_read_input_token_cost: 1e-7
       input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 0.000005
       output_cost_per_token_batches: 0.0000025
       region: ap-south-1
     - cache_creation_input_token_cost: 0.00000125
-      cache_read_input_token_cost: 1.e-7
+      cache_read_input_token_cost: 1e-7
       input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 0.000005
       output_cost_per_token_batches: 0.0000025
       region: ap-northeast-3
     - cache_creation_input_token_cost: 0.00000125
-      cache_read_input_token_cost: 1.e-7
+      cache_read_input_token_cost: 1e-7
       input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 0.000005
       output_cost_per_token_batches: 0.0000025
       region: ap-northeast-2
     - cache_creation_input_token_cost: 0.00000125
-      cache_read_input_token_cost: 1.e-7
+      cache_read_input_token_cost: 1e-7
       input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 0.000005
       output_cost_per_token_batches: 0.0000025
       region: ap-northeast-1
     - cache_creation_input_token_cost: 0.00000125
-      cache_read_input_token_cost: 1.e-7
+      cache_read_input_token_cost: 1e-7
       input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 0.000005
       output_cost_per_token_batches: 0.0000025
       region: ap-east-2
     - cache_creation_input_token_cost: 0.00000125
-      cache_read_input_token_cost: 1.e-7
+      cache_read_input_token_cost: 1e-7
       input_cost_per_token: 0.000001
-      input_cost_per_token_batches: 5.e-7
+      input_cost_per_token_batches: 5e-7
       output_cost_per_token: 0.000005
       output_cost_per_token_batches: 0.0000025
       region: af-south-1

--- a/providers/aws-bedrock/global.anthropic.claude-opus-4-5-20251101-v1:0.yaml
+++ b/providers/aws-bedrock/global.anthropic.claude-opus-4-5-20251101-v1:0.yaml
@@ -1,223 +1,223 @@
 costs:
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: us-west-2
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: us-west-1
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: us-east-2
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: us-east-1
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: sa-east-1
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: mx-central-1
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: me-south-1
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: me-central-1
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: il-central-1
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: eu-west-3
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: eu-west-2
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: eu-west-1
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: eu-south-2
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: eu-south-1
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: eu-north-1
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: eu-central-2
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: eu-central-1
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: ca-west-1
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: ca-central-1
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: ap-southeast-7
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: ap-southeast-5
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: ap-southeast-4
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: ap-southeast-3
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: ap-southeast-2
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: ap-southeast-1
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: ap-south-2
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: ap-south-1
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: ap-northeast-3
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: ap-northeast-2
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: ap-northeast-1
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: ap-east-2
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025

--- a/providers/aws-bedrock/global.anthropic.claude-opus-4-6-v1.yaml
+++ b/providers/aws-bedrock/global.anthropic.claude-opus-4-6-v1.yaml
@@ -1,223 +1,223 @@
 costs:
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: us-west-2
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: us-west-1
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: us-east-2
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: us-east-1
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: sa-east-1
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: mx-central-1
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: me-south-1
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: me-central-1
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: il-central-1
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: eu-west-3
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: eu-west-2
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: eu-west-1
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: eu-south-2
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: eu-south-1
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: eu-north-1
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: eu-central-2
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: eu-central-1
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: ca-west-1
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: ca-central-1
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: ap-southeast-7
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: ap-southeast-5
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: ap-southeast-4
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: ap-southeast-3
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: ap-southeast-2
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: ap-southeast-1
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: ap-south-2
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: ap-south-1
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: ap-northeast-3
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: ap-northeast-2
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: ap-northeast-1
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: ap-east-2
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       input_cost_per_token_batches: 0.0000025
       output_cost_per_token: 0.000025

--- a/providers/aws-bedrock/global.anthropic.claude-opus-4-7.yaml
+++ b/providers/aws-bedrock/global.anthropic.claude-opus-4-7.yaml
@@ -1,156 +1,156 @@
 costs:
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       output_cost_per_token: 0.000025
       region: us-west-2
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       output_cost_per_token: 0.000025
       region: us-west-1
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       output_cost_per_token: 0.000025
       region: us-east-2
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       output_cost_per_token: 0.000025
       region: us-east-1
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       output_cost_per_token: 0.000025
       region: sa-east-1
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       output_cost_per_token: 0.000025
       region: mx-central-1
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       output_cost_per_token: 0.000025
       region: il-central-1
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       output_cost_per_token: 0.000025
       region: eu-west-3
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       output_cost_per_token: 0.000025
       region: eu-west-2
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       output_cost_per_token: 0.000025
       region: eu-west-1
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       output_cost_per_token: 0.000025
       region: eu-south-2
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       output_cost_per_token: 0.000025
       region: eu-south-1
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       output_cost_per_token: 0.000025
       region: eu-north-1
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       output_cost_per_token: 0.000025
       region: eu-central-2
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       output_cost_per_token: 0.000025
       region: eu-central-1
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       output_cost_per_token: 0.000025
       region: ca-west-1
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       output_cost_per_token: 0.000025
       region: ca-central-1
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       output_cost_per_token: 0.000025
       region: ap-southeast-7
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       output_cost_per_token: 0.000025
       region: ap-southeast-6
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       output_cost_per_token: 0.000025
       region: ap-southeast-5
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       output_cost_per_token: 0.000025
       region: ap-southeast-4
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       output_cost_per_token: 0.000025
       region: ap-southeast-3
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       output_cost_per_token: 0.000025
       region: ap-southeast-2
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       output_cost_per_token: 0.000025
       region: ap-southeast-1
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       output_cost_per_token: 0.000025
       region: ap-south-2
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       output_cost_per_token: 0.000025
       region: ap-south-1
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       output_cost_per_token: 0.000025
       region: ap-northeast-3
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       output_cost_per_token: 0.000025
       region: ap-northeast-2
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       output_cost_per_token: 0.000025
       region: ap-northeast-1
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       output_cost_per_token: 0.000025
       region: ap-east-2
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       output_cost_per_token: 0.000025
       region: af-south-1

--- a/providers/aws-bedrock/global.anthropic.claude-sonnet-4-20250514-v1:0.yaml
+++ b/providers/aws-bedrock/global.anthropic.claude-sonnet-4-20250514-v1:0.yaml
@@ -1,32 +1,32 @@
 costs:
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: us-west-2
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: us-east-2
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: us-east-1
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: eu-west-1
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015

--- a/providers/aws-bedrock/global.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
+++ b/providers/aws-bedrock/global.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
@@ -8,7 +8,7 @@ costs:
       region: us-west-2
       tiered_pricing:
           cache_read:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 200000
           cache_write:
               - cost_per_token: 0.0000075
@@ -20,7 +20,7 @@ costs:
               - cost_per_token: 0.0000225
                 from: 200000
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
@@ -28,7 +28,7 @@ costs:
       region: us-west-1
       tiered_pricing:
           cache_read:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 200000
           cache_write:
               - cost_per_token: 0.0000075
@@ -40,7 +40,7 @@ costs:
               - cost_per_token: 0.0000225
                 from: 200000
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
@@ -48,7 +48,7 @@ costs:
       region: us-east-2
       tiered_pricing:
           cache_read:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 200000
           cache_write:
               - cost_per_token: 0.0000075
@@ -60,7 +60,7 @@ costs:
               - cost_per_token: 0.0000225
                 from: 200000
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
@@ -68,7 +68,7 @@ costs:
       region: us-east-1
       tiered_pricing:
           cache_read:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 200000
           cache_write:
               - cost_per_token: 0.0000075
@@ -80,7 +80,7 @@ costs:
               - cost_per_token: 0.0000225
                 from: 200000
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
@@ -88,7 +88,7 @@ costs:
       region: sa-east-1
       tiered_pricing:
           cache_read:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 200000
           cache_write:
               - cost_per_token: 0.0000075
@@ -100,7 +100,7 @@ costs:
               - cost_per_token: 0.0000225
                 from: 200000
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
@@ -108,7 +108,7 @@ costs:
       region: mx-central-1
       tiered_pricing:
           cache_read:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 200000
           cache_write:
               - cost_per_token: 0.0000075
@@ -120,7 +120,7 @@ costs:
               - cost_per_token: 0.0000225
                 from: 200000
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
@@ -128,7 +128,7 @@ costs:
       region: me-south-1
       tiered_pricing:
           cache_read:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 200000
           cache_write:
               - cost_per_token: 0.0000075
@@ -140,7 +140,7 @@ costs:
               - cost_per_token: 0.0000225
                 from: 200000
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
@@ -148,7 +148,7 @@ costs:
       region: me-central-1
       tiered_pricing:
           cache_read:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 200000
           cache_write:
               - cost_per_token: 0.0000075
@@ -160,7 +160,7 @@ costs:
               - cost_per_token: 0.0000225
                 from: 200000
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
@@ -168,7 +168,7 @@ costs:
       region: il-central-1
       tiered_pricing:
           cache_read:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 200000
           cache_write:
               - cost_per_token: 0.0000075
@@ -180,7 +180,7 @@ costs:
               - cost_per_token: 0.0000225
                 from: 200000
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
@@ -188,7 +188,7 @@ costs:
       region: eu-west-3
       tiered_pricing:
           cache_read:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 200000
           cache_write:
               - cost_per_token: 0.0000075
@@ -200,7 +200,7 @@ costs:
               - cost_per_token: 0.0000225
                 from: 200000
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
@@ -208,7 +208,7 @@ costs:
       region: eu-west-2
       tiered_pricing:
           cache_read:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 200000
           cache_write:
               - cost_per_token: 0.0000075
@@ -220,7 +220,7 @@ costs:
               - cost_per_token: 0.0000225
                 from: 200000
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
@@ -228,7 +228,7 @@ costs:
       region: eu-west-1
       tiered_pricing:
           cache_read:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 200000
           cache_write:
               - cost_per_token: 0.0000075
@@ -240,7 +240,7 @@ costs:
               - cost_per_token: 0.0000225
                 from: 200000
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
@@ -248,7 +248,7 @@ costs:
       region: eu-south-2
       tiered_pricing:
           cache_read:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 200000
           cache_write:
               - cost_per_token: 0.0000075
@@ -260,7 +260,7 @@ costs:
               - cost_per_token: 0.0000225
                 from: 200000
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
@@ -268,7 +268,7 @@ costs:
       region: eu-south-1
       tiered_pricing:
           cache_read:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 200000
           cache_write:
               - cost_per_token: 0.0000075
@@ -280,7 +280,7 @@ costs:
               - cost_per_token: 0.0000225
                 from: 200000
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
@@ -288,7 +288,7 @@ costs:
       region: eu-north-1
       tiered_pricing:
           cache_read:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 200000
           cache_write:
               - cost_per_token: 0.0000075
@@ -300,7 +300,7 @@ costs:
               - cost_per_token: 0.0000225
                 from: 200000
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
@@ -308,7 +308,7 @@ costs:
       region: eu-central-2
       tiered_pricing:
           cache_read:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 200000
           cache_write:
               - cost_per_token: 0.0000075
@@ -320,7 +320,7 @@ costs:
               - cost_per_token: 0.0000225
                 from: 200000
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
@@ -328,7 +328,7 @@ costs:
       region: eu-central-1
       tiered_pricing:
           cache_read:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 200000
           cache_write:
               - cost_per_token: 0.0000075
@@ -340,7 +340,7 @@ costs:
               - cost_per_token: 0.0000225
                 from: 200000
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
@@ -348,7 +348,7 @@ costs:
       region: ca-west-1
       tiered_pricing:
           cache_read:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 200000
           cache_write:
               - cost_per_token: 0.0000075
@@ -360,7 +360,7 @@ costs:
               - cost_per_token: 0.0000225
                 from: 200000
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
@@ -368,7 +368,7 @@ costs:
       region: ca-central-1
       tiered_pricing:
           cache_read:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 200000
           cache_write:
               - cost_per_token: 0.0000075
@@ -380,7 +380,7 @@ costs:
               - cost_per_token: 0.0000225
                 from: 200000
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
@@ -388,7 +388,7 @@ costs:
       region: ap-southeast-7
       tiered_pricing:
           cache_read:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 200000
           cache_write:
               - cost_per_token: 0.0000075
@@ -400,7 +400,7 @@ costs:
               - cost_per_token: 0.0000225
                 from: 200000
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
@@ -408,7 +408,7 @@ costs:
       region: ap-southeast-5
       tiered_pricing:
           cache_read:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 200000
           cache_write:
               - cost_per_token: 0.0000075
@@ -420,7 +420,7 @@ costs:
               - cost_per_token: 0.0000225
                 from: 200000
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
@@ -428,7 +428,7 @@ costs:
       region: ap-southeast-4
       tiered_pricing:
           cache_read:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 200000
           cache_write:
               - cost_per_token: 0.0000075
@@ -440,7 +440,7 @@ costs:
               - cost_per_token: 0.0000225
                 from: 200000
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
@@ -448,7 +448,7 @@ costs:
       region: ap-southeast-3
       tiered_pricing:
           cache_read:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 200000
           cache_write:
               - cost_per_token: 0.0000075
@@ -460,7 +460,7 @@ costs:
               - cost_per_token: 0.0000225
                 from: 200000
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
@@ -468,7 +468,7 @@ costs:
       region: ap-southeast-2
       tiered_pricing:
           cache_read:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 200000
           cache_write:
               - cost_per_token: 0.0000075
@@ -480,7 +480,7 @@ costs:
               - cost_per_token: 0.0000225
                 from: 200000
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
@@ -488,7 +488,7 @@ costs:
       region: ap-southeast-1
       tiered_pricing:
           cache_read:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 200000
           cache_write:
               - cost_per_token: 0.0000075
@@ -500,7 +500,7 @@ costs:
               - cost_per_token: 0.0000225
                 from: 200000
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
@@ -508,7 +508,7 @@ costs:
       region: ap-south-2
       tiered_pricing:
           cache_read:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 200000
           cache_write:
               - cost_per_token: 0.0000075
@@ -520,7 +520,7 @@ costs:
               - cost_per_token: 0.0000225
                 from: 200000
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
@@ -528,7 +528,7 @@ costs:
       region: ap-south-1
       tiered_pricing:
           cache_read:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 200000
           cache_write:
               - cost_per_token: 0.0000075
@@ -540,7 +540,7 @@ costs:
               - cost_per_token: 0.0000225
                 from: 200000
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
@@ -548,7 +548,7 @@ costs:
       region: ap-northeast-3
       tiered_pricing:
           cache_read:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 200000
           cache_write:
               - cost_per_token: 0.0000075
@@ -560,7 +560,7 @@ costs:
               - cost_per_token: 0.0000225
                 from: 200000
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
@@ -568,7 +568,7 @@ costs:
       region: ap-northeast-2
       tiered_pricing:
           cache_read:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 200000
           cache_write:
               - cost_per_token: 0.0000075
@@ -580,7 +580,7 @@ costs:
               - cost_per_token: 0.0000225
                 from: 200000
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
@@ -588,7 +588,7 @@ costs:
       region: ap-northeast-1
       tiered_pricing:
           cache_read:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 200000
           cache_write:
               - cost_per_token: 0.0000075
@@ -600,7 +600,7 @@ costs:
               - cost_per_token: 0.0000225
                 from: 200000
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
@@ -608,7 +608,7 @@ costs:
       region: ap-east-2
       tiered_pricing:
           cache_read:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 200000
           cache_write:
               - cost_per_token: 0.0000075
@@ -620,7 +620,7 @@ costs:
               - cost_per_token: 0.0000225
                 from: 200000
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
@@ -628,7 +628,7 @@ costs:
       region: af-south-1
       tiered_pricing:
           cache_read:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 200000
           cache_write:
               - cost_per_token: 0.0000075

--- a/providers/aws-bedrock/global.anthropic.claude-sonnet-4-6.yaml
+++ b/providers/aws-bedrock/global.anthropic.claude-sonnet-4-6.yaml
@@ -1,223 +1,223 @@
 costs:
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: us-west-2
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: us-west-1
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: us-east-2
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: us-east-1
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: sa-east-1
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: mx-central-1
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: me-south-1
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: me-central-1
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: il-central-1
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: eu-west-3
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: eu-west-2
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: eu-west-1
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: eu-south-2
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: eu-south-1
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: eu-north-1
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: eu-central-2
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: eu-central-1
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ca-west-1
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ca-central-1
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ap-southeast-7
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ap-southeast-5
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ap-southeast-4
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ap-southeast-3
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ap-southeast-2
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ap-southeast-1
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ap-south-2
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ap-south-1
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ap-northeast-3
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ap-northeast-2
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ap-northeast-1
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: ap-east-2
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015

--- a/providers/aws-bedrock/google.gemma-3-12b-it.yaml
+++ b/providers/aws-bedrock/google.gemma-3-12b-it.yaml
@@ -1,11 +1,11 @@
 costs:
-    - input_cost_per_token: 9.e-8
+    - input_cost_per_token: 9e-8
       output_cost_per_token: 2.9e-7
       region: us-west-2
-    - input_cost_per_token: 9.e-8
+    - input_cost_per_token: 9e-8
       output_cost_per_token: 2.9e-7
       region: us-east-2
-    - input_cost_per_token: 9.e-8
+    - input_cost_per_token: 9e-8
       output_cost_per_token: 2.9e-7
       region: us-east-1
     - input_cost_per_token: 1.1e-7

--- a/providers/aws-bedrock/google.gemma-3-4b-it.yaml
+++ b/providers/aws-bedrock/google.gemma-3-4b-it.yaml
@@ -1,33 +1,33 @@
 costs:
-    - input_cost_per_token: 4.e-8
-      output_cost_per_token: 8.e-8
+    - input_cost_per_token: 4e-8
+      output_cost_per_token: 8e-8
       region: us-west-2
-    - input_cost_per_token: 4.e-8
-      output_cost_per_token: 8.e-8
+    - input_cost_per_token: 4e-8
+      output_cost_per_token: 8e-8
       region: us-east-2
-    - input_cost_per_token: 4.e-8
-      output_cost_per_token: 8.e-8
+    - input_cost_per_token: 4e-8
+      output_cost_per_token: 8e-8
       region: us-east-1
-    - input_cost_per_token: 5.e-8
-      output_cost_per_token: 1.e-7
+    - input_cost_per_token: 5e-8
+      output_cost_per_token: 1e-7
       region: sa-east-1
-    - input_cost_per_token: 6.e-8
+    - input_cost_per_token: 6e-8
       output_cost_per_token: 1.2e-7
       region: eu-west-2
-    - input_cost_per_token: 5.e-8
-      output_cost_per_token: 9.e-8
+    - input_cost_per_token: 5e-8
+      output_cost_per_token: 9e-8
       region: eu-west-1
-    - input_cost_per_token: 5.e-8
-      output_cost_per_token: 9.e-8
+    - input_cost_per_token: 5e-8
+      output_cost_per_token: 9e-8
       region: eu-south-1
     - input_cost_per_token: 4.12e-8
       output_cost_per_token: 8.24e-8
       region: ap-southeast-2
-    - input_cost_per_token: 5.e-8
-      output_cost_per_token: 9.e-8
+    - input_cost_per_token: 5e-8
+      output_cost_per_token: 9e-8
       region: ap-south-1
-    - input_cost_per_token: 5.e-8
-      output_cost_per_token: 1.e-7
+    - input_cost_per_token: 5e-8
+      output_cost_per_token: 1e-7
       region: ap-northeast-1
 limits:
     context_window: 128000

--- a/providers/aws-bedrock/meta.llama3-8b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/meta.llama3-8b-instruct-v1:0.yaml
@@ -1,12 +1,12 @@
 costs:
-    - input_cost_per_token: 3.e-7
-      output_cost_per_token: 6.e-7
+    - input_cost_per_token: 3e-7
+      output_cost_per_token: 6e-7
       region: us-west-2
-    - input_cost_per_token: 3.e-7
-      output_cost_per_token: 6.e-7
+    - input_cost_per_token: 3e-7
+      output_cost_per_token: 6e-7
       region: us-gov-west-1
-    - input_cost_per_token: 3.e-7
-      output_cost_per_token: 6.e-7
+    - input_cost_per_token: 3e-7
+      output_cost_per_token: 6e-7
       region: us-east-1
     - input_cost_per_token: 3.9e-7
       output_cost_per_token: 7.8e-7

--- a/providers/aws-bedrock/minimax.minimax-m2.1.yaml
+++ b/providers/aws-bedrock/minimax.minimax-m2.1.yaml
@@ -1,11 +1,11 @@
 costs:
-    - input_cost_per_token: 3.e-7
+    - input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000012
       region: us-west-2
-    - input_cost_per_token: 3.e-7
+    - input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000012
       region: us-east-2
-    - input_cost_per_token: 3.e-7
+    - input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000012
       region: us-east-1
     - input_cost_per_token: 3.6e-7

--- a/providers/aws-bedrock/minimax.minimax-m2.5.yaml
+++ b/providers/aws-bedrock/minimax.minimax-m2.5.yaml
@@ -1,67 +1,67 @@
 costs:
     - cache_creation_input_token_cost: 3.75e-7
-      cache_read_input_token_cost: 3.e-8
-      input_cost_per_token: 3.e-7
+      cache_read_input_token_cost: 3e-8
+      input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000012
       region: us-west-2
     - cache_creation_input_token_cost: 3.75e-7
-      cache_read_input_token_cost: 3.e-8
-      input_cost_per_token: 3.e-7
+      cache_read_input_token_cost: 3e-8
+      input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000012
       region: us-east-2
     - cache_creation_input_token_cost: 3.75e-7
-      cache_read_input_token_cost: 3.e-8
-      input_cost_per_token: 3.e-7
+      cache_read_input_token_cost: 3e-8
+      input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000012
       region: us-east-1
     - cache_creation_input_token_cost: 3.75e-7
-      cache_read_input_token_cost: 3.e-8
-      input_cost_per_token: 3.e-7
+      cache_read_input_token_cost: 3e-8
+      input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000012
       region: sa-east-1
     - cache_creation_input_token_cost: 3.75e-7
-      cache_read_input_token_cost: 3.e-8
-      input_cost_per_token: 3.e-7
+      cache_read_input_token_cost: 3e-8
+      input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000012
       region: eu-west-2
     - cache_creation_input_token_cost: 3.75e-7
-      cache_read_input_token_cost: 3.e-8
-      input_cost_per_token: 3.e-7
+      cache_read_input_token_cost: 3e-8
+      input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000012
       region: eu-west-1
     - cache_creation_input_token_cost: 3.75e-7
-      cache_read_input_token_cost: 3.e-8
-      input_cost_per_token: 3.e-7
+      cache_read_input_token_cost: 3e-8
+      input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000012
       region: eu-south-1
     - cache_creation_input_token_cost: 3.75e-7
-      cache_read_input_token_cost: 3.e-8
-      input_cost_per_token: 3.e-7
+      cache_read_input_token_cost: 3e-8
+      input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000012
       region: eu-north-1
     - cache_creation_input_token_cost: 3.75e-7
-      cache_read_input_token_cost: 3.e-8
-      input_cost_per_token: 3.e-7
+      cache_read_input_token_cost: 3e-8
+      input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000012
       region: eu-central-1
     - cache_creation_input_token_cost: 3.75e-7
-      cache_read_input_token_cost: 3.e-8
-      input_cost_per_token: 3.e-7
+      cache_read_input_token_cost: 3e-8
+      input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000012
       region: ap-southeast-3
     - cache_creation_input_token_cost: 3.75e-7
-      cache_read_input_token_cost: 3.e-8
-      input_cost_per_token: 3.e-7
+      cache_read_input_token_cost: 3e-8
+      input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000012
       region: ap-southeast-2
     - cache_creation_input_token_cost: 3.75e-7
-      cache_read_input_token_cost: 3.e-8
-      input_cost_per_token: 3.e-7
+      cache_read_input_token_cost: 3e-8
+      input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000012
       region: ap-south-1
     - cache_creation_input_token_cost: 3.75e-7
-      cache_read_input_token_cost: 3.e-8
-      input_cost_per_token: 3.e-7
+      cache_read_input_token_cost: 3e-8
+      input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000012
       region: ap-northeast-1
 features:

--- a/providers/aws-bedrock/minimax.minimax-m2.yaml
+++ b/providers/aws-bedrock/minimax.minimax-m2.yaml
@@ -1,11 +1,11 @@
 costs:
-    - input_cost_per_token: 3.e-7
+    - input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000012
       region: us-west-2
-    - input_cost_per_token: 3.e-7
+    - input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000012
       region: us-east-2
-    - input_cost_per_token: 3.e-7
+    - input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000012
       region: us-east-1
     - input_cost_per_token: 3.6e-7

--- a/providers/aws-bedrock/mistral.devstral-2-123b.yaml
+++ b/providers/aws-bedrock/mistral.devstral-2-123b.yaml
@@ -1,11 +1,11 @@
 costs:
-    - input_cost_per_token: 4.e-7
+    - input_cost_per_token: 4e-7
       output_cost_per_token: 0.000002
       region: us-west-2
-    - input_cost_per_token: 4.e-7
+    - input_cost_per_token: 4e-7
       output_cost_per_token: 0.000002
       region: us-east-2
-    - input_cost_per_token: 4.e-7
+    - input_cost_per_token: 4e-7
       output_cost_per_token: 0.000002
       region: us-east-1
     - input_cost_per_token: 4.8e-7

--- a/providers/aws-bedrock/mistral.magistral-small-2509.yaml
+++ b/providers/aws-bedrock/mistral.magistral-small-2509.yaml
@@ -1,11 +1,11 @@
 costs:
-    - input_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
       output_cost_per_token: 0.0000015
       region: us-west-2
-    - input_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
       output_cost_per_token: 0.0000015
       region: us-east-2
-    - input_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
       output_cost_per_token: 0.0000015
       region: us-east-1
     - input_cost_per_token: 6.1e-7

--- a/providers/aws-bedrock/mistral.ministral-3-14b-instruct.yaml
+++ b/providers/aws-bedrock/mistral.ministral-3-14b-instruct.yaml
@@ -1,12 +1,12 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 2.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 2e-7
       region: us-west-2
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 2.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 2e-7
       region: us-east-2
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 2.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 2e-7
       region: us-east-1
     - input_cost_per_token: 2.4e-7
       output_cost_per_token: 2.4e-7

--- a/providers/aws-bedrock/mistral.ministral-3-3b-instruct.yaml
+++ b/providers/aws-bedrock/mistral.ministral-3-3b-instruct.yaml
@@ -1,12 +1,12 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 1.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 1e-7
       region: us-west-2
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 1.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 1e-7
       region: us-east-2
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 1.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 1e-7
       region: us-east-1
     - input_cost_per_token: 1.2e-7
       output_cost_per_token: 1.2e-7

--- a/providers/aws-bedrock/mistral.mistral-7b-instruct-v0:2.yaml
+++ b/providers/aws-bedrock/mistral.mistral-7b-instruct-v0:2.yaml
@@ -1,17 +1,17 @@
 costs:
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 2.e-7
+      output_cost_per_token: 2e-7
       region: us-west-2
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 2.e-7
+      output_cost_per_token: 2e-7
       region: us-east-1
     - input_cost_per_token: 2.5e-7
       output_cost_per_token: 3.4e-7
       region: sa-east-1
-    - input_cost_per_token: 2.e-7
+    - input_cost_per_token: 2e-7
       output_cost_per_token: 2.6e-7
       region: eu-west-3
-    - input_cost_per_token: 2.e-7
+    - input_cost_per_token: 2e-7
       output_cost_per_token: 2.6e-7
       region: eu-west-2
     - input_cost_per_token: 1.6e-7
@@ -20,7 +20,7 @@ costs:
     - input_cost_per_token: 1.7e-7
       output_cost_per_token: 2.3e-7
       region: ca-central-1
-    - input_cost_per_token: 2.e-7
+    - input_cost_per_token: 2e-7
       output_cost_per_token: 2.6e-7
       region: ap-southeast-2
     - input_cost_per_token: 1.8e-7

--- a/providers/aws-bedrock/mistral.mistral-large-3-675b-instruct.yaml
+++ b/providers/aws-bedrock/mistral.mistral-large-3-675b-instruct.yaml
@@ -1,11 +1,11 @@
 costs:
-    - input_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
       output_cost_per_token: 0.0000015
       region: us-west-2
-    - input_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
       output_cost_per_token: 0.0000015
       region: us-east-2
-    - input_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
       output_cost_per_token: 0.0000015
       region: us-east-1
     - input_cost_per_token: 6.1e-7

--- a/providers/aws-bedrock/mistral.mixtral-8x7b-instruct-v0:1.yaml
+++ b/providers/aws-bedrock/mistral.mixtral-8x7b-instruct-v0:1.yaml
@@ -1,9 +1,9 @@
 costs:
     - input_cost_per_token: 4.5e-7
-      output_cost_per_token: 7.e-7
+      output_cost_per_token: 7e-7
       region: us-west-2
     - input_cost_per_token: 4.5e-7
-      output_cost_per_token: 7.e-7
+      output_cost_per_token: 7e-7
       region: us-east-1
     - input_cost_per_token: 7.6e-7
       output_cost_per_token: 0.00000118

--- a/providers/aws-bedrock/mistral.voxtral-mini-3b-2507.yaml
+++ b/providers/aws-bedrock/mistral.voxtral-mini-3b-2507.yaml
@@ -1,33 +1,33 @@
 costs:
-    - input_cost_per_token: 4.e-8
-      output_cost_per_token: 4.e-8
+    - input_cost_per_token: 4e-8
+      output_cost_per_token: 4e-8
       region: us-west-2
-    - input_cost_per_token: 4.e-8
-      output_cost_per_token: 4.e-8
+    - input_cost_per_token: 4e-8
+      output_cost_per_token: 4e-8
       region: us-east-2
-    - input_cost_per_token: 4.e-8
-      output_cost_per_token: 4.e-8
+    - input_cost_per_token: 4e-8
+      output_cost_per_token: 4e-8
       region: us-east-1
-    - input_cost_per_token: 5.e-8
-      output_cost_per_token: 5.e-8
+    - input_cost_per_token: 5e-8
+      output_cost_per_token: 5e-8
       region: sa-east-1
-    - input_cost_per_token: 6.e-8
-      output_cost_per_token: 6.e-8
+    - input_cost_per_token: 6e-8
+      output_cost_per_token: 6e-8
       region: eu-west-2
-    - input_cost_per_token: 5.e-8
-      output_cost_per_token: 5.e-8
+    - input_cost_per_token: 5e-8
+      output_cost_per_token: 5e-8
       region: eu-west-1
-    - input_cost_per_token: 5.e-8
-      output_cost_per_token: 5.e-8
+    - input_cost_per_token: 5e-8
+      output_cost_per_token: 5e-8
       region: eu-south-1
-    - input_cost_per_token: 5.e-8
-      output_cost_per_token: 5.e-8
+    - input_cost_per_token: 5e-8
+      output_cost_per_token: 5e-8
       region: ap-southeast-2
-    - input_cost_per_token: 5.e-8
-      output_cost_per_token: 5.e-8
+    - input_cost_per_token: 5e-8
+      output_cost_per_token: 5e-8
       region: ap-south-1
-    - input_cost_per_token: 5.e-8
-      output_cost_per_token: 5.e-8
+    - input_cost_per_token: 5e-8
+      output_cost_per_token: 5e-8
       region: ap-northeast-1
 features:
     - function_calling

--- a/providers/aws-bedrock/mistral.voxtral-small-24b-2507.yaml
+++ b/providers/aws-bedrock/mistral.voxtral-small-24b-2507.yaml
@@ -1,12 +1,12 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 3.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 3e-7
       region: us-west-2
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 3.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 3e-7
       region: us-east-2
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 3.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 3e-7
       region: us-east-1
     - input_cost_per_token: 1.2e-7
       output_cost_per_token: 3.6e-7

--- a/providers/aws-bedrock/moonshot.kimi-k2-thinking.yaml
+++ b/providers/aws-bedrock/moonshot.kimi-k2-thinking.yaml
@@ -1,11 +1,11 @@
 costs:
-    - input_cost_per_token: 6.e-7
+    - input_cost_per_token: 6e-7
       output_cost_per_token: 0.0000025
       region: us-west-2
-    - input_cost_per_token: 6.e-7
+    - input_cost_per_token: 6e-7
       output_cost_per_token: 0.0000025
       region: us-east-2
-    - input_cost_per_token: 6.e-7
+    - input_cost_per_token: 6e-7
       output_cost_per_token: 0.0000025
       region: us-east-1
     - input_cost_per_token: 7.3e-7

--- a/providers/aws-bedrock/moonshotai.kimi-k2.5.yaml
+++ b/providers/aws-bedrock/moonshotai.kimi-k2.5.yaml
@@ -1,11 +1,11 @@
 costs:
-    - input_cost_per_token: 6.e-7
+    - input_cost_per_token: 6e-7
       output_cost_per_token: 0.000003
       region: us-west-2
-    - input_cost_per_token: 6.e-7
+    - input_cost_per_token: 6e-7
       output_cost_per_token: 0.000003
       region: us-east-2
-    - input_cost_per_token: 6.e-7
+    - input_cost_per_token: 6e-7
       output_cost_per_token: 0.000003
       region: us-east-1
     - input_cost_per_token: 7.2e-7

--- a/providers/aws-bedrock/nvidia.nemotron-nano-12b-v2.yaml
+++ b/providers/aws-bedrock/nvidia.nemotron-nano-12b-v2.yaml
@@ -1,12 +1,12 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 6.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 6e-7
       region: us-west-2
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 6.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 6e-7
       region: us-east-2
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 6.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 6e-7
       region: us-east-1
     - input_cost_per_token: 2.4e-7
       output_cost_per_token: 7.3e-7

--- a/providers/aws-bedrock/nvidia.nemotron-nano-3-30b.yaml
+++ b/providers/aws-bedrock/nvidia.nemotron-nano-3-30b.yaml
@@ -1,32 +1,32 @@
 costs:
-    - input_cost_per_token: 6.e-8
+    - input_cost_per_token: 6e-8
       output_cost_per_token: 2.4e-7
       region: us-west-2
-    - input_cost_per_token: 6.e-8
+    - input_cost_per_token: 6e-8
       output_cost_per_token: 2.4e-7
       region: us-east-2
-    - input_cost_per_token: 6.e-8
+    - input_cost_per_token: 6e-8
       output_cost_per_token: 2.4e-7
       region: us-east-1
-    - input_cost_per_token: 7.e-8
+    - input_cost_per_token: 7e-8
       output_cost_per_token: 2.9e-7
       region: sa-east-1
-    - input_cost_per_token: 9.e-8
+    - input_cost_per_token: 9e-8
       output_cost_per_token: 3.7e-7
       region: eu-west-2
-    - input_cost_per_token: 7.e-8
+    - input_cost_per_token: 7e-8
       output_cost_per_token: 2.8e-7
       region: eu-west-1
-    - input_cost_per_token: 7.e-8
+    - input_cost_per_token: 7e-8
       output_cost_per_token: 2.8e-7
       region: eu-south-1
     - input_cost_per_token: 6.18e-8
       output_cost_per_token: 2.472e-7
       region: ap-southeast-2
-    - input_cost_per_token: 7.e-8
+    - input_cost_per_token: 7e-8
       output_cost_per_token: 2.8e-7
       region: ap-south-1
-    - input_cost_per_token: 7.e-8
+    - input_cost_per_token: 7e-8
       output_cost_per_token: 2.9e-7
       region: ap-northeast-1
 features:

--- a/providers/aws-bedrock/nvidia.nemotron-nano-9b-v2.yaml
+++ b/providers/aws-bedrock/nvidia.nemotron-nano-9b-v2.yaml
@@ -1,32 +1,32 @@
 costs:
-    - input_cost_per_token: 6.e-8
+    - input_cost_per_token: 6e-8
       output_cost_per_token: 2.3e-7
       region: us-west-2
-    - input_cost_per_token: 6.e-8
+    - input_cost_per_token: 6e-8
       output_cost_per_token: 2.3e-7
       region: us-east-2
-    - input_cost_per_token: 6.e-8
+    - input_cost_per_token: 6e-8
       output_cost_per_token: 2.3e-7
       region: us-east-1
-    - input_cost_per_token: 7.e-8
+    - input_cost_per_token: 7e-8
       output_cost_per_token: 2.8e-7
       region: sa-east-1
-    - input_cost_per_token: 9.e-8
+    - input_cost_per_token: 9e-8
       output_cost_per_token: 3.6e-7
       region: eu-west-2
-    - input_cost_per_token: 7.e-8
+    - input_cost_per_token: 7e-8
       output_cost_per_token: 2.7e-7
       region: eu-west-1
-    - input_cost_per_token: 6.e-8
+    - input_cost_per_token: 6e-8
       output_cost_per_token: 2.3e-7
       region: eu-south-1
     - input_cost_per_token: 6.18e-8
       output_cost_per_token: 2.369e-7
       region: ap-southeast-2
-    - input_cost_per_token: 7.e-8
+    - input_cost_per_token: 7e-8
       output_cost_per_token: 2.7e-7
       region: ap-south-1
-    - input_cost_per_token: 7.e-8
+    - input_cost_per_token: 7e-8
       output_cost_per_token: 2.8e-7
       region: ap-northeast-1
 features:

--- a/providers/aws-bedrock/openai.gpt-oss-120b-1:0.yaml
+++ b/providers/aws-bedrock/openai.gpt-oss-120b-1:0.yaml
@@ -1,12 +1,12 @@
 costs:
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: us-west-2
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: us-east-2
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: us-east-1
     - input_cost_per_token: 1.8e-7
       output_cost_per_token: 7.3e-7
@@ -15,15 +15,15 @@ costs:
       output_cost_per_token: 9.3e-7
       region: eu-west-2
     - input_cost_per_token: 1.8e-7
-      output_cost_per_token: 7.e-7
+      output_cost_per_token: 7e-7
       region: eu-west-1
-    - input_cost_per_token: 2.e-7
+    - input_cost_per_token: 2e-7
       output_cost_per_token: 7.9e-7
       region: eu-south-1
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: eu-north-1
-    - input_cost_per_token: 2.e-7
+    - input_cost_per_token: 2e-7
       output_cost_per_token: 7.9e-7
       region: eu-central-1
     - input_cost_per_token: 1.6e-7

--- a/providers/aws-bedrock/openai.gpt-oss-20b-1:0.yaml
+++ b/providers/aws-bedrock/openai.gpt-oss-20b-1:0.yaml
@@ -1,39 +1,39 @@
 costs:
-    - input_cost_per_token: 7.e-8
-      output_cost_per_token: 3.e-7
+    - input_cost_per_token: 7e-8
+      output_cost_per_token: 3e-7
       region: us-west-2
-    - input_cost_per_token: 7.e-8
-      output_cost_per_token: 3.e-7
+    - input_cost_per_token: 7e-8
+      output_cost_per_token: 3e-7
       region: us-east-2
-    - input_cost_per_token: 7.e-8
-      output_cost_per_token: 3.e-7
+    - input_cost_per_token: 7e-8
+      output_cost_per_token: 3e-7
       region: us-east-1
-    - input_cost_per_token: 8.e-8
+    - input_cost_per_token: 8e-8
       output_cost_per_token: 3.6e-7
       region: sa-east-1
     - input_cost_per_token: 1.1e-7
       output_cost_per_token: 4.7e-7
       region: eu-west-2
-    - input_cost_per_token: 8.e-8
+    - input_cost_per_token: 8e-8
       output_cost_per_token: 3.5e-7
       region: eu-west-1
-    - input_cost_per_token: 9.e-8
-      output_cost_per_token: 4.e-7
+    - input_cost_per_token: 9e-8
+      output_cost_per_token: 4e-7
       region: eu-south-1
-    - input_cost_per_token: 7.e-8
-      output_cost_per_token: 3.e-7
+    - input_cost_per_token: 7e-8
+      output_cost_per_token: 3e-7
       region: eu-north-1
-    - input_cost_per_token: 9.e-8
-      output_cost_per_token: 4.e-7
+    - input_cost_per_token: 9e-8
+      output_cost_per_token: 4e-7
       region: eu-central-1
-    - input_cost_per_token: 7.e-8
+    - input_cost_per_token: 7e-8
       output_cost_per_token: 3.1e-7
       region: ap-southeast-3
     - region: ap-southeast-2
-    - input_cost_per_token: 8.e-8
+    - input_cost_per_token: 8e-8
       output_cost_per_token: 3.5e-7
       region: ap-south-1
-    - input_cost_per_token: 8.e-8
+    - input_cost_per_token: 8e-8
       output_cost_per_token: 3.6e-7
       region: ap-northeast-1
 features:

--- a/providers/aws-bedrock/openai.gpt-oss-safeguard-120b.yaml
+++ b/providers/aws-bedrock/openai.gpt-oss-safeguard-120b.yaml
@@ -1,12 +1,12 @@
 costs:
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: us-west-2
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: us-east-2
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: us-east-1
     - input_cost_per_token: 1.8e-7
       output_cost_per_token: 7.1e-7
@@ -15,10 +15,10 @@ costs:
       output_cost_per_token: 9.3e-7
       region: eu-west-2
     - input_cost_per_token: 1.8e-7
-      output_cost_per_token: 7.e-7
+      output_cost_per_token: 7e-7
       region: eu-west-1
     - input_cost_per_token: 1.8e-7
-      output_cost_per_token: 7.e-7
+      output_cost_per_token: 7e-7
       region: eu-south-1
     - input_cost_per_token: 1.545e-7
       output_cost_per_token: 6.18e-7

--- a/providers/aws-bedrock/openai.gpt-oss-safeguard-20b.yaml
+++ b/providers/aws-bedrock/openai.gpt-oss-safeguard-20b.yaml
@@ -1,32 +1,32 @@
 costs:
-    - input_cost_per_token: 7.e-8
-      output_cost_per_token: 2.e-7
+    - input_cost_per_token: 7e-8
+      output_cost_per_token: 2e-7
       region: us-west-2
-    - input_cost_per_token: 7.e-8
-      output_cost_per_token: 2.e-7
+    - input_cost_per_token: 7e-8
+      output_cost_per_token: 2e-7
       region: us-east-2
-    - input_cost_per_token: 7.e-8
-      output_cost_per_token: 2.e-7
+    - input_cost_per_token: 7e-8
+      output_cost_per_token: 2e-7
       region: us-east-1
-    - input_cost_per_token: 8.e-8
+    - input_cost_per_token: 8e-8
       output_cost_per_token: 2.4e-7
       region: sa-east-1
     - input_cost_per_token: 1.1e-7
       output_cost_per_token: 3.1e-7
       region: eu-west-2
-    - input_cost_per_token: 8.e-8
+    - input_cost_per_token: 8e-8
       output_cost_per_token: 2.3e-7
       region: eu-west-1
-    - input_cost_per_token: 8.e-8
+    - input_cost_per_token: 8e-8
       output_cost_per_token: 2.3e-7
       region: eu-south-1
     - input_cost_per_token: 7.21e-8
       output_cost_per_token: 2.06e-7
       region: ap-southeast-2
-    - input_cost_per_token: 8.e-8
+    - input_cost_per_token: 8e-8
       output_cost_per_token: 2.4e-7
       region: ap-south-1
-    - input_cost_per_token: 8.e-8
+    - input_cost_per_token: 8e-8
       output_cost_per_token: 2.4e-7
       region: ap-northeast-1
 features:

--- a/providers/aws-bedrock/qwen.qwen3-32b-v1:0.yaml
+++ b/providers/aws-bedrock/qwen.qwen3-32b-v1:0.yaml
@@ -1,12 +1,12 @@
 costs:
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: us-west-2
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: us-east-2
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: us-east-1
     - input_cost_per_token: 1.8e-7
       output_cost_per_token: 7.3e-7
@@ -15,15 +15,15 @@ costs:
       output_cost_per_token: 9.3e-7
       region: eu-west-2
     - input_cost_per_token: 1.8e-7
-      output_cost_per_token: 7.e-7
+      output_cost_per_token: 7e-7
       region: eu-west-1
-    - input_cost_per_token: 2.e-7
+    - input_cost_per_token: 2e-7
       output_cost_per_token: 7.9e-7
       region: eu-south-1
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: eu-north-1
-    - input_cost_per_token: 2.e-7
+    - input_cost_per_token: 2e-7
       output_cost_per_token: 7.9e-7
       region: eu-central-1
     - input_cost_per_token: 1.6e-7

--- a/providers/aws-bedrock/qwen.qwen3-coder-30b-a3b-v1:0.yaml
+++ b/providers/aws-bedrock/qwen.qwen3-coder-30b-a3b-v1:0.yaml
@@ -1,12 +1,12 @@
 costs:
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: us-west-2
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: us-east-2
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: us-east-1
     - input_cost_per_token: 1.8e-7
       output_cost_per_token: 7.3e-7
@@ -15,22 +15,22 @@ costs:
       output_cost_per_token: 9.3e-7
       region: eu-west-2
     - input_cost_per_token: 1.8e-7
-      output_cost_per_token: 7.e-7
+      output_cost_per_token: 7e-7
       region: eu-west-1
-    - input_cost_per_token: 2.e-7
+    - input_cost_per_token: 2e-7
       output_cost_per_token: 7.9e-7
       region: eu-south-1
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: eu-north-1
-    - input_cost_per_token: 2.e-7
+    - input_cost_per_token: 2e-7
       output_cost_per_token: 7.9e-7
       region: eu-central-1
     - input_cost_per_token: 1.6e-7
       output_cost_per_token: 6.2e-7
       region: ap-southeast-3
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: ap-southeast-2
     - input_cost_per_token: 1.8e-7
       output_cost_per_token: 7.1e-7

--- a/providers/aws-bedrock/qwen.qwen3-coder-480b-a35b-v1:0.yaml
+++ b/providers/aws-bedrock/qwen.qwen3-coder-480b-a35b-v1:0.yaml
@@ -5,7 +5,7 @@ costs:
     - input_cost_per_token: 4.5e-7
       output_cost_per_token: 0.0000018
       region: us-east-2
-    - input_cost_per_token: 7.e-7
+    - input_cost_per_token: 7e-7
       output_cost_per_token: 0.00000279
       region: eu-west-2
     - input_cost_per_token: 4.5e-7

--- a/providers/aws-bedrock/qwen.qwen3-coder-next.yaml
+++ b/providers/aws-bedrock/qwen.qwen3-coder-next.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
       output_cost_per_token: 0.0000012
       region: us-east-1
     - input_cost_per_token: 7.8e-7

--- a/providers/aws-bedrock/stability.sd3-large-v1:0.yaml
+++ b/providers/aws-bedrock/stability.sd3-large-v1:0.yaml
@@ -1,7 +1,7 @@
 costs:
-    - output_cost_per_image: 8.e-8
+    - output_cost_per_image: 8e-8
       region: us-west-2
-    - output_cost_per_image: 8.e-8
+    - output_cost_per_image: 8e-8
       region: us-east-1
 isDeprecated: true
 limits:

--- a/providers/aws-bedrock/stability.stable-image-core-v1:0.yaml
+++ b/providers/aws-bedrock/stability.stable-image-core-v1:0.yaml
@@ -1,7 +1,7 @@
 costs:
-    - input_cost_per_image: 4.e-8
+    - input_cost_per_image: 4e-8
       region: us-west-2
-    - input_cost_per_image: 4.e-8
+    - input_cost_per_image: 4e-8
       region: us-east-1
 isDeprecated: true
 limits:

--- a/providers/aws-bedrock/us-gov.anthropic.claude-3-haiku-20240307-v1:0.yaml
+++ b/providers/aws-bedrock/us-gov.anthropic.claude-3-haiku-20240307-v1:0.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 3.e-7
+    - input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000015
       region: us-gov-east-1
 deprecationDate: "2026-09-10"

--- a/providers/aws-bedrock/us.amazon.nova-2-lite-v1:0.yaml
+++ b/providers/aws-bedrock/us.amazon.nova-2-lite-v1:0.yaml
@@ -19,7 +19,7 @@ costs:
       input_cost_per_token: 3.74e-7
       output_cost_per_token: 0.000003091
       region: ca-west-1
-    - cache_read_input_token_cost: 8.e-8
+    - cache_read_input_token_cost: 8e-8
       input_cost_per_token: 3.52e-7
       output_cost_per_token: 0.00000297
       region: ca-central-1

--- a/providers/aws-bedrock/us.amazon.nova-lite-v1:0.yaml
+++ b/providers/aws-bedrock/us.amazon.nova-lite-v1:0.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_read_input_token_cost: 1.5e-8
-      input_cost_per_token: 6.e-8
-      input_cost_per_token_batches: 3.e-8
+      input_cost_per_token: 6e-8
+      input_cost_per_token_batches: 3e-8
       output_cost_per_token: 2.4e-7
       output_cost_per_token_batches: 1.2e-7
       region: us-west-2
@@ -15,14 +15,14 @@ costs:
       output_cost_per_token_batches: 1.44e-7
       region: us-gov-west-1
     - cache_read_input_token_cost: 1.5e-8
-      input_cost_per_token: 6.e-8
-      input_cost_per_token_batches: 3.e-8
+      input_cost_per_token: 6e-8
+      input_cost_per_token_batches: 3e-8
       output_cost_per_token: 2.4e-7
       output_cost_per_token_batches: 1.2e-7
       region: us-east-2
     - cache_read_input_token_cost: 1.5e-8
-      input_cost_per_token: 6.e-8
-      input_cost_per_token_batches: 3.e-8
+      input_cost_per_token: 6e-8
+      input_cost_per_token_batches: 3e-8
       output_cost_per_token: 2.4e-7
       output_cost_per_token_batches: 1.2e-7
       region: us-east-1

--- a/providers/aws-bedrock/us.amazon.nova-micro-v1:0.yaml
+++ b/providers/aws-bedrock/us.amazon.nova-micro-v1:0.yaml
@@ -4,21 +4,21 @@ costs:
       input_cost_per_token: 3.5e-8
       input_cost_per_token_batches: 1.75e-8
       output_cost_per_token: 1.4e-7
-      output_cost_per_token_batches: 7.e-8
+      output_cost_per_token_batches: 7e-8
       region: us-west-2
     - cache_creation_input_token_cost: 4.38e-8
       cache_read_input_token_cost: 8.75e-9
       input_cost_per_token: 3.5e-8
       input_cost_per_token_batches: 1.75e-8
       output_cost_per_token: 1.4e-7
-      output_cost_per_token_batches: 7.e-8
+      output_cost_per_token_batches: 7e-8
       region: us-east-2
     - cache_creation_input_token_cost: 4.38e-8
       cache_read_input_token_cost: 8.75e-9
       input_cost_per_token: 3.5e-8
       input_cost_per_token_batches: 1.75e-8
       output_cost_per_token: 1.4e-7
-      output_cost_per_token_batches: 7.e-8
+      output_cost_per_token_batches: 7e-8
       region: us-east-1
 features:
     - function_calling

--- a/providers/aws-bedrock/us.amazon.nova-pro-v1:0.yaml
+++ b/providers/aws-bedrock/us.amazon.nova-pro-v1:0.yaml
@@ -1,17 +1,17 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
-      input_cost_per_token: 8.e-7
+    - cache_read_input_token_cost: 2e-7
+      input_cost_per_token: 8e-7
       output_cost_per_token: 0.0000032
       region: us-west-2
     - input_cost_per_token: 0.00000103
       output_cost_per_token: 0.00000412
       region: us-west-1
-    - cache_read_input_token_cost: 2.e-7
-      input_cost_per_token: 8.e-7
+    - cache_read_input_token_cost: 2e-7
+      input_cost_per_token: 8e-7
       output_cost_per_token: 0.0000032
       region: us-east-2
-    - cache_read_input_token_cost: 2.e-7
-      input_cost_per_token: 8.e-7
+    - cache_read_input_token_cost: 2e-7
+      input_cost_per_token: 8e-7
       output_cost_per_token: 0.0000032
       region: us-east-1
 deprecationDate: "2026-09-14"

--- a/providers/aws-bedrock/us.anthropic.claude-3-5-haiku-20241022-v1:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-3-5-haiku-20241022-v1:0.yaml
@@ -1,20 +1,20 @@
 costs:
     - cache_creation_input_token_cost: 0.000001
-      cache_read_input_token_cost: 8.e-8
-      input_cost_per_token: 8.e-7
-      input_cost_per_token_batches: 4.e-7
+      cache_read_input_token_cost: 8e-8
+      input_cost_per_token: 8e-7
+      input_cost_per_token_batches: 4e-7
       output_cost_per_token: 0.000004
       output_cost_per_token_batches: 0.000002
       region: us-west-2
     - cache_creation_input_token_cost: 0.000001
-      cache_read_input_token_cost: 8.e-8
-      input_cost_per_token: 8.e-7
+      cache_read_input_token_cost: 8e-8
+      input_cost_per_token: 8e-7
       output_cost_per_token: 0.000004
       region: us-east-2
     - cache_creation_input_token_cost: 0.000001
-      cache_read_input_token_cost: 8.e-8
-      input_cost_per_token: 8.e-7
-      input_cost_per_token_batches: 4.e-7
+      cache_read_input_token_cost: 8e-8
+      input_cost_per_token: 8e-7
+      input_cost_per_token_batches: 4e-7
       output_cost_per_token: 0.000004
       output_cost_per_token_batches: 0.000002
       region: us-east-1

--- a/providers/aws-bedrock/us.anthropic.claude-3-5-sonnet-20241022-v2:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-3-5-sonnet-20241022-v2:0.yaml
@@ -1,20 +1,20 @@
 costs:
     - cache_creation_input_token_cost: 0.0000075
-      cache_read_input_token_cost: 6.e-7
+      cache_read_input_token_cost: 6e-7
       input_cost_per_token: 0.000006
       input_cost_per_token_batches: 0.000003
       output_cost_per_token: 0.00003
       output_cost_per_token_batches: 0.000015
       region: us-west-2
     - cache_creation_input_token_cost: 0.0000075
-      cache_read_input_token_cost: 6.e-7
+      cache_read_input_token_cost: 6e-7
       input_cost_per_token: 0.000006
       input_cost_per_token_batches: 0.000003
       output_cost_per_token: 0.00003
       output_cost_per_token_batches: 0.000015
       region: us-east-2
     - cache_creation_input_token_cost: 0.0000075
-      cache_read_input_token_cost: 6.e-7
+      cache_read_input_token_cost: 6e-7
       input_cost_per_token: 0.000006
       input_cost_per_token_batches: 0.000003
       output_cost_per_token: 0.00003

--- a/providers/aws-bedrock/us.anthropic.claude-3-7-sonnet-20250219-v1:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-3-7-sonnet-20250219-v1:0.yaml
@@ -1,20 +1,20 @@
 costs:
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: us-west-2
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: us-east-2
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015

--- a/providers/aws-bedrock/us.anthropic.claude-sonnet-4-20250514-v1:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-sonnet-4-20250514-v1:0.yaml
@@ -1,27 +1,27 @@
 costs:
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: us-west-2
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: us-west-1
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: us-east-2
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       input_cost_per_token_batches: 0.0000015
       output_cost_per_token: 0.000015

--- a/providers/aws-bedrock/us.meta.llama3-2-1b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/us.meta.llama3-2-1b-instruct-v1:0.yaml
@@ -1,12 +1,12 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 1.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 1e-7
       region: us-west-2
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 1.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 1e-7
       region: us-east-2
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 1.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 1e-7
       region: us-east-1
 features:
     - function_calling

--- a/providers/aws-bedrock/us.writer.palmyra-x5-v1:0.yaml
+++ b/providers/aws-bedrock/us.writer.palmyra-x5-v1:0.yaml
@@ -1,14 +1,14 @@
 costs:
-    - input_cost_per_token: 6.e-7
+    - input_cost_per_token: 6e-7
       output_cost_per_token: 0.000006
       region: us-west-2
-    - input_cost_per_token: 6.e-7
+    - input_cost_per_token: 6e-7
       output_cost_per_token: 0.000006
       region: us-west-1
-    - input_cost_per_token: 6.e-7
+    - input_cost_per_token: 6e-7
       output_cost_per_token: 0.000006
       region: us-east-2
-    - input_cost_per_token: 6.e-7
+    - input_cost_per_token: 6e-7
       output_cost_per_token: 0.000006
       region: us-east-1
 features:

--- a/providers/aws-bedrock/zai.glm-4.7-flash.yaml
+++ b/providers/aws-bedrock/zai.glm-4.7-flash.yaml
@@ -1,41 +1,41 @@
 costs:
-    - input_cost_per_token: 7.e-8
-      output_cost_per_token: 4.e-7
+    - input_cost_per_token: 7e-8
+      output_cost_per_token: 4e-7
       region: us-west-2
-    - input_cost_per_token: 7.e-8
-      output_cost_per_token: 4.e-7
+    - input_cost_per_token: 7e-8
+      output_cost_per_token: 4e-7
       region: us-east-2
-    - input_cost_per_token: 7.e-8
-      output_cost_per_token: 4.e-7
+    - input_cost_per_token: 7e-8
+      output_cost_per_token: 4e-7
       region: us-east-1
-    - input_cost_per_token: 8.e-8
+    - input_cost_per_token: 8e-8
       output_cost_per_token: 4.8e-7
       region: sa-east-1
     - input_cost_per_token: 1.1e-7
       output_cost_per_token: 6.2e-7
       region: eu-west-2
-    - input_cost_per_token: 8.e-8
+    - input_cost_per_token: 8e-8
       output_cost_per_token: 4.8e-7
       region: eu-west-1
-    - input_cost_per_token: 8.e-8
+    - input_cost_per_token: 8e-8
       output_cost_per_token: 4.8e-7
       region: eu-south-1
-    - input_cost_per_token: 8.e-8
+    - input_cost_per_token: 8e-8
       output_cost_per_token: 4.8e-7
       region: eu-north-1
-    - input_cost_per_token: 8.e-8
+    - input_cost_per_token: 8e-8
       output_cost_per_token: 4.8e-7
       region: eu-central-1
-    - input_cost_per_token: 8.e-8
+    - input_cost_per_token: 8e-8
       output_cost_per_token: 4.8e-7
       region: ap-southeast-3
     - input_cost_per_token: 7.21e-8
       output_cost_per_token: 4.12e-7
       region: ap-southeast-2
-    - input_cost_per_token: 8.e-8
+    - input_cost_per_token: 8e-8
       output_cost_per_token: 4.8e-7
       region: ap-south-1
-    - input_cost_per_token: 8.e-8
+    - input_cost_per_token: 8e-8
       output_cost_per_token: 4.8e-7
       region: ap-northeast-1
 features:

--- a/providers/aws-bedrock/zai.glm-4.7.yaml
+++ b/providers/aws-bedrock/zai.glm-4.7.yaml
@@ -1,11 +1,11 @@
 costs:
-    - input_cost_per_token: 6.e-7
+    - input_cost_per_token: 6e-7
       output_cost_per_token: 0.0000022
       region: us-west-2
-    - input_cost_per_token: 6.e-7
+    - input_cost_per_token: 6e-7
       output_cost_per_token: 0.0000022
       region: us-east-2
-    - input_cost_per_token: 6.e-7
+    - input_cost_per_token: 6e-7
       output_cost_per_token: 0.0000022
       region: us-east-1
     - input_cost_per_token: 7.2e-7

--- a/providers/azure-ai-foundry/Cohere-embed-v3-english.yaml
+++ b/providers/azure-ai-foundry/Cohere-embed-v3-english.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 1.e-7
+    - input_cost_per_token: 1e-7
       output_cost_per_token: 0
       region: "*"
 limits:

--- a/providers/azure-ai-foundry/Cohere-embed-v3-multilingual.yaml
+++ b/providers/azure-ai-foundry/Cohere-embed-v3-multilingual.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 1.e-7
+    - input_cost_per_token: 1e-7
       output_cost_per_token: 0
       region: "*"
 limits:

--- a/providers/azure-ai-foundry/Llama-4-Scout-17B-16E-Instruct.yaml
+++ b/providers/azure-ai-foundry/Llama-4-Scout-17B-16E-Instruct.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 2.e-7
+    - input_cost_per_token: 2e-7
       output_cost_per_token: 7.8e-7
       region: "*"
 features:

--- a/providers/azure-ai-foundry/Meta-Llama-3.1-8B-Instruct.yaml
+++ b/providers/azure-ai-foundry/Meta-Llama-3.1-8B-Instruct.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 3.e-7
+    - input_cost_per_token: 3e-7
       output_cost_per_token: 6.1e-7
       region: "*"
 features:

--- a/providers/azure-ai-foundry/Phi-3-small-128k-instruct.yaml
+++ b/providers/azure-ai-foundry/Phi-3-small-128k-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: "*"
 features:
     - tool_choice

--- a/providers/azure-ai-foundry/Phi-3-small-8k-instruct.yaml
+++ b/providers/azure-ai-foundry/Phi-3-small-8k-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: "*"
 features:
     - tool_choice

--- a/providers/azure-ai-foundry/Phi-4-mini-instruct.yaml
+++ b/providers/azure-ai-foundry/Phi-4-mini-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 7.5e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       region: "*"
 features:
     - function_calling

--- a/providers/azure-ai-foundry/Phi-4-mini-reasoning.yaml
+++ b/providers/azure-ai-foundry/Phi-4-mini-reasoning.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 8.e-8
+    - input_cost_per_token: 8e-8
       output_cost_per_token: 3.2e-7
       region: "*"
 features:

--- a/providers/azure-ai-foundry/Phi-4-multimodal-instruct.yaml
+++ b/providers/azure-ai-foundry/Phi-4-multimodal-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_audio_token: 0.000004
-      input_cost_per_token: 8.e-8
+      input_cost_per_token: 8e-8
       output_cost_per_token: 3.2e-7
       region: "*"
 features:

--- a/providers/azure-ai-foundry/Phi-4-reasoning.yaml
+++ b/providers/azure-ai-foundry/Phi-4-reasoning.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 1.25e-7
-      output_cost_per_token: 5.e-7
+      output_cost_per_token: 5e-7
       region: "*"
 features:
     - function_calling

--- a/providers/azure-ai-foundry/Phi-4.yaml
+++ b/providers/azure-ai-foundry/Phi-4.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 1.25e-7
-      output_cost_per_token: 5.e-7
+      output_cost_per_token: 5e-7
       region: "*"
 features:
     - function_calling

--- a/providers/azure-ai-foundry/claude-haiku-4-5.yaml
+++ b/providers/azure-ai-foundry/claude-haiku-4-5.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 0.00000125
-      cache_read_input_token_cost: 1.e-7
+      cache_read_input_token_cost: 1e-7
       input_cost_per_token: 0.000001
       output_cost_per_token: 0.000005
       region: "*"

--- a/providers/azure-ai-foundry/claude-opus-4-5.yaml
+++ b/providers/azure-ai-foundry/claude-opus-4-5.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       output_cost_per_token: 0.000025
       region: "*"

--- a/providers/azure-ai-foundry/claude-opus-4-6.yaml
+++ b/providers/azure-ai-foundry/claude-opus-4-6.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       output_cost_per_token: 0.000025
       region: "*"

--- a/providers/azure-ai-foundry/claude-sonnet-4-5.yaml
+++ b/providers/azure-ai-foundry/claude-sonnet-4-5.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: "*"

--- a/providers/azure-ai-foundry/gpt-oss-120b.yaml
+++ b/providers/azure-ai-foundry/gpt-oss-120b.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: "*"
 features:
     - function_calling

--- a/providers/azure-ai-foundry/grok-4-fast-non-reasoning.yaml
+++ b/providers/azure-ai-foundry/grok-4-fast-non-reasoning.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 5.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 5e-7
       region: "*"
 features:
     - function_calling

--- a/providers/azure-ai-foundry/grok-4-fast-reasoning.yaml
+++ b/providers/azure-ai-foundry/grok-4-fast-reasoning.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 5.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 5e-7
       region: "*"
 features:
     - function_calling

--- a/providers/azure-ai-foundry/grok-code-fast-1.yaml
+++ b/providers/azure-ai-foundry/grok-code-fast-1.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 2.e-7
+    - input_cost_per_token: 2e-7
       output_cost_per_token: 0.0000015
       region: "*"
 features:

--- a/providers/azure-ai-foundry/jamba-instruct.yaml
+++ b/providers/azure-ai-foundry/jamba-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 5.e-7
-      output_cost_per_token: 7.e-7
+    - input_cost_per_token: 5e-7
+      output_cost_per_token: 7e-7
       region: "*"
 features:
     - tool_choice

--- a/providers/azure-ai-foundry/kimi-k2.5.yaml
+++ b/providers/azure-ai-foundry/kimi-k2.5.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 6.e-7
+    - input_cost_per_token: 6e-7
       output_cost_per_token: 0.000003
       region: "*"
 features:

--- a/providers/azure-ai-foundry/ministral-3b.yaml
+++ b/providers/azure-ai-foundry/ministral-3b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 4.e-8
-      output_cost_per_token: 4.e-8
+    - input_cost_per_token: 4e-8
+      output_cost_per_token: 4e-8
       region: "*"
 features:
     - function_calling

--- a/providers/azure-ai-foundry/mistral-large-3.yaml
+++ b/providers/azure-ai-foundry/mistral-large-3.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
       output_cost_per_token: 0.0000015
       region: "*"
 features:

--- a/providers/azure-ai-foundry/mistral-medium-2505.yaml
+++ b/providers/azure-ai-foundry/mistral-medium-2505.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 4.e-7
+    - input_cost_per_token: 4e-7
       output_cost_per_token: 0.000002
       region: "*"
 features:

--- a/providers/azure-open-ai/ada.yaml
+++ b/providers/azure-open-ai/ada.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 1.e-7
+    - input_cost_per_token: 1e-7
       output_cost_per_token: 0
       region: "*"
 deprecationDate: "2024-06-14"

--- a/providers/azure-open-ai/gpt-3.5-turbo-0125.yaml
+++ b/providers/azure-open-ai/gpt-3.5-turbo-0125.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
       output_cost_per_token: 0.0000015
       region: "*"
 deprecationDate: "2025-03-31"

--- a/providers/azure-open-ai/gpt-3.5-turbo.yaml
+++ b/providers/azure-open-ai/gpt-3.5-turbo.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
       output_cost_per_token: 0.0000015
       region: "*"
 deprecationDate: "2025-02-13"

--- a/providers/azure-open-ai/gpt-35-turbo-0125.yaml
+++ b/providers/azure-open-ai/gpt-35-turbo-0125.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
       output_cost_per_token: 0.0000015
       region: "*"
 deprecationDate: "2025-05-31"

--- a/providers/azure-open-ai/gpt-35-turbo-0301.yaml
+++ b/providers/azure-open-ai/gpt-35-turbo-0301.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 2.e-7
+    - input_cost_per_token: 2e-7
       output_cost_per_token: 0.000002
       region: "*"
 deprecationDate: "2025-02-13"

--- a/providers/azure-open-ai/gpt-35-turbo.yaml
+++ b/providers/azure-open-ai/gpt-35-turbo.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
       output_cost_per_token: 0.0000015
       region: "*"
 deprecationDate: "2025-02-13"

--- a/providers/azure-open-ai/gpt-4.1-2025-04-14-text.yaml
+++ b/providers/azure-open-ai/gpt-4.1-2025-04-14-text.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 5.e-7
+    - cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000008

--- a/providers/azure-open-ai/gpt-4.1-2025-04-14.yaml
+++ b/providers/azure-open-ai/gpt-4.1-2025-04-14.yaml
@@ -5,7 +5,7 @@ costs:
       output_cost_per_token: 0.0000088
       output_cost_per_token_batches: 0.0000044
       region: datazone_us
-    - cache_read_input_token_cost: 5.e-7
+    - cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000008

--- a/providers/azure-open-ai/gpt-4.1-mini-2025-04-14.yaml
+++ b/providers/azure-open-ai/gpt-4.1-mini-2025-04-14.yaml
@@ -5,11 +5,11 @@ costs:
       output_cost_per_token: 0.00000176
       output_cost_per_token_batches: 8.8e-7
       region: datazone_us
-    - cache_read_input_token_cost: 1.e-7
-      input_cost_per_token: 4.e-7
-      input_cost_per_token_batches: 2.e-7
+    - cache_read_input_token_cost: 1e-7
+      input_cost_per_token: 4e-7
+      input_cost_per_token_batches: 2e-7
       output_cost_per_token: 0.0000016
-      output_cost_per_token_batches: 8.e-7
+      output_cost_per_token_batches: 8e-7
       region: "*"
 deprecationDate: "2026-10-14"
 features:

--- a/providers/azure-open-ai/gpt-4.1-mini.yaml
+++ b/providers/azure-open-ai/gpt-4.1-mini.yaml
@@ -5,11 +5,11 @@ costs:
       output_cost_per_token: 0.00000176
       output_cost_per_token_batches: 8.8e-7
       region: datazone_us
-    - cache_read_input_token_cost: 1.e-7
-      input_cost_per_token: 4.e-7
-      input_cost_per_token_batches: 2.e-7
+    - cache_read_input_token_cost: 1e-7
+      input_cost_per_token: 4e-7
+      input_cost_per_token_batches: 2e-7
       output_cost_per_token: 0.0000016
-      output_cost_per_token_batches: 8.e-7
+      output_cost_per_token_batches: 8e-7
       region: "*"
 deprecationDate: "2026-10-14"
 features:

--- a/providers/azure-open-ai/gpt-4.1-nano-2025-04-14.yaml
+++ b/providers/azure-open-ai/gpt-4.1-nano-2025-04-14.yaml
@@ -1,15 +1,15 @@
 costs:
     - cache_read_input_token_cost: 2.5e-8
       input_cost_per_token: 1.1e-7
-      input_cost_per_token_batches: 6.e-8
+      input_cost_per_token_batches: 6e-8
       output_cost_per_token: 4.4e-7
       output_cost_per_token_batches: 2.2e-7
       region: datazone_us
     - cache_read_input_token_cost: 2.5e-8
-      input_cost_per_token: 1.e-7
-      input_cost_per_token_batches: 5.e-8
-      output_cost_per_token: 4.e-7
-      output_cost_per_token_batches: 2.e-7
+      input_cost_per_token: 1e-7
+      input_cost_per_token_batches: 5e-8
+      output_cost_per_token: 4e-7
+      output_cost_per_token_batches: 2e-7
       region: "*"
 deprecationDate: "2026-10-14"
 features:

--- a/providers/azure-open-ai/gpt-4.1-nano.yaml
+++ b/providers/azure-open-ai/gpt-4.1-nano.yaml
@@ -1,15 +1,15 @@
 costs:
     - cache_read_input_token_cost: 2.5e-8
       input_cost_per_token: 1.1e-7
-      input_cost_per_token_batches: 6.e-8
+      input_cost_per_token_batches: 6e-8
       output_cost_per_token: 4.4e-7
       output_cost_per_token_batches: 2.2e-7
       region: datazone_us
     - cache_read_input_token_cost: 2.5e-8
-      input_cost_per_token: 1.e-7
-      input_cost_per_token_batches: 5.e-8
-      output_cost_per_token: 4.e-7
-      output_cost_per_token_batches: 2.e-7
+      input_cost_per_token: 1e-7
+      input_cost_per_token_batches: 5e-8
+      output_cost_per_token: 4e-7
+      output_cost_per_token_batches: 2e-7
       region: "*"
 deprecationDate: "2026-10-14"
 features:

--- a/providers/azure-open-ai/gpt-4.1.yaml
+++ b/providers/azure-open-ai/gpt-4.1.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 5.e-7
+    - cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000008

--- a/providers/azure-open-ai/gpt-4o-mini-2024-07-18.yaml
+++ b/providers/azure-open-ai/gpt-4o-mini-2024-07-18.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: global
     - cache_read_input_token_cost: 8.3e-8
       input_cost_per_token: 1.65e-7

--- a/providers/azure-open-ai/gpt-4o-mini-realtime-preview-2024-12-17.yaml
+++ b/providers/azure-open-ai/gpt-4o-mini-realtime-preview-2024-12-17.yaml
@@ -1,8 +1,8 @@
 costs:
-    - cache_creation_input_audio_token_cost: 3.e-7
-      cache_read_input_token_cost: 3.e-7
+    - cache_creation_input_audio_token_cost: 3e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_audio_token: 0.00001
-      input_cost_per_token: 6.e-7
+      input_cost_per_token: 6e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token: 0.0000024
       region: global

--- a/providers/azure-open-ai/gpt-4o-mini.yaml
+++ b/providers/azure-open-ai/gpt-4o-mini.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: global
     - cache_read_input_token_cost: 8.3e-8
       input_cost_per_token: 1.65e-7

--- a/providers/azure-open-ai/gpt-5-nano.yaml
+++ b/providers/azure-open-ai/gpt-5-nano.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_token_cost: 5.e-9
-      input_cost_per_token: 5.e-8
-      output_cost_per_token: 4.e-7
+    - cache_read_input_token_cost: 5e-9
+      input_cost_per_token: 5e-8
+      output_cost_per_token: 4e-7
       region: global
     - cache_read_input_token_cost: 5.5e-9
       input_cost_per_token: 5.5e-8

--- a/providers/azure-open-ai/gpt-5.4-2026-03-05.yaml
+++ b/providers/azure-open-ai/gpt-5.4-2026-03-05.yaml
@@ -5,7 +5,7 @@ costs:
       region: "*"
       tiered_pricing:
           cache_read:
-              - cost_per_token: 5.e-7
+              - cost_per_token: 5e-7
                 from: 272000
           input:
               - cost_per_token: 0.000005

--- a/providers/azure-open-ai/gpt-5.4-nano-2026-03-17.yaml
+++ b/providers/azure-open-ai/gpt-5.4-nano-2026-03-17.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 2.e-8
-      input_cost_per_token: 2.e-7
+    - cache_read_input_token_cost: 2e-8
+      input_cost_per_token: 2e-7
       output_cost_per_token: 0.00000125
       region: "*"
 deprecationDate: "2027-03-17"

--- a/providers/azure-open-ai/gpt-audio-mini-2025-10-06.yaml
+++ b/providers/azure-open-ai/gpt-audio-mini-2025-10-06.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_audio_token: 0.00001
-      input_cost_per_token: 6.e-7
+      input_cost_per_token: 6e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token: 0.0000024
       region: "*"

--- a/providers/azure-open-ai/gpt-image-1-mini-2025-10-06.yaml
+++ b/providers/azure-open-ai/gpt-image-1-mini-2025-10-06.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_image_token: 0.0000025
       input_cost_per_token: 0.000002
       output_cost_per_image_token: 0.000008

--- a/providers/azure-open-ai/gpt-image-1-mini.yaml
+++ b/providers/azure-open-ai/gpt-image-1-mini.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_image_token: 0.0000025
       input_cost_per_token: 0.000002
       output_cost_per_image_token: 0.000008

--- a/providers/azure-open-ai/gpt-realtime-mini-2025-10-06.yaml
+++ b/providers/azure-open-ai/gpt-realtime-mini-2025-10-06.yaml
@@ -1,9 +1,9 @@
 costs:
-    - cache_creation_input_audio_token_cost: 3.e-7
-      cache_read_input_token_cost: 6.e-8
+    - cache_creation_input_audio_token_cost: 3e-7
+      cache_read_input_token_cost: 6e-8
       input_cost_per_audio_token: 0.00001
-      input_cost_per_image: 8.e-7
-      input_cost_per_token: 6.e-7
+      input_cost_per_image: 8e-7
+      input_cost_per_token: 6e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token: 0.0000024
       region: "*"

--- a/providers/azure-open-ai/gpt-realtime-mini-2025-12-15.yaml
+++ b/providers/azure-open-ai/gpt-realtime-mini-2025-12-15.yaml
@@ -1,8 +1,8 @@
 costs:
-    - cache_creation_input_audio_token_cost: 3.e-7
-      cache_read_input_token_cost: 6.e-8
+    - cache_creation_input_audio_token_cost: 3e-7
+      cache_read_input_token_cost: 6e-8
       input_cost_per_audio_token: 0.00001
-      input_cost_per_token: 6.e-7
+      input_cost_per_token: 6e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token: 0.0000024
       region: "*"

--- a/providers/azure-open-ai/gpt-realtime-mini.yaml
+++ b/providers/azure-open-ai/gpt-realtime-mini.yaml
@@ -1,9 +1,9 @@
 costs:
-    - cache_read_input_audio_token_cost: 3.e-7
-      cache_read_input_token_cost: 6.e-8
+    - cache_read_input_audio_token_cost: 3e-7
+      cache_read_input_token_cost: 6e-8
       input_cost_per_audio_token: 0.00001
-      input_cost_per_image_token: 8.e-7
-      input_cost_per_token: 6.e-7
+      input_cost_per_image_token: 8e-7
+      input_cost_per_token: 6e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token: 0.0000024
       region: "*"

--- a/providers/azure-open-ai/o3-2025-04-16.yaml
+++ b/providers/azure-open-ai/o3-2025-04-16.yaml
@@ -3,7 +3,7 @@ costs:
       input_cost_per_token: 0.0000022
       output_cost_per_token: 0.0000088
       region: datazone_us
-    - cache_read_input_token_cost: 5.e-7
+    - cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000008
       region: "*"

--- a/providers/azure-open-ai/o3.yaml
+++ b/providers/azure-open-ai/o3.yaml
@@ -3,7 +3,7 @@ costs:
       input_cost_per_token: 0.0000022
       output_cost_per_token: 0.0000088
       region: datazone_us
-    - cache_read_input_token_cost: 5.e-7
+    - cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000008
       region: "*"

--- a/providers/azure-open-ai/text-embedding-3-small.yaml
+++ b/providers/azure-open-ai/text-embedding-3-small.yaml
@@ -2,7 +2,7 @@ costs:
     - input_cost_per_token: 2.2e-8
       output_cost_per_token: 0
       region: datazone_eu
-    - input_cost_per_token: 2.e-8
+    - input_cost_per_token: 2e-8
       output_cost_per_token: 0
       region: "*"
 limits:

--- a/providers/azure-open-ai/text-embedding-ada-002-2.yaml
+++ b/providers/azure-open-ai/text-embedding-ada-002-2.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 1.e-7
+    - input_cost_per_token: 1e-7
       output_cost_per_token: 0
       region: "*"
 limits:

--- a/providers/azure-open-ai/text-embedding-ada-002.yaml
+++ b/providers/azure-open-ai/text-embedding-ada-002.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 1.e-7
+    - input_cost_per_token: 1e-7
       output_cost_per_token: 0
       region: "*"
 limits:

--- a/providers/cerebras/llama3.1-70b.yaml
+++ b/providers/cerebras/llama3.1-70b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 6.e-7
-      output_cost_per_token: 6.e-7
+    - input_cost_per_token: 6e-7
+      output_cost_per_token: 6e-7
       region: "*"
 features:
     - function_calling

--- a/providers/cerebras/llama3.1-8b.yaml
+++ b/providers/cerebras/llama3.1-8b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 1.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 1e-7
       region: "*"
 features:
     - function_calling

--- a/providers/cerebras/qwen-3-235b-a22b-instruct-2507.yaml
+++ b/providers/cerebras/qwen-3-235b-a22b-instruct-2507.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 6.e-7
+    - input_cost_per_token: 6e-7
       output_cost_per_token: 0.0000012
       region: "*"
 features:

--- a/providers/cohere/c4ai-aya-expanse-32b.yaml
+++ b/providers/cohere/c4ai-aya-expanse-32b.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
       output_cost_per_token: 0.0000015
       region: "*"
 features:

--- a/providers/cohere/command-r-08-2024.yaml
+++ b/providers/cohere/command-r-08-2024.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: "*"
 features:
     - function_calling

--- a/providers/cohere/embed-english-light-v2.0.yaml
+++ b/providers/cohere/embed-english-light-v2.0.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 1.e-7
+    - input_cost_per_token: 1e-7
       output_cost_per_token: 0
       region: "*"
 isDeprecated: true

--- a/providers/cohere/embed-english-light-v3.0.yaml
+++ b/providers/cohere/embed-english-light-v3.0.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 1.e-7
+    - input_cost_per_token: 1e-7
       output_cost_per_token: 0
       region: "*"
 limits:

--- a/providers/cohere/embed-english-v2.0.yaml
+++ b/providers/cohere/embed-english-v2.0.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 1.e-7
+    - input_cost_per_token: 1e-7
       output_cost_per_token: 0
       region: "*"
 isDeprecated: true

--- a/providers/cohere/embed-english-v3.0.yaml
+++ b/providers/cohere/embed-english-v3.0.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_image: 0.0001
-      input_cost_per_token: 1.e-7
+      input_cost_per_token: 1e-7
       output_cost_per_token: 0
       region: "*"
 limits:

--- a/providers/cohere/embed-multilingual-light-v3.0.yaml
+++ b/providers/cohere/embed-multilingual-light-v3.0.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 1.e-7
+    - input_cost_per_token: 1e-7
       output_cost_per_token: 0
       region: "*"
 limits:

--- a/providers/cohere/embed-multilingual-v2.0.yaml
+++ b/providers/cohere/embed-multilingual-v2.0.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 1.e-7
+    - input_cost_per_token: 1e-7
       output_cost_per_token: 0
       region: "*"
 isDeprecated: true

--- a/providers/cohere/embed-multilingual-v3.0.yaml
+++ b/providers/cohere/embed-multilingual-v3.0.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 1.e-7
+    - input_cost_per_token: 1e-7
       output_cost_per_token: 0
       region: "*"
 limits:

--- a/providers/databricks/databricks-bge-large-en.yaml
+++ b/providers/databricks/databricks-bge-large-en.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 1.e-7
+    - input_cost_per_token: 1e-7
       output_cost_per_token: 0
       region: "*"
 limits:

--- a/providers/databricks/databricks-gemini-2-5-flash.yaml
+++ b/providers/databricks/databricks-gemini-2-5-flash.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 3.e-7
+    - input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000025
       region: "*"
 features:

--- a/providers/databricks/databricks-gemma-3-12b.yaml
+++ b/providers/databricks/databricks-gemma-3-12b.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 5.e-7
+      output_cost_per_token: 5e-7
       region: "*"
 features:
     - function_calling

--- a/providers/databricks/databricks-gpt-5-nano.yaml
+++ b/providers/databricks/databricks-gpt-5-nano.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 5.e-8
-      output_cost_per_token: 4.e-7
+    - input_cost_per_token: 5e-8
+      output_cost_per_token: 4e-7
       region: "*"
 features:
     - system_messages

--- a/providers/databricks/databricks-gpt-oss-120b.yaml
+++ b/providers/databricks/databricks-gpt-oss-120b.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: "*"
 features:
     - function_calling

--- a/providers/databricks/databricks-gpt-oss-20b.yaml
+++ b/providers/databricks/databricks-gpt-oss-20b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 7.e-8
-      output_cost_per_token: 3.e-7
+    - input_cost_per_token: 7e-8
+      output_cost_per_token: 3e-7
       region: "*"
 limits:
     context_window: 128000

--- a/providers/databricks/databricks-llama-2-70b-chat.yaml
+++ b/providers/databricks/databricks-llama-2-70b-chat.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
       output_cost_per_token: 0.0000015
       region: "*"
 features:

--- a/providers/databricks/databricks-llama-4-maverick.yaml
+++ b/providers/databricks/databricks-llama-4-maverick.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
       output_cost_per_token: 0.0000015
       region: "*"
 features:

--- a/providers/databricks/databricks-meta-llama-3-3-70b-instruct.yaml
+++ b/providers/databricks/databricks-meta-llama-3-3-70b-instruct.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
       output_cost_per_token: 0.0000015
       region: "*"
 features:

--- a/providers/databricks/databricks-mixtral-8x7b-instruct.yaml
+++ b/providers/databricks/databricks-mixtral-8x7b-instruct.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
       output_cost_per_token: 0.000001
       region: "*"
 features:

--- a/providers/databricks/databricks-mpt-7b-instruct.yaml
+++ b/providers/databricks/databricks-mpt-7b-instruct.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
       output_cost_per_token: 0
       region: "*"
 features:

--- a/providers/deepinfra/BAAI/bge-base-en-v1.5.yaml
+++ b/providers/deepinfra/BAAI/bge-base-en-v1.5.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 1.e-8
+    - input_cost_per_token: 1e-8
       region: "*"
 limits:
     max_input_tokens: 512

--- a/providers/deepinfra/BAAI/bge-en-icl.yaml
+++ b/providers/deepinfra/BAAI/bge-en-icl.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 1.e-8
+    - input_cost_per_token: 1e-8
       region: "*"
 modalities:
     input:

--- a/providers/deepinfra/BAAI/bge-large-en-v1.5.yaml
+++ b/providers/deepinfra/BAAI/bge-large-en-v1.5.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 1.e-8
+    - input_cost_per_token: 1e-8
       region: "*"
 limits:
     max_input_tokens: 512

--- a/providers/deepinfra/BAAI/bge-m3-multi.yaml
+++ b/providers/deepinfra/BAAI/bge-m3-multi.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 1.e-8
+    - input_cost_per_token: 1e-8
       region: "*"
 limits:
     max_input_tokens: 8192

--- a/providers/deepinfra/BAAI/bge-m3.yaml
+++ b/providers/deepinfra/BAAI/bge-m3.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 1.e-8
+    - input_cost_per_token: 1e-8
       region: "*"
 limits:
     max_input_tokens: 8192

--- a/providers/deepinfra/ByteDance/Seed-1.8.yaml
+++ b/providers/deepinfra/ByteDance/Seed-1.8.yaml
@@ -1,14 +1,14 @@
 costs:
-    - cache_read_input_token_cost: 5.e-8
+    - cache_read_input_token_cost: 5e-8
       input_cost_per_token: 2.5e-7
       output_cost_per_token: 0.000002
       region: "*"
       tiered_pricing:
           cache_read:
-              - cost_per_token: 1.e-7
+              - cost_per_token: 1e-7
                 from: 128000
           input:
-              - cost_per_token: 5.e-7
+              - cost_per_token: 5e-7
                 from: 128000
           output:
               - cost_per_token: 0.000004

--- a/providers/deepinfra/ByteDance/Seed-2.0-mini.yaml
+++ b/providers/deepinfra/ByteDance/Seed-2.0-mini.yaml
@@ -1,17 +1,17 @@
 costs:
-    - cache_read_input_token_cost: 2.e-8
-      input_cost_per_token: 1.e-7
-      output_cost_per_token: 4.e-7
+    - cache_read_input_token_cost: 2e-8
+      input_cost_per_token: 1e-7
+      output_cost_per_token: 4e-7
       region: "*"
       tiered_pricing:
           cache_read:
-              - cost_per_token: 2.e-7
+              - cost_per_token: 2e-7
                 from: 128000
           input:
-              - cost_per_token: 2.e-7
+              - cost_per_token: 2e-7
                 from: 128000
           output:
-              - cost_per_token: 8.e-7
+              - cost_per_token: 8e-7
                 from: 128000
 features:
     - function_calling

--- a/providers/deepinfra/ByteDance/Seed-2.0-pro.yaml
+++ b/providers/deepinfra/ByteDance/Seed-2.0-pro.yaml
@@ -1,11 +1,11 @@
 costs:
-    - cache_read_input_token_cost: 1.e-7
-      input_cost_per_token: 5.e-7
+    - cache_read_input_token_cost: 1e-7
+      input_cost_per_token: 5e-7
       output_cost_per_token: 0.000003
       region: "*"
       tiered_pricing:
           cache_read:
-              - cost_per_token: 2.e-7
+              - cost_per_token: 2e-7
                 from: 128000
           input:
               - cost_per_token: 0.000001

--- a/providers/deepinfra/Gryphe/MythoMax-L2-13b.yaml
+++ b/providers/deepinfra/Gryphe/MythoMax-L2-13b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 4.e-7
-      output_cost_per_token: 4.e-7
+    - input_cost_per_token: 4e-7
+      output_cost_per_token: 4e-7
       region: "*"
 features:
     - structured_output

--- a/providers/deepinfra/MiniMaxAI/MiniMax-M2.5.yaml
+++ b/providers/deepinfra/MiniMaxAI/MiniMax-M2.5.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 3.e-8
+    - cache_read_input_token_cost: 3e-8
       input_cost_per_token: 2.7e-7
       output_cost_per_token: 9.5e-7
       region: "*"

--- a/providers/deepinfra/NousResearch/Hermes-3-Llama-3.1-70B.yaml
+++ b/providers/deepinfra/NousResearch/Hermes-3-Llama-3.1-70B.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 3.e-7
-      output_cost_per_token: 3.e-7
+    - input_cost_per_token: 3e-7
+      output_cost_per_token: 3e-7
       region: "*"
 features:
     - json_output

--- a/providers/deepinfra/PaddlePaddle/PaddleOCR-VL-0.9B.yaml
+++ b/providers/deepinfra/PaddlePaddle/PaddleOCR-VL-0.9B.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 1.4e-7
-      output_cost_per_token: 8.e-7
+      output_cost_per_token: 8e-7
       region: "*"
 features:
     - json_output

--- a/providers/deepinfra/Qwen/QwQ-32B.yaml
+++ b/providers/deepinfra/Qwen/QwQ-32B.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 4.e-7
+      output_cost_per_token: 4e-7
       region: "*"
 features:
     - tool_choice

--- a/providers/deepinfra/Qwen/Qwen2.5-7B-Instruct.yaml
+++ b/providers/deepinfra/Qwen/Qwen2.5-7B-Instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 4.e-8
-      output_cost_per_token: 1.e-7
+    - input_cost_per_token: 4e-8
+      output_cost_per_token: 1e-7
       region: "*"
 deprecationDate: "2025-11-06"
 features:

--- a/providers/deepinfra/Qwen/Qwen2.5-VL-32B-Instruct.yaml
+++ b/providers/deepinfra/Qwen/Qwen2.5-VL-32B-Instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 6.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 6e-7
       region: "*"
 features:
     - json_output

--- a/providers/deepinfra/Qwen/Qwen3-235B-A22B-Instruct-2507.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-235B-A22B-Instruct-2507.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 7.1e-8
-      output_cost_per_token: 1.e-7
+      output_cost_per_token: 1e-7
       region: "*"
 features:
     - function_calling

--- a/providers/deepinfra/Qwen/Qwen3-235B-A22B-Thinking-2507.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-235B-A22B-Thinking-2507.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 2.3e-7
       output_cost_per_token: 0.0000023
       region: "*"

--- a/providers/deepinfra/Qwen/Qwen3-235B-A22B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-235B-A22B.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 1.3e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: "*"
 deprecationDate: "2025-10-09"
 features:

--- a/providers/deepinfra/Qwen/Qwen3-30B-A3B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-30B-A3B.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 8.e-8
+    - input_cost_per_token: 8e-8
       output_cost_per_token: 2.8e-7
       region: "*"
 features:

--- a/providers/deepinfra/Qwen/Qwen3-32B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-32B.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 8.e-8
+    - input_cost_per_token: 8e-8
       output_cost_per_token: 2.8e-7
       region: "*"
 features:

--- a/providers/deepinfra/Qwen/Qwen3-Coder-480B-A35B-Instruct.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Coder-480B-A35B-Instruct.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 4.e-7
+    - input_cost_per_token: 4e-7
       output_cost_per_token: 0.0000016
       region: "*"
 features:

--- a/providers/deepinfra/Qwen/Qwen3-Embedding-0.6B-batch.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Embedding-0.6B-batch.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-9
+    - input_cost_per_token: 5e-9
       region: "*"
 limits:
     context_window: 32768

--- a/providers/deepinfra/Qwen/Qwen3-Embedding-0.6B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Embedding-0.6B.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 1.e-8
+    - input_cost_per_token: 1e-8
       region: "*"
 limits:
     context_window: 32768

--- a/providers/deepinfra/Qwen/Qwen3-Embedding-4B-batch.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Embedding-4B-batch.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 1.e-8
+    - input_cost_per_token: 1e-8
       region: "*"
 limits:
     context_window: 32768

--- a/providers/deepinfra/Qwen/Qwen3-Embedding-4B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Embedding-4B.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 2.e-8
+    - input_cost_per_token: 2e-8
       region: "*"
 limits:
     context_window: 32768

--- a/providers/deepinfra/Qwen/Qwen3-Embedding-8B-batch.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Embedding-8B-batch.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 4.e-8
+    - input_cost_per_token: 4e-8
       region: "*"
 limits:
     context_window: 32768

--- a/providers/deepinfra/Qwen/Qwen3-Embedding-8B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Embedding-8B.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 1.e-8
+    - input_cost_per_token: 1e-8
       region: "*"
 limits:
     context_window: 32768

--- a/providers/deepinfra/Qwen/Qwen3-Max-Thinking.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Max-Thinking.yaml
@@ -7,7 +7,7 @@ costs:
           cache_read:
               - cost_per_token: 4.8e-7
                 from: 32000
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 128000
           input:
               - cost_per_token: 0.0000024

--- a/providers/deepinfra/Qwen/Qwen3-Max.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Max.yaml
@@ -7,7 +7,7 @@ costs:
           cache_read:
               - cost_per_token: 4.8e-7
                 from: 32000
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 128000
           input:
               - cost_per_token: 0.0000024

--- a/providers/deepinfra/Qwen/Qwen3-Next-80B-A3B-Instruct.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Next-80B-A3B-Instruct.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 9.e-8
+    - input_cost_per_token: 9e-8
       output_cost_per_token: 0.0000011
       region: "*"
 features:

--- a/providers/deepinfra/Qwen/Qwen3-VL-235B-A22B-Instruct.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-VL-235B-A22B-Instruct.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_read_input_token_cost: 1.1e-7
-      input_cost_per_token: 2.e-7
+      input_cost_per_token: 2e-7
       output_cost_per_token: 8.8e-7
       region: "*"
 features:

--- a/providers/deepinfra/Qwen/Qwen3-VL-30B-A3B-Instruct.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-VL-30B-A3B-Instruct.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: "*"
 features:
     - function_calling

--- a/providers/deepinfra/Qwen/Qwen3.5-0.8B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3.5-0.8B.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 1.e-8
-      output_cost_per_token: 5.e-8
+    - input_cost_per_token: 1e-8
+      output_cost_per_token: 5e-8
       region: "*"
 features:
     - function_calling

--- a/providers/deepinfra/Qwen/Qwen3.5-2B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3.5-2B.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-8
-      output_cost_per_token: 1.e-7
+    - input_cost_per_token: 2e-8
+      output_cost_per_token: 1e-7
       region: "*"
 features:
     - function_calling

--- a/providers/deepinfra/Qwen/Qwen3.5-35B-A3B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3.5-35B-A3B.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 1.e-7
-      input_cost_per_token: 2.e-7
+    - cache_read_input_token_cost: 1e-7
+      input_cost_per_token: 2e-7
       output_cost_per_token: 9.5e-7
       region: "*"
 features:

--- a/providers/deepinfra/Qwen/Qwen3.5-4B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3.5-4B.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 3.e-8
+    - input_cost_per_token: 3e-8
       output_cost_per_token: 1.5e-7
       region: "*"
 features:

--- a/providers/deepinfra/Qwen/Qwen3.5-9B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3.5-9B.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 4.e-8
-      output_cost_per_token: 2.e-7
+    - input_cost_per_token: 4e-8
+      output_cost_per_token: 2e-7
       region: "*"
 features:
     - function_calling

--- a/providers/deepinfra/Qwen/Qwen3.6-35B-A3B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3.6-35B-A3B.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 2.e-7
+    - input_cost_per_token: 2e-7
       output_cost_per_token: 0.000001
       region: "*"
 limits:

--- a/providers/deepinfra/Sao10K/L3-8B-Lunaris-v1-Turbo.yaml
+++ b/providers/deepinfra/Sao10K/L3-8B-Lunaris-v1-Turbo.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 4.e-8
-      output_cost_per_token: 5.e-8
+    - input_cost_per_token: 4e-8
+      output_cost_per_token: 5e-8
       region: "*"
 limits:
     context_window: 8192

--- a/providers/deepinfra/allenai/Olmo-3.1-32B-Instruct.yaml
+++ b/providers/deepinfra/allenai/Olmo-3.1-32B-Instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 6.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 6e-7
       region: "*"
 limits:
     context_window: 65536

--- a/providers/deepinfra/allenai/olmOCR-2-7B-1025.yaml
+++ b/providers/deepinfra/allenai/olmOCR-2-7B-1025.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 9.e-8
+    - input_cost_per_token: 9e-8
       output_cost_per_token: 1.9e-7
       region: "*"
 limits:

--- a/providers/deepinfra/deepseek-ai/DeepSeek-OCR.yaml
+++ b/providers/deepinfra/deepseek-ai/DeepSeek-OCR.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 3.e-8
-      output_cost_per_token: 1.e-7
+    - input_cost_per_token: 3e-8
+      output_cost_per_token: 1e-7
       region: "*"
 limits:
     context_window: 8192

--- a/providers/deepinfra/deepseek-ai/DeepSeek-R1-0528.yaml
+++ b/providers/deepinfra/deepseek-ai/DeepSeek-R1-0528.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_read_input_token_cost: 3.5e-7
-      input_cost_per_token: 5.e-7
+      input_cost_per_token: 5e-7
       output_cost_per_token: 0.00000215
       region: "*"
 features:

--- a/providers/deepinfra/deepseek-ai/DeepSeek-R1-Distill-Llama-70B.yaml
+++ b/providers/deepinfra/deepseek-ai/DeepSeek-R1-Distill-Llama-70B.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 7.e-7
-      output_cost_per_token: 8.e-7
+    - input_cost_per_token: 7e-7
+      output_cost_per_token: 8e-7
       region: "*"
 features:
     - json_output

--- a/providers/deepinfra/deepseek-ai/DeepSeek-R1.yaml
+++ b/providers/deepinfra/deepseek-ai/DeepSeek-R1.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 7.e-7
+    - input_cost_per_token: 7e-7
       output_cost_per_token: 0.0000024
       region: "*"
 features:

--- a/providers/deepinfra/deepseek-ai/DeepSeek-V3-0324.yaml
+++ b/providers/deepinfra/deepseek-ai/DeepSeek-V3-0324.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_read_input_token_cost: 1.35e-7
-      input_cost_per_token: 2.e-7
+      input_cost_per_token: 2e-7
       output_cost_per_token: 7.7e-7
       region: "*"
 features:

--- a/providers/deepinfra/google/embeddinggemma-300m.yaml
+++ b/providers/deepinfra/google/embeddinggemma-300m.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 2.e-9
+    - input_cost_per_token: 2e-9
       region: "*"
 limits:
     max_input_tokens: 2048

--- a/providers/deepinfra/google/gemini-1.5-flash.yaml
+++ b/providers/deepinfra/google/gemini-1.5-flash.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 7.5e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       region: "*"
 isDeprecated: true
 limits:

--- a/providers/deepinfra/google/gemini-2.0-flash-001.yaml
+++ b/providers/deepinfra/google/gemini-2.0-flash-001.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 4.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 4e-7
       region: "*"
 features:
     - tool_choice

--- a/providers/deepinfra/google/gemini-2.5-flash.yaml
+++ b/providers/deepinfra/google/gemini-2.5-flash.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 3.e-7
+    - input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000025
       region: "*"
 features:

--- a/providers/deepinfra/google/gemma-3-12b-it.yaml
+++ b/providers/deepinfra/google/gemma-3-12b-it.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 4.e-8
+    - input_cost_per_token: 4e-8
       output_cost_per_token: 1.3e-7
       region: "*"
 features:

--- a/providers/deepinfra/google/gemma-3-27b-it.yaml
+++ b/providers/deepinfra/google/gemma-3-27b-it.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 8.e-8
+    - input_cost_per_token: 8e-8
       output_cost_per_token: 1.6e-7
       region: "*"
 features:

--- a/providers/deepinfra/google/gemma-3-4b-it.yaml
+++ b/providers/deepinfra/google/gemma-3-4b-it.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 4.e-8
-      output_cost_per_token: 8.e-8
+    - input_cost_per_token: 4e-8
+      output_cost_per_token: 8e-8
       region: "*"
 features:
     - function_calling

--- a/providers/deepinfra/google/gemma-4-26B-A4B-it.yaml
+++ b/providers/deepinfra/google/gemma-4-26B-A4B-it.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 1.e-8
-      input_cost_per_token: 8.e-8
+    - cache_read_input_token_cost: 1e-8
+      input_cost_per_token: 8e-8
       output_cost_per_token: 3.5e-7
       region: "*"
 features:

--- a/providers/deepinfra/intfloat/e5-base-v2.yaml
+++ b/providers/deepinfra/intfloat/e5-base-v2.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-9
+    - input_cost_per_token: 5e-9
       region: "*"
 limits:
     max_input_tokens: 512

--- a/providers/deepinfra/intfloat/e5-large-v2.yaml
+++ b/providers/deepinfra/intfloat/e5-large-v2.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 1.e-8
+    - input_cost_per_token: 1e-8
       region: "*"
 limits:
     context_window: 512

--- a/providers/deepinfra/intfloat/multilingual-e5-large-instruct.yaml
+++ b/providers/deepinfra/intfloat/multilingual-e5-large-instruct.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 1.e-8
+    - input_cost_per_token: 1e-8
       region: "*"
 limits:
     max_input_tokens: 512

--- a/providers/deepinfra/intfloat/multilingual-e5-large.yaml
+++ b/providers/deepinfra/intfloat/multilingual-e5-large.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 1.e-8
+    - input_cost_per_token: 1e-8
       region: "*"
 limits:
     max_input_tokens: 512

--- a/providers/deepinfra/meta-llama/Llama-3.2-3B-Instruct.yaml
+++ b/providers/deepinfra/meta-llama/Llama-3.2-3B-Instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-8
-      output_cost_per_token: 2.e-8
+    - input_cost_per_token: 2e-8
+      output_cost_per_token: 2e-8
       region: "*"
 limits:
     context_window: 131072

--- a/providers/deepinfra/meta-llama/Llama-3.3-70B-Instruct-Turbo.yaml
+++ b/providers/deepinfra/meta-llama/Llama-3.3-70B-Instruct-Turbo.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 1.e-7
+    - input_cost_per_token: 1e-7
       output_cost_per_token: 3.2e-7
       region: "*"
 features:

--- a/providers/deepinfra/meta-llama/Llama-3.3-70B-Instruct.yaml
+++ b/providers/deepinfra/meta-llama/Llama-3.3-70B-Instruct.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 2.3e-7
-      output_cost_per_token: 4.e-7
+      output_cost_per_token: 4e-7
       region: "*"
 features:
     - tool_choice

--- a/providers/deepinfra/meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8.yaml
+++ b/providers/deepinfra/meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: "*"
 features:
     - json_output

--- a/providers/deepinfra/meta-llama/Llama-4-Scout-17B-16E-Instruct.yaml
+++ b/providers/deepinfra/meta-llama/Llama-4-Scout-17B-16E-Instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 8.e-8
-      output_cost_per_token: 3.e-7
+    - input_cost_per_token: 8e-8
+      output_cost_per_token: 3e-7
       region: "*"
 features:
     - function_calling

--- a/providers/deepinfra/meta-llama/Meta-Llama-3-8B-Instruct.yaml
+++ b/providers/deepinfra/meta-llama/Meta-Llama-3-8B-Instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 3.e-8
-      output_cost_per_token: 4.e-8
+    - input_cost_per_token: 3e-8
+      output_cost_per_token: 4e-8
       region: "*"
 features:
     - function_calling

--- a/providers/deepinfra/meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo.yaml
+++ b/providers/deepinfra/meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 4.e-7
-      output_cost_per_token: 4.e-7
+    - input_cost_per_token: 4e-7
+      output_cost_per_token: 4e-7
       region: "*"
 features:
     - function_calling

--- a/providers/deepinfra/meta-llama/Meta-Llama-3.1-70B-Instruct.yaml
+++ b/providers/deepinfra/meta-llama/Meta-Llama-3.1-70B-Instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 4.e-7
-      output_cost_per_token: 4.e-7
+    - input_cost_per_token: 4e-7
+      output_cost_per_token: 4e-7
       region: "*"
 features:
     - function_calling

--- a/providers/deepinfra/meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo.yaml
+++ b/providers/deepinfra/meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-8
-      output_cost_per_token: 3.e-8
+    - input_cost_per_token: 2e-8
+      output_cost_per_token: 3e-8
       region: "*"
 features:
     - function_calling

--- a/providers/deepinfra/meta-llama/Meta-Llama-3.1-8B-Instruct.yaml
+++ b/providers/deepinfra/meta-llama/Meta-Llama-3.1-8B-Instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-8
-      output_cost_per_token: 5.e-8
+    - input_cost_per_token: 2e-8
+      output_cost_per_token: 5e-8
       region: "*"
 features:
     - function_calling

--- a/providers/deepinfra/microsoft/phi-4.yaml
+++ b/providers/deepinfra/microsoft/phi-4.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 7.e-8
+    - input_cost_per_token: 7e-8
       output_cost_per_token: 1.4e-7
       region: "*"
 features:

--- a/providers/deepinfra/mistralai/Mistral-Nemo-Instruct-2407.yaml
+++ b/providers/deepinfra/mistralai/Mistral-Nemo-Instruct-2407.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-8
-      output_cost_per_token: 4.e-8
+    - input_cost_per_token: 2e-8
+      output_cost_per_token: 4e-8
       region: "*"
 features:
     - function_calling

--- a/providers/deepinfra/mistralai/Mistral-Small-24B-Instruct-2501.yaml
+++ b/providers/deepinfra/mistralai/Mistral-Small-24B-Instruct-2501.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 5.e-8
-      output_cost_per_token: 8.e-8
+    - input_cost_per_token: 5e-8
+      output_cost_per_token: 8e-8
       region: "*"
 features:
     - structured_output

--- a/providers/deepinfra/mistralai/Mistral-Small-3.2-24B-Instruct-2506.yaml
+++ b/providers/deepinfra/mistralai/Mistral-Small-3.2-24B-Instruct-2506.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 7.5e-8
-      output_cost_per_token: 2.e-7
+      output_cost_per_token: 2e-7
       region: "*"
 features:
     - function_calling

--- a/providers/deepinfra/moonshotai/Kimi-K2-Instruct-0905.yaml
+++ b/providers/deepinfra/moonshotai/Kimi-K2-Instruct-0905.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_read_input_token_cost: 1.5e-7
-      input_cost_per_token: 4.e-7
+      input_cost_per_token: 4e-7
       output_cost_per_token: 0.000002
       region: "*"
 features:

--- a/providers/deepinfra/moonshotai/Kimi-K2-Instruct.yaml
+++ b/providers/deepinfra/moonshotai/Kimi-K2-Instruct.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
       output_cost_per_token: 0.000002
       region: "*"
 features:

--- a/providers/deepinfra/moonshotai/Kimi-K2.5-Turbo.yaml
+++ b/providers/deepinfra/moonshotai/Kimi-K2.5-Turbo.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 1.e-7
-      input_cost_per_token: 6.e-7
+    - cache_read_input_token_cost: 1e-7
+      input_cost_per_token: 6e-7
       output_cost_per_token: 0.000003
       region: "*"
 deprecationDate: "2026-04-15"

--- a/providers/deepinfra/moonshotai/Kimi-K2.5.yaml
+++ b/providers/deepinfra/moonshotai/Kimi-K2.5.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 7.e-8
+    - cache_read_input_token_cost: 7e-8
       input_cost_per_token: 4.5e-7
       output_cost_per_token: 0.00000225
       region: "*"

--- a/providers/deepinfra/nvidia/Llama-3.3-Nemotron-Super-49B-v1.5.yaml
+++ b/providers/deepinfra/nvidia/Llama-3.3-Nemotron-Super-49B-v1.5.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 4.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 4e-7
       region: "*"
 features:
     - function_calling

--- a/providers/deepinfra/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B.yaml
+++ b/providers/deepinfra/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_token_cost: 4.e-8
-      input_cost_per_token: 1.e-7
-      output_cost_per_token: 5.e-7
+    - cache_read_input_token_cost: 4e-8
+      input_cost_per_token: 1e-7
+      output_cost_per_token: 5e-7
       region: "*"
 features:
     - prompt_caching

--- a/providers/deepinfra/nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL.yaml
+++ b/providers/deepinfra/nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 6.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 6e-7
       region: "*"
 limits:
     context_window: 128000

--- a/providers/deepinfra/nvidia/NVIDIA-Nemotron-Nano-9B-v2.yaml
+++ b/providers/deepinfra/nvidia/NVIDIA-Nemotron-Nano-9B-v2.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 4.e-8
+    - input_cost_per_token: 4e-8
       output_cost_per_token: 1.6e-7
       region: "*"
 features:

--- a/providers/deepinfra/nvidia/Nemotron-3-Nano-30B-A3B.yaml
+++ b/providers/deepinfra/nvidia/Nemotron-3-Nano-30B-A3B.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 5.e-8
-      output_cost_per_token: 2.e-7
+    - input_cost_per_token: 5e-8
+      output_cost_per_token: 2e-7
       region: "*"
 features:
     - function_calling

--- a/providers/deepinfra/nvidia/llama-nemotron-embed-vl-1b-v2.yaml
+++ b/providers/deepinfra/nvidia/llama-nemotron-embed-vl-1b-v2.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 1.e-8
+    - input_cost_per_token: 1e-8
       region: "*"
 limits:
     context_window: 10240

--- a/providers/deepinfra/openai/gpt-oss-120b-Turbo.yaml
+++ b/providers/deepinfra/openai/gpt-oss-120b-Turbo.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: "*"
 features:
     - function_calling

--- a/providers/deepinfra/openai/gpt-oss-20b.yaml
+++ b/providers/deepinfra/openai/gpt-oss-20b.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 3.e-8
+    - input_cost_per_token: 3e-8
       output_cost_per_token: 1.4e-7
       region: "*"
 features:

--- a/providers/deepinfra/sentence-transformers/all-MiniLM-L12-v2.yaml
+++ b/providers/deepinfra/sentence-transformers/all-MiniLM-L12-v2.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-9
+    - input_cost_per_token: 5e-9
       region: "*"
 limits:
     max_tokens: 512

--- a/providers/deepinfra/sentence-transformers/all-MiniLM-L6-v2.yaml
+++ b/providers/deepinfra/sentence-transformers/all-MiniLM-L6-v2.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-9
+    - input_cost_per_token: 5e-9
       region: "*"
 limits:
     max_input_tokens: 512

--- a/providers/deepinfra/sentence-transformers/all-mpnet-base-v2.yaml
+++ b/providers/deepinfra/sentence-transformers/all-mpnet-base-v2.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-9
+    - input_cost_per_token: 5e-9
       region: "*"
 limits:
     max_input_tokens: 512

--- a/providers/deepinfra/sentence-transformers/clip-ViT-B-32-multilingual-v1.yaml
+++ b/providers/deepinfra/sentence-transformers/clip-ViT-B-32-multilingual-v1.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-9
+    - input_cost_per_token: 5e-9
       region: "*"
 limits:
     output_vector_size: 512

--- a/providers/deepinfra/sentence-transformers/clip-ViT-B-32.yaml
+++ b/providers/deepinfra/sentence-transformers/clip-ViT-B-32.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-9
+    - input_cost_per_token: 5e-9
       region: "*"
 limits:
     output_vector_size: 512

--- a/providers/deepinfra/sentence-transformers/multi-qa-mpnet-base-dot-v1.yaml
+++ b/providers/deepinfra/sentence-transformers/multi-qa-mpnet-base-dot-v1.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-9
+    - input_cost_per_token: 5e-9
       region: "*"
 limits:
     max_input_tokens: 512

--- a/providers/deepinfra/sentence-transformers/paraphrase-MiniLM-L6-v2.yaml
+++ b/providers/deepinfra/sentence-transformers/paraphrase-MiniLM-L6-v2.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-9
+    - input_cost_per_token: 5e-9
       region: "*"
 limits:
     max_input_tokens: 512

--- a/providers/deepinfra/shibing624/text2vec-base-chinese.yaml
+++ b/providers/deepinfra/shibing624/text2vec-base-chinese.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-9
+    - input_cost_per_token: 5e-9
       region: "*"
 limits:
     context_window: 512

--- a/providers/deepinfra/stepfun-ai/Step-3.5-Flash.yaml
+++ b/providers/deepinfra/stepfun-ai/Step-3.5-Flash.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_token_cost: 2.e-8
-      input_cost_per_token: 1.e-7
-      output_cost_per_token: 3.e-7
+    - cache_read_input_token_cost: 2e-8
+      input_cost_per_token: 1e-7
+      output_cost_per_token: 3e-7
       region: "*"
 features:
     - function_calling

--- a/providers/deepinfra/thenlper/gte-base.yaml
+++ b/providers/deepinfra/thenlper/gte-base.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-9
+    - input_cost_per_token: 5e-9
       region: "*"
 limits:
     max_input_tokens: 512

--- a/providers/deepinfra/thenlper/gte-large.yaml
+++ b/providers/deepinfra/thenlper/gte-large.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 1.e-8
+    - input_cost_per_token: 1e-8
       region: "*"
 limits:
     max_input_tokens: 512

--- a/providers/deepinfra/zai-org/GLM-4.5.yaml
+++ b/providers/deepinfra/zai-org/GLM-4.5.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 4.e-7
+    - input_cost_per_token: 4e-7
       output_cost_per_token: 0.0000016
       region: "*"
 features:

--- a/providers/deepinfra/zai-org/GLM-4.6.yaml
+++ b/providers/deepinfra/zai-org/GLM-4.6.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 8.e-8
+    - cache_read_input_token_cost: 8e-8
       input_cost_per_token: 4.3e-7
       output_cost_per_token: 0.00000174
       region: "*"

--- a/providers/deepinfra/zai-org/GLM-4.6V.yaml
+++ b/providers/deepinfra/zai-org/GLM-4.6V.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 3.e-7
-      output_cost_per_token: 9.e-7
+    - input_cost_per_token: 3e-7
+      output_cost_per_token: 9e-7
       region: "*"
 features:
     - function_calling

--- a/providers/deepinfra/zai-org/GLM-4.7-Flash.yaml
+++ b/providers/deepinfra/zai-org/GLM-4.7-Flash.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_token_cost: 1.e-8
-      input_cost_per_token: 6.e-8
-      output_cost_per_token: 4.e-7
+    - cache_read_input_token_cost: 1e-8
+      input_cost_per_token: 6e-8
+      output_cost_per_token: 4e-7
       region: "*"
 features:
     - prompt_caching

--- a/providers/deepinfra/zai-org/GLM-4.7.yaml
+++ b/providers/deepinfra/zai-org/GLM-4.7.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 8.e-8
-      input_cost_per_token: 4.e-7
+    - cache_read_input_token_cost: 8e-8
+      input_cost_per_token: 4e-7
       output_cost_per_token: 0.00000175
       region: "*"
 features:

--- a/providers/deepinfra/zai-org/GLM-5.yaml
+++ b/providers/deepinfra/zai-org/GLM-5.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_read_input_token_cost: 1.6e-7
-      input_cost_per_token: 8.e-7
+      input_cost_per_token: 8e-7
       output_cost_per_token: 0.00000256
       region: "*"
 features:

--- a/providers/groq/gemma-7b-it.yaml
+++ b/providers/groq/gemma-7b-it.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 5.e-8
-      output_cost_per_token: 8.e-8
+    - input_cost_per_token: 5e-8
+      output_cost_per_token: 8e-8
       region: "*"
 features:
     - function_calling

--- a/providers/groq/llama-3.1-8b-instant.yaml
+++ b/providers/groq/llama-3.1-8b-instant.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 5.e-8
-      output_cost_per_token: 8.e-8
+    - input_cost_per_token: 5e-8
+      output_cost_per_token: 8e-8
       region: "*"
 features:
     - function_calling

--- a/providers/groq/meta-llama/llama-4-maverick-17b-128e-instruct.yaml
+++ b/providers/groq/meta-llama/llama-4-maverick-17b-128e-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 6.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 6e-7
       region: "*"
 features:
     - function_calling

--- a/providers/groq/meta-llama/llama-guard-4-12b.yaml
+++ b/providers/groq/meta-llama/llama-guard-4-12b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 2.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 2e-7
       region: "*"
 isDeprecated: true
 limits:

--- a/providers/groq/meta-llama/llama-prompt-guard-2-22m.yaml
+++ b/providers/groq/meta-llama/llama-prompt-guard-2-22m.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 4.e-8
-      output_cost_per_token: 4.e-8
+    - input_cost_per_token: 4e-8
+      output_cost_per_token: 4e-8
       region: "*"
 limits:
     context_window: 512

--- a/providers/groq/meta-llama/llama-prompt-guard-2-86m.yaml
+++ b/providers/groq/meta-llama/llama-prompt-guard-2-86m.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 4.e-8
-      output_cost_per_token: 4.e-8
+    - input_cost_per_token: 4e-8
+      output_cost_per_token: 4e-8
       region: "*"
 limits:
     context_window: 512

--- a/providers/groq/moonshotai/kimi-k2-instruct-0905.yaml
+++ b/providers/groq/moonshotai/kimi-k2-instruct-0905.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 5.e-7
+    - cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000001
       output_cost_per_token: 0.000003
       region: "*"

--- a/providers/groq/openai/gpt-oss-120b.yaml
+++ b/providers/groq/openai/gpt-oss-120b.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_read_input_token_cost: 7.5e-8
       input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: "*"
 features:
     - function_calling

--- a/providers/groq/openai/gpt-oss-20b.yaml
+++ b/providers/groq/openai/gpt-oss-20b.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_read_input_token_cost: 3.75e-8
       input_cost_per_token: 7.5e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       region: "*"
 features:
     - function_calling

--- a/providers/groq/openai/gpt-oss-safeguard-20b.yaml
+++ b/providers/groq/openai/gpt-oss-safeguard-20b.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_read_input_token_cost: 3.7e-8
       input_cost_per_token: 7.5e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       region: "*"
 features:
     - function_calling

--- a/providers/mistral-ai/codestral-2508.yaml
+++ b/providers/mistral-ai/codestral-2508.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 3.e-7
-      output_cost_per_token: 9.e-7
+    - input_cost_per_token: 3e-7
+      output_cost_per_token: 9e-7
       region: "*"
 features:
     - function_calling

--- a/providers/mistral-ai/codestral-latest.yaml
+++ b/providers/mistral-ai/codestral-latest.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 3.e-7
-      output_cost_per_token: 9.e-7
+    - input_cost_per_token: 3e-7
+      output_cost_per_token: 9e-7
       region: "*"
 features:
     - function_calling

--- a/providers/mistral-ai/devstral-2512.yaml
+++ b/providers/mistral-ai/devstral-2512.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 4.e-7
+    - input_cost_per_token: 4e-7
       output_cost_per_token: 0.000002
       region: "*"
 features:

--- a/providers/mistral-ai/devstral-latest.yaml
+++ b/providers/mistral-ai/devstral-latest.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 4.e-7
-      input_cost_per_token_batches: 2.e-7
+    - input_cost_per_token: 4e-7
+      input_cost_per_token_batches: 2e-7
       output_cost_per_token: 0.000002
       output_cost_per_token_batches: 0.000001
       region: "*"

--- a/providers/mistral-ai/devstral-medium-2507.yaml
+++ b/providers/mistral-ai/devstral-medium-2507.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 4.e-7
+    - input_cost_per_token: 4e-7
       output_cost_per_token: 0.000002
       region: "*"
 deprecationDate: "2026-05-31"

--- a/providers/mistral-ai/devstral-medium-latest.yaml
+++ b/providers/mistral-ai/devstral-medium-latest.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 4.e-7
+    - input_cost_per_token: 4e-7
       output_cost_per_token: 0.000002
       region: "*"
 features:

--- a/providers/mistral-ai/devstral-small-2505.yaml
+++ b/providers/mistral-ai/devstral-small-2505.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 3.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 3e-7
       region: "*"
 features:
     - function_calling

--- a/providers/mistral-ai/devstral-small-2507.yaml
+++ b/providers/mistral-ai/devstral-small-2507.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 3.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 3e-7
       region: "*"
 deprecationDate: "2026-05-31"
 features:

--- a/providers/mistral-ai/devstral-small-latest.yaml
+++ b/providers/mistral-ai/devstral-small-latest.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 3.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 3e-7
       region: "*"
 features:
     - function_calling

--- a/providers/mistral-ai/labs-devstral-small-2512.yaml
+++ b/providers/mistral-ai/labs-devstral-small-2512.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 3.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 3e-7
       region: "*"
 features:
     - function_calling

--- a/providers/mistral-ai/labs-mistral-small-creative.yaml
+++ b/providers/mistral-ai/labs-mistral-small-creative.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 3.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 3e-7
       region: "*"
 deprecationDate: "2026-04-30"
 features:

--- a/providers/mistral-ai/magistral-small-2506.yaml
+++ b/providers/mistral-ai/magistral-small-2506.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
       output_cost_per_token: 0.0000015
       region: "*"
 features:

--- a/providers/mistral-ai/magistral-small-2509.yaml
+++ b/providers/mistral-ai/magistral-small-2509.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
       output_cost_per_token: 0.0000015
       region: "*"
 features:

--- a/providers/mistral-ai/magistral-small-latest.yaml
+++ b/providers/mistral-ai/magistral-small-latest.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
       output_cost_per_token: 0.0000015
       region: "*"
 features:

--- a/providers/mistral-ai/ministral-14b-2512.yaml
+++ b/providers/mistral-ai/ministral-14b-2512.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 2.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 2e-7
       region: "*"
 features:
     - function_calling

--- a/providers/mistral-ai/ministral-14b-latest.yaml
+++ b/providers/mistral-ai/ministral-14b-latest.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 2.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 2e-7
       region: "*"
 features:
     - function_calling

--- a/providers/mistral-ai/ministral-3b-2512.yaml
+++ b/providers/mistral-ai/ministral-3b-2512.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 1.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 1e-7
       region: "*"
 features:
     - function_calling

--- a/providers/mistral-ai/ministral-3b-latest.yaml
+++ b/providers/mistral-ai/ministral-3b-latest.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 1.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 1e-7
       region: "*"
 features:
     - function_calling

--- a/providers/mistral-ai/mistral-embed-2312.yaml
+++ b/providers/mistral-ai/mistral-embed-2312.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 1.e-7
+    - input_cost_per_token: 1e-7
       region: "*"
 isDeprecated: true
 limits:

--- a/providers/mistral-ai/mistral-embed.yaml
+++ b/providers/mistral-ai/mistral-embed.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 1.e-7
+    - input_cost_per_token: 1e-7
       region: "*"
 isDeprecated: true
 limits:

--- a/providers/mistral-ai/mistral-large-2512.yaml
+++ b/providers/mistral-ai/mistral-large-2512.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
       output_cost_per_token: 0.0000015
       region: "*"
 features:

--- a/providers/mistral-ai/mistral-large-latest.yaml
+++ b/providers/mistral-ai/mistral-large-latest.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
       input_cost_per_token_batches: 2.5e-7
       output_cost_per_token: 0.0000015
       output_cost_per_token_batches: 7.5e-7

--- a/providers/mistral-ai/mistral-medium-2505.yaml
+++ b/providers/mistral-ai/mistral-medium-2505.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 4.e-7
+    - input_cost_per_token: 4e-7
       output_cost_per_token: 0.000002
       region: "*"
 features:

--- a/providers/mistral-ai/mistral-medium-2508.yaml
+++ b/providers/mistral-ai/mistral-medium-2508.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 4.e-7
+    - input_cost_per_token: 4e-7
       output_cost_per_token: 0.000002
       region: "*"
 features:

--- a/providers/mistral-ai/mistral-medium-3.yaml
+++ b/providers/mistral-ai/mistral-medium-3.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 4.e-7
+    - input_cost_per_token: 4e-7
       output_cost_per_token: 0.000002
       region: "*"
 features:

--- a/providers/mistral-ai/mistral-medium-c21211-r0-75.yaml
+++ b/providers/mistral-ai/mistral-medium-c21211-r0-75.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 4.e-7
+    - input_cost_per_token: 4e-7
       output_cost_per_token: 0.000002
       region: "*"
 features:

--- a/providers/mistral-ai/mistral-medium-latest.yaml
+++ b/providers/mistral-ai/mistral-medium-latest.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 4.e-7
-      input_cost_per_token_batches: 2.e-7
+    - input_cost_per_token: 4e-7
+      input_cost_per_token_batches: 2e-7
       output_cost_per_token: 0.000002
       output_cost_per_token_batches: 0.000001
       region: "*"

--- a/providers/mistral-ai/mistral-moderation-2411.yaml
+++ b/providers/mistral-ai/mistral-moderation-2411.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 1.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 1e-7
       region: "*"
 deprecationDate: "2026-06-30"
 isDeprecated: true

--- a/providers/mistral-ai/mistral-small-2506.yaml
+++ b/providers/mistral-ai/mistral-small-2506.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 3.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 3e-7
       region: "*"
 features:
     - function_calling

--- a/providers/mistral-ai/mistral-small-2603.yaml
+++ b/providers/mistral-ai/mistral-small-2603.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: "*"
 features:
     - function_calling

--- a/providers/mistral-ai/mistral-small-latest.yaml
+++ b/providers/mistral-ai/mistral-small-latest.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: "*"
 features:
     - function_calling

--- a/providers/mistral-ai/mistral-small.yaml
+++ b/providers/mistral-ai/mistral-small.yaml
@@ -1,7 +1,7 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      input_cost_per_token_batches: 5.e-8
-      output_cost_per_token: 3.e-7
+    - input_cost_per_token: 1e-7
+      input_cost_per_token_batches: 5e-8
+      output_cost_per_token: 3e-7
       output_cost_per_token_batches: 1.5e-7
       region: "*"
 features:

--- a/providers/mistral-ai/mistral-vibe-cli-with-tools.yaml
+++ b/providers/mistral-ai/mistral-vibe-cli-with-tools.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 4.e-7
+    - input_cost_per_token: 4e-7
       output_cost_per_token: 0.000002
       region: "*"
 features:

--- a/providers/mistral-ai/open-mixtral-8x7b.yaml
+++ b/providers/mistral-ai/open-mixtral-8x7b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 7.e-7
-      output_cost_per_token: 7.e-7
+    - input_cost_per_token: 7e-7
+      output_cost_per_token: 7e-7
       region: "*"
 features:
     - function_calling

--- a/providers/mistral-ai/voxtral-mini-2507.yaml
+++ b/providers/mistral-ai/voxtral-mini-2507.yaml
@@ -1,7 +1,7 @@
 costs:
     - input_cost_per_second: 0.0000166667
-      input_cost_per_token: 4.e-8
-      output_cost_per_token: 4.e-8
+      input_cost_per_token: 4e-8
+      output_cost_per_token: 4e-8
       region: "*"
 deprecationDate: "2026-05-31"
 isDeprecated: true

--- a/providers/mistral-ai/voxtral-mini-latest.yaml
+++ b/providers/mistral-ai/voxtral-mini-latest.yaml
@@ -1,7 +1,7 @@
 costs:
     - input_cost_per_second: 0.00001666666667
-      input_cost_per_token: 4.e-8
-      output_cost_per_token: 4.e-8
+      input_cost_per_token: 4e-8
+      output_cost_per_token: 4e-8
       region: "*"
 isDeprecated: true
 limits:

--- a/providers/mistral-ai/voxtral-small-2507.yaml
+++ b/providers/mistral-ai/voxtral-small-2507.yaml
@@ -1,7 +1,7 @@
 costs:
     - input_cost_per_second: 0.0000666667
-      input_cost_per_token: 1.e-7
-      output_cost_per_token: 3.e-7
+      input_cost_per_token: 1e-7
+      output_cost_per_token: 3e-7
       region: "*"
 features:
     - function_calling

--- a/providers/mistral-ai/voxtral-small-latest.yaml
+++ b/providers/mistral-ai/voxtral-small-latest.yaml
@@ -1,7 +1,7 @@
 costs:
     - input_cost_per_second: 0.0000666667
-      input_cost_per_token: 1.e-7
-      output_cost_per_token: 3.e-7
+      input_cost_per_token: 1e-7
+      output_cost_per_token: 3e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openai/gpt-3.5-turbo-0125.yaml
+++ b/providers/openai/gpt-3.5-turbo-0125.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
       input_cost_per_token_batches: 2.5e-7
       output_cost_per_token: 0.0000015
       output_cost_per_token_batches: 7.5e-7

--- a/providers/openai/gpt-3.5-turbo.yaml
+++ b/providers/openai/gpt-3.5-turbo.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
       output_cost_per_token: 0.0000015
       region: "*"
 features:

--- a/providers/openai/gpt-4.1-2025-04-14.yaml
+++ b/providers/openai/gpt-4.1-2025-04-14.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 5.e-7
+    - cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000008

--- a/providers/openai/gpt-4.1-mini-2025-04-14.yaml
+++ b/providers/openai/gpt-4.1-mini-2025-04-14.yaml
@@ -1,9 +1,9 @@
 costs:
-    - cache_read_input_token_cost: 1.e-7
-      input_cost_per_token: 4.e-7
-      input_cost_per_token_batches: 2.e-7
+    - cache_read_input_token_cost: 1e-7
+      input_cost_per_token: 4e-7
+      input_cost_per_token_batches: 2e-7
       output_cost_per_token: 0.0000016
-      output_cost_per_token_batches: 8.e-7
+      output_cost_per_token_batches: 8e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openai/gpt-4.1-mini.yaml
+++ b/providers/openai/gpt-4.1-mini.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 1.e-7
-      input_cost_per_token: 4.e-7
+    - cache_read_input_token_cost: 1e-7
+      input_cost_per_token: 4e-7
       output_cost_per_token: 0.0000016
       region: "*"
 features:

--- a/providers/openai/gpt-4.1-nano-2025-04-14.yaml
+++ b/providers/openai/gpt-4.1-nano-2025-04-14.yaml
@@ -1,9 +1,9 @@
 costs:
     - cache_read_input_token_cost: 2.5e-8
-      input_cost_per_token: 1.e-7
-      input_cost_per_token_batches: 5.e-8
-      output_cost_per_token: 4.e-7
-      output_cost_per_token_batches: 2.e-7
+      input_cost_per_token: 1e-7
+      input_cost_per_token_batches: 5e-8
+      output_cost_per_token: 4e-7
+      output_cost_per_token_batches: 2e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openai/gpt-4.1-nano.yaml
+++ b/providers/openai/gpt-4.1-nano.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_read_input_token_cost: 2.5e-8
-      input_cost_per_token: 1.e-7
-      output_cost_per_token: 4.e-7
+      input_cost_per_token: 1e-7
+      output_cost_per_token: 4e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openai/gpt-4.1.yaml
+++ b/providers/openai/gpt-4.1.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 5.e-7
+    - cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000008

--- a/providers/openai/gpt-4o-mini-2024-07-18.yaml
+++ b/providers/openai/gpt-4o-mini-2024-07-18.yaml
@@ -2,8 +2,8 @@ costs:
     - cache_read_input_token_cost: 7.5e-8
       input_cost_per_token: 1.5e-7
       input_cost_per_token_batches: 7.5e-8
-      output_cost_per_token: 6.e-7
-      output_cost_per_token_batches: 3.e-7
+      output_cost_per_token: 6e-7
+      output_cost_per_token_batches: 3e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openai/gpt-4o-mini-audio-preview.yaml
+++ b/providers/openai/gpt-4o-mini-audio-preview.yaml
@@ -2,7 +2,7 @@ costs:
     - input_cost_per_audio_token: 0.00001
       input_cost_per_token: 1.5e-7
       output_cost_per_audio_token: 0.00002
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openai/gpt-4o-mini-search-preview-2025-03-11.yaml
+++ b/providers/openai/gpt-4o-mini-search-preview-2025-03-11.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: "*"
 features:
     - system_messages

--- a/providers/openai/gpt-4o-mini-search-preview.yaml
+++ b/providers/openai/gpt-4o-mini-search-preview.yaml
@@ -1,7 +1,7 @@
 costs:
     - input_cost_per_query: 0.025
       input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: "*"
 features:
     - system_messages

--- a/providers/openai/gpt-4o-mini-tts-2025-03-20.yaml
+++ b/providers/openai/gpt-4o-mini-tts-2025-03-20.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 6.e-7
+    - input_cost_per_token: 6e-7
       output_cost_per_audio_token: 0.000012
       region: "*"
 limits:

--- a/providers/openai/gpt-4o-mini-tts-2025-12-15.yaml
+++ b/providers/openai/gpt-4o-mini-tts-2025-12-15.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 6.e-7
+    - input_cost_per_token: 6e-7
       output_cost_per_audio_token: 0.000012
       region: "*"
 limits:

--- a/providers/openai/gpt-4o-mini-tts.yaml
+++ b/providers/openai/gpt-4o-mini-tts.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 6.e-7
+    - input_cost_per_token: 6e-7
       output_cost_per_audio_token: 0.000012
       region: "*"
 limits:

--- a/providers/openai/gpt-4o-mini.yaml
+++ b/providers/openai/gpt-4o-mini.yaml
@@ -2,8 +2,8 @@ costs:
     - cache_read_input_token_cost: 7.5e-8
       input_cost_per_token: 1.5e-7
       input_cost_per_token_batches: 7.5e-8
-      output_cost_per_token: 6.e-7
-      output_cost_per_token_batches: 3.e-7
+      output_cost_per_token: 6e-7
+      output_cost_per_token_batches: 3e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openai/gpt-5-nano-2025-08-07.yaml
+++ b/providers/openai/gpt-5-nano-2025-08-07.yaml
@@ -1,9 +1,9 @@
 costs:
-    - cache_read_input_token_cost: 5.e-9
-      input_cost_per_token: 5.e-8
+    - cache_read_input_token_cost: 5e-9
+      input_cost_per_token: 5e-8
       input_cost_per_token_batches: 2.5e-8
-      output_cost_per_token: 4.e-7
-      output_cost_per_token_batches: 2.e-7
+      output_cost_per_token: 4e-7
+      output_cost_per_token_batches: 2e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openai/gpt-5-nano.yaml
+++ b/providers/openai/gpt-5-nano.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_token_cost: 5.e-9
-      input_cost_per_token: 5.e-8
-      output_cost_per_token: 4.e-7
+    - cache_read_input_token_cost: 5e-9
+      input_cost_per_token: 5e-8
+      output_cost_per_token: 4e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openai/gpt-5.4-2026-03-05.yaml
+++ b/providers/openai/gpt-5.4-2026-03-05.yaml
@@ -7,7 +7,7 @@ costs:
       region: "*"
       tiered_pricing:
           cache_read:
-              - cost_per_token: 5.e-7
+              - cost_per_token: 5e-7
                 from: 272000
           input:
               - cost_per_token: 0.000005

--- a/providers/openai/gpt-5.4-nano-2026-03-17.yaml
+++ b/providers/openai/gpt-5.4-nano-2026-03-17.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_token_cost: 2.e-8
-      input_cost_per_token: 2.e-7
-      input_cost_per_token_batches: 1.e-7
+    - cache_read_input_token_cost: 2e-8
+      input_cost_per_token: 2e-7
+      input_cost_per_token_batches: 1e-7
       output_cost_per_token: 0.00000125
       output_cost_per_token_batches: 6.25e-7
       region: "*"

--- a/providers/openai/gpt-5.4-nano.yaml
+++ b/providers/openai/gpt-5.4-nano.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_token_cost: 2.e-8
-      input_cost_per_token: 2.e-7
-      input_cost_per_token_batches: 1.e-7
+    - cache_read_input_token_cost: 2e-8
+      input_cost_per_token: 2e-7
+      input_cost_per_token_batches: 1e-7
       output_cost_per_token: 0.00000125
       output_cost_per_token_batches: 6.25e-7
       region: "*"

--- a/providers/openai/gpt-5.4.yaml
+++ b/providers/openai/gpt-5.4.yaml
@@ -7,7 +7,7 @@ costs:
       region: "*"
       tiered_pricing:
           cache_read:
-              - cost_per_token: 5.e-7
+              - cost_per_token: 5e-7
                 from: 272000
           input:
               - cost_per_token: 0.000005

--- a/providers/openai/gpt-audio-mini-2025-10-06.yaml
+++ b/providers/openai/gpt-audio-mini-2025-10-06.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_audio_token_cost: 3.e-7
+    - cache_read_input_audio_token_cost: 3e-7
       input_cost_per_audio_token: 0.00001
-      input_cost_per_token: 6.e-7
+      input_cost_per_token: 6e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token: 0.0000024
       region: "*"

--- a/providers/openai/gpt-audio-mini-2025-12-15.yaml
+++ b/providers/openai/gpt-audio-mini-2025-12-15.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_audio_token_cost: 3.e-7
+    - cache_read_input_audio_token_cost: 3e-7
       input_cost_per_audio_token: 0.00001
-      input_cost_per_token: 6.e-7
+      input_cost_per_token: 6e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token: 0.0000024
       region: "*"

--- a/providers/openai/gpt-audio-mini.yaml
+++ b/providers/openai/gpt-audio-mini.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_audio_token_cost: 3.e-7
+    - cache_read_input_audio_token_cost: 3e-7
       input_cost_per_audio_token: 0.00001
-      input_cost_per_token: 6.e-7
+      input_cost_per_token: 6e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token: 0.0000024
       region: "*"

--- a/providers/openai/gpt-image-1-mini.yaml
+++ b/providers/openai/gpt-image-1-mini.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_image_token: 0.0000025
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001

--- a/providers/openai/gpt-realtime-1.5.yaml
+++ b/providers/openai/gpt-realtime-1.5.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_audio_token_cost: 4.e-7
-      cache_read_input_token_cost: 4.e-7
+    - cache_read_input_audio_token_cost: 4e-7
+      cache_read_input_token_cost: 4e-7
       input_cost_per_audio_token: 0.000032
       input_cost_per_image_token: 0.000005
       input_cost_per_token: 0.000004

--- a/providers/openai/gpt-realtime-2025-08-28.yaml
+++ b/providers/openai/gpt-realtime-2025-08-28.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_audio_token_cost: 4.e-7
-      cache_read_input_token_cost: 4.e-7
+    - cache_read_input_audio_token_cost: 4e-7
+      cache_read_input_token_cost: 4e-7
       input_cost_per_audio_token: 0.000032
       input_cost_per_token: 0.000004
       output_cost_per_audio_token: 0.000064

--- a/providers/openai/gpt-realtime-mini-2025-10-06.yaml
+++ b/providers/openai/gpt-realtime-mini-2025-10-06.yaml
@@ -1,8 +1,8 @@
 costs:
-    - cache_read_input_audio_token_cost: 3.e-7
-      cache_read_input_token_cost: 6.e-8
+    - cache_read_input_audio_token_cost: 3e-7
+      cache_read_input_token_cost: 6e-8
       input_cost_per_audio_token: 0.00001
-      input_cost_per_token: 6.e-7
+      input_cost_per_token: 6e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token: 0.0000024
       region: "*"

--- a/providers/openai/gpt-realtime-mini-2025-12-15.yaml
+++ b/providers/openai/gpt-realtime-mini-2025-12-15.yaml
@@ -1,9 +1,9 @@
 costs:
-    - cache_read_input_audio_token_cost: 3.e-7
-      cache_read_input_token_cost: 6.e-8
+    - cache_read_input_audio_token_cost: 3e-7
+      cache_read_input_token_cost: 6e-8
       input_cost_per_audio_token: 0.00001
-      input_cost_per_image_token: 8.e-7
-      input_cost_per_token: 6.e-7
+      input_cost_per_image_token: 8e-7
+      input_cost_per_token: 6e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token: 0.0000024
       region: "*"

--- a/providers/openai/gpt-realtime-mini.yaml
+++ b/providers/openai/gpt-realtime-mini.yaml
@@ -1,9 +1,9 @@
 costs:
-    - cache_read_input_audio_token_cost: 3.e-7
-      cache_read_input_token_cost: 6.e-8
+    - cache_read_input_audio_token_cost: 3e-7
+      cache_read_input_token_cost: 6e-8
       input_cost_per_audio_token: 0.00001
-      input_cost_per_image_token: 8.e-7
-      input_cost_per_token: 6.e-7
+      input_cost_per_image_token: 8e-7
+      input_cost_per_token: 6e-7
       output_cost_per_audio_token: 0.00002
       output_cost_per_token: 0.0000024
       region: "*"

--- a/providers/openai/gpt-realtime.yaml
+++ b/providers/openai/gpt-realtime.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_audio_token_cost: 4.e-7
-      cache_read_input_token_cost: 4.e-7
+    - cache_read_input_audio_token_cost: 4e-7
+      cache_read_input_token_cost: 4e-7
       input_cost_per_audio_token: 0.000032
       input_cost_per_image_token: 0.000005
       input_cost_per_token: 0.000004

--- a/providers/openai/o3-2025-04-16.yaml
+++ b/providers/openai/o3-2025-04-16.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 5.e-7
+    - cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000008

--- a/providers/openai/o3.yaml
+++ b/providers/openai/o3.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 5.e-7
+    - cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000008

--- a/providers/openai/o4-mini-deep-research.yaml
+++ b/providers/openai/o4-mini-deep-research.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 5.e-7
+    - cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000008

--- a/providers/openai/text-embedding-3-small.yaml
+++ b/providers/openai/text-embedding-3-small.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-8
-      input_cost_per_token_batches: 1.e-8
+    - input_cost_per_token: 2e-8
+      input_cost_per_token_batches: 1e-8
       output_cost_per_token: 0
       output_cost_per_token_batches: 0
       region: "*"

--- a/providers/openai/text-embedding-ada-002.yaml
+++ b/providers/openai/text-embedding-ada-002.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      input_cost_per_token_batches: 5.e-8
+    - input_cost_per_token: 1e-7
+      input_cost_per_token_batches: 5e-8
       output_cost_per_token: 0
       region: "*"
 limits:

--- a/providers/openrouter/aion-1.0-mini.yaml
+++ b/providers/openrouter/aion-1.0-mini.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 7.e-7
+    - input_cost_per_token: 7e-7
       output_cost_per_token: 0.0000014
       region: "*"
 features:

--- a/providers/openrouter/aion-labs/aion-1.0-mini.yaml
+++ b/providers/openrouter/aion-labs/aion-1.0-mini.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 7.e-7
+    - input_cost_per_token: 7e-7
       output_cost_per_token: 0.0000014
       region: "*"
 limits:

--- a/providers/openrouter/aion-labs/aion-2.0.yaml
+++ b/providers/openrouter/aion-labs/aion-2.0.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
-      input_cost_per_token: 8.e-7
+    - cache_read_input_token_cost: 2e-7
+      input_cost_per_token: 8e-7
       output_cost_per_token: 0.0000016
       region: "*"
 features:

--- a/providers/openrouter/aion-labs/aion-rp-llama-3.1-8b.yaml
+++ b/providers/openrouter/aion-labs/aion-rp-llama-3.1-8b.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 8.e-7
+    - input_cost_per_token: 8e-7
       output_cost_per_token: 0.0000016
       region: "*"
 limits:

--- a/providers/openrouter/aion-rp-llama-3.1-8b.yaml
+++ b/providers/openrouter/aion-rp-llama-3.1-8b.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 8.e-7
+    - input_cost_per_token: 8e-7
       output_cost_per_token: 0.0000016
       region: "*"
 features:

--- a/providers/openrouter/alfredpros/codellama-7b-instruct-solidity.yaml
+++ b/providers/openrouter/alfredpros/codellama-7b-instruct-solidity.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 8.e-7
+    - input_cost_per_token: 8e-7
       output_cost_per_token: 0.0000012
       region: "*"
 limits:

--- a/providers/openrouter/alibaba/tongyi-deepresearch-30b-a3b.yaml
+++ b/providers/openrouter/alibaba/tongyi-deepresearch-30b-a3b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 9.e-8
-      input_cost_per_token: 9.e-8
+    - cache_read_input_token_cost: 9e-8
+      input_cost_per_token: 9e-8
       output_cost_per_token: 4.5e-7
       region: "*"
 features:

--- a/providers/openrouter/allenai/olmo-2-0325-32b-instruct.yaml
+++ b/providers/openrouter/allenai/olmo-2-0325-32b-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 5.e-8
-      output_cost_per_token: 2.e-7
+    - input_cost_per_token: 5e-8
+      output_cost_per_token: 2e-7
       region: "*"
 isDeprecated: true
 limits:

--- a/providers/openrouter/allenai/olmo-3-32b-think.yaml
+++ b/providers/openrouter/allenai/olmo-3-32b-think.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 5.e-7
+      output_cost_per_token: 5e-7
       region: "*"
 deprecationDate: "2026-04-06"
 features:

--- a/providers/openrouter/allenai/olmo-3.1-32b-instruct.yaml
+++ b/providers/openrouter/allenai/olmo-3.1-32b-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 6.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 6e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/allenai/olmo-3.1-32b-think.yaml
+++ b/providers/openrouter/allenai/olmo-3.1-32b-think.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 5.e-7
+      output_cost_per_token: 5e-7
       region: "*"
 deprecationDate: "2026-04-06"
 features:

--- a/providers/openrouter/amazon/nova-2-lite-v1.yaml
+++ b/providers/openrouter/amazon/nova-2-lite-v1.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 3.e-7
+    - input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000025
       region: "*"
 features:

--- a/providers/openrouter/amazon/nova-lite-v1.yaml
+++ b/providers/openrouter/amazon/nova-lite-v1.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 6.e-8
+    - input_cost_per_token: 6e-8
       output_cost_per_token: 2.4e-7
       region: "*"
 features:

--- a/providers/openrouter/amazon/nova-pro-v1.yaml
+++ b/providers/openrouter/amazon/nova-pro-v1.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 8.e-7
+    - input_cost_per_token: 8e-7
       output_cost_per_token: 0.0000032
       region: "*"
 features:

--- a/providers/openrouter/anthropic/claude-3-5-haiku-20241022.yaml
+++ b/providers/openrouter/anthropic/claude-3-5-haiku-20241022.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_creation_input_token_cost: 0.000001
-      cache_read_input_token_cost: 8.e-8
-      input_cost_per_token: 8.e-7
+      cache_read_input_token_cost: 8e-8
+      input_cost_per_token: 8e-7
       output_cost_per_token: 0.000004
       region: "*"
 features:

--- a/providers/openrouter/anthropic/claude-3-5-haiku.yaml
+++ b/providers/openrouter/anthropic/claude-3-5-haiku.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_creation_input_token_cost: 0.000001
-      cache_read_input_token_cost: 8.e-8
-      input_cost_per_token: 8.e-7
+      cache_read_input_token_cost: 8e-8
+      input_cost_per_token: 8e-7
       output_cost_per_token: 0.000004
       region: "*"
 features:

--- a/providers/openrouter/anthropic/claude-3-haiku.yaml
+++ b/providers/openrouter/anthropic/claude-3-haiku.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_creation_input_token_cost: 3.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_creation_input_token_cost: 3e-7
+      cache_read_input_token_cost: 3e-8
       input_cost_per_token: 2.5e-7
       output_cost_per_token: 0.00000125
       region: "*"

--- a/providers/openrouter/anthropic/claude-3.5-haiku.yaml
+++ b/providers/openrouter/anthropic/claude-3.5-haiku.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_creation_input_token_cost: 0.000001
-      cache_read_input_token_cost: 8.e-8
-      input_cost_per_token: 8.e-7
+      cache_read_input_token_cost: 8e-8
+      input_cost_per_token: 8e-7
       output_cost_per_token: 0.000004
       region: "*"
 features:

--- a/providers/openrouter/anthropic/claude-3.5-sonnet.yaml
+++ b/providers/openrouter/anthropic/claude-3.5-sonnet.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 0.0000075
-      cache_read_input_token_cost: 6.e-7
+      cache_read_input_token_cost: 6e-7
       input_cost_per_token: 0.000006
       output_cost_per_token: 0.00003
       region: "*"

--- a/providers/openrouter/anthropic/claude-3.5-sonnet:beta.yaml
+++ b/providers/openrouter/anthropic/claude-3.5-sonnet:beta.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 0.0000075
-      cache_read_input_token_cost: 6.e-7
+      cache_read_input_token_cost: 6e-7
       input_cost_per_token: 0.000006
       output_cost_per_token: 0.00003
       region: "*"

--- a/providers/openrouter/anthropic/claude-3.7-sonnet.yaml
+++ b/providers/openrouter/anthropic/claude-3.7-sonnet.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: "*"

--- a/providers/openrouter/anthropic/claude-haiku-4.5.yaml
+++ b/providers/openrouter/anthropic/claude-haiku-4.5.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 0.00000125
-      cache_read_input_token_cost: 1.e-7
+      cache_read_input_token_cost: 1e-7
       input_cost_per_token: 0.000001
       output_cost_per_token: 0.000005
       region: "*"

--- a/providers/openrouter/anthropic/claude-opus-4.5.yaml
+++ b/providers/openrouter/anthropic/claude-opus-4.5.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       output_cost_per_token: 0.000025
       region: "*"

--- a/providers/openrouter/anthropic/claude-opus-4.6.yaml
+++ b/providers/openrouter/anthropic/claude-opus-4.6.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       output_cost_per_token: 0.000025
       region: "*"

--- a/providers/openrouter/anthropic/claude-opus-4.7.yaml
+++ b/providers/openrouter/anthropic/claude-opus-4.7.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5.e-7
+      cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       output_cost_per_token: 0.000025
       region: "*"

--- a/providers/openrouter/anthropic/claude-sonnet-4.5.yaml
+++ b/providers/openrouter/anthropic/claude-sonnet-4.5.yaml
@@ -1,12 +1,12 @@
 costs:
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: "*"
       tiered_pricing:
           cache_read:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 200000
           cache_write:
               - cost_per_token: 0.0000075

--- a/providers/openrouter/anthropic/claude-sonnet-4.6.yaml
+++ b/providers/openrouter/anthropic/claude-sonnet-4.6.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: "*"

--- a/providers/openrouter/anthropic/claude-sonnet-4.yaml
+++ b/providers/openrouter/anthropic/claude-sonnet-4.yaml
@@ -1,12 +1,12 @@
 costs:
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: "*"
       tiered_pricing:
           cache_read:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 200000
           cache_write:
               - cost_per_token: 0.0000075

--- a/providers/openrouter/arcee-ai/coder-large.yaml
+++ b/providers/openrouter/arcee-ai/coder-large.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 5.e-7
-      output_cost_per_token: 8.e-7
+    - input_cost_per_token: 5e-7
+      output_cost_per_token: 8e-7
       region: "*"
 limits:
     context_window: 32768

--- a/providers/openrouter/arcee-ai/maestro-reasoning.yaml
+++ b/providers/openrouter/arcee-ai/maestro-reasoning.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 9.e-7
+    - input_cost_per_token: 9e-7
       output_cost_per_token: 0.0000033
       region: "*"
 limits:

--- a/providers/openrouter/arcee-ai/trinity-large-thinking.yaml
+++ b/providers/openrouter/arcee-ai/trinity-large-thinking.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 6.e-8
+    - cache_read_input_token_cost: 6e-8
       input_cost_per_token: 2.2e-7
       output_cost_per_token: 8.5e-7
       region: "*"

--- a/providers/openrouter/baidu/ernie-4.5-21b-a3b-thinking.yaml
+++ b/providers/openrouter/baidu/ernie-4.5-21b-a3b-thinking.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 7.e-8
+    - input_cost_per_token: 7e-8
       output_cost_per_token: 2.8e-7
       region: "*"
 limits:

--- a/providers/openrouter/baidu/ernie-4.5-21b-a3b.yaml
+++ b/providers/openrouter/baidu/ernie-4.5-21b-a3b.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 7.e-8
+    - input_cost_per_token: 7e-8
       output_cost_per_token: 2.8e-7
       region: "*"
 features:

--- a/providers/openrouter/bytedance-seed/seed-1.6-flash.yaml
+++ b/providers/openrouter/bytedance-seed/seed-1.6-flash.yaml
@@ -1,13 +1,13 @@
 costs:
     - input_cost_per_token: 7.5e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       region: "*"
       tiered_pricing:
           input:
-              - cost_per_token: 1.e-7
+              - cost_per_token: 1e-7
                 from: 128000
           output:
-              - cost_per_token: 8.e-7
+              - cost_per_token: 8e-7
                 from: 128000
 features:
     - function_calling

--- a/providers/openrouter/bytedance-seed/seed-1.6.yaml
+++ b/providers/openrouter/bytedance-seed/seed-1.6.yaml
@@ -4,7 +4,7 @@ costs:
       region: "*"
       tiered_pricing:
           input:
-              - cost_per_token: 5.e-7
+              - cost_per_token: 5e-7
                 from: 128000
           output:
               - cost_per_token: 0.000004

--- a/providers/openrouter/bytedance-seed/seed-2.0-lite.yaml
+++ b/providers/openrouter/bytedance-seed/seed-2.0-lite.yaml
@@ -4,7 +4,7 @@ costs:
       region: "*"
       tiered_pricing:
           input:
-              - cost_per_token: 5.e-7
+              - cost_per_token: 5e-7
                 from: 128000
           output:
               - cost_per_token: 0.000004

--- a/providers/openrouter/bytedance-seed/seed-2.0-mini.yaml
+++ b/providers/openrouter/bytedance-seed/seed-2.0-mini.yaml
@@ -1,13 +1,13 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 4.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 4e-7
       region: "*"
       tiered_pricing:
           input:
-              - cost_per_token: 2.e-7
+              - cost_per_token: 2e-7
                 from: 128000
           output:
-              - cost_per_token: 8.e-7
+              - cost_per_token: 8e-7
                 from: 128000
 features:
     - function_calling

--- a/providers/openrouter/bytedance/ui-tars-1.5-7b.yaml
+++ b/providers/openrouter/bytedance/ui-tars-1.5-7b.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_token_cost: 1.e-7
-      input_cost_per_token: 1.e-7
-      output_cost_per_token: 2.e-7
+    - cache_read_input_token_cost: 1e-7
+      input_cost_per_token: 1e-7
+      output_cost_per_token: 2e-7
       region: "*"
 limits:
     context_window: 128000

--- a/providers/openrouter/claude-3-haiku.yaml
+++ b/providers/openrouter/claude-3-haiku.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_creation_input_token_cost: 3.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_creation_input_token_cost: 3e-7
+      cache_read_input_token_cost: 3e-8
       input_cost_per_token: 2.5e-7
       output_cost_per_token: 0.00000125
       region: "*"

--- a/providers/openrouter/claude-3-haiku:beta.yaml
+++ b/providers/openrouter/claude-3-haiku:beta.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_creation_input_token_cost: 3.e-7
-      cache_read_input_token_cost: 3.e-8
+    - cache_creation_input_token_cost: 3e-7
+      cache_read_input_token_cost: 3e-8
       input_cost_per_token: 2.5e-7
       output_cost_per_token: 0.00000125
       region: "*"

--- a/providers/openrouter/claude-3.5-haiku-20241022.yaml
+++ b/providers/openrouter/claude-3.5-haiku-20241022.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_creation_input_token_cost: 0.000001
-      cache_read_input_token_cost: 8.e-8
-      input_cost_per_token: 8.e-7
+      cache_read_input_token_cost: 8e-8
+      input_cost_per_token: 8e-7
       output_cost_per_token: 0.000004
       region: "*"
 features:

--- a/providers/openrouter/claude-3.5-haiku.yaml
+++ b/providers/openrouter/claude-3.5-haiku.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_creation_input_token_cost: 0.000001
-      cache_read_input_token_cost: 8.e-8
-      input_cost_per_token: 8.e-7
+      cache_read_input_token_cost: 8e-8
+      input_cost_per_token: 8e-7
       output_cost_per_token: 0.000004
       region: "*"
 features:

--- a/providers/openrouter/claude-3.5-haiku:beta.yaml
+++ b/providers/openrouter/claude-3.5-haiku:beta.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_creation_input_token_cost: 0.000001
-      cache_read_input_token_cost: 8.e-8
-      input_cost_per_token: 8.e-7
+      cache_read_input_token_cost: 8e-8
+      input_cost_per_token: 8e-7
       output_cost_per_token: 0.000004
       region: "*"
 features:

--- a/providers/openrouter/claude-3.5-sonnet.yaml
+++ b/providers/openrouter/claude-3.5-sonnet.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 0.0000075
-      cache_read_input_token_cost: 6.e-7
+      cache_read_input_token_cost: 6e-7
       input_cost_per_token: 0.000006
       output_cost_per_token: 0.00003
       region: "*"

--- a/providers/openrouter/claude-3.5-sonnet:beta.yaml
+++ b/providers/openrouter/claude-3.5-sonnet:beta.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 0.0000075
-      cache_read_input_token_cost: 6.e-7
+      cache_read_input_token_cost: 6e-7
       input_cost_per_token: 0.000006
       output_cost_per_token: 0.00003
       region: "*"

--- a/providers/openrouter/claude-3.7-sonnet:beta.yaml
+++ b/providers/openrouter/claude-3.7-sonnet:beta.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: "*"

--- a/providers/openrouter/claude-3.7-sonnet:thinking.yaml
+++ b/providers/openrouter/claude-3.7-sonnet:thinking.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 0.000006
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: "*"

--- a/providers/openrouter/claude-sonnet-4.yaml
+++ b/providers/openrouter/claude-sonnet-4.yaml
@@ -1,12 +1,12 @@
 costs:
     - cache_creation_input_token_cost: 0.00000375
-      cache_read_input_token_cost: 3.e-7
+      cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
       output_cost_per_token: 0.000015
       region: "*"
       tiered_pricing:
           cache_read:
-              - cost_per_token: 6.e-7
+              - cost_per_token: 6e-7
                 from: 200000
           cache_write:
               - cost_per_token: 0.0000075

--- a/providers/openrouter/cognitivecomputations/dolphin-mixtral-8x7b.yaml
+++ b/providers/openrouter/cognitivecomputations/dolphin-mixtral-8x7b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 5.e-7
-      output_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
+      output_cost_per_token: 5e-7
       region: "*"
 limits:
     context_window: 32768

--- a/providers/openrouter/cohere/command-r-08-2024.yaml
+++ b/providers/openrouter/cohere/command-r-08-2024.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/command-r-03-2024.yaml
+++ b/providers/openrouter/command-r-03-2024.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
       output_cost_per_token: 0.0000015
       region: "*"
 features:

--- a/providers/openrouter/command-r-08-2024.yaml
+++ b/providers/openrouter/command-r-08-2024.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/databricks/dbrx-instruct.yaml
+++ b/providers/openrouter/databricks/dbrx-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 6.e-7
-      output_cost_per_token: 6.e-7
+    - input_cost_per_token: 6e-7
+      output_cost_per_token: 6e-7
       region: "*"
 limits:
     context_window: 32768

--- a/providers/openrouter/deepseek-chat-v3-0324.yaml
+++ b/providers/openrouter/deepseek-chat-v3-0324.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_read_input_token_cost: 1.35e-7
-      input_cost_per_token: 2.e-7
+      input_cost_per_token: 2e-7
       output_cost_per_token: 7.7e-7
       region: "*"
 features:

--- a/providers/openrouter/deepseek-r1-distill-llama-70b.yaml
+++ b/providers/openrouter/deepseek-r1-distill-llama-70b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 7.e-7
-      output_cost_per_token: 8.e-7
+    - input_cost_per_token: 7e-7
+      output_cost_per_token: 8e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/deepseek-r1.yaml
+++ b/providers/openrouter/deepseek-r1.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 7.e-7
+    - input_cost_per_token: 7e-7
       output_cost_per_token: 0.0000025
       region: "*"
 features:

--- a/providers/openrouter/deepseek-r1t2-chimera.yaml
+++ b/providers/openrouter/deepseek-r1t2-chimera.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_read_input_token_cost: 1.5e-7
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000011
       region: "*"
 features:

--- a/providers/openrouter/deepseek/deepseek-chat-v3-0324.yaml
+++ b/providers/openrouter/deepseek/deepseek-chat-v3-0324.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_read_input_token_cost: 1.35e-7
-      input_cost_per_token: 2.e-7
+      input_cost_per_token: 2e-7
       output_cost_per_token: 7.7e-7
       region: "*"
 features:

--- a/providers/openrouter/deepseek/deepseek-r1-0528.yaml
+++ b/providers/openrouter/deepseek/deepseek-r1-0528.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_read_input_token_cost: 3.5e-7
-      input_cost_per_token: 5.e-7
+      input_cost_per_token: 5e-7
       output_cost_per_token: 0.00000215
       region: "*"
 features:

--- a/providers/openrouter/deepseek/deepseek-r1-distill-llama-70b.yaml
+++ b/providers/openrouter/deepseek/deepseek-r1-distill-llama-70b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 7.e-7
-      output_cost_per_token: 8.e-7
+    - input_cost_per_token: 7e-7
+      output_cost_per_token: 8e-7
       region: "*"
 features:
     - json_output

--- a/providers/openrouter/deepseek/deepseek-r1.yaml
+++ b/providers/openrouter/deepseek/deepseek-r1.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 7.e-7
+    - input_cost_per_token: 7e-7
       output_cost_per_token: 0.0000025
       region: "*"
 features:

--- a/providers/openrouter/deepseek/deepseek-v3.2-speciale.yaml
+++ b/providers/openrouter/deepseek/deepseek-v3.2-speciale.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
-      input_cost_per_token: 4.e-7
+    - cache_read_input_token_cost: 2e-7
+      input_cost_per_token: 4e-7
       output_cost_per_token: 0.0000012
       region: "*"
 features:

--- a/providers/openrouter/devstral-medium.yaml
+++ b/providers/openrouter/devstral-medium.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 4.e-8
-      input_cost_per_token: 4.e-7
+    - cache_read_input_token_cost: 4e-8
+      input_cost_per_token: 4e-7
       output_cost_per_token: 0.000002
       region: "*"
 features:

--- a/providers/openrouter/devstral-small.yaml
+++ b/providers/openrouter/devstral-small.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_token_cost: 1.e-8
-      input_cost_per_token: 1.e-7
-      output_cost_per_token: 3.e-7
+    - cache_read_input_token_cost: 1e-8
+      input_cost_per_token: 1e-7
+      output_cost_per_token: 3e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/fireworks/firellava-13b.yaml
+++ b/providers/openrouter/fireworks/firellava-13b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 2.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 2e-7
       region: "*"
 limits:
     context_window: 4096

--- a/providers/openrouter/gemini-2.5-flash-lite.yaml
+++ b/providers/openrouter/gemini-2.5-flash-lite.yaml
@@ -1,14 +1,14 @@
 costs:
-    - cache_read_input_audio_token_cost: 3.e-8
-      cache_read_input_token_cost: 1.e-8
+    - cache_read_input_audio_token_cost: 3e-8
+      cache_read_input_token_cost: 1e-8
       cache_storage_cost_per_token_per_hour: 0.000001
-      input_cost_per_audio_token: 3.e-7
-      input_cost_per_image_token: 1.e-7
-      input_cost_per_token: 1.e-7
-      input_cost_per_token_batches: 5.e-8
-      input_cost_per_video_token: 1.e-7
-      output_cost_per_token: 4.e-7
-      output_cost_per_token_batches: 2.e-7
+      input_cost_per_audio_token: 3e-7
+      input_cost_per_image_token: 1e-7
+      input_cost_per_token: 1e-7
+      input_cost_per_token_batches: 5e-8
+      input_cost_per_video_token: 1e-7
+      output_cost_per_token: 4e-7
+      output_cost_per_token_batches: 2e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/gemini-2.5-flash.yaml
+++ b/providers/openrouter/gemini-2.5-flash.yaml
@@ -1,10 +1,10 @@
 costs:
     - cache_creation_input_token_cost: 8.33e-8
-      cache_read_input_token_cost: 3.e-8
+      cache_read_input_token_cost: 3e-8
       input_cost_per_audio_token: 0.000001
-      input_cost_per_image_token: 3.e-7
-      input_cost_per_token: 3.e-7
-      input_cost_per_video_token: 3.e-7
+      input_cost_per_image_token: 3e-7
+      input_cost_per_token: 3e-7
+      input_cost_per_video_token: 3e-7
       output_cost_per_token: 0.0000025
       region: "*"
 features:

--- a/providers/openrouter/gemma-2-9b-it.yaml
+++ b/providers/openrouter/gemma-2-9b-it.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 3.e-8
-      output_cost_per_token: 9.e-8
+    - input_cost_per_token: 3e-8
+      output_cost_per_token: 9e-8
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/gemma-3-12b-it.yaml
+++ b/providers/openrouter/gemma-3-12b-it.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 4.e-8
+    - input_cost_per_token: 4e-8
       output_cost_per_token: 1.3e-7
       region: "*"
 features:

--- a/providers/openrouter/gemma-3-27b-it.yaml
+++ b/providers/openrouter/gemma-3-27b-it.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 8.e-8
+    - input_cost_per_token: 8e-8
       output_cost_per_token: 1.6e-7
       region: "*"
 features:

--- a/providers/openrouter/gemma-3-4b-it.yaml
+++ b/providers/openrouter/gemma-3-4b-it.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 4.e-8
-      output_cost_per_token: 8.e-8
+    - input_cost_per_token: 4e-8
+      output_cost_per_token: 8e-8
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/gemma-3n-e4b-it.yaml
+++ b/providers/openrouter/gemma-3n-e4b-it.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-8
-      output_cost_per_token: 4.e-8
+    - input_cost_per_token: 2e-8
+      output_cost_per_token: 4e-8
       region: "*"
 limits:
     context_window: 32768

--- a/providers/openrouter/glm-4-32b.yaml
+++ b/providers/openrouter/glm-4-32b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 1.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 1e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/glm-4.5.yaml
+++ b/providers/openrouter/glm-4.5.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_read_input_token_cost: 1.1e-7
-      input_cost_per_token: 6.e-7
+      input_cost_per_token: 6e-7
       output_cost_per_token: 0.0000022
       region: "*"
 features:

--- a/providers/openrouter/google/gemini-2.0-flash-001.yaml
+++ b/providers/openrouter/google/gemini-2.0-flash-001.yaml
@@ -2,9 +2,9 @@ costs:
     - cache_creation_input_token_cost: 8.333333333333334e-8
       cache_read_input_token_cost: 2.5e-8
       cache_storage_cost_per_token_per_hour: 0.000001
-      input_cost_per_audio_token: 7.e-7
-      input_cost_per_token: 1.e-7
-      output_cost_per_token: 4.e-7
+      input_cost_per_audio_token: 7e-7
+      input_cost_per_token: 1e-7
+      output_cost_per_token: 4e-7
       region: "*"
 deprecationDate: "2026-06-01"
 features:

--- a/providers/openrouter/google/gemini-2.5-flash-image.yaml
+++ b/providers/openrouter/google/gemini-2.5-flash-image.yaml
@@ -1,9 +1,9 @@
 costs:
     - cache_creation_input_token_cost: 8.33e-8
-      cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+      cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       output_cost_per_image_token: 0.00003
       output_cost_per_token: 0.0000025
       region: "*"

--- a/providers/openrouter/google/gemini-2.5-flash-lite-preview-09-2025.yaml
+++ b/providers/openrouter/google/gemini-2.5-flash-lite-preview-09-2025.yaml
@@ -1,11 +1,11 @@
 costs:
     - cache_creation_input_token_cost: 8.33e-8
-      cache_read_input_audio_token_cost: 3.e-8
-      cache_read_input_token_cost: 1.e-8
+      cache_read_input_audio_token_cost: 3e-8
+      cache_read_input_token_cost: 1e-8
       cache_storage_cost_per_token_per_hour: 0.000001
-      input_cost_per_audio_token: 3.e-7
-      input_cost_per_token: 1.e-7
-      output_cost_per_token: 4.e-7
+      input_cost_per_audio_token: 3e-7
+      input_cost_per_token: 1e-7
+      output_cost_per_token: 4e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/google/gemini-2.5-flash-lite.yaml
+++ b/providers/openrouter/google/gemini-2.5-flash-lite.yaml
@@ -1,10 +1,10 @@
 costs:
     - cache_creation_input_token_cost: 8.33e-8
-      cache_read_input_audio_token_cost: 3.e-8
-      cache_read_input_token_cost: 1.e-8
-      input_cost_per_audio_token: 3.e-7
-      input_cost_per_token: 1.e-7
-      output_cost_per_token: 4.e-7
+      cache_read_input_audio_token_cost: 3e-8
+      cache_read_input_token_cost: 1e-8
+      input_cost_per_audio_token: 3e-7
+      input_cost_per_token: 1e-7
+      output_cost_per_token: 4e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/google/gemini-2.5-flash.yaml
+++ b/providers/openrouter/google/gemini-2.5-flash.yaml
@@ -1,9 +1,9 @@
 costs:
     - cache_creation_input_token_cost: 8.33e-8
-      cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 3.e-8
+      cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 3e-8
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000025
       region: "*"
 features:

--- a/providers/openrouter/google/gemini-3-flash-preview.yaml
+++ b/providers/openrouter/google/gemini-3-flash-preview.yaml
@@ -1,9 +1,9 @@
 costs:
     - cache_creation_input_token_cost: 8.333333333333334e-8
-      cache_read_input_audio_token_cost: 1.e-7
-      cache_read_input_token_cost: 5.e-8
+      cache_read_input_audio_token_cost: 1e-7
+      cache_read_input_token_cost: 5e-8
       input_cost_per_audio_token: 0.000001
-      input_cost_per_token: 5.e-7
+      input_cost_per_token: 5e-7
       output_cost_per_token: 0.000003
       region: "*"
 features:

--- a/providers/openrouter/google/gemini-3-pro-image-preview.yaml
+++ b/providers/openrouter/google/gemini-3-pro-image-preview.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_creation_input_token_cost: 3.75e-7
-      cache_read_input_token_cost: 2.e-7
+      cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       output_cost_per_image_token: 0.00012
       output_cost_per_token: 0.000012

--- a/providers/openrouter/google/gemini-3.1-flash-image-preview.yaml
+++ b/providers/openrouter/google/gemini-3.1-flash-image-preview.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
       output_cost_per_image_token: 0.00006
       output_cost_per_token: 0.000003
       region: "*"

--- a/providers/openrouter/google/gemini-3.1-flash-lite-preview.yaml
+++ b/providers/openrouter/google/gemini-3.1-flash-lite-preview.yaml
@@ -1,8 +1,8 @@
 costs:
     - cache_creation_input_token_cost: 8.333333333333334e-8
-      cache_read_input_audio_token_cost: 5.e-8
+      cache_read_input_audio_token_cost: 5e-8
       cache_read_input_token_cost: 2.5e-8
-      input_cost_per_audio_token: 5.e-7
+      input_cost_per_audio_token: 5e-7
       input_cost_per_token: 2.5e-7
       output_cost_per_token: 0.0000015
       region: "*"

--- a/providers/openrouter/google/gemini-3.1-pro-preview-customtools.yaml
+++ b/providers/openrouter/google/gemini-3.1-pro-preview-customtools.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_creation_input_token_cost: 3.75e-7
-      cache_read_input_audio_token_cost: 2.e-7
-      cache_read_input_token_cost: 2.e-7
+      cache_read_input_audio_token_cost: 2e-7
+      cache_read_input_token_cost: 2e-7
       cache_storage_cost_per_token_per_hour: 0.0000045
       input_cost_per_audio_token: 0.000002
       input_cost_per_token: 0.000002
@@ -9,7 +9,7 @@ costs:
       region: "*"
       tiered_pricing:
           cache_read:
-              - cost_per_token: 4.e-7
+              - cost_per_token: 4e-7
                 from: 200000
           input:
               - cost_per_token: 0.000004

--- a/providers/openrouter/google/gemini-3.1-pro-preview.yaml
+++ b/providers/openrouter/google/gemini-3.1-pro-preview.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       cache_storage_cost_per_token_per_hour: 0.0000045
       input_cost_per_audio_token: 0.000002
       input_cost_per_token: 0.000002
@@ -7,7 +7,7 @@ costs:
       region: "*"
       tiered_pricing:
           cache_read:
-              - cost_per_token: 4.e-7
+              - cost_per_token: 4e-7
                 from: 200000
           input:
               - cost_per_token: 0.000004

--- a/providers/openrouter/google/gemma-3-12b-it.yaml
+++ b/providers/openrouter/google/gemma-3-12b-it.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 4.e-8
+    - input_cost_per_token: 4e-8
       output_cost_per_token: 1.3e-7
       region: "*"
 features:

--- a/providers/openrouter/google/gemma-3-27b-it.yaml
+++ b/providers/openrouter/google/gemma-3-27b-it.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 8.e-8
+    - input_cost_per_token: 8e-8
       output_cost_per_token: 1.6e-7
       region: "*"
 features:

--- a/providers/openrouter/google/gemma-3-4b-it.yaml
+++ b/providers/openrouter/google/gemma-3-4b-it.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 4.e-8
-      output_cost_per_token: 8.e-8
+    - input_cost_per_token: 4e-8
+      output_cost_per_token: 8e-8
       region: "*"
 features:
     - json_output

--- a/providers/openrouter/google/gemma-3n-e4b-it.yaml
+++ b/providers/openrouter/google/gemma-3n-e4b-it.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 6.e-8
+    - input_cost_per_token: 6e-8
       output_cost_per_token: 1.2e-7
       region: "*"
 limits:

--- a/providers/openrouter/google/gemma-4-26b-a4b-it.yaml
+++ b/providers/openrouter/google/gemma-4-26b-a4b-it.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 8.e-8
+    - input_cost_per_token: 8e-8
       output_cost_per_token: 3.5e-7
       region: "*"
 features:

--- a/providers/openrouter/google/gemma-4-31b-it.yaml
+++ b/providers/openrouter/google/gemma-4-31b-it.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-8
+    - cache_read_input_token_cost: 2e-8
       input_cost_per_token: 1.3e-7
       output_cost_per_token: 3.8e-7
       region: "*"

--- a/providers/openrouter/google/palm-2-chat-bison.yaml
+++ b/providers/openrouter/google/palm-2-chat-bison.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 5.e-7
-      output_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
+      output_cost_per_token: 5e-7
       region: "*"
 limits:
     context_window: 9216

--- a/providers/openrouter/google/palm-2-codechat-bison.yaml
+++ b/providers/openrouter/google/palm-2-codechat-bison.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 5.e-7
-      output_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
+      output_cost_per_token: 5e-7
       region: "*"
 limits:
     context_window: 7168

--- a/providers/openrouter/gpt-3.5-turbo.yaml
+++ b/providers/openrouter/gpt-3.5-turbo.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
       output_cost_per_token: 0.0000015
       region: "*"
 features:

--- a/providers/openrouter/gpt-4.1-mini.yaml
+++ b/providers/openrouter/gpt-4.1-mini.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 1.e-7
-      input_cost_per_token: 4.e-7
+    - cache_read_input_token_cost: 1e-7
+      input_cost_per_token: 4e-7
       output_cost_per_token: 0.0000016
       region: "*"
 features:

--- a/providers/openrouter/gpt-4.1-nano.yaml
+++ b/providers/openrouter/gpt-4.1-nano.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_read_input_token_cost: 2.5e-8
-      input_cost_per_token: 1.e-7
-      output_cost_per_token: 4.e-7
+      input_cost_per_token: 1e-7
+      output_cost_per_token: 4e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/gpt-4.1.yaml
+++ b/providers/openrouter/gpt-4.1.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 5.e-7
+    - cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000008
       region: "*"

--- a/providers/openrouter/gpt-4o-mini-2024-07-18.yaml
+++ b/providers/openrouter/gpt-4o-mini-2024-07-18.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_read_input_token_cost: 7.5e-8
       input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/gpt-4o-mini.yaml
+++ b/providers/openrouter/gpt-4o-mini.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_read_input_token_cost: 7.5e-8
       input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/gpt-oss-20b.yaml
+++ b/providers/openrouter/gpt-oss-20b.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_read_input_token_cost: 1.5e-8
-      input_cost_per_token: 3.e-8
+      input_cost_per_token: 3e-8
       output_cost_per_token: 1.1e-7
       region: "*"
 features:

--- a/providers/openrouter/grok-3-mini-beta.yaml
+++ b/providers/openrouter/grok-3-mini-beta.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_read_input_token_cost: 7.5e-8
-      input_cost_per_token: 3.e-7
-      output_cost_per_token: 5.e-7
+      input_cost_per_token: 3e-7
+      output_cost_per_token: 5e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/grok-3-mini.yaml
+++ b/providers/openrouter/grok-3-mini.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_read_input_token_cost: 7.5e-8
-      input_cost_per_token: 3.e-7
-      output_cost_per_token: 5.e-7
+      input_cost_per_token: 3e-7
+      output_cost_per_token: 5e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/gryphe/mythomax-l2-13b.yaml
+++ b/providers/openrouter/gryphe/mythomax-l2-13b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 6.e-8
-      output_cost_per_token: 6.e-8
+    - input_cost_per_token: 6e-8
+      output_cost_per_token: 6e-8
       region: "*"
 features:
     - json_output

--- a/providers/openrouter/hermes-3-llama-3.1-70b.yaml
+++ b/providers/openrouter/hermes-3-llama-3.1-70b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 3.e-7
-      output_cost_per_token: 3.e-7
+    - input_cost_per_token: 3e-7
+      output_cost_per_token: 3e-7
       region: "*"
 limits:
     context_window: 131072

--- a/providers/openrouter/kwaipilot/kat-coder-pro-v2.yaml
+++ b/providers/openrouter/kwaipilot/kat-coder-pro-v2.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 6.e-8
-      input_cost_per_token: 3.e-7
+    - cache_read_input_token_cost: 6e-8
+      input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000012
       region: "*"
 features:

--- a/providers/openrouter/liquid/lfm-2-24b-a2b.yaml
+++ b/providers/openrouter/liquid/lfm-2-24b-a2b.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 3.e-8
+    - input_cost_per_token: 3e-8
       output_cost_per_token: 1.2e-7
       region: "*"
 limits:

--- a/providers/openrouter/liquid/lfm-2.2-6b.yaml
+++ b/providers/openrouter/liquid/lfm-2.2-6b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 1.e-8
-      output_cost_per_token: 2.e-8
+    - input_cost_per_token: 1e-8
+      output_cost_per_token: 2e-8
       region: "*"
 limits:
     context_window: 32768

--- a/providers/openrouter/liquid/lfm2-8b-a1b.yaml
+++ b/providers/openrouter/liquid/lfm2-8b-a1b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 1.e-8
-      output_cost_per_token: 2.e-8
+    - input_cost_per_token: 1e-8
+      output_cost_per_token: 2e-8
       region: "*"
 limits:
     context_window: 8192

--- a/providers/openrouter/llama-3-8b-instruct.yaml
+++ b/providers/openrouter/llama-3-8b-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 3.e-8
-      output_cost_per_token: 4.e-8
+    - input_cost_per_token: 3e-8
+      output_cost_per_token: 4e-8
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/llama-3.1-70b-instruct.yaml
+++ b/providers/openrouter/llama-3.1-70b-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 4.e-7
-      output_cost_per_token: 4.e-7
+    - input_cost_per_token: 4e-7
+      output_cost_per_token: 4e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/llama-3.1-8b-instruct.yaml
+++ b/providers/openrouter/llama-3.1-8b-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-8
-      output_cost_per_token: 5.e-8
+    - input_cost_per_token: 2e-8
+      output_cost_per_token: 5e-8
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/llama-3.1-nemotron-ultra-253b-v1.yaml
+++ b/providers/openrouter/llama-3.1-nemotron-ultra-253b-v1.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 6.e-7
+    - input_cost_per_token: 6e-7
       output_cost_per_token: 0.0000018
       region: "*"
 features:

--- a/providers/openrouter/llama-3.2-1b-instruct.yaml
+++ b/providers/openrouter/llama-3.2-1b-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 2.7e-8
-      output_cost_per_token: 2.e-7
+      output_cost_per_token: 2e-7
       region: "*"
 limits:
     context_window: 60000

--- a/providers/openrouter/llama-3.3-70b-instruct.yaml
+++ b/providers/openrouter/llama-3.3-70b-instruct.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 1.e-7
+    - input_cost_per_token: 1e-7
       output_cost_per_token: 3.2e-7
       region: "*"
 features:

--- a/providers/openrouter/llama-4-maverick.yaml
+++ b/providers/openrouter/llama-4-maverick.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/llama-4-scout.yaml
+++ b/providers/openrouter/llama-4-scout.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 8.e-8
-      output_cost_per_token: 3.e-7
+    - input_cost_per_token: 8e-8
+      output_cost_per_token: 3e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/llama-guard-3-8b.yaml
+++ b/providers/openrouter/llama-guard-3-8b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-8
-      output_cost_per_token: 6.e-8
+    - input_cost_per_token: 2e-8
+      output_cost_per_token: 6e-8
       region: "*"
 limits:
     context_window: 131072

--- a/providers/openrouter/llemma_7b.yaml
+++ b/providers/openrouter/llemma_7b.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 8.e-7
+    - input_cost_per_token: 8e-7
       output_cost_per_token: 0.0000012
       region: "*"
 limits:

--- a/providers/openrouter/maestro-reasoning.yaml
+++ b/providers/openrouter/maestro-reasoning.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 9.e-7
+    - input_cost_per_token: 9e-7
       output_cost_per_token: 0.0000033
       region: "*"
 features:

--- a/providers/openrouter/magistral-small-2506.yaml
+++ b/providers/openrouter/magistral-small-2506.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
       output_cost_per_token: 0.0000015
       region: "*"
 deprecationDate: "2025-10-31"

--- a/providers/openrouter/meituan/longcat-flash-chat.yaml
+++ b/providers/openrouter/meituan/longcat-flash-chat.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 8.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 8e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/meta-llama/codellama-34b-instruct.yaml
+++ b/providers/openrouter/meta-llama/codellama-34b-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 5.e-7
-      output_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
+      output_cost_per_token: 5e-7
       region: "*"
 limits:
     context_window: 8192

--- a/providers/openrouter/meta-llama/llama-2-13b-chat.yaml
+++ b/providers/openrouter/meta-llama/llama-2-13b-chat.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 2.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 2e-7
       region: "*"
 limits:
     context_window: 4096

--- a/providers/openrouter/meta-llama/llama-3-8b-instruct.yaml
+++ b/providers/openrouter/meta-llama/llama-3-8b-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 3.e-8
-      output_cost_per_token: 4.e-8
+    - input_cost_per_token: 3e-8
+      output_cost_per_token: 4e-8
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/meta-llama/llama-3.1-70b-instruct.yaml
+++ b/providers/openrouter/meta-llama/llama-3.1-70b-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 4.e-7
-      output_cost_per_token: 4.e-7
+    - input_cost_per_token: 4e-7
+      output_cost_per_token: 4e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/meta-llama/llama-3.1-8b-instruct.yaml
+++ b/providers/openrouter/meta-llama/llama-3.1-8b-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-8
-      output_cost_per_token: 5.e-8
+    - input_cost_per_token: 2e-8
+      output_cost_per_token: 5e-8
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/meta-llama/llama-3.2-1b-instruct.yaml
+++ b/providers/openrouter/meta-llama/llama-3.2-1b-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 2.7e-8
-      output_cost_per_token: 2.e-7
+      output_cost_per_token: 2e-7
       region: "*"
 limits:
     context_window: 60000

--- a/providers/openrouter/meta-llama/llama-4-maverick.yaml
+++ b/providers/openrouter/meta-llama/llama-4-maverick.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/meta-llama/llama-4-scout.yaml
+++ b/providers/openrouter/meta-llama/llama-4-scout.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 8.e-8
-      output_cost_per_token: 3.e-7
+    - input_cost_per_token: 8e-8
+      output_cost_per_token: 3e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/meta-llama/llama-guard-3-8b.yaml
+++ b/providers/openrouter/meta-llama/llama-guard-3-8b.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 4.8e-7
-      output_cost_per_token: 3.e-8
+      output_cost_per_token: 3e-8
       region: "*"
 limits:
     context_window: 131072

--- a/providers/openrouter/minimax-01.yaml
+++ b/providers/openrouter/minimax-01.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 2.e-7
+    - input_cost_per_token: 2e-7
       output_cost_per_token: 0.0000011
       region: "*"
 features:

--- a/providers/openrouter/minimax-m1.yaml
+++ b/providers/openrouter/minimax-m1.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 4.e-7
+    - input_cost_per_token: 4e-7
       output_cost_per_token: 0.0000022
       region: "*"
       tiered_pricing:

--- a/providers/openrouter/minimax/minimax-01.yaml
+++ b/providers/openrouter/minimax/minimax-01.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 2.e-7
+    - input_cost_per_token: 2e-7
       output_cost_per_token: 0.0000011
       region: "*"
 limits:

--- a/providers/openrouter/minimax/minimax-m1.yaml
+++ b/providers/openrouter/minimax/minimax-m1.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 4.e-7
+    - input_cost_per_token: 4e-7
       output_cost_per_token: 0.0000022
       region: "*"
       tiered_pricing:

--- a/providers/openrouter/minimax/minimax-m2-her.yaml
+++ b/providers/openrouter/minimax/minimax-m2-her.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_creation_input_token_cost: 3.75e-7
-      cache_read_input_token_cost: 3.e-8
-      input_cost_per_token: 3.e-7
+      cache_read_input_token_cost: 3e-8
+      input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000012
       region: "*"
 features:

--- a/providers/openrouter/minimax/minimax-m2.1.yaml
+++ b/providers/openrouter/minimax/minimax-m2.1.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 3.e-8
+    - cache_read_input_token_cost: 3e-8
       input_cost_per_token: 2.9e-7
       output_cost_per_token: 9.5e-7
       region: "*"

--- a/providers/openrouter/minimax/minimax-m2.7.yaml
+++ b/providers/openrouter/minimax/minimax-m2.7.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 6.e-8
-      input_cost_per_token: 3.e-7
+    - cache_read_input_token_cost: 6e-8
+      input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000012
       region: "*"
 features:

--- a/providers/openrouter/minimax/minimax-m2.yaml
+++ b/providers/openrouter/minimax/minimax-m2.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 3.e-8
+    - cache_read_input_token_cost: 3e-8
       input_cost_per_token: 2.55e-7
       output_cost_per_token: 0.000001
       region: "*"

--- a/providers/openrouter/mistral-large-2407.yaml
+++ b/providers/openrouter/mistral-large-2407.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000006
       region: "*"

--- a/providers/openrouter/mistral-large-2411.yaml
+++ b/providers/openrouter/mistral-large-2411.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000006
       region: "*"

--- a/providers/openrouter/mistral-large.yaml
+++ b/providers/openrouter/mistral-large.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000006
       region: "*"

--- a/providers/openrouter/mistral-medium-3.yaml
+++ b/providers/openrouter/mistral-medium-3.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 4.e-8
-      input_cost_per_token: 4.e-7
+    - cache_read_input_token_cost: 4e-8
+      input_cost_per_token: 4e-7
       output_cost_per_token: 0.000002
       region: "*"
 features:

--- a/providers/openrouter/mistral-nemo.yaml
+++ b/providers/openrouter/mistral-nemo.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-8
-      output_cost_per_token: 4.e-8
+    - input_cost_per_token: 2e-8
+      output_cost_per_token: 4e-8
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/mistral-saba.yaml
+++ b/providers/openrouter/mistral-saba.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 6.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 6e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/mistral-small-24b-instruct-2501.yaml
+++ b/providers/openrouter/mistral-small-24b-instruct-2501.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 5.e-8
-      output_cost_per_token: 8.e-8
+    - input_cost_per_token: 5e-8
+      output_cost_per_token: 8e-8
       region: "*"
 limits:
     context_window: 32768

--- a/providers/openrouter/mistral-small-3.1-24b-instruct.yaml
+++ b/providers/openrouter/mistral-small-3.1-24b-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_read_input_token_cost: 1.5e-8
-      input_cost_per_token: 3.e-8
+      input_cost_per_token: 3e-8
       output_cost_per_token: 1.1e-7
       region: "*"
 features:

--- a/providers/openrouter/mistral-small-3.2-24b-instruct.yaml
+++ b/providers/openrouter/mistral-small-3.2-24b-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 7.5e-8
-      output_cost_per_token: 2.e-7
+      output_cost_per_token: 2e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/mistral-small.yaml
+++ b/providers/openrouter/mistral-small.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 3.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 3e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/mistralai/codestral-2508.yaml
+++ b/providers/openrouter/mistralai/codestral-2508.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_token_cost: 3.e-8
-      input_cost_per_token: 3.e-7
-      output_cost_per_token: 9.e-7
+    - cache_read_input_token_cost: 3e-8
+      input_cost_per_token: 3e-7
+      output_cost_per_token: 9e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/mistralai/devstral-2512.yaml
+++ b/providers/openrouter/mistralai/devstral-2512.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 4.e-8
-      input_cost_per_token: 4.e-7
+    - cache_read_input_token_cost: 4e-8
+      input_cost_per_token: 4e-7
       output_cost_per_token: 0.000002
       region: "*"
 features:

--- a/providers/openrouter/mistralai/devstral-medium.yaml
+++ b/providers/openrouter/mistralai/devstral-medium.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 4.e-8
-      input_cost_per_token: 4.e-7
+    - cache_read_input_token_cost: 4e-8
+      input_cost_per_token: 4e-7
       output_cost_per_token: 0.000002
       region: "*"
 features:

--- a/providers/openrouter/mistralai/devstral-small.yaml
+++ b/providers/openrouter/mistralai/devstral-small.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_token_cost: 1.e-8
-      input_cost_per_token: 1.e-7
-      output_cost_per_token: 3.e-7
+    - cache_read_input_token_cost: 1e-8
+      input_cost_per_token: 1e-7
+      output_cost_per_token: 3e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/mistralai/ministral-14b-2512.yaml
+++ b/providers/openrouter/mistralai/ministral-14b-2512.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_token_cost: 2.e-8
-      input_cost_per_token: 2.e-7
-      output_cost_per_token: 2.e-7
+    - cache_read_input_token_cost: 2e-8
+      input_cost_per_token: 2e-7
+      output_cost_per_token: 2e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/mistralai/ministral-3b-2512.yaml
+++ b/providers/openrouter/mistralai/ministral-3b-2512.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_token_cost: 1.e-8
-      input_cost_per_token: 1.e-7
-      output_cost_per_token: 1.e-7
+    - cache_read_input_token_cost: 1e-8
+      input_cost_per_token: 1e-7
+      output_cost_per_token: 1e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/mistralai/mistral-large-2407.yaml
+++ b/providers/openrouter/mistralai/mistral-large-2407.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000006
       region: "*"

--- a/providers/openrouter/mistralai/mistral-large-2411.yaml
+++ b/providers/openrouter/mistralai/mistral-large-2411.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000006
       region: "*"

--- a/providers/openrouter/mistralai/mistral-large-2512.yaml
+++ b/providers/openrouter/mistralai/mistral-large-2512.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 5.e-8
-      input_cost_per_token: 5.e-7
+    - cache_read_input_token_cost: 5e-8
+      input_cost_per_token: 5e-7
       output_cost_per_token: 0.0000015
       region: "*"
 features:

--- a/providers/openrouter/mistralai/mistral-large.yaml
+++ b/providers/openrouter/mistralai/mistral-large.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000006
       region: "*"

--- a/providers/openrouter/mistralai/mistral-medium-3.1.yaml
+++ b/providers/openrouter/mistralai/mistral-medium-3.1.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 4.e-8
-      input_cost_per_token: 4.e-7
+    - cache_read_input_token_cost: 4e-8
+      input_cost_per_token: 4e-7
       output_cost_per_token: 0.000002
       region: "*"
 features:

--- a/providers/openrouter/mistralai/mistral-medium-3.yaml
+++ b/providers/openrouter/mistralai/mistral-medium-3.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 4.e-8
-      input_cost_per_token: 4.e-7
+    - cache_read_input_token_cost: 4e-8
+      input_cost_per_token: 4e-7
       output_cost_per_token: 0.000002
       region: "*"
 features:

--- a/providers/openrouter/mistralai/mistral-nemo.yaml
+++ b/providers/openrouter/mistralai/mistral-nemo.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-8
-      output_cost_per_token: 4.e-8
+    - input_cost_per_token: 2e-8
+      output_cost_per_token: 4e-8
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/mistralai/mistral-saba.yaml
+++ b/providers/openrouter/mistralai/mistral-saba.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_token_cost: 2.e-8
-      input_cost_per_token: 2.e-7
-      output_cost_per_token: 6.e-7
+    - cache_read_input_token_cost: 2e-8
+      input_cost_per_token: 2e-7
+      output_cost_per_token: 6e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/mistralai/mistral-small-24b-instruct-2501.yaml
+++ b/providers/openrouter/mistralai/mistral-small-24b-instruct-2501.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 5.e-8
-      output_cost_per_token: 8.e-8
+    - input_cost_per_token: 5e-8
+      output_cost_per_token: 8e-8
       region: "*"
 features:
     - json_output

--- a/providers/openrouter/mistralai/mistral-small-2603.yaml
+++ b/providers/openrouter/mistralai/mistral-small-2603.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_read_input_token_cost: 1.5e-8
       input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/mistralai/mistral-small-3.2-24b-instruct.yaml
+++ b/providers/openrouter/mistralai/mistral-small-3.2-24b-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 7.5e-8
-      output_cost_per_token: 2.e-7
+      output_cost_per_token: 2e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/mistralai/mistral-small-creative.yaml
+++ b/providers/openrouter/mistralai/mistral-small-creative.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_token_cost: 1.e-8
-      input_cost_per_token: 1.e-7
-      output_cost_per_token: 3.e-7
+    - cache_read_input_token_cost: 1e-8
+      input_cost_per_token: 1e-7
+      output_cost_per_token: 3e-7
       region: "*"
 deprecationDate: "2026-04-30"
 features:

--- a/providers/openrouter/mistralai/mixtral-8x22b-instruct.yaml
+++ b/providers/openrouter/mistralai/mixtral-8x22b-instruct.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000006
       region: "*"

--- a/providers/openrouter/mistralai/pixtral-12b.yaml
+++ b/providers/openrouter/mistralai/pixtral-12b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 1.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 1e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/mistralai/pixtral-large-2411.yaml
+++ b/providers/openrouter/mistralai/pixtral-large-2411.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000006
       region: "*"

--- a/providers/openrouter/mistralai/voxtral-small-24b-2507.yaml
+++ b/providers/openrouter/mistralai/voxtral-small-24b-2507.yaml
@@ -1,8 +1,8 @@
 costs:
-    - cache_read_input_token_cost: 1.e-8
+    - cache_read_input_token_cost: 1e-8
       input_cost_per_second: 0.0001
-      input_cost_per_token: 1.e-7
-      output_cost_per_token: 3.e-7
+      input_cost_per_token: 1e-7
+      output_cost_per_token: 3e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/mixtral-8x22b-instruct.yaml
+++ b/providers/openrouter/mixtral-8x22b-instruct.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000006
       region: "*"

--- a/providers/openrouter/moonshotai/kimi-k2-0905.yaml
+++ b/providers/openrouter/moonshotai/kimi-k2-0905.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_read_input_token_cost: 1.5e-7
-      input_cost_per_token: 4.e-7
+      input_cost_per_token: 4e-7
       output_cost_per_token: 0.000002
       region: "*"
 features:

--- a/providers/openrouter/moonshotai/kimi-k2-0905:exacto.yaml
+++ b/providers/openrouter/moonshotai/kimi-k2-0905:exacto.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_read_input_token_cost: 1.5e-7
-      input_cost_per_token: 4.e-7
+      input_cost_per_token: 4e-7
       output_cost_per_token: 0.000002
       region: "*"
 features:

--- a/providers/openrouter/moonshotai/kimi-k2-thinking.yaml
+++ b/providers/openrouter/moonshotai/kimi-k2-thinking.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_read_input_token_cost: 1.5e-7
-      input_cost_per_token: 6.e-7
+      input_cost_per_token: 6e-7
       output_cost_per_token: 0.0000025
       region: "*"
 features:

--- a/providers/openrouter/moonshotai/kimi-k2.6.yaml
+++ b/providers/openrouter/moonshotai/kimi-k2.6.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
-      input_cost_per_token: 6.e-7
+    - cache_read_input_token_cost: 2e-7
+      input_cost_per_token: 6e-7
       output_cost_per_token: 0.0000028
       region: "*"
 features:

--- a/providers/openrouter/morph-v3-fast.yaml
+++ b/providers/openrouter/morph-v3-fast.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 8.e-7
+    - input_cost_per_token: 8e-7
       output_cost_per_token: 0.0000012
       region: "*"
 limits:

--- a/providers/openrouter/morph-v3-large.yaml
+++ b/providers/openrouter/morph-v3-large.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 9.e-7
+    - input_cost_per_token: 9e-7
       output_cost_per_token: 0.0000019
       region: "*"
 limits:

--- a/providers/openrouter/morph/morph-v3-fast.yaml
+++ b/providers/openrouter/morph/morph-v3-fast.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 8.e-7
+    - input_cost_per_token: 8e-7
       output_cost_per_token: 0.0000012
       region: "*"
 limits:

--- a/providers/openrouter/morph/morph-v3-large.yaml
+++ b/providers/openrouter/morph/morph-v3-large.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 9.e-7
+    - input_cost_per_token: 9e-7
       output_cost_per_token: 0.0000019
       region: "*"
 limits:

--- a/providers/openrouter/mythomax-l2-13b.yaml
+++ b/providers/openrouter/mythomax-l2-13b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 6.e-8
-      output_cost_per_token: 6.e-8
+    - input_cost_per_token: 6e-8
+      output_cost_per_token: 6e-8
       region: "*"
 features:
     - structured_output

--- a/providers/openrouter/nex-agi/deepseek-v3.1-nex-n1.yaml
+++ b/providers/openrouter/nex-agi/deepseek-v3.1-nex-n1.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 1.35e-7
-      output_cost_per_token: 5.e-7
+      output_cost_per_token: 5e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/nousresearch/hermes-3-llama-3.1-70b.yaml
+++ b/providers/openrouter/nousresearch/hermes-3-llama-3.1-70b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 3.e-7
-      output_cost_per_token: 3.e-7
+    - input_cost_per_token: 3e-7
+      output_cost_per_token: 3e-7
       region: "*"
 features:
     - json_output

--- a/providers/openrouter/nousresearch/hermes-4-70b.yaml
+++ b/providers/openrouter/nousresearch/hermes-4-70b.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 1.3e-7
-      output_cost_per_token: 4.e-7
+      output_cost_per_token: 4e-7
       region: "*"
 features:
     - json_output

--- a/providers/openrouter/nousresearch/nous-hermes-llama2-13b.yaml
+++ b/providers/openrouter/nousresearch/nous-hermes-llama2-13b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 2.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 2e-7
       region: "*"
 limits:
     context_window: 4096

--- a/providers/openrouter/nova-lite-v1.yaml
+++ b/providers/openrouter/nova-lite-v1.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 6.e-8
+    - input_cost_per_token: 6e-8
       output_cost_per_token: 2.4e-7
       region: "*"
 features:

--- a/providers/openrouter/nova-pro-v1.yaml
+++ b/providers/openrouter/nova-pro-v1.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 8.e-7
+    - input_cost_per_token: 8e-7
       output_cost_per_token: 0.0000032
       region: "*"
 features:

--- a/providers/openrouter/nvidia/llama-3.3-nemotron-super-49b-v1.5.yaml
+++ b/providers/openrouter/nvidia/llama-3.3-nemotron-super-49b-v1.5.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 4.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 4e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/nvidia/nemotron-3-nano-30b-a3b.yaml
+++ b/providers/openrouter/nvidia/nemotron-3-nano-30b-a3b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 5.e-8
-      output_cost_per_token: 2.e-7
+    - input_cost_per_token: 5e-8
+      output_cost_per_token: 2e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/nvidia/nemotron-3-super-120b-a12b.yaml
+++ b/providers/openrouter/nvidia/nemotron-3-super-120b-a12b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 5.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 5e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/nvidia/nemotron-nano-12b-v2-vl.yaml
+++ b/providers/openrouter/nvidia/nemotron-nano-12b-v2-vl.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 6.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 6e-7
       region: "*"
 limits:
     context_window: 131072

--- a/providers/openrouter/nvidia/nemotron-nano-9b-v2.yaml
+++ b/providers/openrouter/nvidia/nemotron-nano-9b-v2.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 4.e-8
+    - input_cost_per_token: 4e-8
       output_cost_per_token: 1.6e-7
       region: "*"
 features:

--- a/providers/openrouter/o3.yaml
+++ b/providers/openrouter/o3.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 5.e-7
+    - cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000008
       region: "*"

--- a/providers/openrouter/openai/gpt-3.5-turbo.yaml
+++ b/providers/openrouter/openai/gpt-3.5-turbo.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
       output_cost_per_token: 0.0000015
       region: "*"
 features:

--- a/providers/openrouter/openai/gpt-4.1-2025-04-14.yaml
+++ b/providers/openrouter/openai/gpt-4.1-2025-04-14.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 5.e-7
+    - cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000008
       region: "*"

--- a/providers/openrouter/openai/gpt-4.1-mini-2025-04-14.yaml
+++ b/providers/openrouter/openai/gpt-4.1-mini-2025-04-14.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 1.e-7
-      input_cost_per_token: 4.e-7
+    - cache_read_input_token_cost: 1e-7
+      input_cost_per_token: 4e-7
       output_cost_per_token: 0.0000016
       region: "*"
 features:

--- a/providers/openrouter/openai/gpt-4.1-mini.yaml
+++ b/providers/openrouter/openai/gpt-4.1-mini.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 1.e-7
-      input_cost_per_token: 4.e-7
+    - cache_read_input_token_cost: 1e-7
+      input_cost_per_token: 4e-7
       output_cost_per_token: 0.0000016
       region: "*"
 features:

--- a/providers/openrouter/openai/gpt-4.1-nano-2025-04-14.yaml
+++ b/providers/openrouter/openai/gpt-4.1-nano-2025-04-14.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_read_input_token_cost: 2.5e-8
-      input_cost_per_token: 1.e-7
-      output_cost_per_token: 4.e-7
+      input_cost_per_token: 1e-7
+      output_cost_per_token: 4e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/openai/gpt-4.1-nano.yaml
+++ b/providers/openrouter/openai/gpt-4.1-nano.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_read_input_token_cost: 2.5e-8
-      input_cost_per_token: 1.e-7
-      output_cost_per_token: 4.e-7
+      input_cost_per_token: 1e-7
+      output_cost_per_token: 4e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/openai/gpt-4.1.yaml
+++ b/providers/openrouter/openai/gpt-4.1.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 5.e-7
+    - cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000008
       region: "*"

--- a/providers/openrouter/openai/gpt-4o-mini-2024-07-18.yaml
+++ b/providers/openrouter/openai/gpt-4o-mini-2024-07-18.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_read_input_token_cost: 7.5e-8
       input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/openai/gpt-4o-mini-search-preview.yaml
+++ b/providers/openrouter/openai/gpt-4o-mini-search-preview.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: "*"
 features:
     - structured_output

--- a/providers/openrouter/openai/gpt-4o-mini.yaml
+++ b/providers/openrouter/openai/gpt-4o-mini.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_read_input_token_cost: 7.5e-8
       input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/openai/gpt-5-nano.yaml
+++ b/providers/openrouter/openai/gpt-5-nano.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_token_cost: 1.e-8
-      input_cost_per_token: 5.e-8
-      output_cost_per_token: 4.e-7
+    - cache_read_input_token_cost: 1e-8
+      input_cost_per_token: 5e-8
+      output_cost_per_token: 4e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/openai/gpt-5.1-codex-mini.yaml
+++ b/providers/openrouter/openai/gpt-5.1-codex-mini.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 3.e-8
+    - cache_read_input_token_cost: 3e-8
       input_cost_per_token: 2.5e-7
       output_cost_per_token: 0.000002
       region: "*"

--- a/providers/openrouter/openai/gpt-5.4-nano.yaml
+++ b/providers/openrouter/openai/gpt-5.4-nano.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 2.e-8
-      input_cost_per_token: 2.e-7
+    - cache_read_input_token_cost: 2e-8
+      input_cost_per_token: 2e-7
       output_cost_per_token: 0.00000125
       region: "*"
 features:

--- a/providers/openrouter/openai/gpt-5.4.yaml
+++ b/providers/openrouter/openai/gpt-5.4.yaml
@@ -5,7 +5,7 @@ costs:
       region: "*"
       tiered_pricing:
           cache_read:
-              - cost_per_token: 5.e-7
+              - cost_per_token: 5e-7
                 from: 272000
           input:
               - cost_per_token: 0.000005

--- a/providers/openrouter/openai/gpt-audio-mini.yaml
+++ b/providers/openrouter/openai/gpt-audio-mini.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_audio_token: 6.e-7
-      input_cost_per_token: 6.e-7
+    - input_cost_per_audio_token: 6e-7
+      input_cost_per_token: 6e-7
       output_cost_per_audio_token: 0.0000024
       output_cost_per_token: 0.0000024
       region: "*"

--- a/providers/openrouter/openai/gpt-oss-20b.yaml
+++ b/providers/openrouter/openai/gpt-oss-20b.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_read_input_token_cost: 1.5e-8
-      input_cost_per_token: 3.e-8
+      input_cost_per_token: 3e-8
       output_cost_per_token: 1.4e-7
       region: "*"
 features:

--- a/providers/openrouter/openai/gpt-oss-safeguard-20b.yaml
+++ b/providers/openrouter/openai/gpt-oss-safeguard-20b.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_read_input_token_cost: 3.7e-8
       input_cost_per_token: 7.5e-8
-      output_cost_per_token: 3.e-7
+      output_cost_per_token: 3e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/openai/o3.yaml
+++ b/providers/openrouter/openai/o3.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 5.e-7
+    - cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000008
       region: "*"

--- a/providers/openrouter/openai/o4-mini-deep-research.yaml
+++ b/providers/openrouter/openai/o4-mini-deep-research.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 5.e-7
+    - cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000008
       region: "*"

--- a/providers/openrouter/pixtral-12b.yaml
+++ b/providers/openrouter/pixtral-12b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 1.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 1e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/pixtral-large-2411.yaml
+++ b/providers/openrouter/pixtral-large-2411.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000006
       region: "*"

--- a/providers/openrouter/prime-intellect/intellect-3.yaml
+++ b/providers/openrouter/prime-intellect/intellect-3.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 2.e-7
+    - input_cost_per_token: 2e-7
       output_cost_per_token: 0.0000011
       region: "*"
 features:

--- a/providers/openrouter/qwen-2.5-7b-instruct.yaml
+++ b/providers/openrouter/qwen-2.5-7b-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 4.e-8
-      output_cost_per_token: 1.e-7
+    - input_cost_per_token: 4e-8
+      output_cost_per_token: 1e-7
       region: "*"
 features:
     - json_output

--- a/providers/openrouter/qwen-2.5-vl-7b-instruct.yaml
+++ b/providers/openrouter/qwen-2.5-vl-7b-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 2.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 2e-7
       region: "*"
 limits:
     context_window: 32768

--- a/providers/openrouter/qwen/qwen-2.5-7b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen-2.5-7b-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 4.e-8
-      output_cost_per_token: 1.e-7
+    - input_cost_per_token: 4e-8
+      output_cost_per_token: 1e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/qwen/qwen-2.5-vl-7b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen-2.5-vl-7b-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 2.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 2e-7
       region: "*"
 limits:
     context_window: 32768

--- a/providers/openrouter/qwen/qwen2.5-vl-32b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen2.5-vl-32b-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 6.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 6e-7
       region: "*"
 features:
     - json_output

--- a/providers/openrouter/qwen/qwen3-14b.yaml
+++ b/providers/openrouter/qwen/qwen3-14b.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 6.e-8
+    - input_cost_per_token: 6e-8
       output_cost_per_token: 2.4e-7
       region: "*"
 features:

--- a/providers/openrouter/qwen/qwen3-235b-a22b-2507.yaml
+++ b/providers/openrouter/qwen/qwen3-235b-a22b-2507.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 7.1e-8
-      output_cost_per_token: 1.e-7
+      output_cost_per_token: 1e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/qwen/qwen3-235b-a22b-thinking-2507.yaml
+++ b/providers/openrouter/qwen/qwen3-235b-a22b-thinking-2507.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 1.3e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/qwen/qwen3-30b-a3b-instruct-2507.yaml
+++ b/providers/openrouter/qwen/qwen3-30b-a3b-instruct-2507.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 9.e-8
-      output_cost_per_token: 3.e-7
+    - input_cost_per_token: 9e-8
+      output_cost_per_token: 3e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/qwen/qwen3-30b-a3b-thinking-2507.yaml
+++ b/providers/openrouter/qwen/qwen3-30b-a3b-thinking-2507.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 8.e-8
-      output_cost_per_token: 4.e-7
+    - input_cost_per_token: 8e-8
+      output_cost_per_token: 4e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/qwen/qwen3-30b-a3b.yaml
+++ b/providers/openrouter/qwen/qwen3-30b-a3b.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 8.e-8
+    - input_cost_per_token: 8e-8
       output_cost_per_token: 2.8e-7
       region: "*"
 features:

--- a/providers/openrouter/qwen/qwen3-32b.yaml
+++ b/providers/openrouter/qwen/qwen3-32b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 4.e-8
-      input_cost_per_token: 8.e-8
+    - cache_read_input_token_cost: 4e-8
+      input_cost_per_token: 8e-8
       output_cost_per_token: 2.4e-7
       region: "*"
 features:

--- a/providers/openrouter/qwen/qwen3-8b.yaml
+++ b/providers/openrouter/qwen/qwen3-8b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 5.e-8
-      output_cost_per_token: 4.e-7
+    - input_cost_per_token: 5e-8
+      output_cost_per_token: 4e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/qwen/qwen3-coder-30b-a3b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen3-coder-30b-a3b-instruct.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 7.e-8
+    - input_cost_per_token: 7e-8
       output_cost_per_token: 2.7e-7
       region: "*"
 features:

--- a/providers/openrouter/qwen/qwen3-coder-next.yaml
+++ b/providers/openrouter/qwen/qwen3-coder-next.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_read_input_token_cost: 1.2e-7
       input_cost_per_token: 1.5e-7
-      output_cost_per_token: 8.e-7
+      output_cost_per_token: 8e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/qwen/qwen3-next-80b-a3b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen3-next-80b-a3b-instruct.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 9.e-8
+    - input_cost_per_token: 9e-8
       output_cost_per_token: 0.0000011
       region: "*"
 features:

--- a/providers/openrouter/qwen/qwen3-vl-235b-a22b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen3-vl-235b-a22b-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_read_input_token_cost: 1.1e-7
-      input_cost_per_token: 2.e-7
+      input_cost_per_token: 2e-7
       output_cost_per_token: 8.8e-7
       region: "*"
 features:

--- a/providers/openrouter/qwen/qwen3-vl-8b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen3-vl-8b-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 8.e-8
-      output_cost_per_token: 5.e-7
+    - input_cost_per_token: 8e-8
+      output_cost_per_token: 5e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/qwen/qwen3.5-9b.yaml
+++ b/providers/openrouter/qwen/qwen3.5-9b.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-8
+    - input_cost_per_token: 5e-8
       output_cost_per_token: 1.5e-7
       region: "*"
 features:

--- a/providers/openrouter/qwen2.5-vl-32b-instruct.yaml
+++ b/providers/openrouter/qwen2.5-vl-32b-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 6.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 6e-7
       region: "*"
 features:
     - system_messages

--- a/providers/openrouter/qwen2.5-vl-72b-instruct.yaml
+++ b/providers/openrouter/qwen2.5-vl-72b-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 8.e-7
-      output_cost_per_token: 8.e-7
+    - input_cost_per_token: 8e-7
+      output_cost_per_token: 8e-7
       region: "*"
 limits:
     context_window: 32768

--- a/providers/openrouter/qwen3-14b.yaml
+++ b/providers/openrouter/qwen3-14b.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 6.e-8
+    - input_cost_per_token: 6e-8
       output_cost_per_token: 2.4e-7
       region: "*"
 features:

--- a/providers/openrouter/qwen3-235b-a22b-2507.yaml
+++ b/providers/openrouter/qwen3-235b-a22b-2507.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 7.1e-8
-      output_cost_per_token: 1.e-7
+      output_cost_per_token: 1e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/qwen3-30b-a3b-instruct-2507.yaml
+++ b/providers/openrouter/qwen3-30b-a3b-instruct-2507.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 9.e-8
-      output_cost_per_token: 3.e-7
+    - input_cost_per_token: 9e-8
+      output_cost_per_token: 3e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/qwen3-30b-a3b.yaml
+++ b/providers/openrouter/qwen3-30b-a3b.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 8.e-8
+    - input_cost_per_token: 8e-8
       output_cost_per_token: 2.8e-7
       region: "*"
 features:

--- a/providers/openrouter/qwen3-32b.yaml
+++ b/providers/openrouter/qwen3-32b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 4.e-8
-      input_cost_per_token: 8.e-8
+    - cache_read_input_token_cost: 4e-8
+      input_cost_per_token: 8e-8
       output_cost_per_token: 2.4e-7
       region: "*"
 features:

--- a/providers/openrouter/qwen3-8b.yaml
+++ b/providers/openrouter/qwen3-8b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 5.e-8
-      output_cost_per_token: 4.e-7
+    - input_cost_per_token: 5e-8
+      output_cost_per_token: 4e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/reka-flash-3.yaml
+++ b/providers/openrouter/reka-flash-3.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_image: 0.01
-      input_cost_per_token: 8.e-7
+      input_cost_per_token: 8e-7
       output_cost_per_token: 0.000002
       region: "*"
 features:

--- a/providers/openrouter/reka/reka-edge.yaml
+++ b/providers/openrouter/reka/reka-edge.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 1.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 1e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/rekaai/reka-edge.yaml
+++ b/providers/openrouter/rekaai/reka-edge.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 1.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 1e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/rekaai/reka-flash-3.yaml
+++ b/providers/openrouter/rekaai/reka-flash-3.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 2.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 2e-7
       region: "*"
 limits:
     context_window: 65536

--- a/providers/openrouter/sao10k/l3-lunaris-8b.yaml
+++ b/providers/openrouter/sao10k/l3-lunaris-8b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 4.e-8
-      output_cost_per_token: 5.e-8
+    - input_cost_per_token: 4e-8
+      output_cost_per_token: 5e-8
       region: "*"
 features:
     - json_output

--- a/providers/openrouter/stepfun/step-3.5-flash.yaml
+++ b/providers/openrouter/stepfun/step-3.5-flash.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 3.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 3e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/thedrummer/cydonia-24b-v4.1.yaml
+++ b/providers/openrouter/thedrummer/cydonia-24b-v4.1.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_read_input_token_cost: 1.5e-7
-      input_cost_per_token: 3.e-7
-      output_cost_per_token: 5.e-7
+      input_cost_per_token: 3e-7
+      output_cost_per_token: 5e-7
       region: "*"
 limits:
     context_window: 131072

--- a/providers/openrouter/thedrummer/skyfall-36b-v2.yaml
+++ b/providers/openrouter/thedrummer/skyfall-36b-v2.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_read_input_token_cost: 2.5e-7
       input_cost_per_token: 5.5e-7
-      output_cost_per_token: 8.e-7
+      output_cost_per_token: 8e-7
       region: "*"
 limits:
     context_window: 32768

--- a/providers/openrouter/thedrummer/unslopnemo-12b.yaml
+++ b/providers/openrouter/thedrummer/unslopnemo-12b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 4.e-7
-      output_cost_per_token: 4.e-7
+    - input_cost_per_token: 4e-7
+      output_cost_per_token: 4e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/tngtech/deepseek-r1t2-chimera.yaml
+++ b/providers/openrouter/tngtech/deepseek-r1t2-chimera.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_read_input_token_cost: 1.5e-7
-      input_cost_per_token: 3.e-7
+      input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000011
       region: "*"
 features:

--- a/providers/openrouter/ui-tars-1.5-7b.yaml
+++ b/providers/openrouter/ui-tars-1.5-7b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 2.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 2e-7
       region: "*"
 limits:
     context_window: 128000

--- a/providers/openrouter/unslopnemo-12b.yaml
+++ b/providers/openrouter/unslopnemo-12b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 4.e-7
-      output_cost_per_token: 4.e-7
+    - input_cost_per_token: 4e-7
+      output_cost_per_token: 4e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/upstage/solar-pro-3.yaml
+++ b/providers/openrouter/upstage/solar-pro-3.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_read_input_token_cost: 1.5e-8
       input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/writer/palmyra-x5.yaml
+++ b/providers/openrouter/writer/palmyra-x5.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 6.e-7
+    - input_cost_per_token: 6e-7
       output_cost_per_token: 0.000006
       region: "*"
 limits:

--- a/providers/openrouter/x-ai/grok-3-mini-beta.yaml
+++ b/providers/openrouter/x-ai/grok-3-mini-beta.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_read_input_token_cost: 7.5e-8
-      input_cost_per_token: 3.e-7
-      output_cost_per_token: 5.e-7
+      input_cost_per_token: 3e-7
+      output_cost_per_token: 5e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/x-ai/grok-3-mini.yaml
+++ b/providers/openrouter/x-ai/grok-3-mini.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_read_input_token_cost: 7.5e-8
-      input_cost_per_token: 3.e-7
-      output_cost_per_token: 5.e-7
+      input_cost_per_token: 3e-7
+      output_cost_per_token: 5e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/x-ai/grok-4-fast.yaml
+++ b/providers/openrouter/x-ai/grok-4-fast.yaml
@@ -1,11 +1,11 @@
 costs:
-    - cache_read_input_token_cost: 5.e-8
-      input_cost_per_token: 2.e-7
-      output_cost_per_token: 5.e-7
+    - cache_read_input_token_cost: 5e-8
+      input_cost_per_token: 2e-7
+      output_cost_per_token: 5e-7
       region: "*"
       tiered_pricing:
           input:
-              - cost_per_token: 4.e-7
+              - cost_per_token: 4e-7
                 from: 128000
           output:
               - cost_per_token: 0.000001

--- a/providers/openrouter/x-ai/grok-4.1-fast.yaml
+++ b/providers/openrouter/x-ai/grok-4.1-fast.yaml
@@ -1,11 +1,11 @@
 costs:
-    - cache_read_input_token_cost: 5.e-8
-      input_cost_per_token: 2.e-7
-      output_cost_per_token: 5.e-7
+    - cache_read_input_token_cost: 5e-8
+      input_cost_per_token: 2e-7
+      output_cost_per_token: 5e-7
       region: "*"
       tiered_pricing:
           input:
-              - cost_per_token: 4.e-7
+              - cost_per_token: 4e-7
                 from: 128000
           output:
               - cost_per_token: 0.000001

--- a/providers/openrouter/x-ai/grok-4.20-beta.yaml
+++ b/providers/openrouter/x-ai/grok-4.20-beta.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000006
       region: "*"

--- a/providers/openrouter/x-ai/grok-4.20-multi-agent-beta.yaml
+++ b/providers/openrouter/x-ai/grok-4.20-multi-agent-beta.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000006
       region: "*"

--- a/providers/openrouter/x-ai/grok-4.20-multi-agent.yaml
+++ b/providers/openrouter/x-ai/grok-4.20-multi-agent.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000006
@@ -7,7 +7,7 @@ costs:
       region: "*"
       tiered_pricing:
           cache_read:
-              - cost_per_token: 4.e-7
+              - cost_per_token: 4e-7
                 from: 200000
           input:
               - cost_per_token: 0.000004

--- a/providers/openrouter/x-ai/grok-4.20.yaml
+++ b/providers/openrouter/x-ai/grok-4.20.yaml
@@ -1,11 +1,11 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000006
       region: "*"
       tiered_pricing:
           cache_read:
-              - cost_per_token: 4.e-7
+              - cost_per_token: 4e-7
                 from: 200000
           input:
               - cost_per_token: 0.000004

--- a/providers/openrouter/x-ai/grok-code-fast-1.yaml
+++ b/providers/openrouter/x-ai/grok-code-fast-1.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 2.e-8
-      input_cost_per_token: 2.e-7
+    - cache_read_input_token_cost: 2e-8
+      input_cost_per_token: 2e-7
       output_cost_per_token: 0.0000015
       region: "*"
 features:

--- a/providers/openrouter/xiaomi/mimo-v2-flash.yaml
+++ b/providers/openrouter/xiaomi/mimo-v2-flash.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_read_input_token_cost: 4.5e-8
-      input_cost_per_token: 9.e-8
+      input_cost_per_token: 9e-8
       output_cost_per_token: 2.9e-7
       region: "*"
 features:

--- a/providers/openrouter/xiaomi/mimo-v2-omni.yaml
+++ b/providers/openrouter/xiaomi/mimo-v2-omni.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 8.e-8
-      input_cost_per_token: 4.e-7
+    - cache_read_input_token_cost: 8e-8
+      input_cost_per_token: 4e-7
       output_cost_per_token: 0.000002
       region: "*"
 features:

--- a/providers/openrouter/xiaomi/mimo-v2-pro.yaml
+++ b/providers/openrouter/xiaomi/mimo-v2-pro.yaml
@@ -1,11 +1,11 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000001
       output_cost_per_token: 0.000003
       region: "*"
       tiered_pricing:
           cache_read:
-              - cost_per_token: 4.e-7
+              - cost_per_token: 4e-7
                 from: 256000
           input:
               - cost_per_token: 0.000002

--- a/providers/openrouter/z-ai/glm-4-32b.yaml
+++ b/providers/openrouter/z-ai/glm-4-32b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 1.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 1e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/z-ai/glm-4.5.yaml
+++ b/providers/openrouter/z-ai/glm-4.5.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_read_input_token_cost: 1.1e-7
-      input_cost_per_token: 6.e-7
+      input_cost_per_token: 6e-7
       output_cost_per_token: 0.0000022
       region: "*"
 features:

--- a/providers/openrouter/z-ai/glm-4.5v.yaml
+++ b/providers/openrouter/z-ai/glm-4.5v.yaml
@@ -1,6 +1,6 @@
 costs:
     - cache_read_input_token_cost: 1.1e-7
-      input_cost_per_token: 6.e-7
+      input_cost_per_token: 6e-7
       output_cost_per_token: 0.0000018
       region: "*"
 features:

--- a/providers/openrouter/z-ai/glm-4.6v.yaml
+++ b/providers/openrouter/z-ai/glm-4.6v.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 3.e-7
-      output_cost_per_token: 9.e-7
+    - input_cost_per_token: 3e-7
+      output_cost_per_token: 9e-7
       region: "*"
 features:
     - function_calling

--- a/providers/openrouter/z-ai/glm-4.7-flash.yaml
+++ b/providers/openrouter/z-ai/glm-4.7-flash.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_token_cost: 1.e-8
-      input_cost_per_token: 6.e-8
-      output_cost_per_token: 4.e-7
+    - cache_read_input_token_cost: 1e-8
+      input_cost_per_token: 6e-8
+      output_cost_per_token: 4e-7
       region: "*"
 features:
     - function_calling

--- a/providers/perplexity-ai/codellama-70b-instruct.yaml
+++ b/providers/perplexity-ai/codellama-70b-instruct.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 7.e-7
+    - input_cost_per_token: 7e-7
       output_cost_per_token: 0.0000028
       region: "*"
 isDeprecated: true

--- a/providers/perplexity-ai/llama-2-70b-chat.yaml
+++ b/providers/perplexity-ai/llama-2-70b-chat.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 7.e-7
+    - input_cost_per_token: 7e-7
       output_cost_per_token: 0.0000028
       region: "*"
 isDeprecated: true

--- a/providers/perplexity-ai/llama-3.1-8b-instruct.yaml
+++ b/providers/perplexity-ai/llama-3.1-8b-instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 2.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 2e-7
       region: "*"
 isDeprecated: true
 limits:

--- a/providers/perplexity-ai/llama-3.1-sonar-small-128k-chat.yaml
+++ b/providers/perplexity-ai/llama-3.1-sonar-small-128k-chat.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 2.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 2e-7
       region: "*"
 isDeprecated: true
 limits:

--- a/providers/perplexity-ai/llama-3.1-sonar-small-128k-online.yaml
+++ b/providers/perplexity-ai/llama-3.1-sonar-small-128k-online.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 2.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 2e-7
       region: "*"
 isDeprecated: true
 limits:

--- a/providers/perplexity-ai/mistral-7b-instruct.yaml
+++ b/providers/perplexity-ai/mistral-7b-instruct.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 7.e-8
+    - input_cost_per_token: 7e-8
       output_cost_per_token: 2.8e-7
       region: "*"
 isDeprecated: true

--- a/providers/perplexity-ai/mixtral-8x7b-instruct.yaml
+++ b/providers/perplexity-ai/mixtral-8x7b-instruct.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 7.e-8
+    - input_cost_per_token: 7e-8
       output_cost_per_token: 2.8e-7
       region: "*"
 isDeprecated: true

--- a/providers/perplexity-ai/pplx-70b-chat.yaml
+++ b/providers/perplexity-ai/pplx-70b-chat.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 7.e-7
+    - input_cost_per_token: 7e-7
       output_cost_per_token: 0.0000028
       region: "*"
 isDeprecated: true

--- a/providers/perplexity-ai/pplx-7b-chat.yaml
+++ b/providers/perplexity-ai/pplx-7b-chat.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 7.e-8
+    - input_cost_per_token: 7e-8
       output_cost_per_token: 2.8e-7
       region: "*"
 isDeprecated: true

--- a/providers/perplexity-ai/sonar-medium-chat.yaml
+++ b/providers/perplexity-ai/sonar-medium-chat.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 6.e-7
+    - input_cost_per_token: 6e-7
       output_cost_per_token: 0.0000018
       region: "*"
 isDeprecated: true

--- a/providers/perplexity-ai/sonar-small-chat.yaml
+++ b/providers/perplexity-ai/sonar-small-chat.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 7.e-8
+    - input_cost_per_token: 7e-8
       output_cost_per_token: 2.8e-7
       region: "*"
 isDeprecated: true

--- a/providers/sambanova/DeepSeek-R1-Distill-Llama-70B.yaml
+++ b/providers/sambanova/DeepSeek-R1-Distill-Llama-70B.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 7.e-7
+    - input_cost_per_token: 7e-7
       output_cost_per_token: 0.0000014
       region: "*"
 isDeprecated: true

--- a/providers/sambanova/Llama-3.3-Swallow-70B-Instruct-v0.4.yaml
+++ b/providers/sambanova/Llama-3.3-Swallow-70B-Instruct-v0.4.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 6.e-7
+    - input_cost_per_token: 6e-7
       output_cost_per_token: 0.0000012
       region: "*"
 features:

--- a/providers/sambanova/Llama-4-Scout-17B-16E-Instruct.yaml
+++ b/providers/sambanova/Llama-4-Scout-17B-16E-Instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 4.e-7
-      output_cost_per_token: 7.e-7
+    - input_cost_per_token: 4e-7
+      output_cost_per_token: 7e-7
       region: "*"
 features:
     - function_calling

--- a/providers/sambanova/Meta-Llama-3.1-8B-Instruct.yaml
+++ b/providers/sambanova/Meta-Llama-3.1-8B-Instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 2.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 2e-7
       region: "*"
 features:
     - function_calling

--- a/providers/sambanova/Meta-Llama-3.2-1B-Instruct.yaml
+++ b/providers/sambanova/Meta-Llama-3.2-1B-Instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 4.e-8
-      output_cost_per_token: 8.e-8
+    - input_cost_per_token: 4e-8
+      output_cost_per_token: 8e-8
       region: "*"
 isDeprecated: true
 limits:

--- a/providers/sambanova/Meta-Llama-3.2-3B-Instruct.yaml
+++ b/providers/sambanova/Meta-Llama-3.2-3B-Instruct.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 8.e-8
+    - input_cost_per_token: 8e-8
       output_cost_per_token: 1.6e-7
       region: "*"
 isDeprecated: true

--- a/providers/sambanova/Meta-Llama-3.3-70B-Instruct.yaml
+++ b/providers/sambanova/Meta-Llama-3.3-70B-Instruct.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 6.e-7
+    - input_cost_per_token: 6e-7
       output_cost_per_token: 0.0000012
       region: "*"
 features:

--- a/providers/sambanova/Meta-Llama-Guard-3-8B.yaml
+++ b/providers/sambanova/Meta-Llama-Guard-3-8B.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 3.e-7
-      output_cost_per_token: 3.e-7
+    - input_cost_per_token: 3e-7
+      output_cost_per_token: 3e-7
       region: "*"
 isDeprecated: true
 limits:

--- a/providers/sambanova/MiniMax-M2.5.yaml
+++ b/providers/sambanova/MiniMax-M2.5.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 3.e-7
+    - input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000012
       region: "*"
 features:

--- a/providers/sambanova/QwQ-32B.yaml
+++ b/providers/sambanova/QwQ-32B.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
       output_cost_per_token: 0.000001
       region: "*"
 isDeprecated: true

--- a/providers/sambanova/Qwen2-Audio-7B-Instruct.yaml
+++ b/providers/sambanova/Qwen2-Audio-7B-Instruct.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
       output_cost_per_token: 0.0001
       region: "*"
 isDeprecated: true

--- a/providers/sambanova/Qwen3-235B.yaml
+++ b/providers/sambanova/Qwen3-235B.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 4.e-7
-      output_cost_per_token: 8.e-7
+    - input_cost_per_token: 4e-7
+      output_cost_per_token: 8e-7
       region: "*"
 features:
     - function_calling

--- a/providers/sambanova/Qwen3-32B.yaml
+++ b/providers/sambanova/Qwen3-32B.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 4.e-7
-      output_cost_per_token: 8.e-7
+    - input_cost_per_token: 4e-7
+      output_cost_per_token: 8e-7
       region: "*"
 features:
     - function_calling

--- a/providers/sambanova/gemma-3-12b-it.yaml
+++ b/providers/sambanova/gemma-3-12b-it.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 2.e-7
+    - input_cost_per_token: 2e-7
       output_cost_per_token: 3.5e-7
       region: "*"
 features:

--- a/providers/together-ai/LiquidAI/LFM2-24B-A2B.yaml
+++ b/providers/together-ai/LiquidAI/LFM2-24B-A2B.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 3.e-8
+    - input_cost_per_token: 3e-8
       output_cost_per_token: 1.2e-7
       region: "*"
 features:

--- a/providers/together-ai/MiniMaxAI/MiniMax-M2.5-FP4.yaml
+++ b/providers/together-ai/MiniMaxAI/MiniMax-M2.5-FP4.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 6.e-8
-      input_cost_per_token: 3.e-7
+    - cache_read_input_token_cost: 6e-8
+      input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000012
       region: "*"
 features:

--- a/providers/together-ai/MiniMaxAI/MiniMax-M2.5.yaml
+++ b/providers/together-ai/MiniMaxAI/MiniMax-M2.5.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 6.e-8
-      input_cost_per_token: 3.e-7
+    - cache_read_input_token_cost: 6e-8
+      input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000012
       region: "*"
 features:

--- a/providers/together-ai/MiniMaxAI/MiniMax-M2.7.yaml
+++ b/providers/together-ai/MiniMaxAI/MiniMax-M2.7.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 6.e-8
-      input_cost_per_token: 3.e-7
+    - cache_read_input_token_cost: 6e-8
+      input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000012
       region: "*"
 features:

--- a/providers/together-ai/MiniMaxAI/MiniMax-M2.yaml
+++ b/providers/together-ai/MiniMaxAI/MiniMax-M2.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 6.e-8
-      input_cost_per_token: 3.e-7
+    - cache_read_input_token_cost: 6e-8
+      input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000012
       region: "*"
 features:

--- a/providers/together-ai/Qwen/Qwen2.5-72B.yaml
+++ b/providers/together-ai/Qwen/Qwen2.5-72B.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 9.e-7
-      output_cost_per_token: 9.e-7
+    - input_cost_per_token: 9e-7
+      output_cost_per_token: 9e-7
       region: "*"
 features:
     - function_calling

--- a/providers/together-ai/Qwen/Qwen2.5-7B-Instruct-Turbo.yaml
+++ b/providers/together-ai/Qwen/Qwen2.5-7B-Instruct-Turbo.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 3.e-7
-      output_cost_per_token: 3.e-7
+    - input_cost_per_token: 3e-7
+      output_cost_per_token: 3e-7
       region: "*"
 features:
     - function_calling

--- a/providers/together-ai/Qwen/Qwen2.5-7B-Instruct.yaml
+++ b/providers/together-ai/Qwen/Qwen2.5-7B-Instruct.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 3.e-7
-      output_cost_per_token: 3.e-7
+    - input_cost_per_token: 3e-7
+      output_cost_per_token: 3e-7
       region: "*"
 features:
     - function_calling

--- a/providers/together-ai/Qwen/Qwen3-235B-A22B-Instruct-2507-tput.yaml
+++ b/providers/together-ai/Qwen/Qwen3-235B-A22B-Instruct-2507-tput.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 6.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 6e-7
       region: "*"
 features:
     - function_calling

--- a/providers/together-ai/Qwen/Qwen3-Coder-Next-FP8.yaml
+++ b/providers/together-ai/Qwen/Qwen3-Coder-Next-FP8.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
       output_cost_per_token: 0.0000012
       region: "*"
 features:

--- a/providers/together-ai/Qwen/Qwen3.5-27B.yaml
+++ b/providers/together-ai/Qwen/Qwen3.5-27B.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 1.e-7
+    - input_cost_per_token: 1e-7
       output_cost_per_token: 1.5e-7
       region: "*"
 features:

--- a/providers/together-ai/Qwen/Qwen3.5-397B-A17B-FP4.yaml
+++ b/providers/together-ai/Qwen/Qwen3.5-397B-A17B-FP4.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 6.e-7
+    - input_cost_per_token: 6e-7
       output_cost_per_token: 0.0000036
       region: "*"
 features:

--- a/providers/together-ai/Qwen/Qwen3.5-397B-A17B-FP8.yaml
+++ b/providers/together-ai/Qwen/Qwen3.5-397B-A17B-FP8.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 6.e-7
-      input_cost_per_token: 6.e-7
+    - cache_read_input_token_cost: 6e-7
+      input_cost_per_token: 6e-7
       output_cost_per_token: 0.0000036
       region: "*"
 features:

--- a/providers/together-ai/Qwen/Qwen3.5-397B-A17B.yaml
+++ b/providers/together-ai/Qwen/Qwen3.5-397B-A17B.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 6.e-7
+    - input_cost_per_token: 6e-7
       output_cost_per_token: 0.0000036
       region: "*"
 features:

--- a/providers/together-ai/Qwen/Qwen3.5-9B-FP8.yaml
+++ b/providers/together-ai/Qwen/Qwen3.5-9B-FP8.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 1.e-7
+    - input_cost_per_token: 1e-7
       output_cost_per_token: 1.5e-7
       region: "*"
 features:

--- a/providers/together-ai/Qwen/Qwen3.5-9B.yaml
+++ b/providers/together-ai/Qwen/Qwen3.5-9B.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 1.e-7
+    - input_cost_per_token: 1e-7
       output_cost_per_token: 1.5e-7
       region: "*"
 features:

--- a/providers/together-ai/Virtue-AI/VirtueGuard-Text-Lite.yaml
+++ b/providers/together-ai/Virtue-AI/VirtueGuard-Text-Lite.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 2.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 2e-7
       region: "*"
 limits:
     context_window: 32768

--- a/providers/together-ai/deepseek-ai/DeepSeek-V3.1-Base.yaml
+++ b/providers/together-ai/deepseek-ai/DeepSeek-V3.1-Base.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 6.e-7
+    - input_cost_per_token: 6e-7
       output_cost_per_token: 0.0000017
       region: "*"
 limits:

--- a/providers/together-ai/deepseek-ai/DeepSeek-V3.1-Terminus.yaml
+++ b/providers/together-ai/deepseek-ai/DeepSeek-V3.1-Terminus.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 6.e-7
+    - input_cost_per_token: 6e-7
       output_cost_per_token: 0.0000017
       region: "*"
 features:

--- a/providers/together-ai/deepseek-ai/DeepSeek-V3.1.yaml
+++ b/providers/together-ai/deepseek-ai/DeepSeek-V3.1.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 6.e-7
+    - input_cost_per_token: 6e-7
       output_cost_per_token: 0.0000017
       region: "*"
 features:

--- a/providers/together-ai/deepseek-ai/DeepSeek-V3.yaml
+++ b/providers/together-ai/deepseek-ai/DeepSeek-V3.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 6.e-7
+    - input_cost_per_token: 6e-7
       output_cost_per_token: 0.0000017
       region: "*"
 features:

--- a/providers/together-ai/google/gemma-3n-E4B-it.yaml
+++ b/providers/together-ai/google/gemma-3n-E4B-it.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 6.e-8
+    - input_cost_per_token: 6e-8
       output_cost_per_token: 1.2e-7
       region: "*"
 features:

--- a/providers/together-ai/google/gemma-4-31B-it.yaml
+++ b/providers/together-ai/google/gemma-4-31B-it.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 5.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 5e-7
       region: "*"
 features:
     - function_calling

--- a/providers/together-ai/intfloat/multilingual-e5-large-instruct.yaml
+++ b/providers/together-ai/intfloat/multilingual-e5-large-instruct.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 2.e-8
+    - input_cost_per_token: 2e-8
       region: "*"
 limits:
     context_window: 514

--- a/providers/together-ai/meta-llama/Llama-3.2-3B-Instruct-Turbo.yaml
+++ b/providers/together-ai/meta-llama/Llama-3.2-3B-Instruct-Turbo.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 6.e-8
-      output_cost_per_token: 6.e-8
+    - input_cost_per_token: 6e-8
+      output_cost_per_token: 6e-8
       region: "*"
 features:
     - function_calling

--- a/providers/together-ai/meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8.yaml
+++ b/providers/together-ai/meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 2.7e-7
-      input_cost_per_token_batches: 3.e-7
+      input_cost_per_token_batches: 3e-7
       output_cost_per_token: 8.5e-7
       output_cost_per_token_batches: 0.0000012
       region: "*"

--- a/providers/together-ai/meta-llama/Llama-Guard-4-12B.yaml
+++ b/providers/together-ai/meta-llama/Llama-Guard-4-12B.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 2.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 2e-7
       region: "*"
 limits:
     context_window: 1048576

--- a/providers/together-ai/meta-llama/Meta-Llama-3-8B-Instruct-Lite.yaml
+++ b/providers/together-ai/meta-llama/Meta-Llama-3-8B-Instruct-Lite.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 1.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 1e-7
       region: "*"
 deprecationDate: "2025-03-11"
 features:

--- a/providers/together-ai/mistralai/Mistral-7B-Instruct-v0.2.yaml
+++ b/providers/together-ai/mistralai/Mistral-7B-Instruct-v0.2.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 2.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 2e-7
       region: "*"
 features:
     - system_messages

--- a/providers/together-ai/mistralai/Mistral-Small-24B-Instruct-2501.yaml
+++ b/providers/together-ai/mistralai/Mistral-Small-24B-Instruct-2501.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 3.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 3e-7
       region: "*"
 deprecationDate: "2026-04-02"
 features:

--- a/providers/together-ai/mistralai/Mixtral-8x7B-Instruct-v0.1.yaml
+++ b/providers/together-ai/mistralai/Mixtral-8x7B-Instruct-v0.1.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 6.e-7
-      output_cost_per_token: 6.e-7
+    - input_cost_per_token: 6e-7
+      output_cost_per_token: 6e-7
       region: "*"
 deprecationDate: "2026-04-16"
 isDeprecated: true

--- a/providers/together-ai/moonshotai/Kimi-K2.5-fp4.yaml
+++ b/providers/together-ai/moonshotai/Kimi-K2.5-fp4.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
       output_cost_per_token: 0.0000028
       region: "*"
 features:

--- a/providers/together-ai/moonshotai/Kimi-K2.5.yaml
+++ b/providers/together-ai/moonshotai/Kimi-K2.5.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 5.e-7
+    - input_cost_per_token: 5e-7
       output_cost_per_token: 0.0000028
       region: "*"
 features:

--- a/providers/together-ai/nim/mistralai/mixtral-8x7b-instruct-v01.yaml
+++ b/providers/together-ai/nim/mistralai/mixtral-8x7b-instruct-v01.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 6.e-7
-      output_cost_per_token: 6.e-7
+    - input_cost_per_token: 6e-7
+      output_cost_per_token: 6e-7
       region: "*"
 features:
     - system_messages

--- a/providers/together-ai/openai/gpt-oss-120b.yaml
+++ b/providers/together-ai/openai/gpt-oss-120b.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6.e-7
+      output_cost_per_token: 6e-7
       region: "*"
 features:
     - function_calling

--- a/providers/together-ai/openai/gpt-oss-20b.yaml
+++ b/providers/together-ai/openai/gpt-oss-20b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 5.e-8
-      output_cost_per_token: 2.e-7
+    - input_cost_per_token: 5e-8
+      output_cost_per_token: 2e-7
       region: "*"
 features:
     - function_calling

--- a/providers/together-ai/together-ai-21.1b-41b.yaml
+++ b/providers/together-ai/together-ai-21.1b-41b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 8.e-7
-      output_cost_per_token: 8.e-7
+    - input_cost_per_token: 8e-7
+      output_cost_per_token: 8e-7
       region: "*"
 isDeprecated: true
 mode: chat

--- a/providers/together-ai/together-ai-4.1b-8b.yaml
+++ b/providers/together-ai/together-ai-4.1b-8b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 2.e-7
-      output_cost_per_token: 2.e-7
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 2e-7
       region: "*"
 isDeprecated: true
 mode: chat

--- a/providers/together-ai/together-ai-41.1b-80b.yaml
+++ b/providers/together-ai/together-ai-41.1b-80b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 9.e-7
-      output_cost_per_token: 9.e-7
+    - input_cost_per_token: 9e-7
+      output_cost_per_token: 9e-7
       region: "*"
 isDeprecated: true
 mode: chat

--- a/providers/together-ai/together-ai-8.1b-21b.yaml
+++ b/providers/together-ai/together-ai-8.1b-21b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 3.e-7
-      output_cost_per_token: 3.e-7
+    - input_cost_per_token: 3e-7
+      output_cost_per_token: 3e-7
       region: "*"
 isDeprecated: true
 limits:

--- a/providers/together-ai/together-ai-up-to-4b.yaml
+++ b/providers/together-ai/together-ai-up-to-4b.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 1.e-7
-      output_cost_per_token: 1.e-7
+    - input_cost_per_token: 1e-7
+      output_cost_per_token: 1e-7
       region: "*"
 isDeprecated: true
 mode: chat

--- a/providers/together-ai/zai-org/GLM-4.5-Air-FP8.yaml
+++ b/providers/together-ai/zai-org/GLM-4.5-Air-FP8.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 2.e-7
+    - input_cost_per_token: 2e-7
       output_cost_per_token: 0.0000011
       region: "*"
 deprecationDate: "2026-04-02"

--- a/providers/together-ai/zai-org/GLM-4.6.yaml
+++ b/providers/together-ai/zai-org/GLM-4.6.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 6.e-7
+    - input_cost_per_token: 6e-7
       output_cost_per_token: 0.0000022
       region: "*"
 features:

--- a/providers/xai/grok-3-mini-beta.yaml
+++ b/providers/xai/grok-3-mini-beta.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_token_cost: 7.e-8
-      input_cost_per_token: 3.e-7
-      output_cost_per_token: 5.e-7
+    - cache_read_input_token_cost: 7e-8
+      input_cost_per_token: 3e-7
+      output_cost_per_token: 5e-7
       region: "*"
 features:
     - function_calling

--- a/providers/xai/grok-3-mini-fast-beta.yaml
+++ b/providers/xai/grok-3-mini-fast-beta.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_token_cost: 7.e-8
-      input_cost_per_token: 3.e-7
-      output_cost_per_token: 5.e-7
+    - cache_read_input_token_cost: 7e-8
+      input_cost_per_token: 3e-7
+      output_cost_per_token: 5e-7
       region: "*"
 features:
     - function_calling

--- a/providers/xai/grok-3-mini-fast-latest.yaml
+++ b/providers/xai/grok-3-mini-fast-latest.yaml
@@ -1,8 +1,8 @@
 costs:
-    - cache_read_input_token_cost: 7.e-8
+    - cache_read_input_token_cost: 7e-8
       input_cost_per_query: 0.005
-      input_cost_per_token: 3.e-7
-      output_cost_per_token: 5.e-7
+      input_cost_per_token: 3e-7
+      output_cost_per_token: 5e-7
       region: "*"
 features:
     - function_calling

--- a/providers/xai/grok-3-mini-fast.yaml
+++ b/providers/xai/grok-3-mini-fast.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_token_cost: 7.e-8
-      input_cost_per_token: 3.e-7
-      output_cost_per_token: 5.e-7
+    - cache_read_input_token_cost: 7e-8
+      input_cost_per_token: 3e-7
+      output_cost_per_token: 5e-7
       region: "*"
 features:
     - function_calling

--- a/providers/xai/grok-3-mini-latest.yaml
+++ b/providers/xai/grok-3-mini-latest.yaml
@@ -1,8 +1,8 @@
 costs:
-    - cache_read_input_token_cost: 7.e-8
-      input_cost_per_token: 3.e-7
+    - cache_read_input_token_cost: 7e-8
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
-      output_cost_per_token: 5.e-7
+      output_cost_per_token: 5e-7
       output_cost_per_token_batches: 2.5e-7
       region: "*"
 features:

--- a/providers/xai/grok-3-mini.yaml
+++ b/providers/xai/grok-3-mini.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_token_cost: 7.e-8
-      input_cost_per_token: 3.e-7
-      output_cost_per_token: 5.e-7
+    - cache_read_input_token_cost: 7e-8
+      input_cost_per_token: 3e-7
+      output_cost_per_token: 5e-7
       region: "*"
 features:
     - function_calling

--- a/providers/xai/grok-4-1-fast-non-reasoning-latest.yaml
+++ b/providers/xai/grok-4-1-fast-non-reasoning-latest.yaml
@@ -1,8 +1,8 @@
 costs:
-    - cache_read_input_token_cost: 5.e-8
-      input_cost_per_token: 2.e-7
-      input_cost_per_token_batches: 1.e-7
-      output_cost_per_token: 5.e-7
+    - cache_read_input_token_cost: 5e-8
+      input_cost_per_token: 2e-7
+      input_cost_per_token_batches: 1e-7
+      output_cost_per_token: 5e-7
       output_cost_per_token_batches: 2.5e-7
       region: "*"
 features:

--- a/providers/xai/grok-4-1-fast-non-reasoning.yaml
+++ b/providers/xai/grok-4-1-fast-non-reasoning.yaml
@@ -1,8 +1,8 @@
 costs:
-    - cache_read_input_token_cost: 5.e-8
-      input_cost_per_token: 2.e-7
-      input_cost_per_token_batches: 1.e-7
-      output_cost_per_token: 5.e-7
+    - cache_read_input_token_cost: 5e-8
+      input_cost_per_token: 2e-7
+      input_cost_per_token_batches: 1e-7
+      output_cost_per_token: 5e-7
       output_cost_per_token_batches: 2.5e-7
       region: "*"
 features:

--- a/providers/xai/grok-4-1-fast-reasoning-latest.yaml
+++ b/providers/xai/grok-4-1-fast-reasoning-latest.yaml
@@ -1,8 +1,8 @@
 costs:
-    - cache_read_input_token_cost: 5.e-8
-      input_cost_per_token: 2.e-7
-      input_cost_per_token_batches: 1.e-7
-      output_cost_per_token: 5.e-7
+    - cache_read_input_token_cost: 5e-8
+      input_cost_per_token: 2e-7
+      input_cost_per_token_batches: 1e-7
+      output_cost_per_token: 5e-7
       output_cost_per_token_batches: 2.5e-7
       region: "*"
 features:

--- a/providers/xai/grok-4-1-fast-reasoning.yaml
+++ b/providers/xai/grok-4-1-fast-reasoning.yaml
@@ -1,8 +1,8 @@
 costs:
-    - cache_read_input_token_cost: 5.e-8
-      input_cost_per_token: 2.e-7
-      input_cost_per_token_batches: 1.e-7
-      output_cost_per_token: 5.e-7
+    - cache_read_input_token_cost: 5e-8
+      input_cost_per_token: 2e-7
+      input_cost_per_token_batches: 1e-7
+      output_cost_per_token: 5e-7
       output_cost_per_token_batches: 2.5e-7
       region: "*"
 features:

--- a/providers/xai/grok-4-1-fast.yaml
+++ b/providers/xai/grok-4-1-fast.yaml
@@ -1,8 +1,8 @@
 costs:
-    - cache_read_input_token_cost: 5.e-8
-      input_cost_per_token: 2.e-7
-      input_cost_per_token_batches: 1.e-7
-      output_cost_per_token: 5.e-7
+    - cache_read_input_token_cost: 5e-8
+      input_cost_per_token: 2e-7
+      input_cost_per_token_batches: 1e-7
+      output_cost_per_token: 5e-7
       output_cost_per_token_batches: 2.5e-7
       region: "*"
 features:

--- a/providers/xai/grok-4-fast-non-reasoning-latest.yaml
+++ b/providers/xai/grok-4-fast-non-reasoning-latest.yaml
@@ -1,8 +1,8 @@
 costs:
-    - cache_read_input_token_cost: 5.e-8
-      input_cost_per_token: 2.e-7
-      input_cost_per_token_batches: 1.e-7
-      output_cost_per_token: 5.e-7
+    - cache_read_input_token_cost: 5e-8
+      input_cost_per_token: 2e-7
+      input_cost_per_token_batches: 1e-7
+      output_cost_per_token: 5e-7
       output_cost_per_token_batches: 2.5e-7
       region: "*"
 features:

--- a/providers/xai/grok-4-fast-non-reasoning.yaml
+++ b/providers/xai/grok-4-fast-non-reasoning.yaml
@@ -1,8 +1,8 @@
 costs:
-    - cache_read_input_token_cost: 5.e-8
-      input_cost_per_token: 2.e-7
-      input_cost_per_token_batches: 1.e-7
-      output_cost_per_token: 5.e-7
+    - cache_read_input_token_cost: 5e-8
+      input_cost_per_token: 2e-7
+      input_cost_per_token_batches: 1e-7
+      output_cost_per_token: 5e-7
       output_cost_per_token_batches: 2.5e-7
       region: "*"
 features:

--- a/providers/xai/grok-4-fast-reasoning-latest.yaml
+++ b/providers/xai/grok-4-fast-reasoning-latest.yaml
@@ -1,8 +1,8 @@
 costs:
-    - cache_read_input_token_cost: 5.e-8
-      input_cost_per_token: 2.e-7
-      input_cost_per_token_batches: 1.e-7
-      output_cost_per_token: 5.e-7
+    - cache_read_input_token_cost: 5e-8
+      input_cost_per_token: 2e-7
+      input_cost_per_token_batches: 1e-7
+      output_cost_per_token: 5e-7
       output_cost_per_token_batches: 2.5e-7
       region: "*"
 features:

--- a/providers/xai/grok-4-fast-reasoning.yaml
+++ b/providers/xai/grok-4-fast-reasoning.yaml
@@ -1,8 +1,8 @@
 costs:
-    - cache_read_input_token_cost: 5.e-8
-      input_cost_per_token: 2.e-7
-      input_cost_per_token_batches: 1.e-7
-      output_cost_per_token: 5.e-7
+    - cache_read_input_token_cost: 5e-8
+      input_cost_per_token: 2e-7
+      input_cost_per_token_batches: 1e-7
+      output_cost_per_token: 5e-7
       output_cost_per_token_batches: 2.5e-7
       region: "*"
 features:

--- a/providers/xai/grok-4-fast.yaml
+++ b/providers/xai/grok-4-fast.yaml
@@ -1,8 +1,8 @@
 costs:
-    - cache_read_input_token_cost: 5.e-8
-      input_cost_per_token: 2.e-7
-      input_cost_per_token_batches: 1.e-7
-      output_cost_per_token: 5.e-7
+    - cache_read_input_token_cost: 5e-8
+      input_cost_per_token: 2e-7
+      input_cost_per_token_batches: 1e-7
+      output_cost_per_token: 5e-7
       output_cost_per_token_batches: 2.5e-7
       region: "*"
 features:

--- a/providers/xai/grok-4-latest.yaml
+++ b/providers/xai/grok-4-latest.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000006

--- a/providers/xai/grok-4.20-0309-non-reasoning.yaml
+++ b/providers/xai/grok-4.20-0309-non-reasoning.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000006

--- a/providers/xai/grok-4.20-0309-reasoning.yaml
+++ b/providers/xai/grok-4.20-0309-reasoning.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_image_token: 0.000002
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001

--- a/providers/xai/grok-4.20-0309.yaml
+++ b/providers/xai/grok-4.20-0309.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_image_token: 0.000002
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001

--- a/providers/xai/grok-4.20-beta-0309-non-reasoning.yaml
+++ b/providers/xai/grok-4.20-beta-0309-non-reasoning.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000006

--- a/providers/xai/grok-4.20-beta-0309-reasoning.yaml
+++ b/providers/xai/grok-4.20-beta-0309-reasoning.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000006

--- a/providers/xai/grok-4.20-beta-0309.yaml
+++ b/providers/xai/grok-4.20-beta-0309.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000006

--- a/providers/xai/grok-4.20-beta-latest-non-reasoning.yaml
+++ b/providers/xai/grok-4.20-beta-latest-non-reasoning.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000006

--- a/providers/xai/grok-4.20-beta-latest-reasoning.yaml
+++ b/providers/xai/grok-4.20-beta-latest-reasoning.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000006

--- a/providers/xai/grok-4.20-beta-latest.yaml
+++ b/providers/xai/grok-4.20-beta-latest.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000006

--- a/providers/xai/grok-4.20-beta-non-reasoning.yaml
+++ b/providers/xai/grok-4.20-beta-non-reasoning.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000006

--- a/providers/xai/grok-4.20-beta-reasoning.yaml
+++ b/providers/xai/grok-4.20-beta-reasoning.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000006

--- a/providers/xai/grok-4.20-beta.yaml
+++ b/providers/xai/grok-4.20-beta.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000006

--- a/providers/xai/grok-4.20-experimental-beta-0304-non-reasoning.yaml
+++ b/providers/xai/grok-4.20-experimental-beta-0304-non-reasoning.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000006

--- a/providers/xai/grok-4.20-experimental-beta-0304-reasoning.yaml
+++ b/providers/xai/grok-4.20-experimental-beta-0304-reasoning.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000006

--- a/providers/xai/grok-4.20-experimental-beta-0304.yaml
+++ b/providers/xai/grok-4.20-experimental-beta-0304.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000006

--- a/providers/xai/grok-4.20-experimental-beta-latest.yaml
+++ b/providers/xai/grok-4.20-experimental-beta-latest.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000006

--- a/providers/xai/grok-4.20-experimental-beta-non-reasoning-latest.yaml
+++ b/providers/xai/grok-4.20-experimental-beta-non-reasoning-latest.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000006

--- a/providers/xai/grok-4.20-experimental-beta-reasoning-latest.yaml
+++ b/providers/xai/grok-4.20-experimental-beta-reasoning-latest.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000006

--- a/providers/xai/grok-4.20-multi-agent-0309.yaml
+++ b/providers/xai/grok-4.20-multi-agent-0309.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_image_token: 0.000002
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001

--- a/providers/xai/grok-4.20-multi-agent-beta-0309-exp-ma.yaml
+++ b/providers/xai/grok-4.20-multi-agent-beta-0309-exp-ma.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000006

--- a/providers/xai/grok-4.20-multi-agent-beta-0309.yaml
+++ b/providers/xai/grok-4.20-multi-agent-beta-0309.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000006

--- a/providers/xai/grok-4.20-multi-agent-beta-latest.yaml
+++ b/providers/xai/grok-4.20-multi-agent-beta-latest.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000006

--- a/providers/xai/grok-4.20-multi-agent-experimental-beta-0304.yaml
+++ b/providers/xai/grok-4.20-multi-agent-experimental-beta-0304.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000006
       region: "*"

--- a/providers/xai/grok-4.20-multi-agent-experimental-beta-latest.yaml
+++ b/providers/xai/grok-4.20-multi-agent-experimental-beta-latest.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000006

--- a/providers/xai/grok-4.20-multi-agent-latest.yaml
+++ b/providers/xai/grok-4.20-multi-agent-latest.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000006

--- a/providers/xai/grok-4.20-multi-agent.yaml
+++ b/providers/xai/grok-4.20-multi-agent.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_image_token: 0.000002
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001

--- a/providers/xai/grok-4.20-non-reasoning-gv2.yaml
+++ b/providers/xai/grok-4.20-non-reasoning-gv2.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_image_token: 0.000002
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000006

--- a/providers/xai/grok-4.20-non-reasoning-latest.yaml
+++ b/providers/xai/grok-4.20-non-reasoning-latest.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_image_token: 0.000002
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001

--- a/providers/xai/grok-4.20-non-reasoning.yaml
+++ b/providers/xai/grok-4.20-non-reasoning.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_image_token: 0.000002
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001

--- a/providers/xai/grok-4.20-reasoning-gv2.yaml
+++ b/providers/xai/grok-4.20-reasoning-gv2.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_image_token: 0.000002
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000006

--- a/providers/xai/grok-4.20-reasoning-latest.yaml
+++ b/providers/xai/grok-4.20-reasoning-latest.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000006
       region: "*"

--- a/providers/xai/grok-4.20-reasoning.yaml
+++ b/providers/xai/grok-4.20-reasoning.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000006
       region: "*"

--- a/providers/xai/grok-4.20.yaml
+++ b/providers/xai/grok-4.20.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_image_token: 0.000002
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001

--- a/providers/xai/grok-4.yaml
+++ b/providers/xai/grok-4.yaml
@@ -1,5 +1,5 @@
 costs:
-    - cache_read_input_token_cost: 2.e-7
+    - cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000006

--- a/providers/xai/grok-code-fast-1-0825.yaml
+++ b/providers/xai/grok-code-fast-1-0825.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 2.e-8
-      input_cost_per_token: 2.e-7
+    - cache_read_input_token_cost: 2e-8
+      input_cost_per_token: 2e-7
       output_cost_per_token: 0.0000015
       region: "*"
 features:

--- a/providers/xai/grok-code-fast-1.yaml
+++ b/providers/xai/grok-code-fast-1.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 2.e-8
-      input_cost_per_token: 2.e-7
+    - cache_read_input_token_cost: 2e-8
+      input_cost_per_token: 2e-7
       output_cost_per_token: 0.0000015
       region: "*"
 features:

--- a/providers/xai/grok-code-fast.yaml
+++ b/providers/xai/grok-code-fast.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_token_cost: 2.e-8
-      input_cost_per_token: 2.e-7
-      input_cost_per_token_batches: 1.e-7
+    - cache_read_input_token_cost: 2e-8
+      input_cost_per_token: 2e-7
+      input_cost_per_token_batches: 1e-7
       output_cost_per_token: 0.0000015
       output_cost_per_token_batches: 7.5e-7
       region: "*"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Config-only change that standardizes numeric formatting for token/image cost fields across many provider YAMLs; low risk aside from potential downstream parsing/validation differences if any tooling relied on the previous string form.
> 
> **Overview**
> Standardizes cost values across provider model YAMLs by rewriting scientific-notation numbers from forms like `2.e-7`/`8.e-8` to `2e-7`/`8e-8` (including nested `tiered_pricing` entries).
> 
> No model capabilities or limits are otherwise changed; this is primarily a formatting/compatibility update for cost fields across AI21, Anthropic, AWS Bedrock, Azure AI Foundry, and Azure OpenAI configs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5bc48ebac4d074d855e9904705589eb3b2c2f95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->