### PR TITLE
feat(openrouter): add new models [bot]

### DIFF
--- a/providers/openrouter/inclusionai/ling-2.6-flash.yaml
+++ b/providers/openrouter/inclusionai/ling-2.6-flash.yaml
@@ -19,3 +19,9 @@ modalities:
         - text
 mode: chat
 model: inclusionai/ling-2.6-flash
+provisioning: serverless
+sources:
+    - https://openrouter.ai/inclusionai/ling-2.6-flash
+status: active
+supportedModes:
+    - chat

--- a/providers/openrouter/inclusionai/ling-2.6-flash.yaml
+++ b/providers/openrouter/inclusionai/ling-2.6-flash.yaml
@@ -1,0 +1,21 @@
+costs:
+    - cache_read_input_token_cost: 1.6e-8
+      input_cost_per_token: 8e-8
+      output_cost_per_token: 2.4e-7
+      region: "*"
+features:
+    - function_calling
+    - json_output
+    - prompt_caching
+    - structured_output
+    - tool_choice
+limits:
+    context_window: 262144
+    max_output_tokens: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: chat
+model: inclusionai/ling-2.6-flash

--- a/providers/openrouter/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free.yaml
+++ b/providers/openrouter/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free.yaml
@@ -23,4 +23,10 @@ params:
       key: temperature
     - defaultValue: 0.95
       key: top_p
+provisioning: serverless
+sources:
+    - https://openrouter.ai/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free
+status: active
+supportedModes:
+    - chat
 thinking: true

--- a/providers/openrouter/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free.yaml
+++ b/providers/openrouter/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free.yaml
@@ -1,0 +1,26 @@
+costs:
+    - input_cost_per_token: 0.0
+      output_cost_per_token: 0.0
+      region: "*"
+features:
+    - function_calling
+    - tool_choice
+limits:
+    context_window: 256000
+    max_output_tokens: 65536
+modalities:
+    input:
+        - text
+        - audio
+        - image
+        - video
+    output:
+        - text
+mode: chat
+model: nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free
+params:
+    - defaultValue: 0.6
+      key: temperature
+    - defaultValue: 0.95
+      key: top_p
+thinking: true

--- a/providers/openrouter/poolside/laguna-m.1:free.yaml
+++ b/providers/openrouter/poolside/laguna-m.1:free.yaml
@@ -15,4 +15,9 @@ modalities:
         - text
 mode: chat
 model: poolside/laguna-m.1:free
+sources:
+    - https://openrouter.ai/poolside/laguna-m.1:free
+status: active
+supportedModes:
+    - chat
 thinking: true

--- a/providers/openrouter/poolside/laguna-m.1:free.yaml
+++ b/providers/openrouter/poolside/laguna-m.1:free.yaml
@@ -1,0 +1,18 @@
+costs:
+    - input_cost_per_token: 0.0
+      output_cost_per_token: 0.0
+      region: "*"
+features:
+    - function_calling
+    - tool_choice
+limits:
+    context_window: 131072
+    max_output_tokens: 8192
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: chat
+model: poolside/laguna-m.1:free
+thinking: true

--- a/providers/openrouter/poolside/laguna-xs.2:free.yaml
+++ b/providers/openrouter/poolside/laguna-xs.2:free.yaml
@@ -20,4 +20,10 @@ params:
       key: temperature
     - defaultValue: 0.9
       key: top_p
+provisioning: serverless
+sources:
+    - https://openrouter.ai/poolside/laguna-xs.2:free
+status: active
+supportedModes:
+    - chat
 thinking: true

--- a/providers/openrouter/poolside/laguna-xs.2:free.yaml
+++ b/providers/openrouter/poolside/laguna-xs.2:free.yaml
@@ -1,0 +1,23 @@
+costs:
+    - input_cost_per_token: 0.0
+      output_cost_per_token: 0.0
+      region: "*"
+features:
+    - function_calling
+    - tool_choice
+limits:
+    context_window: 131072
+    max_output_tokens: 8192
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: chat
+model: poolside/laguna-xs.2:free
+params:
+    - defaultValue: 0.7
+      key: temperature
+    - defaultValue: 0.9
+      key: top_p
+thinking: true


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `openrouter`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds new provider model metadata YAML files with no changes to runtime logic. Primary risk is incorrect limits/pricing/features causing misconfiguration at selection or billing time.
> 
> **Overview**
> Registers four new `openrouter` model configs via YAML: `inclusionai/ling-2.6-flash`, `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free`, `poolside/laguna-m.1:free`, and `poolside/laguna-xs.2:free`.
> 
> Each file defines **pricing (including free tiers)**, supported features (e.g., `function_calling`, `tool_choice`, and for Ling `json_output`/`prompt_caching`/`structured_output`), context/output limits, modalities (Nemotron adds audio/image/video input), and default params where applicable, with `thinking: true` set on the reasoning/free models.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b3251b9f6b5961a54807e4fb517649939dbea27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->