### PR TITLE
feat(deepinfra): add new models [bot]

### DIFF
--- a/providers/deepinfra/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning.yaml
+++ b/providers/deepinfra/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning.yaml
@@ -2,11 +2,26 @@ costs:
     - input_cost_per_token: 2e-7
       output_cost_per_token: 8e-7
       region: "*"
+features:
+    - function_calling
+    - json_output
 limits:
     context_window: 262144
     max_tokens: 262144
 modalities:
     input:
+        - text
         - image
-mode: unknown
+        - audio
+        - video
+    output:
+        - text
+mode: chat
 model: nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning
+provisioning: serverless
+sources:
+    - https://deepinfra.com/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning
+status: active
+supportedModes:
+    - chat
+thinking: true

--- a/providers/deepinfra/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning.yaml
+++ b/providers/deepinfra/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning.yaml
@@ -1,0 +1,12 @@
+costs:
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 8e-7
+      region: "*"
+limits:
+    context_window: 262144
+    max_tokens: 262144
+modalities:
+    input:
+        - image
+mode: unknown
+model: nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `deepinfra`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new DeepInfra model definition YAML without changing runtime code paths; main risk is incorrect metadata (pricing/limits/modalities) affecting model selection or cost estimation.
> 
> **Overview**
> Registers the DeepInfra chat model `nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning` by adding a new YAML definition, including **token pricing**, **262k context/max token limits**, supported *multimodal inputs* (text/image/audio/video), and capability flags (`function_calling`, `json_output`, `thinking`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fa39184091db617a62cf7e4f84aaa20f07222f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->