### PR TITLE
feat(google-vertex): update model YAMLs [bot]

### DIFF
--- a/providers/google-vertex/openai/gpt-oss-20b-maas.yaml
+++ b/providers/google-vertex/openai/gpt-oss-20b-maas.yaml
@@ -10,7 +10,6 @@ features:
     - structured_output
     - system_messages
     - tool_choice
-    - prompt_caching
 limits:
     context_window: 131072
     max_input_tokens: 131072
@@ -33,3 +32,4 @@ status: active
 supportedModes:
     - completion
     - chat
+thinking: true


### PR DESCRIPTION
Auto-generated by poc-agent for provider `google-vertex`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change to a single model YAML, mainly affecting advertised capabilities (removing `prompt_caching` and marking `thinking: true`).
> 
> **Overview**
> Updates the `openai/gpt-oss-20b-maas` Vertex model metadata to **drop `prompt_caching` from the declared `features`** and to **explicitly enable `thinking`** via a new `thinking: true` flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0748bff057171223d8a163be81927be92113963. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->