### PR TITLE
feat(openrouter): add new models [bot]

### DIFF
--- a/providers/openrouter/arcee-ai/trinity-large-preview.yaml
+++ b/providers/openrouter/arcee-ai/trinity-large-preview.yaml
@@ -1,0 +1,22 @@
+costs:
+    - input_cost_per_token: 1.5e-7
+      output_cost_per_token: 4.5e-7
+      region: "*"
+features:
+    - function_calling
+    - json_output
+    - structured_output
+limits:
+    context_window: 131000
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: chat
+model: arcee-ai/trinity-large-preview
+params:
+    - defaultValue: 0.8
+      key: temperature
+    - defaultValue: 0.8
+      key: top_p

--- a/providers/openrouter/xiaomi/mimo-v2.5-pro.yaml
+++ b/providers/openrouter/xiaomi/mimo-v2.5-pro.yaml
@@ -1,0 +1,26 @@
+costs:
+    - cache_read_input_token_cost: 2e-7
+      input_cost_per_token: 1e-6
+      output_cost_per_token: 3e-6
+      region: "*"
+features:
+    - function_calling
+    - json_output
+    - prompt_caching
+    - tool_choice
+limits:
+    context_window: 1048576
+    max_output_tokens: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: chat
+model: xiaomi/mimo-v2.5-pro
+params:
+    - defaultValue: 1
+      key: temperature
+    - defaultValue: 0.95
+      key: top_p
+thinking: true

--- a/providers/openrouter/xiaomi/mimo-v2.5.yaml
+++ b/providers/openrouter/xiaomi/mimo-v2.5.yaml
@@ -1,0 +1,29 @@
+costs:
+    - cache_read_input_token_cost: 8e-8
+      input_cost_per_token: 4e-7
+      output_cost_per_token: 2e-6
+      region: "*"
+features:
+    - function_calling
+    - json_output
+    - prompt_caching
+    - tool_choice
+limits:
+    context_window: 1048576
+    max_output_tokens: 131072
+modalities:
+    input:
+        - text
+        - audio
+        - image
+        - video
+    output:
+        - text
+mode: chat
+model: xiaomi/mimo-v2.5
+params:
+    - defaultValue: 1
+      key: temperature
+    - defaultValue: 0.95
+      key: top_p
+thinking: true


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `openrouter`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only adds new model metadata/config files (pricing, limits, features) with no changes to execution logic. Main risk is misconfigured limits/costs affecting routing or billing.
> 
> **Overview**
> Adds new OpenRouter model configs for `arcee-ai/trinity-large-preview`, `xiaomi/mimo-v2.5`, and `xiaomi/mimo-v2.5-pro`, including token pricing, supported features (e.g., *function calling*, *prompt caching*, *tool choice*), and modality/limits (notably 1M context and 131k max output for MiMo).
> 
> Sets default sampling params (`temperature`, `top_p`) and marks both MiMo models with `thinking: true`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e388472ac5035e904647dffc8f6650f794e484b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->