### PR TITLE
feat(google-vertex): add new models [bot]

### DIFF
--- a/providers/google-vertex/internal-test-google/multi-region-test-model.yaml
+++ b/providers/google-vertex/internal-test-google/multi-region-test-model.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: internal-test-google/multi-region-test-model

--- a/providers/google-vertex/moonshotai/kimi-k2-6.yaml
+++ b/providers/google-vertex/moonshotai/kimi-k2-6.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: moonshotai/kimi-k2-6

--- a/providers/google-vertex/moonshotai/kimi-k2-6.yaml
+++ b/providers/google-vertex/moonshotai/kimi-k2-6.yaml
@@ -1,2 +1,12 @@
-mode: unknown
+mode: chat
 model: moonshotai/kimi-k2-6
+# costs: not found in official Vertex AI docs (Kimi K2.6 is not listed on
+# https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/kimi or the
+# Vertex AI pricing page as of 2026-04-30; only kimi-k2-thinking-maas is documented)
+# limits: not found in official Vertex AI docs
+sources:
+    - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/kimi
+    - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/kimi/kimi-k2-thinking
+status: preview
+supportedModes:
+    - chat


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `google-vertex`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily data/config additions, but introducing a model with `mode: unknown` could trip schema/validation or downstream routing if `mode` values are assumed to be known.
> 
> **Overview**
> Adds two new Google Vertex model definition YAMLs: an *internal* `internal-test-google/multi-region-test-model` entry (with `mode: unknown`) and a new `moonshotai/kimi-k2-6` chat model marked `preview` with documented source links and an explicit note that pricing/limits are not available in official Vertex docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cd26d8bbbfbb5829e1c3fb78108e3a0b0c8eed9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->