### PR TITLE
fix(ci): allow ~vendor/ model paths and hard-fail on parse errors

### DIFF
--- a/.github/scripts/trigger_changed_model_tests.py
+++ b/.github/scripts/trigger_changed_model_tests.py
@@ -33,7 +33,7 @@ from collections import defaultdict
 from typing import Dict, List
 
 _SAFE_PROVIDER = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
-_SAFE_MODEL = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._@:/-]*$")
+_SAFE_MODEL = re.compile(r"^[A-Za-z0-9~][A-Za-z0-9._@:/~-]*$")
 
 
 def _require_env(name: str) -> str:
@@ -148,8 +148,7 @@ def main() -> None:
         try:
             provider, model = _parse_provider_model(path)
         except ValueError as exc:
-            print(f"::warning::Skipping {path}: {exc}")
-            continue
+            sys.exit(f"::error::Cannot parse provider/model from {path}: {exc}")
         provider_to_models[provider].append(model)
 
     if not provider_to_models:

--- a/providers/openrouter/meta-llama/llama-guard-3-8b.yaml
+++ b/providers/openrouter/meta-llama/llama-guard-3-8b.yaml
@@ -9,7 +9,7 @@ modalities:
         - text
     output:
         - text
-mode: chat
+mode: moderation
 model: meta-llama/llama-guard-3-8b
 provisioning: serverless
 sources:

--- a/providers/sambanova/gemma-3-27b-it.yaml
+++ b/providers/sambanova/gemma-3-27b-it.yaml
@@ -13,7 +13,7 @@ modalities:
         - text
 mode: chat
 model: gemma-3-27b-it
-provisioning: serverless
+provisioning: provisioned
 sources:
     - https://docs.sambanova.ai/docs/en/features/function-calling
     - https://docs.sambanova.ai/docs/en/features/openai-compatibility


### PR DESCRIPTION
_SAFE_MODEL rejected paths like ~anthropic/claude-haiku-latest, so changes under openrouter/~anthropic, ~google, ~moonshotai, ~openai were silently skipped via ::warning::, leaving them untested in CI.

Also promote the parse-error path from a warning to ::error:: + exit so the next unparseable shape fails the workflow loudly instead of hiding behind a green check.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI behavior changes: provider/model parsing now hard-fails instead of warning, which can turn previously-green PRs red if paths are malformed. Low runtime risk, but impacts test triggering and workflow reliability.
> 
> **Overview**
> Fixes changed-model test triggering in CI by expanding `_SAFE_MODEL` to accept `~`-prefixed model names (e.g. `openrouter/~vendor/...`) and by **failing the workflow** when a provider/model path can’t be parsed instead of silently skipping it.
> 
> Updates a couple of provider YAMLs: `openrouter/meta-llama/llama-guard-3-8b` switches `mode` to `moderation`, and `sambanova/gemma-3-27b-it` changes `provisioning` to `provisioned`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e22469336b8d2bb3cc368e28ffeb6816495de759. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->