### PR TITLE
feat(google-gemini): add new models [bot]

### DIFF
--- a/providers/google-gemini/gemini-embedding-2.yaml
+++ b/providers/google-gemini/gemini-embedding-2.yaml
@@ -1,0 +1,5 @@
+limits:
+    max_input_tokens: 8192
+    max_output_tokens: 1
+mode: unknown
+model: gemini-embedding-2


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `google-gemini`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new standalone model YAML with limits and no changes to runtime logic.
> 
> **Overview**
> Adds a new provider model definition `providers/google-gemini/gemini-embedding-2.yaml`, declaring token limits (`max_input_tokens: 8192`, `max_output_tokens: 1`) and registering the model name `gemini-embedding-2` with `mode: unknown`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 671fe3bfe357ae68e1a71a6f589f369aef69164e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->