### PR TITLE
feat(together-ai): add new models [bot]

### DIFF
--- a/providers/together-ai/HappyHorse/HappyHorse-1.0-T2V.yaml
+++ b/providers/together-ai/HappyHorse/HappyHorse-1.0-T2V.yaml
@@ -2,7 +2,7 @@ costs:
     - input_cost_per_token: 0.0
       output_cost_per_token: 0.0
       region: "*"
-mode: unknown
+mode: video
 model: HappyHorse/HappyHorse-1.0-T2V
 supportedModes:
     - video

--- a/providers/together-ai/HappyHorse/HappyHorse-1.0-T2V.yaml
+++ b/providers/together-ai/HappyHorse/HappyHorse-1.0-T2V.yaml
@@ -1,0 +1,8 @@
+costs:
+    - input_cost_per_token: 0.0
+      output_cost_per_token: 0.0
+      region: "*"
+mode: unknown
+model: HappyHorse/HappyHorse-1.0-T2V
+supportedModes:
+    - video

--- a/providers/together-ai/Qwen/Qwen3.6-Plus.yaml
+++ b/providers/together-ai/Qwen/Qwen3.6-Plus.yaml
@@ -4,7 +4,7 @@ costs:
       region: "*"
 limits:
     context_window: 1000000
-mode: unknown
+mode: chat
 model: Qwen/Qwen3.6-Plus
 supportedModes:
     - chat

--- a/providers/together-ai/Qwen/Qwen3.6-Plus.yaml
+++ b/providers/together-ai/Qwen/Qwen3.6-Plus.yaml
@@ -1,0 +1,10 @@
+costs:
+    - input_cost_per_token: 5e-7
+      output_cost_per_token: 3e-6
+      region: "*"
+limits:
+    context_window: 1000000
+mode: unknown
+model: Qwen/Qwen3.6-Plus
+supportedModes:
+    - chat

--- a/providers/together-ai/deepseek-ai/DeepSeek-V4-Pro.yaml
+++ b/providers/together-ai/deepseek-ai/DeepSeek-V4-Pro.yaml
@@ -1,0 +1,11 @@
+costs:
+    - cache_read_input_token_cost: 2e-7
+      input_cost_per_token: 2.1e-6
+      output_cost_per_token: 4.4e-6
+      region: "*"
+limits:
+    context_window: 512000
+mode: unknown
+model: deepseek-ai/DeepSeek-V4-Pro
+supportedModes:
+    - chat

--- a/providers/together-ai/deepseek-ai/DeepSeek-V4-Pro.yaml
+++ b/providers/together-ai/deepseek-ai/DeepSeek-V4-Pro.yaml
@@ -5,7 +5,7 @@ costs:
       region: "*"
 limits:
     context_window: 512000
-mode: unknown
+mode: chat
 model: deepseek-ai/DeepSeek-V4-Pro
 supportedModes:
     - chat

--- a/providers/together-ai/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning-fp8.yaml
+++ b/providers/together-ai/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning-fp8.yaml
@@ -16,7 +16,7 @@ modalities:
         - text
 mode: chat
 model: nvidia/nemotron-3-nano-omni-30b-a3b-reasoning-fp8
-provisioning: serverless
+provisioning: provisioned
 sources:
     - https://www.together.ai/models/nvidia-nemotron-3-nano-omni
 status: active

--- a/providers/together-ai/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning-fp8.yaml
+++ b/providers/together-ai/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning-fp8.yaml
@@ -1,0 +1,10 @@
+costs:
+    - input_cost_per_token: 0.0
+      output_cost_per_token: 0.0
+      region: "*"
+limits:
+    context_window: 131072
+mode: unknown
+model: nvidia/nemotron-3-nano-omni-30b-a3b-reasoning-fp8
+supportedModes:
+    - chat

--- a/providers/together-ai/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning-fp8.yaml
+++ b/providers/together-ai/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning-fp8.yaml
@@ -3,8 +3,23 @@ costs:
       output_cost_per_token: 0.0
       region: "*"
 limits:
-    context_window: 131072
-mode: unknown
+    context_window: 256000
+modalities:
+    input:
+        - text
+        - image
+        - video
+        - audio
+        - pdf
+        - doc
+    output:
+        - text
+mode: chat
 model: nvidia/nemotron-3-nano-omni-30b-a3b-reasoning-fp8
+provisioning: serverless
+sources:
+    - https://www.together.ai/models/nvidia-nemotron-3-nano-omni
+status: active
 supportedModes:
     - chat
+thinking: true


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `together-ai`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change adding new model metadata files; primary risk is incorrect pricing/limits/capability fields affecting downstream model selection or billing display.
> 
> **Overview**
> Adds four new `together-ai` model definition YAMLs for `HappyHorse/HappyHorse-1.0-T2V` (video), `Qwen/Qwen3.6-Plus` (chat, 1M context), `deepseek-ai/DeepSeek-V4-Pro` (chat, 512k context, cache-read pricing), and `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning-fp8` (serverless chat with multimodal inputs and `thinking`).
> 
> Each file defines per-token costs and capability metadata (supported modes, limits, and for Nemotron, modalities/sources/status).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d1c1b16ea0335f54a19216db98fe38dcb840b4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->