### PR TITLE
feat(google-gemini): update model YAMLs [bot]

### DIFF
--- a/providers/google-gemini/gemini-embedding-2.yaml
+++ b/providers/google-gemini/gemini-embedding-2.yaml
@@ -1,5 +1,37 @@
+costs:
+    - input_cost_per_audio_token: 6.5e-6
+      input_cost_per_image_token: 4.5e-7
+      input_cost_per_token: 2e-7
+      input_cost_per_video_token: 1.2e-5
+      region: "*"
 limits:
+    context_window: 8192
     max_input_tokens: 8192
     max_output_tokens: 1
-mode: unknown
+    output_vector_size: 3072
+modalities:
+    input:
+        - text
+        - image
+        - audio
+        - video
+        - pdf
+    output:
+        - embedding
+mode: embedding
 model: gemini-embedding-2
+provisioning: serverless
+removeParams:
+    - max_tokens
+    - temperature
+    - top_p
+    - top_k
+    - stop
+    - stream
+    - tool_choice
+sources:
+    - https://ai.google.dev/gemini-api/docs/embeddings
+    - https://ai.google.dev/gemini-api/docs/models/gemini-embedding-2
+status: active
+supportedModes:
+    - embedding


### PR DESCRIPTION
Auto-generated by poc-agent for provider `google-gemini`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change to a single model YAML; main risk is incorrect limits/costs/parameter stripping affecting embedding requests.
> 
> **Overview**
> Updates `gemini-embedding-2.yaml` to fully specify the model’s embedding configuration, including token costs, `context_window`/`output_vector_size` limits, supported input/output modalities, and `supportedModes`.
> 
> Also marks the model as *serverless* and *active*, adds documentation sources, and lists request parameters to strip via `removeParams` (e.g., `temperature`, `top_p`, `stream`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85868f298d5d68b773523d796ecdd45cd2e5af68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->