### PR TITLE
feat(deepinfra): add new models [bot]

### DIFF
--- a/providers/deepinfra/deepseek-ai/DeepSeek-V4-Flash.yaml
+++ b/providers/deepinfra/deepseek-ai/DeepSeek-V4-Flash.yaml
@@ -1,0 +1,12 @@
+costs:
+    - cache_read_input_token_cost: 2.8e-8
+      input_cost_per_token: 1.4e-7
+      output_cost_per_token: 2.8e-7
+      region: "*"
+features:
+    - prompt_caching
+limits:
+    context_window: 1048576
+    max_tokens: 1048576
+mode: unknown
+model: deepseek-ai/DeepSeek-V4-Flash

--- a/providers/deepinfra/deepseek-ai/DeepSeek-V4-Pro.yaml
+++ b/providers/deepinfra/deepseek-ai/DeepSeek-V4-Pro.yaml
@@ -1,0 +1,12 @@
+costs:
+    - cache_read_input_token_cost: 1.449999942e-7
+      input_cost_per_token: 1.74e-6
+      output_cost_per_token: 3.48e-6
+      region: "*"
+features:
+    - prompt_caching
+limits:
+    context_window: 65536
+    max_tokens: 65536
+mode: unknown
+model: deepseek-ai/DeepSeek-V4-Pro


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `deepinfra`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since this only adds new YAML model metadata (pricing/limits/features) without changing runtime code paths; main risk is incorrect cost/limit values affecting billing or validation.
> 
> **Overview**
> Registers two new DeepInfra models, `deepseek-ai/DeepSeek-V4-Flash` and `deepseek-ai/DeepSeek-V4-Pro`, by adding YAML definitions under `providers/deepinfra/deepseek-ai/`.
> 
> Each definition includes per-token pricing (including `cache_read_input_token_cost`), enables **`prompt_caching`**, and sets model limits (Flash at **1,048,576** context/max tokens; Pro at **65,536**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f84bb413cde6843cff737becc1a2460e475e761. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->