### PR TITLE
feat(together-ai): add new models [bot]

### DIFF
--- a/providers/together-ai/Qwen/Qwen3.6-35B-A3B-FP8.yaml
+++ b/providers/together-ai/Qwen/Qwen3.6-35B-A3B-FP8.yaml
@@ -1,0 +1,10 @@
+costs:
+    - input_cost_per_token: 0.0
+      output_cost_per_token: 0.0
+      region: "*"
+limits:
+    context_window: 262144
+mode: unknown
+model: Qwen/Qwen3.6-35B-A3B-FP8
+supportedModes:
+    - chat

--- a/providers/together-ai/google/gemma-4-E2B-it.yaml
+++ b/providers/together-ai/google/gemma-4-E2B-it.yaml
@@ -1,0 +1,10 @@
+costs:
+    - input_cost_per_token: 0.0
+      output_cost_per_token: 0.0
+      region: "*"
+limits:
+    context_window: 131072
+mode: unknown
+model: google/gemma-4-E2B-it
+supportedModes:
+    - chat

--- a/providers/together-ai/google/gemma-4-E4B-it.yaml
+++ b/providers/together-ai/google/gemma-4-E4B-it.yaml
@@ -1,0 +1,11 @@
+costs:
+    - cache_read_input_token_cost: 0.0
+      input_cost_per_token: 0.0
+      output_cost_per_token: 0.0
+      region: "*"
+limits:
+    context_window: 131072
+mode: unknown
+model: google/gemma-4-E4B-it
+supportedModes:
+    - chat

--- a/providers/together-ai/moonshotai/Kimi-K2.6.yaml
+++ b/providers/together-ai/moonshotai/Kimi-K2.6.yaml
@@ -1,0 +1,11 @@
+costs:
+    - cache_read_input_token_cost: 2e-7
+      input_cost_per_token: 1.2e-6
+      output_cost_per_token: 4.5e-6
+      region: "*"
+limits:
+    context_window: 262144
+mode: unknown
+model: moonshotai/Kimi-K2.6
+supportedModes:
+    - chat


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `together-ai`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds new provider model metadata YAMLs only; no runtime logic changes, so risk is limited to configuration/availability and pricing metadata accuracy.
> 
> **Overview**
> Adds 4 new `together-ai` model definition YAMLs for `Qwen/Qwen3.6-35B-A3B-FP8`, `google/gemma-4-E2B-it`, `google/gemma-4-E4B-it`, and `moonshotai/Kimi-K2.6`, including `context_window`, `supportedModes` (chat), and token pricing fields (with cache-read costs where applicable).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8925682230fc013f1480183a764af4e6ab250fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->