### PR TITLE
feat(openrouter): add new models [bot]

### DIFF
--- a/providers/openrouter/inclusionai/ling-2.6-flash:free.yaml
+++ b/providers/openrouter/inclusionai/ling-2.6-flash:free.yaml
@@ -1,0 +1,19 @@
+costs:
+    - input_cost_per_token: 0.0
+      output_cost_per_token: 0.0
+      region: "*"
+features:
+    - function_calling
+    - json_output
+    - structured_output
+    - tool_choice
+limits:
+    context_window: 262144
+    max_output_tokens: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: chat
+model: inclusionai/ling-2.6-flash:free

--- a/providers/openrouter/openai/gpt-5.4-image-2.yaml
+++ b/providers/openrouter/openai/gpt-5.4-image-2.yaml
@@ -1,0 +1,23 @@
+costs:
+    - cache_read_input_token_cost: 2e-6
+      input_cost_per_token: 8e-6
+      output_cost_per_token: 1.5e-5
+      region: "*"
+features:
+    - json_output
+    - prompt_caching
+    - structured_output
+limits:
+    context_window: 272000
+    max_output_tokens: 128000
+modalities:
+    input:
+        - image
+        - text
+        - pdf
+    output:
+        - image
+        - text
+mode: chat
+model: openai/gpt-5.4-image-2
+thinking: true

--- a/providers/openrouter/~anthropic/claude-opus-latest.yaml
+++ b/providers/openrouter/~anthropic/claude-opus-latest.yaml
@@ -1,0 +1,24 @@
+costs:
+    - cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 2.5e-5
+      region: "*"
+features:
+    - function_calling
+    - json_output
+    - prompt_caching
+    - structured_output
+    - tool_choice
+limits:
+    context_window: 1000000
+    max_output_tokens: 128000
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
+mode: chat
+model: ~anthropic/claude-opus-latest
+thinking: true


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `openrouter`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new OpenRouter model definition YAMLs only, with no code-path or behavior changes beyond expanding available model options and their declared limits/costs.
> 
> **Overview**
> Adds three new OpenRouter model definition YAMLs: `inclusionai/ling-2.6-flash:free`, `openai/gpt-5.4-image-2` (multimodal image/text/pdf with prompt caching), and `~anthropic/claude-opus-latest` (very large context window, prompt caching, and tool/function calling).
> 
> Each file declares the model’s supported features, modalities, token limits, and pricing metadata (including cache read/creation costs where applicable).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4305cea37567fae16cabf60fba85e6e6860731ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->