### PR TITLE
Update GPT 5.5 models

### DIFF
--- a/providers/openai/gpt-5.5-2026-04-23.yaml
+++ b/providers/openai/gpt-5.5-2026-04-23.yaml
@@ -45,6 +45,8 @@ params:
       key: reasoning_effort
       type: string
 provisioning: serverless
+removeParams:
+    - max_tokens
 sources:
     - https://developers.openai.com/api/docs/models/gpt-5.5
 status: active

--- a/providers/openai/gpt-5.5-pro-2026-04-23.yaml
+++ b/providers/openai/gpt-5.5-pro-2026-04-23.yaml
@@ -1,2 +1,0 @@
-mode: unknown
-model: gpt-5.5-pro-2026-04-23

--- a/providers/openai/gpt-5.5-pro.yaml
+++ b/providers/openai/gpt-5.5-pro.yaml
@@ -1,2 +1,0 @@
-mode: unknown
-model: gpt-5.5-pro

--- a/providers/openai/gpt-5.5.yaml
+++ b/providers/openai/gpt-5.5.yaml
@@ -44,6 +44,8 @@ params:
       key: reasoning_effort
       type: string
 provisioning: serverless
+removeParams:
+    - max_tokens
 sources:
     - https://developers.openai.com/api/docs/models/gpt-5.5
 status: active


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk config-only change, but it affects how request parameters are mapped by removing `max_tokens` for GPT-5.5 models, which could break callers still sending that param.
> 
> **Overview**
> Updates the OpenAI GPT-5.5 model definitions to explicitly **drop** the deprecated `max_tokens` parameter via `removeParams`, standardizing on `max_completion_tokens`.
> 
> Removes the placeholder/unknown `gpt-5.5-pro` YAML entries, narrowing the available model configs to the supported GPT-5.5 variants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2941514ee2bed24c9e86c30a47541c631b79393e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->