### PR TITLE
fix: bedrock params, provision models, and change mode

### DIFF
--- a/providers/aws-bedrock/eu.anthropic.claude-opus-4-7.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-opus-4-7.yaml
@@ -70,6 +70,7 @@ params:
 provisioning: serverless
 removeParams:
     - "n"
+    - temperature
 sources:
     - https://platform.claude.com/docs/en/docs/about-claude/models
     - https://platform.claude.com/docs/en/about-claude/pricing

--- a/providers/aws-bedrock/global.anthropic.claude-opus-4-7.yaml
+++ b/providers/aws-bedrock/global.anthropic.claude-opus-4-7.yaml
@@ -183,6 +183,7 @@ params:
 provisioning: serverless
 removeParams:
     - "n"
+    - temperature
 sources:
     - https://platform.claude.com/docs/en/docs/about-claude/models
     - https://platform.claude.com/docs/en/about-claude/pricing

--- a/providers/aws-bedrock/jp.anthropic.claude-opus-4-7.yaml
+++ b/providers/aws-bedrock/jp.anthropic.claude-opus-4-7.yaml
@@ -42,6 +42,7 @@ params:
 provisioning: serverless
 removeParams:
     - "n"
+    - temperature
 sources:
     - https://platform.claude.com/docs/en/docs/about-claude/models
     - https://platform.claude.com/docs/en/about-claude/pricing

--- a/providers/aws-bedrock/us.anthropic.claude-opus-4-7.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-opus-4-7.yaml
@@ -53,10 +53,6 @@ params:
       key: max_tokens
       maxValue: 128000
       minValue: 1
-    - defaultValue: 1
-      key: temperature
-      maxValue: 1
-      minValue: 0
 provisioning: serverless
 removeParams:
     - "n"

--- a/providers/aws-bedrock/us.anthropic.claude-opus-4-7.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-opus-4-7.yaml
@@ -60,6 +60,7 @@ params:
 provisioning: serverless
 removeParams:
     - "n"
+    - temperature
 sources:
     - https://platform.claude.com/docs/en/docs/about-claude/models
     - https://platform.claude.com/docs/en/about-claude/pricing

--- a/providers/mistral-ai/mistral-ocr-2512.yaml
+++ b/providers/mistral-ai/mistral-ocr-2512.yaml
@@ -15,7 +15,7 @@ modalities:
         - doc
     output:
         - text
-mode: chat
+mode: unknown # ocr is the correct mode, but is not supported yet
 model: mistral-ocr-2512
 params:
     - defaultValue: 0

--- a/providers/mistral-ai/mistral-ocr-latest.yaml
+++ b/providers/mistral-ai/mistral-ocr-latest.yaml
@@ -15,7 +15,7 @@ modalities:
         - doc
     output:
         - text
-mode: chat
+mode: unknown # ocr is the correct mode, but is not supported yet
 model: mistral-ocr-latest
 params:
     - defaultValue: 0

--- a/providers/openrouter/arcee-ai/coder-large.yaml
+++ b/providers/openrouter/arcee-ai/coder-large.yaml
@@ -11,7 +11,7 @@ modalities:
         - text
 mode: chat
 model: arcee-ai/coder-large
-provisioning: serverless
+provisioning: provisioned
 sources:
     - https://openrouter.ai/arcee-ai/coder-large
 status: active

--- a/providers/openrouter/arcee-ai/maestro-reasoning.yaml
+++ b/providers/openrouter/arcee-ai/maestro-reasoning.yaml
@@ -13,7 +13,7 @@ modalities:
         - text
 mode: chat
 model: arcee-ai/maestro-reasoning
-provisioning: serverless
+provisioning: provisioned
 sources:
     - https://openrouter.ai/arcee-ai/maestro-reasoning/api
 status: active

--- a/providers/openrouter/arcee-ai/spotlight.yaml
+++ b/providers/openrouter/arcee-ai/spotlight.yaml
@@ -17,7 +17,7 @@ model: arcee-ai/spotlight
 params:
     - key: max_tokens
       maxValue: 65537
-provisioning: serverless
+provisioning: provisioned
 sources:
     - https://openrouter.ai/arcee-ai/spotlight/api
     - https://openrouter.ai/arcee-ai/spotlight

--- a/providers/openrouter/arcee-ai/virtuoso-large.yaml
+++ b/providers/openrouter/arcee-ai/virtuoso-large.yaml
@@ -17,7 +17,7 @@ modalities:
         - text
 mode: chat
 model: arcee-ai/virtuoso-large
-provisioning: serverless
+provisioning: provisioned
 sources:
     - https://openrouter.ai/arcee-ai/virtuoso-large
     - https://openrouter.ai/arcee-ai/virtuoso-large/api


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk metadata-only changes, but could affect request parameter filtering and routing/provisioning selection for the touched models.
> 
> **Overview**
> Adjusts AWS Bedrock Claude Opus 4.7 model configs to *strip `temperature` from requests* (and removes the explicit `temperature` param from the US variant), aligning parameter handling across regions.
> 
> Updates Mistral OCR model manifests to use `mode: unknown` (not `chat`) to reflect unsupported OCR mode, and marks several OpenRouter Arcee AI models as `provisioning: provisioned` instead of `serverless`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04b09f1aef7a98e8737658d765aca68abb4dbb2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->