### PR TITLE
feat(openrouter): add new models [bot]

### DIFF
--- a/providers/openrouter/qwen/qwen3.5-plus-20260420.yaml
+++ b/providers/openrouter/qwen/qwen3.5-plus-20260420.yaml
@@ -19,8 +19,10 @@ modalities:
         - text
 mode: chat
 model: qwen/qwen3.5-plus-20260420
+provisioning: serverless
 sources:
     - https://openrouter.ai/qwen/qwen3.5-plus-20260420
+status: active
 supportedModes:
     - chat
 thinking: true

--- a/providers/openrouter/qwen/qwen3.5-plus-20260420.yaml
+++ b/providers/openrouter/qwen/qwen3.5-plus-20260420.yaml
@@ -19,4 +19,8 @@ modalities:
         - text
 mode: chat
 model: qwen/qwen3.5-plus-20260420
+sources:
+    - https://openrouter.ai/qwen/qwen3.5-plus-20260420
+supportedModes:
+    - chat
 thinking: true

--- a/providers/openrouter/qwen/qwen3.5-plus-20260420.yaml
+++ b/providers/openrouter/qwen/qwen3.5-plus-20260420.yaml
@@ -1,0 +1,22 @@
+costs:
+    - input_cost_per_token: 4e-7
+      output_cost_per_token: 2.4e-6
+      region: "*"
+features:
+    - function_calling
+    - json_output
+    - structured_output
+    - tool_choice
+limits:
+    context_window: 1000000
+    max_output_tokens: 65536
+modalities:
+    input:
+        - text
+        - image
+        - video
+    output:
+        - text
+mode: chat
+model: qwen/qwen3.5-plus-20260420
+thinking: true

--- a/providers/openrouter/qwen/qwen3.6-27b.yaml
+++ b/providers/openrouter/qwen/qwen3.6-27b.yaml
@@ -21,4 +21,10 @@ modalities:
         - text
 mode: chat
 model: qwen/qwen3.6-27b
+provisioning: serverless
+sources:
+    - https://openrouter.ai/qwen/qwen3.6-27b
+status: active
+supportedModes:
+    - chat
 thinking: true

--- a/providers/openrouter/qwen/qwen3.6-27b.yaml
+++ b/providers/openrouter/qwen/qwen3.6-27b.yaml
@@ -1,0 +1,24 @@
+costs:
+    - cache_read_input_token_cost: 9.75e-8
+      input_cost_per_token: 1.95e-7
+      output_cost_per_token: 1.56e-6
+      region: "*"
+features:
+    - function_calling
+    - json_output
+    - prompt_caching
+    - structured_output
+    - tool_choice
+limits:
+    context_window: 262144
+    max_output_tokens: 65536
+modalities:
+    input:
+        - text
+        - image
+        - video
+    output:
+        - text
+mode: chat
+model: qwen/qwen3.6-27b
+thinking: true

--- a/providers/openrouter/qwen/qwen3.6-35b-a3b.yaml
+++ b/providers/openrouter/qwen/qwen3.6-35b-a3b.yaml
@@ -26,4 +26,10 @@ params:
       key: top_p
     - defaultValue: 20
       key: top_k
+provisioning: serverless
+sources:
+    - https://openrouter.ai/qwen/qwen3.6-35b-a3b
+status: active
+supportedModes:
+    - chat
 thinking: true

--- a/providers/openrouter/qwen/qwen3.6-35b-a3b.yaml
+++ b/providers/openrouter/qwen/qwen3.6-35b-a3b.yaml
@@ -1,0 +1,29 @@
+costs:
+    - cache_read_input_token_cost: 1.612e-7
+      input_cost_per_token: 1.612e-7
+      output_cost_per_token: 9.6525e-7
+      region: "*"
+features:
+    - json_output
+    - prompt_caching
+    - structured_output
+limits:
+    context_window: 262144
+    max_output_tokens: 65536
+modalities:
+    input:
+        - text
+        - image
+        - video
+    output:
+        - text
+mode: chat
+model: qwen/qwen3.6-35b-a3b
+params:
+    - defaultValue: 1
+      key: temperature
+    - defaultValue: 0.95
+      key: top_p
+    - defaultValue: 20
+      key: top_k
+thinking: true

--- a/providers/openrouter/qwen/qwen3.6-flash.yaml
+++ b/providers/openrouter/qwen/qwen3.6-flash.yaml
@@ -21,4 +21,10 @@ modalities:
         - text
 mode: chat
 model: qwen/qwen3.6-flash
+provisioning: serverless
+sources:
+    - https://openrouter.ai/qwen/qwen3.6-flash
+status: active
+supportedModes:
+    - chat
 thinking: true

--- a/providers/openrouter/qwen/qwen3.6-flash.yaml
+++ b/providers/openrouter/qwen/qwen3.6-flash.yaml
@@ -1,0 +1,24 @@
+costs:
+    - cache_creation_input_token_cost: 3.125e-7
+      input_cost_per_token: 2.5e-7
+      output_cost_per_token: 1.5e-6
+      region: "*"
+features:
+    - function_calling
+    - json_output
+    - prompt_caching
+    - structured_output
+    - tool_choice
+limits:
+    context_window: 1000000
+    max_output_tokens: 65536
+modalities:
+    input:
+        - text
+        - image
+        - video
+    output:
+        - text
+mode: chat
+model: qwen/qwen3.6-flash
+thinking: true

--- a/providers/openrouter/qwen/qwen3.6-max-preview.yaml
+++ b/providers/openrouter/qwen/qwen3.6-max-preview.yaml
@@ -19,4 +19,9 @@ modalities:
         - text
 mode: chat
 model: qwen/qwen3.6-max-preview
+sources:
+    - https://openrouter.ai/qwen/qwen3.6-max-preview
+status: active
+supportedModes:
+    - chat
 thinking: true

--- a/providers/openrouter/qwen/qwen3.6-max-preview.yaml
+++ b/providers/openrouter/qwen/qwen3.6-max-preview.yaml
@@ -1,0 +1,22 @@
+costs:
+    - cache_creation_input_token_cost: 1.625e-6
+      input_cost_per_token: 1.3e-6
+      output_cost_per_token: 7.8e-6
+      region: "*"
+features:
+    - function_calling
+    - json_output
+    - prompt_caching
+    - structured_output
+    - tool_choice
+limits:
+    context_window: 262144
+    max_output_tokens: 65536
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: chat
+model: qwen/qwen3.6-max-preview
+thinking: true


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `openrouter`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this only adds new provider configuration files (no code or behavior changes) and affects usage only if these new model IDs are selected.
> 
> **Overview**
> Adds five new OpenRouter model configs under `providers/openrouter/qwen/` for `qwen3.5-plus-20260420`, `qwen3.6-27b`, `qwen3.6-35b-a3b`, `qwen3.6-flash`, and `qwen3.6-max-preview`.
> 
> Each definition specifies **token pricing (incl. caching where applicable)**, supported features (e.g., `function_calling`, `structured_output`, `prompt_caching`), modality support, and large context/output limits; `qwen3.6-35b-a3b` also includes default sampling params.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e43df2c335287bd2684e1176bb3ae546053958a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->