### PR TITLE
feat(deepinfra): add new models [bot]

### DIFF
--- a/providers/deepinfra/ByteDance/Seed-2.0-code.yaml
+++ b/providers/deepinfra/ByteDance/Seed-2.0-code.yaml
@@ -5,11 +5,23 @@ costs:
       region: "*"
 features:
     - prompt_caching
+    - function_calling
+    - json_output
 limits:
     context_window: 256000
     max_tokens: 256000
 modalities:
     input:
+        - text
         - image
-mode: unknown
+    output:
+        - text
+        - code
+mode: chat
 model: ByteDance/Seed-2.0-code
+provisioning: serverless
+sources:
+    - https://deepinfra.com/ByteDance/Seed-2.0-code
+status: active
+supportedModes:
+    - chat

--- a/providers/deepinfra/ByteDance/Seed-2.0-code.yaml
+++ b/providers/deepinfra/ByteDance/Seed-2.0-code.yaml
@@ -1,0 +1,15 @@
+costs:
+    - cache_read_input_token_cost: 1e-7
+      input_cost_per_token: 5e-7
+      output_cost_per_token: 3e-6
+      region: "*"
+features:
+    - prompt_caching
+limits:
+    context_window: 256000
+    max_tokens: 256000
+modalities:
+    input:
+        - image
+mode: unknown
+model: ByteDance/Seed-2.0-code

--- a/providers/deepinfra/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning.yaml
+++ b/providers/deepinfra/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning.yaml
@@ -1,0 +1,12 @@
+costs:
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 8e-7
+      region: "*"
+limits:
+    context_window: 262144
+    max_tokens: 262144
+modalities:
+    input:
+        - image
+mode: unknown
+model: nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `deepinfra`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily additive config, but the `mode: unknown` and sparse modality fields for the Nemotron model could cause downstream validation or runtime selection issues if consumers assume known modes/outputs.
> 
> **Overview**
> Adds two new DeepInfra model definition YAMLs: `ByteDance/Seed-2.0-code` (chat, text+image in, text+code out) including token pricing, very large context/max token limits, and declared features like prompt caching/function calling/JSON output.
> 
> Also registers `nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning` with pricing and large context limits, but leaves `mode` as `unknown` and only declares image input modalities (no `supportedModes`/outputs), which may require schema/consumer validation review.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea1a5884ea189da1b4b7701a2c9304c32813c657. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->