### PR TITLE
feat(openrouter): add new models [bot]

### DIFF
--- a/providers/openrouter/deepseek/deepseek-v4-flash.yaml
+++ b/providers/openrouter/deepseek/deepseek-v4-flash.yaml
@@ -1,0 +1,22 @@
+costs:
+    - cache_read_input_token_cost: 2.8e-8
+      input_cost_per_token: 1.4e-7
+      output_cost_per_token: 2.8e-7
+      region: "*"
+features:
+    - function_calling
+    - json_output
+    - prompt_caching
+    - structured_output
+    - tool_choice
+limits:
+    context_window: 1048576
+    max_output_tokens: 384000
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: chat
+model: deepseek/deepseek-v4-flash
+thinking: true

--- a/providers/openrouter/deepseek/deepseek-v4-pro.yaml
+++ b/providers/openrouter/deepseek/deepseek-v4-pro.yaml
@@ -1,0 +1,27 @@
+costs:
+    - cache_read_input_token_cost: 3.625e-8
+      input_cost_per_token: 4.35e-7
+      output_cost_per_token: 8.7e-7
+      region: "*"
+features:
+    - function_calling
+    - json_output
+    - prompt_caching
+    - structured_output
+    - tool_choice
+limits:
+    context_window: 1048576
+    max_output_tokens: 384000
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: chat
+model: deepseek/deepseek-v4-pro
+params:
+    - defaultValue: 1
+      key: temperature
+    - defaultValue: 1
+      key: top_p
+thinking: true

--- a/providers/openrouter/openai/gpt-5.5-pro.yaml
+++ b/providers/openrouter/openai/gpt-5.5-pro.yaml
@@ -1,0 +1,22 @@
+costs:
+    - input_cost_per_token: 3e-5
+      output_cost_per_token: 0.00018
+      region: "*"
+features:
+    - function_calling
+    - json_output
+    - structured_output
+    - tool_choice
+limits:
+    context_window: 1050000
+    max_output_tokens: 128000
+modalities:
+    input:
+        - pdf
+        - image
+        - text
+    output:
+        - text
+mode: chat
+model: openai/gpt-5.5-pro
+thinking: true

--- a/providers/openrouter/openai/gpt-5.5.yaml
+++ b/providers/openrouter/openai/gpt-5.5.yaml
@@ -1,0 +1,24 @@
+costs:
+    - cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 3e-5
+      region: "*"
+features:
+    - function_calling
+    - json_output
+    - prompt_caching
+    - structured_output
+    - tool_choice
+limits:
+    context_window: 1050000
+    max_output_tokens: 128000
+modalities:
+    input:
+        - pdf
+        - image
+        - text
+    output:
+        - text
+mode: chat
+model: openai/gpt-5.5
+thinking: true


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `openrouter`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new OpenRouter model definition YAMLs only (pricing/limits/features metadata) without touching runtime logic. Main risk is misconfigured costs/limits affecting model selection or billing estimates.
> 
> **Overview**
> Adds four new OpenRouter model definition files for `deepseek/deepseek-v4-flash`, `deepseek/deepseek-v4-pro`, `openai/gpt-5.5`, and `openai/gpt-5.5-pro`, including per-token cost metadata, supported features (e.g. tools/structured output/prompt caching), modality support, and large context/output limits.
> 
> Marks these models as `thinking: true`, and introduces default sampling params (`temperature`, `top_p`) for `deepseek-v4-pro`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9231fd0862855b3db8a9ffc21cf5f4c372c457e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->