### PR TITLE
feat(openrouter): update model YAMLs [bot]

### DIFF
--- a/providers/openrouter/anthropic/claude-opus-4.6-fast.yaml
+++ b/providers/openrouter/anthropic/claude-opus-4.6-fast.yaml
@@ -29,7 +29,9 @@ params:
       maxValue: 128000
       minValue: 1
 sources:
+    - https://openrouter.ai/anthropic/claude-opus-4.6-fast
     - https://openrouter.ai/anthropic/claude-opus-4.6-fast/api
+status: active
 supportedModes:
     - chat
 thinking: true

--- a/providers/openrouter/google/gemma-4-31b-it:free.yaml
+++ b/providers/openrouter/google/gemma-4-31b-it:free.yaml
@@ -27,8 +27,10 @@ params:
       key: top_p
     - defaultValue: 64
       key: top_k
+provisioning: serverless
 sources:
-    - https://openrouter.ai/google/gemma-4-31b-it:free/api
+    - https://openrouter.ai/google/gemma-4-31b-it:free
+status: active
 supportedModes:
     - chat
 thinking: true

--- a/providers/openrouter/z-ai/glm-5.1.yaml
+++ b/providers/openrouter/z-ai/glm-5.1.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: 0.00000126
-      output_cost_per_token: 0.00000396
+    - input_cost_per_token: 0.00000105
+      output_cost_per_token: 0.0000035
       region: "*"
 features:
     - function_calling
@@ -22,6 +22,7 @@ params:
     - defaultValue: 0.95
       key: top_p
 sources:
+    - https://openrouter.ai/z-ai/glm-5.1
     - https://openrouter.ai/z-ai/glm-5.1/api
 supportedModes:
     - chat


### PR DESCRIPTION
Auto-generated by poc-agent for provider `openrouter`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Updates are limited to provider model YAML metadata (pricing and discovery fields) and should not affect runtime logic beyond model catalog display/selection.
> 
> **Overview**
> Refreshes OpenRouter model definitions for `claude-opus-4.6-fast`, `gemma-4-31b-it:free`, and `glm-5.1`.
> 
> Adds/adjusts catalog metadata: new non-`/api` `sources` links for all three models, `status: active` for Claude and Gemma, and `provisioning: serverless` for Gemma. Also updates `z-ai/glm-5.1` `costs` to lower the per-token input/output pricing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a880b5489a20f321f86003cb93fce8912df6b65b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->