### PR TITLE
feat(deepinfra): add new models [bot]

### DIFF
--- a/providers/deepinfra/moonshotai/Kimi-K2.6.yaml
+++ b/providers/deepinfra/moonshotai/Kimi-K2.6.yaml
@@ -1,0 +1,15 @@
+costs:
+    - cache_read_input_token_cost: 1.499999985e-7
+      input_cost_per_token: 5.5e-7
+      output_cost_per_token: 2.5e-6
+      region: "*"
+features:
+    - prompt_caching
+limits:
+    context_window: 262144
+    max_tokens: 262144
+modalities:
+    input:
+        - image
+mode: unknown
+model: moonshotai/Kimi-K2.6


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `deepinfra`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because it only adds a new provider model YAML entry (pricing/limits/features) without changing runtime logic.
> 
> **Overview**
> Adds a new DeepInfra model definition `providers/deepinfra/moonshotai/Kimi-K2.6.yaml` with token pricing (including cache read), `prompt_caching` support, large `262144` context/max token limits, and image input modality for `moonshotai/Kimi-K2.6`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09a7dbe422abc33e4b8cc40859df3a97242c203e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->