### PR TITLE
fix: mistral input and output modalities

### DIFF
--- a/providers/mistral-ai/magistral-medium-2509.yaml
+++ b/providers/mistral-ai/magistral-medium-2509.yaml
@@ -12,11 +12,9 @@ modalities:
     input:
         - image
         - text
-        - audio
         - pdf
     output:
         - text
-        - audio
 mode: chat
 model: magistral-medium-2509
 params:

--- a/providers/mistral-ai/mistral-large-latest.yaml
+++ b/providers/mistral-ai/mistral-large-latest.yaml
@@ -14,12 +14,10 @@ modalities:
     input:
         - text
         - image
-        - audio
         - pdf
         - doc
     output:
         - text
-        - audio
 mode: chat
 model: mistral-large-latest
 params:

--- a/providers/mistral-ai/mistral-medium-3.yaml
+++ b/providers/mistral-ai/mistral-medium-3.yaml
@@ -13,10 +13,8 @@ modalities:
         - text
         - pdf
         - doc
-        - audio
     output:
         - text
-        - audio
 mode: chat
 model: mistral-medium-3
 params:

--- a/providers/mistral-ai/mistral-medium-latest.yaml
+++ b/providers/mistral-ai/mistral-medium-latest.yaml
@@ -15,7 +15,6 @@ modalities:
     input:
         - text
         - image
-        - audio
         - pdf
     output:
         - text

--- a/providers/mistral-ai/mistral-small-2603.yaml
+++ b/providers/mistral-ai/mistral-small-2603.yaml
@@ -12,12 +12,10 @@ modalities:
     input:
         - text
         - image
-        - audio
         - pdf
         - doc
     output:
         - text
-        - audio
 mode: chat
 model: mistral-small-2603
 params:

--- a/providers/mistral-ai/mistral-small-latest.yaml
+++ b/providers/mistral-ai/mistral-small-latest.yaml
@@ -14,12 +14,10 @@ modalities:
     input:
         - text
         - image
-        - audio
         - pdf
         - doc
     output:
         - text
-        - audio
 mode: chat
 model: mistral-small-latest
 params:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk metadata-only change: updates model capability YAMLs to stop advertising unsupported `audio` input/output, which could affect clients that previously attempted audio requests based on these flags.
> 
> **Overview**
> Fixes Mistral model capability metadata by removing `audio` from the declared `modalities` for several chat models (including `magistral-medium-2509`, `mistral-large-latest`, `mistral-medium-*`, and `mistral-small-*`). This ensures clients only see the supported `text` output and `text/image/pdf(/doc)` inputs when selecting modalities.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 185448e6548c69fe6fce5c561b49f8ed58e5b570. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->