### PR TITLE
chore: workflow to trigger updation job on addition pr

### DIFF
--- a/.github/workflows/trigger-updation-job-on-addition-pr.yml
+++ b/.github/workflows/trigger-updation-job-on-addition-pr.yml
@@ -1,0 +1,36 @@
+name: Trigger Updation Job on Addition Bot PR
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  trigger-updation-from-pr:
+    name: Trigger updation job for PR changes
+    runs-on: ubuntu-latest
+    # Only run for the bot's "add new models" PRs, and only when the PR is from
+    # this repo (not a fork) so we never expose secrets to untrusted code.
+    if: >-
+      contains(github.event.pull_request.title, 'add new models [bot]') &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    env:
+      TFY_API_KEY: ${{ secrets.TFY_API_KEY }}
+      TFY_HOST: ${{ secrets.TFY_HOST }}
+      TFY_JOB_FQN: ${{ secrets.TFY_JOB_FQN }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install truefoundry
+        run: pipx install truefoundry
+
+      - name: Trigger updation job
+        run: |
+          tfy login --api-key "$TFY_API_KEY" --host "$TFY_HOST"
+          tfy trigger job \
+            --application-fqn "$TFY_JOB_FQN" \
+            --command "python job.py --pr-number $PR_NUMBER"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new pull-request-triggered workflow that runs with repository secrets and triggers an external TrueFoundry job; misconfiguration could unintentionally run on more PRs than intended. Guardrails restrict execution to same-repo bot PR titles, but the PR-trigger + secrets usage warrants review.
> 
> **Overview**
> Adds a new GitHub Actions workflow (`trigger-updation-job-on-addition-pr.yml`) that, on PR `opened`/`reopened`/`synchronize`, logs into TrueFoundry and triggers the configured updation job, passing the PR number as an argument.
> 
> The workflow is gated to only run for in-repo PRs whose title contains `add new models [bot]`, to avoid exposing secrets to forks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0d4b1bbcc8c6e577f9589126bdd39f8f4429a48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->