### PR TITLE
feat(together-ai): add new models [bot]

### DIFF
--- a/providers/together-ai/HappyHorse/HappyHorse-1.0-T2V.yaml
+++ b/providers/together-ai/HappyHorse/HappyHorse-1.0-T2V.yaml
@@ -1,0 +1,8 @@
+costs:
+    - input_cost_per_token: 0.0
+      output_cost_per_token: 0.0
+      region: "*"
+mode: unknown
+model: HappyHorse/HappyHorse-1.0-T2V
+supportedModes:
+    - video

--- a/providers/together-ai/Qwen/Qwen3.6-Plus.yaml
+++ b/providers/together-ai/Qwen/Qwen3.6-Plus.yaml
@@ -1,0 +1,10 @@
+costs:
+    - input_cost_per_token: 5e-7
+      output_cost_per_token: 3e-6
+      region: "*"
+limits:
+    context_window: 1000000
+mode: unknown
+model: Qwen/Qwen3.6-Plus
+supportedModes:
+    - chat

--- a/providers/together-ai/deepseek-ai/DeepSeek-V4-Pro.yaml
+++ b/providers/together-ai/deepseek-ai/DeepSeek-V4-Pro.yaml
@@ -1,0 +1,11 @@
+costs:
+    - cache_read_input_token_cost: 2e-7
+      input_cost_per_token: 2.1e-6
+      output_cost_per_token: 4.4e-6
+      region: "*"
+limits:
+    context_window: 512000
+mode: unknown
+model: deepseek-ai/DeepSeek-V4-Pro
+supportedModes:
+    - chat

--- a/providers/together-ai/mistralai/Voxtral-Mini-3B-2507.yaml
+++ b/providers/together-ai/mistralai/Voxtral-Mini-3B-2507.yaml
@@ -2,7 +2,19 @@ costs:
     - input_cost_per_token: 2.7e-7
       output_cost_per_token: 8.5e-7
       region: "*"
-mode: unknown
+limits:
+    context_window: 32000
+modalities:
+    input:
+        - audio
+        - text
+    output:
+        - text
+mode: audio_transcription
 model: mistralai/Voxtral-Mini-3B-2507
+provisioning: serverless
+sources:
+    - https://www.together.ai/models/voxtral-mini-3b-2507
+status: active
 supportedModes:
     - audio_transcription

--- a/providers/together-ai/mistralai/Voxtral-Mini-3B-2507.yaml
+++ b/providers/together-ai/mistralai/Voxtral-Mini-3B-2507.yaml
@@ -1,0 +1,8 @@
+costs:
+    - input_cost_per_token: 2.7e-7
+      output_cost_per_token: 8.5e-7
+      region: "*"
+mode: unknown
+model: mistralai/Voxtral-Mini-3B-2507
+supportedModes:
+    - audio_transcription

--- a/providers/together-ai/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning-fp8.yaml
+++ b/providers/together-ai/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning-fp8.yaml
@@ -1,0 +1,10 @@
+costs:
+    - input_cost_per_token: 0.0
+      output_cost_per_token: 0.0
+      region: "*"
+limits:
+    context_window: 131072
+mode: unknown
+model: nvidia/nemotron-3-nano-omni-30b-a3b-reasoning-fp8
+supportedModes:
+    - chat


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `together-ai`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only additions that register new model metadata; no runtime logic changes, but incorrect costs/limits/modes could affect billing/selection behavior.
> 
> **Overview**
> Adds five new `together-ai` provider model definition YAMLs for `HappyHorse/HappyHorse-1.0-T2V`, `Qwen/Qwen3.6-Plus`, `deepseek-ai/DeepSeek-V4-Pro`, `mistralai/Voxtral-Mini-3B-2507`, and `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning-fp8`.
> 
> Each file registers pricing and capability metadata (e.g., `supportedModes`, `context_window`, and for Voxtral, audio/text modalities plus serverless provisioning/source/status) so these models can be surfaced/used by the provider integration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b4b1f07f901bba5d71a14e9d77e12b0a3ed4c08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->