### PR TITLE
feat(together-ai): add new models [bot]

### DIFF
--- a/providers/together-ai/HappyHorse/HappyHorse-1.0-T2V.yaml
+++ b/providers/together-ai/HappyHorse/HappyHorse-1.0-T2V.yaml
@@ -1,0 +1,8 @@
+costs:
+    - input_cost_per_token: 0.0
+      output_cost_per_token: 0.0
+      region: "*"
+mode: unknown
+model: HappyHorse/HappyHorse-1.0-T2V
+supportedModes:
+    - video

--- a/providers/together-ai/Qwen/Qwen3.6-Plus.yaml
+++ b/providers/together-ai/Qwen/Qwen3.6-Plus.yaml
@@ -4,7 +4,13 @@ costs:
       region: "*"
 limits:
     context_window: 1000000
-mode: unknown
+mode: chat
 model: Qwen/Qwen3.6-Plus
+provisioning: serverless
 supportedModes:
     - chat
+
+# Model not listed on Together AI's official documentation pages
+# (https://together.ai/models, https://docs.together.ai/docs/serverless-models).
+# Costs, limits, and provisioning preserved from input; features/modalities/params/thinking
+# omitted because they cannot be confirmed from official Together AI documentation.

--- a/providers/together-ai/Qwen/Qwen3.6-Plus.yaml
+++ b/providers/together-ai/Qwen/Qwen3.6-Plus.yaml
@@ -1,0 +1,10 @@
+costs:
+    - input_cost_per_token: 5e-7
+      output_cost_per_token: 3e-6
+      region: "*"
+limits:
+    context_window: 1000000
+mode: unknown
+model: Qwen/Qwen3.6-Plus
+supportedModes:
+    - chat

--- a/providers/together-ai/deepseek-ai/DeepSeek-V4-Pro.yaml
+++ b/providers/together-ai/deepseek-ai/DeepSeek-V4-Pro.yaml
@@ -1,0 +1,11 @@
+costs:
+    - cache_read_input_token_cost: 2e-7
+      input_cost_per_token: 2.1e-6
+      output_cost_per_token: 4.4e-6
+      region: "*"
+limits:
+    context_window: 512000
+mode: unknown
+model: deepseek-ai/DeepSeek-V4-Pro
+supportedModes:
+    - chat


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `together-ai`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds new provider metadata files only; no runtime logic changes, with main risk being incorrect model metadata (e.g., mode/costs/limits).
> 
> **Overview**
> Adds three new Together AI model definition YAMLs: `HappyHorse/HappyHorse-1.0-T2V` (video), `Qwen/Qwen3.6-Plus` (serverless chat with 1M context window), and `deepseek-ai/DeepSeek-V4-Pro` (chat with 512k context window), each including token pricing metadata.
> 
> Includes a note that `Qwen/Qwen3.6-Plus` is not listed in Together AI’s official docs and therefore only costs/limits/provisioning were captured.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 565c344cc35c55c23d46bcb22ebe2a2987e1546c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->