### PR TITLE
feat(openrouter): add new models [bot]

### DIFF
--- a/providers/openrouter/deepseek/deepseek-v4-flash.yaml
+++ b/providers/openrouter/deepseek/deepseek-v4-flash.yaml
@@ -1,0 +1,22 @@
+costs:
+    - cache_read_input_token_cost: 2.8e-8
+      input_cost_per_token: 1.4e-7
+      output_cost_per_token: 2.8e-7
+      region: "*"
+features:
+    - function_calling
+    - json_output
+    - prompt_caching
+    - structured_output
+    - tool_choice
+limits:
+    context_window: 1048576
+    max_output_tokens: 384000
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: chat
+model: deepseek/deepseek-v4-flash
+thinking: true

--- a/providers/openrouter/deepseek/deepseek-v4-pro.yaml
+++ b/providers/openrouter/deepseek/deepseek-v4-pro.yaml
@@ -1,0 +1,27 @@
+costs:
+    - cache_read_input_token_cost: 1.45e-7
+      input_cost_per_token: 1.74e-6
+      output_cost_per_token: 3.48e-6
+      region: "*"
+features:
+    - function_calling
+    - json_output
+    - prompt_caching
+    - structured_output
+    - tool_choice
+limits:
+    context_window: 1048576
+    max_output_tokens: 384000
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: chat
+model: deepseek/deepseek-v4-pro
+params:
+    - defaultValue: 1
+      key: temperature
+    - defaultValue: 1
+      key: top_p
+thinking: true

--- a/providers/openrouter/openai/gpt-5.5-pro.yaml
+++ b/providers/openrouter/openai/gpt-5.5-pro.yaml
@@ -1,0 +1,22 @@
+costs:
+    - input_cost_per_token: 3e-5
+      output_cost_per_token: 0.00018
+      region: "*"
+features:
+    - function_calling
+    - json_output
+    - structured_output
+    - tool_choice
+limits:
+    context_window: 1050000
+    max_output_tokens: 128000
+modalities:
+    input:
+        - pdf
+        - image
+        - text
+    output:
+        - text
+mode: chat
+model: openai/gpt-5.5-pro
+thinking: true

--- a/providers/openrouter/openai/gpt-5.5.yaml
+++ b/providers/openrouter/openai/gpt-5.5.yaml
@@ -1,0 +1,24 @@
+costs:
+    - cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 3e-5
+      region: "*"
+features:
+    - function_calling
+    - json_output
+    - prompt_caching
+    - structured_output
+    - tool_choice
+limits:
+    context_window: 1050000
+    max_output_tokens: 128000
+modalities:
+    input:
+        - pdf
+        - image
+        - text
+    output:
+        - text
+mode: chat
+model: openai/gpt-5.5
+thinking: true


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `openrouter`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk change that only adds new OpenRouter model metadata/config entries; primary risk is misconfigured YAML fields (limits/costs/features) causing model registration or pricing to be incorrect.
> 
> **Overview**
> Adds four new OpenRouter model YAMLs: `deepseek/deepseek-v4-flash`, `deepseek/deepseek-v4-pro`, `openai/gpt-5.5`, and `openai/gpt-5.5-pro`.
> 
> Each entry defines **token pricing**, supported **features** (e.g., tool/function calling, structured/JSON output, and prompt caching where applicable), **token limits/context windows**, **modalities** (text-only for DeepSeek; text+image+pdf for GPT‑5.5), and enables `thinking: true` (with default `temperature`/`top_p` params on `deepseek-v4-pro`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e640386a0c363469d8f3e6728d6dd19728d30896. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->