### PR TITLE
fix: remove response_format features for openrouter audio models

### DIFF
--- a/providers/openrouter/openai/gpt-4o-audio-preview.yaml
+++ b/providers/openrouter/openai/gpt-4o-audio-preview.yaml
@@ -6,8 +6,6 @@ costs:
       region: "*"
 features:
     - function_calling
-    - json_output
-    - structured_output
     - tool_choice
 limits:
     context_window: 128000

--- a/providers/openrouter/openai/gpt-audio-mini.yaml
+++ b/providers/openrouter/openai/gpt-audio-mini.yaml
@@ -6,8 +6,6 @@ costs:
       region: "*"
 features:
     - function_calling
-    - json_output
-    - structured_output
     - tool_choice
 limits:
     context_window: 128000

--- a/providers/openrouter/openai/gpt-audio.yaml
+++ b/providers/openrouter/openai/gpt-audio.yaml
@@ -6,8 +6,6 @@ costs:
       region: "*"
 features:
     - function_calling
-    - json_output
-    - structured_output
     - tool_choice
 limits:
     context_window: 128000


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Metadata-only change to model capability flags; main risk is clients losing access to previously-advertised JSON/structured output options for these models.
> 
> **Overview**
> Removes `json_output` and `structured_output` from the declared `features` of OpenRouter OpenAI audio chat models (`gpt-4o-audio-preview`, `gpt-audio-mini`, `gpt-audio`), leaving only `function_calling` and `tool_choice`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a1383308aa1f6bad8fef624f5d64c9a33e8ecc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->