### PR TITLE
remove reasoning_effort and feature

### DIFF
--- a/providers/openai/gpt-4o-mini-transcribe-2025-12-15.yaml
+++ b/providers/openai/gpt-4o-mini-transcribe-2025-12-15.yaml
@@ -2,8 +2,6 @@ costs:
     - input_cost_per_token: 0.00000125
       output_cost_per_token: 0.000005
       region: "*"
-features:
-    - json_output
 limits:
     context_window: 16000
     max_output_tokens: 2000
@@ -31,3 +29,4 @@ sources:
 status: active
 supportedModes:
     - audio_transcription
+    - realtime

--- a/providers/openai/gpt-5-chat-latest.yaml
+++ b/providers/openai/gpt-5-chat-latest.yaml
@@ -33,14 +33,13 @@ params:
     - defaultValue: null
       key: response_format
       type: string
-    - defaultValue: null
-      key: reasoning
 provisioning: serverless
 removeParams:
     - temperature
     - top_p
     - "n"
     - max_tokens
+    - reasoning_effort
 sources:
     - https://developers.openai.com/docs/models/gpt-5-chat-latest
     - https://developers.openai.com/docs/models/gpt-5

--- a/providers/openai/gpt-5-search-api-2025-10-14.yaml
+++ b/providers/openai/gpt-5-search-api-2025-10-14.yaml
@@ -27,11 +27,10 @@ params:
       key: max_completion_tokens
       maxValue: 128000
       minValue: 1
-    - key: reasoning_effort
-      type: string
 provisioning: serverless
 removeParams:
     - max_tokens
+    - reasoning_effort
 sources:
     - https://developers.openai.com/api/docs/models/gpt-5
 status: active

--- a/providers/openai/gpt-5-search-api.yaml
+++ b/providers/openai/gpt-5-search-api.yaml
@@ -25,9 +25,9 @@ params:
       key: max_tokens
       maxValue: 128000
       minValue: 1
-    - defaultValue: medium
-      key: reasoning_effort
 provisioning: serverless
+removeParams:
+    - reasoning_effort
 sources:
     - https://developers.openai.com/api/docs/guides/tools-web-search/
     - https://developers.openai.com/api/docs/models/gpt-5


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk config-only changes to OpenAI model YAML metadata; main impact is disabling support for the `reasoning_effort` parameter and adjusting declared modes/features, which could affect callers relying on those fields.
> 
> **Overview**
> Updates OpenAI provider model configs to stop advertising/supporting the `reasoning_effort` (and related `reasoning`) parameter on GPT-5 chat/search models by removing it from `params` and explicitly stripping it via `removeParams`.
> 
> Adjusts `gpt-4o-mini-transcribe-2025-12-15` metadata by dropping the `json_output` feature flag and adding `realtime` to `supportedModes`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e6ce11aedb15c804c9fac748844aa4a8d5944fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->