### PR TITLE
chore: retire and provision models

### DIFF
--- a/.github/workflows/auto-test-on-bot-push.yml
+++ b/.github/workflows/auto-test-on-bot-push.yml
@@ -1,7 +1,7 @@
 name: Auto Test on Models Bot Push
 
 on:
-  pull_request:
+  pull_request_target:
     types: [synchronize]
 
 permissions:
@@ -13,7 +13,11 @@ jobs:
   comment:
     name: Comment /test-models
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.title, 'add new models [bot]')
+    # Only run for the bot's "add new models" PRs, and only when the PR is from
+    # this repo (not a fork) so we never expose secrets to untrusted code.
+    if: >-
+      contains(github.event.pull_request.title, 'add new models [bot]') &&
+      github.event.pull_request.head.repo.full_name == github.repository
     outputs:
       comment_id: ${{ steps.post.outputs.comment_id }}
     env:
@@ -34,6 +38,9 @@ jobs:
 
   test:
     needs: comment
+    if: >-
+      contains(github.event.pull_request.title, 'add new models [bot]') &&
+      github.event.pull_request.head.repo.full_name == github.repository
     uses: ./.github/workflows/test-changed-models-impl.yml
     with:
       pr_number: ${{ github.event.pull_request.number }}

--- a/providers/aws-bedrock/amazon.titan-tg1-large.yaml
+++ b/providers/aws-bedrock/amazon.titan-tg1-large.yaml
@@ -5,6 +5,7 @@ costs:
     - input_cost_per_token: 3e-7
       output_cost_per_token: 4e-7
       region: us-east-1
+isDeprecated: true
 limits:
     context_window: 8000
     max_input_tokens: 8000
@@ -33,6 +34,6 @@ removeParams:
     - "n"
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-amazon-titan-text-large.html
-status: active
+status: retired
 supportedModes:
     - chat

--- a/providers/deepinfra/NousResearch/Hermes-3-Llama-3.1-405B.yaml
+++ b/providers/deepinfra/NousResearch/Hermes-3-Llama-3.1-405B.yaml
@@ -3,7 +3,6 @@ costs:
       output_cost_per_token: 0.000001
       region: "*"
 features:
-    - function_calling
     - json_output
 limits:
     context_window: 131072

--- a/providers/deepinfra/Qwen/Qwen3.5-9B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3.5-9B.yaml
@@ -6,6 +6,7 @@ features:
     - function_calling
     - json_output
     - prompt_caching
+isDeprecated: true
 limits:
     context_window: 262144
     max_output_tokens: 262144
@@ -22,7 +23,7 @@ model: Qwen/Qwen3.5-9B
 provisioning: serverless
 sources:
     - https://deepinfra.com/Qwen/Qwen3.5-9B
-status: active
+status: retired
 supportedModes:
     - chat
 thinking: true

--- a/providers/deepinfra/deepseek-ai/DeepSeek-OCR.yaml
+++ b/providers/deepinfra/deepseek-ai/DeepSeek-OCR.yaml
@@ -2,8 +2,6 @@ costs:
     - input_cost_per_token: 3e-8
       output_cost_per_token: 1e-7
       region: "*"
-features:
-    - json_output
 limits:
     context_window: 8192
     max_input_tokens: 8192

--- a/providers/deepinfra/meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8.yaml
+++ b/providers/deepinfra/meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8.yaml
@@ -3,7 +3,6 @@ costs:
       output_cost_per_token: 6e-7
       region: "*"
 features:
-    - function_calling
     - json_output
 limits:
     context_window: 1048576

--- a/providers/deepinfra/meta-llama/Llama-Guard-4-12B.yaml
+++ b/providers/deepinfra/meta-llama/Llama-Guard-4-12B.yaml
@@ -2,8 +2,6 @@ costs:
     - input_cost_per_token: 1.8e-7
       output_cost_per_token: 1.8e-7
       region: "*"
-features:
-    - json_output
 limits:
     context_window: 163840
     max_input_tokens: 163840

--- a/providers/deepinfra/nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL.yaml
+++ b/providers/deepinfra/nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL.yaml
@@ -2,8 +2,6 @@ costs:
     - input_cost_per_token: 2e-7
       output_cost_per_token: 6e-7
       region: "*"
-features:
-    - json_output
 limits:
     context_window: 128000
     max_tokens: 8192

--- a/providers/deepinfra/nvidia/Nemotron-3-Nano-30B-A3B.yaml
+++ b/providers/deepinfra/nvidia/Nemotron-3-Nano-30B-A3B.yaml
@@ -4,7 +4,6 @@ costs:
       region: "*"
 features:
     - function_calling
-    - json_output
 limits:
     context_window: 262144
     max_input_tokens: 262144

--- a/providers/deepinfra/stepfun-ai/Step-3.5-Flash.yaml
+++ b/providers/deepinfra/stepfun-ai/Step-3.5-Flash.yaml
@@ -5,7 +5,6 @@ costs:
       region: "*"
 features:
     - function_calling
-    - json_output
     - prompt_caching
 limits:
     context_window: 262144

--- a/providers/google-vertex/mongodb/voyage-3.5-lite.yaml
+++ b/providers/google-vertex/mongodb/voyage-3.5-lite.yaml
@@ -11,6 +11,7 @@ modalities:
         - embedding
 mode: embedding
 model: mongodb/voyage-3.5-lite
+provisioning: provisioned
 removeParams:
     - temperature
     - top_p

--- a/providers/google-vertex/mongodb/voyage-4-large.yaml
+++ b/providers/google-vertex/mongodb/voyage-4-large.yaml
@@ -12,6 +12,7 @@ modalities:
         - embedding
 mode: embedding
 model: mongodb/voyage-4-large
+provisioning: provisioned
 removeParams:
     - max_tokens
     - temperature

--- a/providers/openrouter/openai/gpt-5-image-mini.yaml
+++ b/providers/openrouter/openai/gpt-5-image-mini.yaml
@@ -5,7 +5,6 @@ costs:
       output_cost_per_token: 0.000002
       region: "*"
 features:
-    - function_calling
     - json_output
     - prompt_caching
     - structured_output
@@ -27,7 +26,6 @@ mode: chat
 model: openai/gpt-5-image-mini
 provisioning: serverless
 sources:
-    - https://openrouter.ai/openai/gpt-5-image-mini/api
     - https://openrouter.ai/openai/gpt-5-image-mini
 supportedModes:
     - chat

--- a/providers/openrouter/z-ai/glm-4.5-air.yaml
+++ b/providers/openrouter/z-ai/glm-4.5-air.yaml
@@ -5,9 +5,7 @@ costs:
       region: "*"
 features:
     - function_calling
-    - json_output
     - prompt_caching
-    - structured_output
     - tool_choice
 limits:
     context_window: 131072
@@ -22,7 +20,6 @@ mode: chat
 model: z-ai/glm-4.5-air
 provisioning: serverless
 sources:
-    - https://openrouter.ai/z-ai/glm-4.5-air/api
     - https://openrouter.ai/z-ai/glm-4.5-air
 supportedModes:
     - chat


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Switches CI to `pull_request_target` (secret-bearing context) and relies on new guards to avoid running on forks; misconfiguration could expose tokens. Model YAML updates are low risk but may affect downstream capability/availability filtering.
> 
> **Overview**
> **CI hardening:** Updates the “Auto Test on Models Bot Push” workflow to run on `pull_request_target` and adds strict job-level conditions so it only posts `/test-models` and runs tests for the bot’s “add new models” PRs originating from the same repository (not forks).
> 
> **Model catalog updates:** Marks `amazon.titan-tg1-large` and `Qwen3.5-9B` as *deprecated/retired*, adds `provisioning: provisioned` to Vertex `voyage-3.5-lite` and `voyage-4-large`, and adjusts several provider model YAMLs to remove/trim advertised features (e.g., `function_calling`, `json_output`, `structured_output`) and clean up source links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 680ccd48cf09cc90824beb56c975c9da791f84a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->