### PR TITLE
fix: features and provision models

### DIFF
--- a/providers/deepinfra/ByteDance/Seed-2.0-pro.yaml
+++ b/providers/deepinfra/ByteDance/Seed-2.0-pro.yaml
@@ -16,7 +16,6 @@ costs:
 features:
     - function_calling
     - prompt_caching
-    - json_output
 limits:
     context_window: 256000
 modalities:

--- a/providers/google-vertex/google/translate-llm.yaml
+++ b/providers/google-vertex/google/translate-llm.yaml
@@ -8,6 +8,7 @@ modalities:
         - text
 mode: chat
 model: google/translate-llm
+provisioning: provisioned
 sources:
     - https://cloud.google.com/translate/pricing
     - https://docs.cloud.google.com/translate/docs/advanced/translate-text-advance

--- a/providers/openrouter/alfredpros/codellama-7b-instruct-solidity.yaml
+++ b/providers/openrouter/alfredpros/codellama-7b-instruct-solidity.yaml
@@ -13,7 +13,7 @@ modalities:
         - text
 mode: chat
 model: alfredpros/codellama-7b-instruct-solidity
-provisioning: serverless
+provisioning: provisioned
 sources:
     - https://openrouter.ai/alfredpros/codellama-7b-instruct-solidity
 status: active

--- a/providers/openrouter/google/gemma-2-27b-it.yaml
+++ b/providers/openrouter/google/gemma-2-27b-it.yaml
@@ -9,6 +9,11 @@ limits:
     context_window: 8192
     max_output_tokens: 2048
     max_tokens: 2048
+messages:
+    options:
+        - system
+        - user
+        - assistant
 modalities:
     input:
         - text

--- a/providers/openrouter/meta-llama/llama-4-maverick.yaml
+++ b/providers/openrouter/meta-llama/llama-4-maverick.yaml
@@ -3,7 +3,6 @@ costs:
       output_cost_per_token: 6e-7
       region: "*"
 features:
-    - function_calling
     - json_output
     - structured_output
     - tool_choice


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Config-only changes to model capability/provisioning metadata; primary risk is misclassification causing incorrect feature gating or model selection at runtime.
> 
> **Overview**
> Updates several provider model YAMLs to correct metadata used by routing/capability checks.
> 
> Removes unsupported `function_calling`/`json_output` feature flags (notably for `meta-llama/llama-4-maverick` and `ByteDance/Seed-2.0-pro`), adds explicit `messages.options` roles for `google/gemma-2-27b-it`, and changes `provisioning` to `provisioned` for `google/translate-llm` and `alfredpros/codellama-7b-instruct-solidity`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2749193c2c05d7f3ac7a0896e0ea06f4e905eea7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->