### PR TITLE
feat(mistral-ai): update model YAMLs [bot]

### DIFF
--- a/providers/mistral-ai/mistral-medium-3.5.0.yaml
+++ b/providers/mistral-ai/mistral-medium-3.5.0.yaml
@@ -1,11 +1,17 @@
+costs:
+    - input_cost_per_token: 4e-7
+      output_cost_per_token: 0.000002
+      region: "*"
 features:
     - function_calling
+    - structured_output
 limits:
     context_window: 262144
 modalities:
     input:
         - text
         - image
+        - doc
     output:
         - text
 mode: chat

--- a/providers/mistral-ai/mistral-medium-3.yaml
+++ b/providers/mistral-ai/mistral-medium-3.yaml
@@ -5,6 +5,9 @@ costs:
 features:
     - function_calling
     - structured_output
+    - system_messages
+    - tool_choice
+    - json_output
 limits:
     context_window: 262144
 modalities:


### PR DESCRIPTION
Auto-generated by poc-agent for provider `mistral-ai`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk metadata-only changes that adjust declared features and input modalities for two Mistral model YAMLs; runtime risk is limited to clients relying on these capability flags.
> 
> **Overview**
> Updates Mistral Medium provider model specs to reflect new declared capabilities.
> 
> `mistral-medium-3.5.0.yaml` now advertises `structured_output` support and adds `doc` as an accepted input modality.
> 
> `mistral-medium-3.yaml` expands its feature flags to include `system_messages`, `tool_choice`, and `json_output`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0134ebc39da3bf234c0a52f0dbd9a0a68b4c4763. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->