### PR TITLE
feat(deepinfra): update model YAMLs [bot]

### DIFF
--- a/providers/deepinfra/Qwen/Qwen3.6-35B-A3B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3.6-35B-A3B.yaml
@@ -2,12 +2,24 @@ costs:
     - input_cost_per_token: 2e-7
       output_cost_per_token: 0.000001
       region: "*"
+features:
+    - function_calling
+    - json_output
 limits:
     context_window: 262144
     max_tokens: 262144
 modalities:
     input:
+        - text
         - image
-mode: unknown
+    output:
+        - text
+mode: chat
 model: Qwen/Qwen3.6-35B-A3B
+provisioning: serverless
+sources:
+    - https://deepinfra.com/Qwen/Qwen3.6-35B-A3B
+status: active
+supportedModes:
+    - chat
 thinking: true


### PR DESCRIPTION
Auto-generated by poc-agent for provider `deepinfra`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only metadata updates; risk is limited to downstream tooling misinterpreting the new `mode`/capability declarations.
> 
> **Overview**
> Updates the DeepInfra model definition for `Qwen/Qwen3.6-35B-A3B` to advertise additional capabilities and metadata.
> 
> The YAML now declares `function_calling` and `json_output` features, explicitly lists text+image inputs and text outputs, and sets `mode`/`supportedModes` to `chat`. It also adds provisioning (`serverless`), source URL, and marks the model `active`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60fd907714491e4b1e50692368230568259a10b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->