### PR TITLE
feat(mistral-ai): update model YAMLs [bot]

### DIFF
--- a/providers/mistral-ai/mistral-embed-dim128-2510.yaml
+++ b/providers/mistral-ai/mistral-embed-dim128-2510.yaml
@@ -1,5 +1,12 @@
 limits:
     context_window: 8192
-mode: unknown
+modalities:
+    input:
+        - text
+    output:
+        - embedding
+mode: embedding
 model: mistral-embed-dim128-2510
 status: active
+
+# costs: not found in official docs

--- a/providers/mistral-ai/mistral-embed-dim256-2510.yaml
+++ b/providers/mistral-ai/mistral-embed-dim256-2510.yaml
@@ -1,5 +1,12 @@
 limits:
     context_window: 8192
-mode: unknown
+modalities:
+    input:
+        - text
+    output:
+        - embedding
+mode: embedding
 model: mistral-embed-dim256-2510
 status: active
+
+# costs: not found in official docs

--- a/providers/mistral-ai/mistral-medium-3-5.yaml
+++ b/providers/mistral-ai/mistral-medium-3-5.yaml
@@ -5,7 +5,7 @@ limits:
 modalities:
     input:
         - image
-mode: unknown
+mode: chat
 model: mistral-medium-3-5
 params:
     - defaultValue: 0.7


### PR DESCRIPTION
Auto-generated by poc-agent for provider `mistral-ai`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk metadata-only change, but it can affect model routing/selection by changing `mode` from `unknown` to `embedding`/`chat`.
> 
> **Overview**
> Updates Mistral provider model YAMLs to replace `mode: unknown` with explicit modes: `embedding` for `mistral-embed-dim128-2510` and `mistral-embed-dim256-2510`, and `chat` for `mistral-medium-3-5`.
> 
> Also adds `modalities` (text input, embedding output) to the two embedding model configs, with a note that pricing was not found in official docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4ae9caccc5d86f7179992f661ee7907da52277e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->