### PR TITLE
feat(openrouter): update model YAMLs [bot]

### DIFF
--- a/providers/openrouter/arcee-ai/trinity-large-preview.yaml
+++ b/providers/openrouter/arcee-ai/trinity-large-preview.yaml
@@ -20,3 +20,9 @@ params:
       key: temperature
     - defaultValue: 0.8
       key: top_p
+provisioning: serverless
+sources:
+    - https://openrouter.ai/arcee-ai/trinity-large-preview
+status: active
+supportedModes:
+    - chat

--- a/providers/openrouter/xiaomi/mimo-v2.5-pro.yaml
+++ b/providers/openrouter/xiaomi/mimo-v2.5-pro.yaml
@@ -23,4 +23,10 @@ params:
       key: temperature
     - defaultValue: 0.95
       key: top_p
+provisioning: serverless
+sources:
+    - https://openrouter.ai/xiaomi/mimo-v2.5-pro
+status: active
+supportedModes:
+    - chat
 thinking: true

--- a/providers/openrouter/xiaomi/mimo-v2.5.yaml
+++ b/providers/openrouter/xiaomi/mimo-v2.5.yaml
@@ -26,4 +26,8 @@ params:
       key: temperature
     - defaultValue: 0.95
       key: top_p
+sources:
+    - https://openrouter.ai/xiaomi/mimo-v2.5
+supportedModes:
+    - chat
 thinking: true


### PR DESCRIPTION
Auto-generated by poc-agent for provider `openrouter`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: YAML-only metadata updates (provisioning/status/supported modes/source URLs) with no code-path or security-sensitive logic changes.
> 
> **Overview**
> Updates OpenRouter model YAMLs to include additional runtime metadata. `arcee-ai/trinity-large-preview` and `xiaomi/mimo-v2.5-pro` now declare **serverless provisioning**, **active status**, **supported chat mode**, and a canonical `sources` URL; `xiaomi/mimo-v2.5` adds `sources` and `supportedModes`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b21276c443ec8412dab897aa2da81836b29ac6ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->