### PR TITLE
feat(openrouter): add new models [bot]

### DIFF
--- a/providers/openrouter/qwen/qwen3.5-plus-20260420.yaml
+++ b/providers/openrouter/qwen/qwen3.5-plus-20260420.yaml
@@ -1,0 +1,22 @@
+costs:
+    - input_cost_per_token: 4e-7
+      output_cost_per_token: 2.4e-6
+      region: "*"
+features:
+    - function_calling
+    - json_output
+    - structured_output
+    - tool_choice
+limits:
+    context_window: 1000000
+    max_output_tokens: 65536
+modalities:
+    input:
+        - text
+        - image
+        - video
+    output:
+        - text
+mode: chat
+model: qwen/qwen3.5-plus-20260420
+thinking: true

--- a/providers/openrouter/qwen/qwen3.6-27b.yaml
+++ b/providers/openrouter/qwen/qwen3.6-27b.yaml
@@ -1,0 +1,24 @@
+costs:
+    - cache_read_input_token_cost: 2.5e-7
+      input_cost_per_token: 5e-7
+      output_cost_per_token: 2e-6
+      region: "*"
+features:
+    - function_calling
+    - json_output
+    - prompt_caching
+    - structured_output
+    - tool_choice
+limits:
+    context_window: 262144
+    max_output_tokens: 65536
+modalities:
+    input:
+        - text
+        - image
+        - video
+    output:
+        - text
+mode: chat
+model: qwen/qwen3.6-27b
+thinking: true

--- a/providers/openrouter/qwen/qwen3.6-35b-a3b.yaml
+++ b/providers/openrouter/qwen/qwen3.6-35b-a3b.yaml
@@ -1,0 +1,29 @@
+costs:
+    - cache_read_input_token_cost: 1.612e-7
+      input_cost_per_token: 1.612e-7
+      output_cost_per_token: 9.6525e-7
+      region: "*"
+features:
+    - json_output
+    - prompt_caching
+    - structured_output
+limits:
+    context_window: 262144
+    max_output_tokens: 65536
+modalities:
+    input:
+        - text
+        - image
+        - video
+    output:
+        - text
+mode: chat
+model: qwen/qwen3.6-35b-a3b
+params:
+    - defaultValue: 1
+      key: temperature
+    - defaultValue: 0.95
+      key: top_p
+    - defaultValue: 20
+      key: top_k
+thinking: true

--- a/providers/openrouter/qwen/qwen3.6-flash.yaml
+++ b/providers/openrouter/qwen/qwen3.6-flash.yaml
@@ -1,0 +1,24 @@
+costs:
+    - cache_creation_input_token_cost: 3.125e-7
+      input_cost_per_token: 2.5e-7
+      output_cost_per_token: 1.5e-6
+      region: "*"
+features:
+    - function_calling
+    - json_output
+    - prompt_caching
+    - structured_output
+    - tool_choice
+limits:
+    context_window: 1000000
+    max_output_tokens: 65536
+modalities:
+    input:
+        - text
+        - image
+        - video
+    output:
+        - text
+mode: chat
+model: qwen/qwen3.6-flash
+thinking: true

--- a/providers/openrouter/qwen/qwen3.6-max-preview.yaml
+++ b/providers/openrouter/qwen/qwen3.6-max-preview.yaml
@@ -1,0 +1,22 @@
+costs:
+    - cache_creation_input_token_cost: 1.625e-6
+      input_cost_per_token: 1.3e-6
+      output_cost_per_token: 7.8e-6
+      region: "*"
+features:
+    - function_calling
+    - json_output
+    - prompt_caching
+    - structured_output
+    - tool_choice
+limits:
+    context_window: 262144
+    max_output_tokens: 65536
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: chat
+model: qwen/qwen3.6-max-preview
+thinking: true

--- a/providers/openrouter/~anthropic/claude-haiku-latest.yaml
+++ b/providers/openrouter/~anthropic/claude-haiku-latest.yaml
@@ -1,0 +1,24 @@
+costs:
+    - cache_creation_input_token_cost: 1.25e-6
+      cache_read_input_token_cost: 1e-7
+      input_cost_per_token: 1e-6
+      output_cost_per_token: 5e-6
+      region: "*"
+features:
+    - function_calling
+    - json_output
+    - prompt_caching
+    - structured_output
+    - tool_choice
+limits:
+    context_window: 200000
+    max_output_tokens: 64000
+modalities:
+    input:
+        - image
+        - text
+    output:
+        - text
+mode: chat
+model: ~anthropic/claude-haiku-latest
+thinking: true

--- a/providers/openrouter/~anthropic/claude-sonnet-latest.yaml
+++ b/providers/openrouter/~anthropic/claude-sonnet-latest.yaml
@@ -1,0 +1,24 @@
+costs:
+    - cache_creation_input_token_cost: 3.75e-6
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 3e-6
+      output_cost_per_token: 1.5e-5
+      region: "*"
+features:
+    - function_calling
+    - json_output
+    - prompt_caching
+    - structured_output
+    - tool_choice
+limits:
+    context_window: 1000000
+    max_output_tokens: 128000
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
+mode: chat
+model: ~anthropic/claude-sonnet-latest
+thinking: true

--- a/providers/openrouter/~google/gemini-flash-latest.yaml
+++ b/providers/openrouter/~google/gemini-flash-latest.yaml
@@ -1,0 +1,28 @@
+costs:
+    - cache_creation_input_token_cost: 8.333333333e-8
+      cache_read_input_token_cost: 5e-8
+      input_cost_per_image: 5e-7
+      input_cost_per_token: 5e-7
+      output_cost_per_token: 3e-6
+      region: "*"
+features:
+    - function_calling
+    - json_output
+    - prompt_caching
+    - structured_output
+    - tool_choice
+limits:
+    context_window: 1048576
+    max_output_tokens: 65536
+modalities:
+    input:
+        - text
+        - image
+        - pdf
+        - audio
+        - video
+    output:
+        - text
+mode: chat
+model: ~google/gemini-flash-latest
+thinking: true

--- a/providers/openrouter/~google/gemini-pro-latest.yaml
+++ b/providers/openrouter/~google/gemini-pro-latest.yaml
@@ -1,0 +1,28 @@
+costs:
+    - cache_creation_input_token_cost: 3.75e-7
+      cache_read_input_token_cost: 2e-7
+      input_cost_per_image: 2e-6
+      input_cost_per_token: 2e-6
+      output_cost_per_token: 1.2e-5
+      region: "*"
+features:
+    - function_calling
+    - json_output
+    - prompt_caching
+    - structured_output
+    - tool_choice
+limits:
+    context_window: 1048576
+    max_output_tokens: 65536
+modalities:
+    input:
+        - audio
+        - pdf
+        - image
+        - text
+        - video
+    output:
+        - text
+mode: chat
+model: ~google/gemini-pro-latest
+thinking: true

--- a/providers/openrouter/~moonshotai/kimi-latest.yaml
+++ b/providers/openrouter/~moonshotai/kimi-latest.yaml
@@ -1,0 +1,24 @@
+costs:
+    - cache_read_input_token_cost: 1.463e-7
+      input_cost_per_token: 7.448e-7
+      output_cost_per_token: 4.655e-6
+      region: "*"
+features:
+    - function_calling
+    - json_output
+    - parallel_function_calling
+    - prompt_caching
+    - structured_output
+    - tool_choice
+limits:
+    context_window: 256000
+    max_output_tokens: 65536
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
+mode: chat
+model: ~moonshotai/kimi-latest
+thinking: true

--- a/providers/openrouter/~openai/gpt-latest.yaml
+++ b/providers/openrouter/~openai/gpt-latest.yaml
@@ -1,0 +1,24 @@
+costs:
+    - cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 3e-5
+      region: "*"
+features:
+    - function_calling
+    - json_output
+    - prompt_caching
+    - structured_output
+    - tool_choice
+limits:
+    context_window: 1050000
+    max_output_tokens: 128000
+modalities:
+    input:
+        - pdf
+        - image
+        - text
+    output:
+        - text
+mode: chat
+model: ~openai/gpt-latest
+thinking: true

--- a/providers/openrouter/~openai/gpt-mini-latest.yaml
+++ b/providers/openrouter/~openai/gpt-mini-latest.yaml
@@ -1,0 +1,24 @@
+costs:
+    - cache_read_input_token_cost: 7.5e-8
+      input_cost_per_token: 7.5e-7
+      output_cost_per_token: 4.5e-6
+      region: "*"
+features:
+    - function_calling
+    - json_output
+    - prompt_caching
+    - structured_output
+    - tool_choice
+limits:
+    context_window: 400000
+    max_output_tokens: 128000
+modalities:
+    input:
+        - pdf
+        - image
+        - text
+    output:
+        - text
+mode: chat
+model: ~openai/gpt-mini-latest
+thinking: true


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `openrouter`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that adds new model definitions; main risk is incorrect `costs`/`limits` metadata causing mispricing or invalid token limits when these models are selected.
> 
> **Overview**
> Adds new OpenRouter model YAML definitions for Qwen (`qwen3.5-plus-20260420`, `qwen3.6-*`) and “latest” aliases for Anthropic (`~anthropic/claude-*-latest`), Google (`~google/gemini-*-latest`), Moonshot (`~moonshotai/kimi-latest`), and OpenAI (`~openai/gpt-*-latest`).
> 
> Each config declares pricing (`costs` including cache read/creation where applicable), supported capabilities (e.g., *function calling*, *structured/JSON output*, *prompt caching*), modality support, and large context/output limits, with `thinking: true` enabled across the added models.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 084d3e7670694e8ba485b47286ca076566544dfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->