### PR TITLE
chore: retire models

### DIFF
--- a/providers/groq/meta-llama/llama-4-maverick-17b-128e-instruct.yaml
+++ b/providers/groq/meta-llama/llama-4-maverick-17b-128e-instruct.yaml
@@ -3,8 +3,6 @@ costs:
       output_cost_per_token: 6e-7
       region: "*"
 features:
-    - function_calling
-    - tool_choice
     - structured_output
 isDeprecated: true
 limits:

--- a/providers/groq/meta-llama/llama-4-maverick-17b-128e-instruct.yaml
+++ b/providers/groq/meta-llama/llama-4-maverick-17b-128e-instruct.yaml
@@ -4,6 +4,8 @@ costs:
       region: "*"
 features:
     - structured_output
+    - function_calling
+    - tool_choice
 isDeprecated: true
 limits:
     max_input_tokens: 131072

--- a/providers/openrouter/google/gemini-2.5-flash-image.yaml
+++ b/providers/openrouter/google/gemini-2.5-flash-image.yaml
@@ -8,9 +8,7 @@ costs:
       output_cost_per_token: 0.0000025
       region: "*"
 features:
-    - json_output
     - prompt_caching
-    - structured_output
 limits:
     context_window: 32768
     max_output_tokens: 32768

--- a/providers/openrouter/google/lyria-3-clip-preview.yaml
+++ b/providers/openrouter/google/lyria-3-clip-preview.yaml
@@ -3,8 +3,6 @@ costs:
       input_cost_per_token: 0
       output_cost_per_token: 0
       region: "*"
-features:
-    - json_output
 limits:
     context_window: 1048576
     max_output_tokens: 65536

--- a/providers/openrouter/google/lyria-3-pro-preview.yaml
+++ b/providers/openrouter/google/lyria-3-pro-preview.yaml
@@ -2,8 +2,6 @@ costs:
     - input_cost_per_token: 0
       output_cost_per_token: 0
       region: "*"
-features:
-    - json_output
 limits:
     context_window: 1048576
     max_output_tokens: 65536

--- a/providers/openrouter/openai/gpt-4-1106-preview.yaml
+++ b/providers/openrouter/openai/gpt-4-1106-preview.yaml
@@ -7,6 +7,7 @@ features:
     - json_output
     - structured_output
     - tool_choice
+isDeprecated: true
 limits:
     context_window: 128000
     max_output_tokens: 4096
@@ -21,6 +22,6 @@ model: openai/gpt-4-1106-preview
 provisioning: serverless
 sources:
     - https://openrouter.ai/openai/gpt-4-1106-preview
-status: active
+status: retired
 supportedModes:
     - chat

--- a/providers/openrouter/openai/gpt-4o:extended.yaml
+++ b/providers/openrouter/openai/gpt-4o:extended.yaml
@@ -7,6 +7,7 @@ features:
     - json_output
     - structured_output
     - tool_choice
+isDeprecated: true
 limits:
     context_window: 128000
     max_output_tokens: 64000
@@ -27,6 +28,6 @@ params:
 provisioning: serverless
 sources:
     - https://openrouter.ai/openai/gpt-4o:extended/api
-status: active
+status: retired
 supportedModes:
     - chat

--- a/providers/openrouter/openai/gpt-5-image.yaml
+++ b/providers/openrouter/openai/gpt-5-image.yaml
@@ -5,7 +5,6 @@ costs:
       output_cost_per_token: 0.00001
       region: "*"
 features:
-    - function_calling
     - json_output
     - prompt_caching
     - structured_output

--- a/providers/openrouter/openrouter/elephant-alpha.yaml
+++ b/providers/openrouter/openrouter/elephant-alpha.yaml
@@ -8,6 +8,7 @@ features:
     - prompt_caching
     - structured_output
     - tool_choice
+isDeprecated: true
 limits:
     context_window: 262144
     max_output_tokens: 32768
@@ -21,6 +22,6 @@ model: openrouter/elephant-alpha
 provisioning: serverless
 sources:
     - https://openrouter.ai/openrouter/elephant-alpha
-status: active
+status: retired
 supportedModes:
     - chat

--- a/providers/openrouter/qwen/qwen2.5-vl-32b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen2.5-vl-32b-instruct.yaml
@@ -4,6 +4,7 @@ costs:
       region: "*"
 features:
     - json_output
+isDeprecated: true
 limits:
     context_window: 128000
 modalities:
@@ -18,6 +19,6 @@ provisioning: serverless
 sources:
     - https://openrouter.ai/qwen/qwen2.5-vl-32b-instruct
     - https://openrouter.ai/qwen/qwen2.5-vl-32b-instruct/api
-status: active
+status: retired
 supportedModes:
     - chat

--- a/providers/openrouter/qwen/qwq-32b.yaml
+++ b/providers/openrouter/qwen/qwq-32b.yaml
@@ -5,6 +5,7 @@ costs:
 features:
     - function_calling
     - tool_choice
+isDeprecated: true
 limits:
     context_window: 131072
     max_output_tokens: 131072
@@ -20,6 +21,7 @@ provisioning: serverless
 sources:
     - https://openrouter.ai/qwen/qwq-32b
     - https://openrouter.ai/qwen/qwq-32b/api
+status: retired
 supportedModes:
     - chat
 thinking: true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Config-only changes to model metadata (deprecation/status/feature flags) with no runtime logic changes; main risk is accidentally hiding or mislabeling a still-supported model in downstream selection.
> 
> **Overview**
> Marks several provider models as **retired/deprecated** by setting `isDeprecated: true` and switching `status` to `retired` (notably `openai/gpt-4-1106-preview`, `openai/gpt-4o:extended`, `openrouter/elephant-alpha`, `qwen/qwen2.5-vl-32b-instruct`, and `qwen/qwq-32b`).
> 
> Adjusts advertised capabilities for a few models: removes `json_output`/`structured_output` flags from some Google OpenRouter configs (`gemini-2.5-flash-image`, `lyria-3-*`) and drops `function_calling` from `openai/gpt-5-image`; also updates the Groq Llama config to include `structured_output` in its `features` list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f51e61c3f8abe61ee9c138138f95184e966e93cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->