### PR TITLE
feat(google-vertex): add new models [bot]

### DIFF
--- a/providers/google-vertex/internal-test-google/multi-region-test-model.yaml
+++ b/providers/google-vertex/internal-test-google/multi-region-test-model.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: internal-test-google/multi-region-test-model

--- a/providers/google-vertex/moonshotai/kimi-k2-6.yaml
+++ b/providers/google-vertex/moonshotai/kimi-k2-6.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: moonshotai/kimi-k2-6


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `google-vertex`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds two new Google Vertex model definition YAML files without changing any runtime logic.
> 
> **Overview**
> Adds two new Google Vertex model definition files: `internal-test-google/multi-region-test-model` and `moonshotai/kimi-k2-6`, each with `mode: unknown` and their respective `model` identifiers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68d8c995a7c3c4a4c3ea552a0a0993f16a02cba6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->