### PR TITLE
retire models

### DIFF
--- a/providers/aws-bedrock/amazon.nova-lite-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.nova-lite-v1:0.yaml
@@ -108,6 +108,7 @@ features:
     - function_calling
     - prompt_caching
     - tool_choice
+isDeprecated: true
 limits:
     context_window: 300000
     max_input_tokens: 300000
@@ -142,6 +143,6 @@ removeParams:
     - "n"
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-amazon-nova-lite.html
-status: active
+status: retired
 supportedModes:
     - chat

--- a/providers/aws-bedrock/amazon.nova-pro-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.nova-pro-v1:0.yaml
@@ -99,6 +99,7 @@ features:
     - tool_choice
     - prompt_caching
     - assistant_prefill
+isDeprecated: true
 limits:
     context_window: 300000
     max_output_tokens: 5000
@@ -133,7 +134,7 @@ sources:
     - https://docs.aws.amazon.com/nova/latest/userguide/what-is-nova.html
     - https://docs.aws.amazon.com/nova/latest/userguide/complete-request-schema.html
     - https://docs.aws.amazon.com/nova/latest/userguide/modalities.html
-status: active
+status: retired
 supportedModes:
     - chat
 thinking: true

--- a/providers/aws-bedrock/anthropic.claude-opus-4-6-v1.yaml
+++ b/providers/aws-bedrock/anthropic.claude-opus-4-6-v1.yaml
@@ -1,5 +1,6 @@
 costs:
     - region: eu-west-2
+isDeprecated: true
 modalities:
     input:
         - text
@@ -8,3 +9,4 @@ modalities:
         - text
 mode: unknown
 model: anthropic.claude-opus-4-6-v1
+status: retired

--- a/providers/aws-bedrock/anthropic.claude-sonnet-4-6.yaml
+++ b/providers/aws-bedrock/anthropic.claude-sonnet-4-6.yaml
@@ -229,6 +229,7 @@ features:
     - function_calling
     - prompt_caching
     - tool_choice
+isDeprecated: true
 limits:
     context_window: 1000000
     max_input_tokens: 1000000
@@ -253,7 +254,7 @@ sources:
     - https://platform.claude.com/docs/en/docs/about-claude/models
     - https://platform.claude.com/docs/en/about-claude/pricing
     - https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html
-status: active
+status: retired
 supportedModes:
     - chat
 thinking: true

--- a/providers/aws-bedrock/meta.llama3-1-70b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/meta.llama3-1-70b-instruct-v1:0.yaml
@@ -12,6 +12,7 @@ features:
     - function_calling
     - system_messages
     - tool_choice
+isDeprecated: true
 limits:
     context_window: 128000
     max_output_tokens: 2048
@@ -27,6 +28,6 @@ provisioning: serverless
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-meta.html
     - https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html
-status: active
+status: retired
 supportedModes:
     - chat

--- a/providers/aws-bedrock/meta.llama3-1-8b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/meta.llama3-1-8b-instruct-v1:0.yaml
@@ -17,6 +17,7 @@ costs:
 features:
     - function_calling
     - system_messages
+isDeprecated: true
 limits:
     context_window: 128000
     max_output_tokens: 2048
@@ -35,6 +36,6 @@ removeParams:
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-meta.html
     - https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference-supported-models-features.html
-status: active
+status: retired
 supportedModes:
     - chat

--- a/providers/aws-bedrock/meta.llama3-3-70b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/meta.llama3-3-70b-instruct-v1:0.yaml
@@ -17,6 +17,7 @@ costs:
 features:
     - function_calling
     - system_messages
+isDeprecated: true
 limits:
     context_window: 128000
     max_output_tokens: 2048
@@ -34,6 +35,6 @@ removeParams:
 sources:
     - https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-meta.html
-status: active
+status: retired
 supportedModes:
     - chat

--- a/providers/openai/gpt-5-pro-2025-10-06.yaml
+++ b/providers/openai/gpt-5-pro-2025-10-06.yaml
@@ -32,6 +32,7 @@ provisioning: serverless
 removeParams:
     - max_tokens
     - max_completion_tokens
+    - reasoning_effort
 sources:
     - https://developers.openai.com/api/docs/models/gpt-5-pro
 status: active

--- a/providers/openai/gpt-5-pro.yaml
+++ b/providers/openai/gpt-5-pro.yaml
@@ -33,6 +33,7 @@ removeParams:
     - parallel_tool_calls
     - max_tokens
     - max_completion_tokens
+    - reasoning_effort
 sources:
     - https://developers.openai.com/api/docs/models/gpt-5-pro
 status: active


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Marks multiple AWS Bedrock model definitions as `retired`/deprecated, which may impact users relying on those model IDs. Also updates OpenAI `gpt-5-pro` configs to strip `reasoning_effort`, potentially changing request behavior for clients passing that parameter.
> 
> **Overview**
> Retires several AWS Bedrock models by setting `status: retired` and adding `isDeprecated: true` across Nova Lite/Pro, Claude Opus/Sonnet 4.6, and Llama 3.x instruct model definitions.
> 
> Updates OpenAI `gpt-5-pro` model configs to additionally remove the `reasoning_effort` parameter via `removeParams`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50fa032b5649f667e9a03d9981253c26363ed888. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->