### PR TITLE
feat(openrouter): add new models [bot]

### DIFF
--- a/providers/openrouter/baidu/qianfan-ocr-fast:free.yaml
+++ b/providers/openrouter/baidu/qianfan-ocr-fast:free.yaml
@@ -1,0 +1,16 @@
+costs:
+    - input_cost_per_token: 0.0
+      output_cost_per_token: 0.0
+      region: "*"
+limits:
+    context_window: 65536
+    max_output_tokens: 28672
+modalities:
+    input:
+        - image
+        - text
+    output:
+        - text
+mode: chat
+model: baidu/qianfan-ocr-fast:free
+thinking: true

--- a/providers/openrouter/tencent/hy3-preview:free.yaml
+++ b/providers/openrouter/tencent/hy3-preview:free.yaml
@@ -1,0 +1,18 @@
+costs:
+    - input_cost_per_token: 0.0
+      output_cost_per_token: 0.0
+      region: "*"
+features:
+    - function_calling
+    - tool_choice
+limits:
+    context_window: 262144
+    max_output_tokens: 262144
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: chat
+model: tencent/hy3-preview:free
+thinking: true


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `openrouter`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds two new OpenRouter model definition YAMLs without changing runtime logic. Main risk is incorrect metadata (limits/features/modalities) affecting model selection or request validation.
> 
> **Overview**
> Adds two new OpenRouter model definition files: `baidu/qianfan-ocr-fast:free` (image+text input, text output; 65k context, 28k max output) and `tencent/hy3-preview:free` (text-only; supports `function_calling`/`tool_choice`; 262k context/output).
> 
> Both models are marked as `mode: chat`, `thinking: true`, and have zero token costs across regions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfae077a331068ad1d271b3dc18781a5998de876. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->