### PR TITLE
chore: add vertex regions

### DIFF
--- a/.github/scripts/autogen/types.ts
+++ b/.github/scripts/autogen/types.ts
@@ -44,7 +44,7 @@ export interface components {
         /** @description Pricing entry; "*" applies to all regions */
         CostWithRegion: {
             /** @enum {string} */
-            region?: "*" | "af-south-1" | "ap-east-1" | "ap-east-2" | "ap-northeast-1" | "ap-northeast-2" | "ap-northeast-3" | "ap-south-1" | "ap-south-2" | "ap-southeast-1" | "ap-southeast-2" | "ap-southeast-3" | "ap-southeast-4" | "ap-southeast-5" | "ap-southeast-6" | "ap-southeast-7" | "ca-central-1" | "ca-west-1" | "cn-north-1" | "cn-northwest-1" | "eu-central-1" | "eu-central-2" | "eu-north-1" | "eu-south-1" | "eu-south-2" | "eu-west-1" | "eu-west-2" | "eu-west-3" | "il-central-1" | "me-central-1" | "me-south-1" | "mx-central-1" | "sa-east-1" | "us-east-1" | "us-east-2" | "us-gov-east-1" | "us-gov-west-1" | "us-west-1" | "us-west-2" | "asia-east1" | "asia-east2" | "asia-northeast1" | "asia-northeast2" | "asia-northeast3" | "asia-south1" | "asia-south2" | "asia-southeast1" | "asia-southeast2" | "australia-southeast1" | "australia-southeast2" | "europe-central2" | "europe-north1" | "europe-southwest1" | "europe-west1" | "europe-west2" | "europe-west3" | "europe-west4" | "europe-west6" | "europe-west8" | "europe-west9" | "global" | "me-central1" | "me-central2" | "me-west1" | "northamerica-northeast1" | "northamerica-northeast2" | "southamerica-east1" | "us-central1" | "us-east1" | "us-east4" | "us-east5" | "us-south1" | "us-west1" | "us-west2" | "us-west3" | "us-west4" | "datazone_eu" | "datazone_us";
+            region?: "*" | "af-south-1" | "ap-east-1" | "ap-east-2" | "ap-northeast-1" | "ap-northeast-2" | "ap-northeast-3" | "ap-south-1" | "ap-south-2" | "ap-southeast-1" | "ap-southeast-2" | "ap-southeast-3" | "ap-southeast-4" | "ap-southeast-5" | "ap-southeast-6" | "ap-southeast-7" | "ca-central-1" | "ca-west-1" | "cn-north-1" | "cn-northwest-1" | "eu-central-1" | "eu-central-2" | "eu-north-1" | "eu-south-1" | "eu-south-2" | "eu-west-1" | "eu-west-2" | "eu-west-3" | "il-central-1" | "me-central-1" | "me-south-1" | "mx-central-1" | "sa-east-1" | "us-east-1" | "us-east-2" | "us-gov-east-1" | "us-gov-west-1" | "us-west-1" | "us-west-2" | "asia-east1" | "asia-east2" | "asia-northeast1" | "asia-northeast2" | "asia-northeast3" | "asia-south1" | "asia-south2" | "asia-southeast1" | "asia-southeast2" | "australia-southeast1" | "australia-southeast2" | "europe-central2" | "europe-north1" | "europe-southwest1" | "europe-west1" | "europe-west2" | "europe-west3" | "europe-west4" | "europe-west6" | "europe-west8" | "europe-west9" | "global" | "me-central1" | "me-central2" | "me-west1" | "northamerica-northeast1" | "northamerica-northeast2" | "southamerica-east1" | "us-central1" | "us-east1" | "us-east4" | "us-east5" | "us-south1" | "us-west1" | "us-west2" | "us-west3" | "us-west4" | "datazone_eu" | "datazone_us" | "us" | "eu";
         } & (components["schemas"]["Cost"] & unknown);
         /** @description Schema for default.yaml files (provider-level defaults) */
         DefaultConfig: {
@@ -156,6 +156,11 @@ export interface components {
             input?: components["schemas"]["PricingTier"][];
             output?: components["schemas"]["PricingTier"][];
         };
+        /**
+         * @description Vertex region identifiers
+         * @enum {string}
+         */
+        VertexRegion: "us" | "eu";
     };
     responses: never;
     parameters: never;
@@ -187,3 +192,4 @@ export type PricingTier = components['schemas']['PricingTier'];
 export type Provisioning = components['schemas']['Provisioning'];
 export type Status = components['schemas']['Status'];
 export type TieredPricing = components['schemas']['TieredPricing'];
+export type VertexRegion = components['schemas']['VertexRegion'];

--- a/.github/test/model.cue
+++ b/.github/test/model.cue
@@ -138,7 +138,7 @@ package model
 
 // Pricing entry; "*" applies to all regions
 #CostWithRegion: {
-	region: "*" | #AWSRegion | #GCPRegion | #AzureRegion
+	region: "*" | #AWSRegion | #GCPRegion | #AzureRegion | #VertexRegion
 	#Cost
 }
 
@@ -194,6 +194,11 @@ package model
 	"us-west2" |
 	"us-west3" |
 	"us-west4"
+
+// Vertex region identifiers
+#VertexRegion: 
+	"us" |
+	"eu"
 
 #Limits: {
 	context_window?:                int & >= 0   // Maximum number of tokens the model can hold in its context at once

--- a/providers/google-vertex/text-embedding-004.yaml
+++ b/providers/google-vertex/text-embedding-004.yaml
@@ -2,7 +2,7 @@ costs:
     - input_cost_per_character: 2.5e-8
       input_cost_per_token: 1e-7
       output_cost_per_token: 0
-      region: "*"
+      region: us-central1
 deprecationDate: "2027-04-01"
 limits:
     max_input_tokens: 2048

--- a/providers/google-vertex/text-embedding-005.yaml
+++ b/providers/google-vertex/text-embedding-005.yaml
@@ -2,7 +2,7 @@ costs:
     - input_cost_per_character: 2.5e-8
       input_cost_per_token: 1e-7
       output_cost_per_token: 0
-      region: "*"
+      region: us-central1
 limits:
     max_input_tokens: 2048
     max_tokens: 2048

--- a/providers/google-vertex/text-multilingual-embedding-002.yaml
+++ b/providers/google-vertex/text-multilingual-embedding-002.yaml
@@ -2,7 +2,7 @@ costs:
     - input_cost_per_character: 2.5e-8
       input_cost_per_token: 1e-7
       output_cost_per_token: 0
-      region: "*"
+      region: us-central1
 limits:
     max_input_tokens: 2048
     max_tokens: 4096

--- a/providers/perplexity-ai/sonar-pro-search.yaml
+++ b/providers/perplexity-ai/sonar-pro-search.yaml
@@ -1,2 +1,3 @@
 mode: unknown
 model: sonar-pro-search
+status: retired


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Type/schema changes to `CostWithRegion.region` and updated pricing-region semantics may break validation or downstream code that assumed `"*"`/GCP-only regions; changes are otherwise localized config updates.
> 
> **Overview**
> Adds explicit Vertex AI region identifiers by introducing `VertexRegion` (`us`/`eu`) and extending `CostWithRegion.region` typing/validation to accept them in both the generated TS types and the CUE schema.
> 
> Updates Google Vertex embedding model configs to use a concrete region (`us-central1`) instead of `"*"` for their pricing entries, and marks Perplexity’s `sonar-pro-search` model as `retired`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afa7992f7b94babcef8db5cd097f1d47a669f0fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->