### PR TITLE
feat(deepinfra): add new models [bot]

### DIFF
--- a/providers/deepinfra/deepseek-ai/DeepSeek-V4-Flash.yaml
+++ b/providers/deepinfra/deepseek-ai/DeepSeek-V4-Flash.yaml
@@ -1,0 +1,12 @@
+costs:
+    - cache_read_input_token_cost: 2.8e-8
+      input_cost_per_token: 1.4e-7
+      output_cost_per_token: 2.8e-7
+      region: "*"
+features:
+    - prompt_caching
+limits:
+    context_window: 1048576
+    max_tokens: 1048576
+mode: unknown
+model: deepseek-ai/DeepSeek-V4-Flash

--- a/providers/deepinfra/deepseek-ai/DeepSeek-V4-Pro.yaml
+++ b/providers/deepinfra/deepseek-ai/DeepSeek-V4-Pro.yaml
@@ -1,0 +1,12 @@
+costs:
+    - cache_read_input_token_cost: 1.449999942e-7
+      input_cost_per_token: 1.74e-6
+      output_cost_per_token: 3.48e-6
+      region: "*"
+features:
+    - prompt_caching
+limits:
+    context_window: 65536
+    max_tokens: 65536
+mode: unknown
+model: deepseek-ai/DeepSeek-V4-Pro


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `deepinfra`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that adds two new model definition YAMLs; primary risk is incorrect pricing/limits metadata affecting downstream cost estimation or validation.
> 
> **Overview**
> Adds new DeepInfra model definition files for `deepseek-ai/DeepSeek-V4-Flash` and `deepseek-ai/DeepSeek-V4-Pro`, including per-token pricing (with cache-read pricing), `prompt_caching` support, and context/max token limits.
> 
> Both models are introduced with `mode: unknown`, which may rely on downstream defaults/validation when integrating these new entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7556985e05719d9cd1f616c5124d911880fdf63e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->