### PR TITLE
feat(together-ai): update model YAMLs [bot]

### DIFF
--- a/providers/together-ai/Qwen/Qwen3.6-35B-A3B-FP8.yaml
+++ b/providers/together-ai/Qwen/Qwen3.6-35B-A3B-FP8.yaml
@@ -11,7 +11,7 @@ modalities:
         - text
 mode: chat
 model: Qwen/Qwen3.6-35B-A3B-FP8
-provisioning: serverless
+provisioning: provisioned
 supportedModes:
     - chat
 thinking: true

--- a/providers/together-ai/Qwen/Qwen3.6-35B-A3B-FP8.yaml
+++ b/providers/together-ai/Qwen/Qwen3.6-35B-A3B-FP8.yaml
@@ -1,10 +1,17 @@
 costs:
-    - input_cost_per_token: 0.0
-      output_cost_per_token: 0.0
+    - input_cost_per_token: 0.0 # not found in official docs
+      output_cost_per_token: 0.0 # not found in official docs
       region: "*"
 limits:
     context_window: 262144
-mode: unknown
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: chat
 model: Qwen/Qwen3.6-35B-A3B-FP8
+provisioning: serverless
 supportedModes:
     - chat
+thinking: true

--- a/providers/together-ai/google/gemma-4-E2B-it.yaml
+++ b/providers/together-ai/google/gemma-4-E2B-it.yaml
@@ -1,10 +1,23 @@
 costs:
-    - input_cost_per_token: 0.0
-      output_cost_per_token: 0.0
+    - input_cost_per_token: 0.0 # not found in official Together AI docs
+      output_cost_per_token: 0.0 # not found in official Together AI docs
       region: "*"
+features:
+    - function_calling
+    - system_messages
 limits:
     context_window: 131072
-mode: unknown
+modalities:
+    input:
+        - text
+        - image
+        - audio
+        - video
+    output:
+        - text
+mode: chat
 model: google/gemma-4-E2B-it
+provisioning: serverless
 supportedModes:
     - chat
+thinking: true

--- a/providers/together-ai/google/gemma-4-E2B-it.yaml
+++ b/providers/together-ai/google/gemma-4-E2B-it.yaml
@@ -17,7 +17,7 @@ modalities:
         - text
 mode: chat
 model: google/gemma-4-E2B-it
-provisioning: serverless
+provisioning: provisioned
 supportedModes:
     - chat
 thinking: true

--- a/providers/together-ai/moonshotai/Kimi-K2.6.yaml
+++ b/providers/together-ai/moonshotai/Kimi-K2.6.yaml
@@ -3,9 +3,26 @@ costs:
       input_cost_per_token: 1.2e-6
       output_cost_per_token: 4.5e-6
       region: "*"
+features:
+    - function_calling
+    - json_output
+    - structured_output
+    - prompt_caching
 limits:
     context_window: 262144
-mode: unknown
+modalities:
+    input:
+        - text
+        - image
+        - video
+    output:
+        - text
+mode: chat
 model: moonshotai/Kimi-K2.6
+provisioning: serverless
+sources:
+    - https://www.together.ai/models/kimi-k26
+status: active
 supportedModes:
     - chat
+thinking: true


### PR DESCRIPTION
Auto-generated by poc-agent for provider `together-ai`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Data-only updates to provider model metadata; main risk is incorrect capability/cost flags causing misrouting or UI display issues.
> 
> **Overview**
> Updates Together AI model YAMLs to replace `mode: unknown` with `mode: chat` and add richer capability metadata.
> 
> Specifically adds `modalities` (input/output types) across the three models, introduces `features` for `gemma-4-E2B-it` and `Kimi-K2.6`, and records provisioning details (`provisioned` vs `serverless`) plus `thinking: true` (and `sources`/`status` for Kimi).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 312b28a4672502bfffbc8c8f9c357e770b6d2580. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->