### PR TITLE
feat(mistral-ai): add new models [bot]

### DIFF
--- a/providers/mistral-ai/mistral-embed-dim128-2510.yaml
+++ b/providers/mistral-ai/mistral-embed-dim128-2510.yaml
@@ -1,0 +1,5 @@
+limits:
+    context_window: 8192
+mode: unknown
+model: mistral-embed-dim128-2510
+status: active

--- a/providers/mistral-ai/mistral-embed-dim256-2510.yaml
+++ b/providers/mistral-ai/mistral-embed-dim256-2510.yaml
@@ -1,0 +1,5 @@
+limits:
+    context_window: 8192
+mode: unknown
+model: mistral-embed-dim256-2510
+status: active

--- a/providers/mistral-ai/mistral-medium-3-5.yaml
+++ b/providers/mistral-ai/mistral-medium-3-5.yaml
@@ -1,0 +1,15 @@
+features:
+    - function_calling
+limits:
+    context_window: 262144
+modalities:
+    input:
+        - image
+mode: unknown
+model: mistral-medium-3-5
+params:
+    - defaultValue: 0.7
+      key: temperature
+status: active
+supportedModes:
+    - chat


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `mistral-ai`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only additions; main risk is misclassification (`mode: unknown`) or incorrect limits/feature flags affecting model selection and validation.
> 
> **Overview**
> Adds three new `mistral-ai` model definition YAMLs: two embedding variants (`mistral-embed-dim128-2510`, `mistral-embed-dim256-2510`) with an 8k context window, and a new chat model (`mistral-medium-3-5`) marked as image-capable with `function_calling`, a 262k context window, and a default `temperature` param.
> 
> All new entries are introduced with `mode: unknown` (and the chat model still declares `supportedModes: [chat]`), expanding the provider’s model catalog without changing runtime code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6378cb79c4ac37da15852b624b501442c951d7dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->