### PR TITLE
feat(deepinfra): update model YAMLs [bot]

### DIFF
--- a/providers/deepinfra/moonshotai/Kimi-K2.6.yaml
+++ b/providers/deepinfra/moonshotai/Kimi-K2.6.yaml
@@ -5,11 +5,22 @@ costs:
       region: "*"
 features:
     - prompt_caching
+    - function_calling
+    - json_output
 limits:
     context_window: 262144
     max_tokens: 262144
 modalities:
     input:
+        - text
         - image
-mode: unknown
+    output:
+        - text
+mode: chat
 model: moonshotai/Kimi-K2.6
+provisioning: serverless
+sources:
+    - https://deepinfra.com/moonshotai/Kimi-K2.6
+status: active
+supportedModes:
+    - chat


### PR DESCRIPTION
Auto-generated by poc-agent for provider `deepinfra`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that updates a single DeepInfra model YAML; main risk is incorrect capability/mode metadata affecting routing or feature toggles for this model.
> 
> **Overview**
> Updates the DeepInfra `moonshotai/Kimi-K2.6` model YAML to reflect **chat** operation and richer capabilities: adds `function_calling` and `json_output`, explicitly lists `text` input and `text` output modalities, and corrects `mode` to `chat`.
> 
> Also adds operational metadata (`provisioning: serverless`, `sources` link, `status: active`, and `supportedModes`) to align this model entry with other provider definitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0efafe03bef8c128f1754c9ac17542cdce1fc56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->