### PR TITLE
feat(openai): update model YAMLs [bot]

### DIFF
--- a/providers/openai/gpt-5.2-pro-2025-12-11.yaml
+++ b/providers/openai/gpt-5.2-pro-2025-12-11.yaml
@@ -34,6 +34,7 @@ removeParams:
     - max_completion_tokens
 sources:
     - https://developers.openai.com/api/docs/models/gpt-5.2-pro
+status: active
 supportedModes:
     - responses
 thinking: true

--- a/providers/openai/gpt-5.5-pro-2026-04-23.yaml
+++ b/providers/openai/gpt-5.5-pro-2026-04-23.yaml
@@ -1,2 +1,44 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0.00003
+      input_cost_per_token_batches: 0.000015
+      output_cost_per_token: 0.00018
+      output_cost_per_token_batches: 0.00009
+      region: "*"
+features:
+    - function_calling
+    - parallel_function_calling
+    - structured_output
+    - system_messages
+    - tool_choice
+    - json_output
+limits:
+    context_window: 1050000
+    max_input_tokens: 1050000
+    max_output_tokens: 128000
+    max_tokens: 128000
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
+mode: chat
 model: gpt-5.5-pro-2026-04-23
+params:
+    - defaultValue: 128
+      key: max_tokens
+      maxValue: 128000
+      minValue: 1
+    - key: reasoning_effort
+      type: string
+provisioning: serverless
+removeParams:
+    - stream
+sources:
+    - https://developers.openai.com/api/docs/models/gpt-5.5-pro
+    - https://developers.openai.com/api/docs/pricing
+status: active
+supportedModes:
+    - chat
+    - responses
+thinking: true

--- a/providers/openai/gpt-5.5-pro-2026-04-23.yaml
+++ b/providers/openai/gpt-5.5-pro-2026-04-23.yaml
@@ -34,6 +34,8 @@ params:
 provisioning: serverless
 removeParams:
     - stream
+    - max_tokens
+    - max_completion_tokens
 sources:
     - https://developers.openai.com/api/docs/models/gpt-5.5-pro
     - https://developers.openai.com/api/docs/pricing

--- a/providers/openai/gpt-5.5-pro-2026-04-23.yaml
+++ b/providers/openai/gpt-5.5-pro-2026-04-23.yaml
@@ -25,10 +25,6 @@ modalities:
 mode: responses
 model: gpt-5.5-pro-2026-04-23
 params:
-    - defaultValue: 128
-      key: max_tokens
-      maxValue: 128000
-      minValue: 1
     - key: reasoning_effort
       type: string
 provisioning: serverless

--- a/providers/openai/gpt-5.5-pro-2026-04-23.yaml
+++ b/providers/openai/gpt-5.5-pro-2026-04-23.yaml
@@ -22,7 +22,7 @@ modalities:
         - image
     output:
         - text
-mode: chat
+mode: responses
 model: gpt-5.5-pro-2026-04-23
 params:
     - defaultValue: 128
@@ -39,6 +39,5 @@ sources:
     - https://developers.openai.com/api/docs/pricing
 status: active
 supportedModes:
-    - chat
     - responses
 thinking: true

--- a/providers/openai/gpt-5.5-pro.yaml
+++ b/providers/openai/gpt-5.5-pro.yaml
@@ -20,7 +20,7 @@ modalities:
         - image
     output:
         - text
-mode: chat
+mode: responses
 model: gpt-5.5-pro
 params:
     - defaultValue: 128
@@ -36,10 +36,7 @@ removeParams:
     - stream
 sources:
     - https://developers.openai.com/api/docs/models/gpt-5.5-pro
-    - https://developers.openai.com/api/docs/pricing
 status: active
 supportedModes:
-    - chat
     - responses
-    - realtime
 thinking: true

--- a/providers/openai/gpt-5.5-pro.yaml
+++ b/providers/openai/gpt-5.5-pro.yaml
@@ -1,2 +1,45 @@
-mode: unknown
+costs:
+    - input_cost_per_token: 0.00003
+      input_cost_per_token_batches: 0.000015
+      output_cost_per_token: 0.00018
+      output_cost_per_token_batches: 0.00009
+      region: "*"
+features:
+    - function_calling
+    - structured_output
+    - system_messages
+    - tool_choice
+    - json_output
+limits:
+    context_window: 1050000
+    max_output_tokens: 128000
+    max_tokens: 128000
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
+mode: chat
 model: gpt-5.5-pro
+params:
+    - defaultValue: 128
+      key: max_tokens
+      maxValue: 128000
+      minValue: 1
+    - defaultValue: medium
+      key: reasoning_effort
+    - defaultValue: medium
+      key: verbosity
+provisioning: serverless
+removeParams:
+    - stream
+sources:
+    - https://developers.openai.com/api/docs/models/gpt-5.5-pro
+    - https://developers.openai.com/api/docs/pricing
+status: active
+supportedModes:
+    - chat
+    - responses
+    - realtime
+thinking: true

--- a/providers/openai/gpt-5.5-pro.yaml
+++ b/providers/openai/gpt-5.5-pro.yaml
@@ -34,6 +34,8 @@ params:
 provisioning: serverless
 removeParams:
     - stream
+    - max_completion_tokens
+    - max_tokens
 sources:
     - https://developers.openai.com/api/docs/models/gpt-5.5-pro
 status: active

--- a/providers/openai/gpt-5.5-pro.yaml
+++ b/providers/openai/gpt-5.5-pro.yaml
@@ -6,6 +6,7 @@ costs:
       region: "*"
 features:
     - function_calling
+    - parallel_function_calling
     - structured_output
     - system_messages
     - tool_choice
@@ -23,10 +24,6 @@ modalities:
 mode: responses
 model: gpt-5.5-pro
 params:
-    - defaultValue: 128
-      key: max_tokens
-      maxValue: 128000
-      minValue: 1
     - defaultValue: medium
       key: reasoning_effort
     - defaultValue: medium

--- a/providers/openai/gpt-audio-1.5.yaml
+++ b/providers/openai/gpt-audio-1.5.yaml
@@ -35,3 +35,5 @@ sources:
 status: active
 supportedModes:
     - chat
+    - realtime
+    - responses

--- a/providers/openai/gpt-audio-1.5.yaml
+++ b/providers/openai/gpt-audio-1.5.yaml
@@ -35,5 +35,3 @@ sources:
 status: active
 supportedModes:
     - chat
-    - realtime
-    - responses

--- a/providers/openai/gpt-audio-mini-2025-10-06.yaml
+++ b/providers/openai/gpt-audio-mini-2025-10-06.yaml
@@ -1,16 +1,18 @@
 costs:
     - cache_read_input_audio_token_cost: 3e-7
-      input_cost_per_audio_token: 0.00001
+      input_cost_per_audio_token: 1e-5
       input_cost_per_token: 6e-7
-      output_cost_per_audio_token: 0.00002
-      output_cost_per_token: 0.0000024
+      output_cost_per_audio_token: 2e-5
+      output_cost_per_token: 2.4e-6
       region: "*"
+deprecationDate: "2026-04-22"
 features:
     - function_calling
     - parallel_function_calling
     - system_messages
     - tool_choice
     - prompt_caching
+isDeprecated: true
 limits:
     context_window: 128000
     max_input_tokens: 128000
@@ -31,6 +33,6 @@ params:
 provisioning: serverless
 sources:
     - https://developers.openai.com/docs/models/gpt-audio-mini
-status: active
+status: deprecated
 supportedModes:
     - chat

--- a/providers/openai/gpt-audio-mini-2025-12-15.yaml
+++ b/providers/openai/gpt-audio-mini-2025-12-15.yaml
@@ -1,5 +1,6 @@
 costs:
     - cache_read_input_audio_token_cost: 3e-7
+      cache_read_input_token_cost: 6e-8
       input_cost_per_audio_token: 0.00001
       input_cost_per_token: 6e-7
       output_cost_per_audio_token: 0.00002
@@ -10,6 +11,7 @@ features:
     - parallel_function_calling
     - system_messages
     - tool_choice
+    - prompt_caching
 limits:
     context_window: 128000
     max_input_tokens: 128000

--- a/providers/openai/o1-2024-12-17.yaml
+++ b/providers/openai/o1-2024-12-17.yaml
@@ -1,10 +1,11 @@
 costs:
-    - cache_read_input_token_cost: 0.0000075
-      input_cost_per_token: 0.000015
-      input_cost_per_token_batches: 0.0000075
-      output_cost_per_token: 0.00006
-      output_cost_per_token_batches: 0.00003
+    - cache_read_input_token_cost: 7.5e-6
+      input_cost_per_token: 1.5e-5
+      input_cost_per_token_batches: 7.5e-6
+      output_cost_per_token: 6e-5
+      output_cost_per_token_batches: 3e-5
       region: "*"
+deprecationDate: "2026-04-22"
 features:
     - function_calling
     - parallel_function_calling
@@ -12,6 +13,7 @@ features:
     - tool_choice
     - prompt_caching
     - structured_output
+isDeprecated: true
 limits:
     context_window: 200000
     max_input_tokens: 200000
@@ -39,11 +41,11 @@ provisioning: serverless
 removeParams:
     - temperature
     - top_p
-    - "n"
+    - n
     - max_tokens
 sources:
     - https://developers.openai.com/docs/models/o1
-status: active
+status: deprecated
 supportedModes:
     - chat
     - responses

--- a/providers/openai/o1-pro.yaml
+++ b/providers/openai/o1-pro.yaml
@@ -2,6 +2,7 @@ costs:
     - input_cost_per_token: 0.00015
       output_cost_per_token: 0.0006
       region: "*"
+deprecationDate: "2026-10-23"
 features:
     - function_calling
     - structured_output

--- a/providers/openai/o1.yaml
+++ b/providers/openai/o1.yaml
@@ -5,6 +5,7 @@ costs:
       output_cost_per_token: 0.00006
       output_cost_per_token_batches: 0.00003
       region: "*"
+deprecationDate: "2026-10-23"
 features:
     - function_calling
     - system_messages
@@ -42,6 +43,7 @@ removeParams:
     - max_tokens
 sources:
     - https://developers.openai.com/api/docs/models/o1
+    - https://developers.openai.com/docs/deprecations
 status: active
 supportedModes:
     - chat

--- a/providers/openai/o3-mini.yaml
+++ b/providers/openai/o3-mini.yaml
@@ -1,16 +1,18 @@
 costs:
     - cache_read_input_token_cost: 5.5e-7
-      input_cost_per_token: 0.0000011
+      input_cost_per_token: 1.1e-6
       input_cost_per_token_batches: 5.5e-7
-      output_cost_per_token: 0.0000044
-      output_cost_per_token_batches: 0.0000022
+      output_cost_per_token: 4.4e-6
+      output_cost_per_token_batches: 2.2e-6
       region: "*"
+deprecationDate: "2026-04-22"
 features:
     - function_calling
     - tool_choice
     - prompt_caching
     - structured_output
     - json_output
+isDeprecated: true
 limits:
     context_window: 200000
     max_input_tokens: 200000
@@ -43,11 +45,11 @@ provisioning: serverless
 removeParams:
     - temperature
     - top_p
-    - "n"
+    - n
     - max_tokens
 sources:
     - https://developers.openai.com/api/docs/models/o3-mini
-status: active
+status: deprecated
 supportedModes:
     - chat
     - responses

--- a/providers/openai/o3-pro.yaml
+++ b/providers/openai/o3-pro.yaml
@@ -4,6 +4,7 @@ costs:
       region: "*"
 features:
     - function_calling
+    - parallel_function_calling
     - system_messages
     - tool_choice
     - structured_output
@@ -30,6 +31,7 @@ params:
 provisioning: serverless
 removeParams:
     - max_tokens
+    - max_completion_tokens
     - temperature
     - top_p
     - "n"

--- a/providers/openai/o3-pro.yaml
+++ b/providers/openai/o3-pro.yaml
@@ -4,7 +4,6 @@ costs:
       region: "*"
 features:
     - function_calling
-    - parallel_function_calling
     - system_messages
     - tool_choice
     - structured_output
@@ -31,7 +30,6 @@ params:
 provisioning: serverless
 removeParams:
     - max_tokens
-    - max_completion_tokens
     - temperature
     - top_p
     - "n"
@@ -40,7 +38,6 @@ removeParams:
     - parallel_tool_calls
 sources:
     - https://developers.openai.com/api/docs/models/o3-pro
-    - https://openrouter.ai/openai/o3-pro/api
 status: active
 supportedModes:
     - responses

--- a/providers/openai/o3.yaml
+++ b/providers/openai/o3.yaml
@@ -1,9 +1,9 @@
 costs:
     - cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000002
-      input_cost_per_token_batches: 0.000002
+      input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000008
-      output_cost_per_token_batches: 0.000008
+      output_cost_per_token_batches: 0.000004
       region: "*"
 features:
     - function_calling
@@ -36,6 +36,7 @@ removeParams:
     - temperature
 sources:
     - https://developers.openai.com/api/docs/models/o3
+status: active
 supportedModes:
     - chat
 thinking: true

--- a/providers/openai/o4-mini-2025-04-16.yaml
+++ b/providers/openai/o4-mini-2025-04-16.yaml
@@ -1,10 +1,11 @@
 costs:
     - cache_read_input_token_cost: 2.75e-7
-      input_cost_per_token: 0.0000011
+      input_cost_per_token: 1.1e-6
       input_cost_per_token_batches: 5.5e-7
-      output_cost_per_token: 0.0000044
-      output_cost_per_token_batches: 0.0000022
+      output_cost_per_token: 4.4e-6
+      output_cost_per_token_batches: 2.2e-6
       region: "*"
+deprecationDate: "2026-04-22"
 features:
     - function_calling
     - tool_choice
@@ -12,6 +13,7 @@ features:
     - structured_output
     - system_messages
     - json_output
+isDeprecated: true
 limits:
     context_window: 200000
     max_input_tokens: 200000
@@ -50,7 +52,7 @@ removeParams:
     - stop
 sources:
     - https://developers.openai.com/api/docs/models/o4-mini
-status: active
+status: deprecated
 supportedModes:
     - chat
     - responses

--- a/providers/openai/o4-mini.yaml
+++ b/providers/openai/o4-mini.yaml
@@ -5,6 +5,7 @@ costs:
       output_cost_per_token: 0.0000044
       output_cost_per_token_batches: 0.0000022
       region: "*"
+deprecationDate: "2026-10-23"
 features:
     - function_calling
     - tool_choice

--- a/providers/openai/tts-1.yaml
+++ b/providers/openai/tts-1.yaml
@@ -2,7 +2,7 @@ costs:
     - input_cost_per_character: 0.000015
       region: "*"
 limits:
-    max_tokens: 4096
+    max_input_tokens: 4096
 modalities:
     input:
         - text
@@ -21,8 +21,8 @@ removeParams:
     - tool_choice
     - parallel_tool_calls
 sources:
-    - https://developers.openai.com/api/docs/guides/text-to-speech/
     - https://developers.openai.com/api/docs/models/tts-1
+    - https://developers.openai.com/api/docs/guides/text-to-speech/
 status: active
 supportedModes:
     - text_to_speech

--- a/providers/openai/whisper-1.yaml
+++ b/providers/openai/whisper-1.yaml
@@ -27,5 +27,5 @@ sources:
     - https://developers.openai.com/docs/guides/speech-to-text
 status: active
 supportedModes:
-    - audio_translation
     - audio_transcription
+    - audio_translation


### PR DESCRIPTION
Auto-generated by poc-agent for provider `openai`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates model metadata that can affect model selection/availability and cost calculations (new models, price/limit tweaks, and multiple deprecations). Risk is moderate because changes are config-only but could impact routing or billing if consumed directly.
> 
> **Overview**
> **Updates OpenAI model YAML catalog.** Adds new `gpt-5.5-pro` entries (including a dated `gpt-5.5-pro-2026-04-23`) with pricing, very large token limits, supported features/modalities, and `reasoning_effort`/`verbosity` params.
> 
> Marks several models as **deprecated** by adding `deprecationDate`/`isDeprecated` and switching `status` to `deprecated` (notably `gpt-audio-mini-2025-10-06`, `o1-2024-12-17`, `o3-mini`, and `o4-mini-2025-04-16`), and adds deprecation dates to `o1`, `o1-pro`, and `o4-mini`. Also includes minor metadata fixes: cost value normalization, adds missing `status: active` in a couple YAMLs, adjusts `tts-1` token limit key to `max_input_tokens`, removes an extra `o3-pro` source URL, and reorders `whisper-1` supported modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0014795d14d272df97715de8d602fcc4152a2ce9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->