### PR TITLE
feat(openrouter): add new models [bot]

### DIFF
--- a/providers/openrouter/ibm-granite/granite-4.1-8b.yaml
+++ b/providers/openrouter/ibm-granite/granite-4.1-8b.yaml
@@ -1,0 +1,21 @@
+costs:
+    - cache_read_input_token_cost: 5e-8
+      input_cost_per_token: 5e-8
+      output_cost_per_token: 1e-7
+      region: "*"
+features:
+    - function_calling
+    - json_output
+    - prompt_caching
+    - structured_output
+    - tool_choice
+limits:
+    context_window: 131072
+    max_output_tokens: 131072
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: chat
+model: ibm-granite/granite-4.1-8b

--- a/providers/openrouter/ibm-granite/granite-4.1-8b.yaml
+++ b/providers/openrouter/ibm-granite/granite-4.1-8b.yaml
@@ -19,3 +19,9 @@ modalities:
         - text
 mode: chat
 model: ibm-granite/granite-4.1-8b
+provisioning: serverless
+sources:
+    - https://openrouter.ai/ibm-granite/granite-4.1-8b
+status: active
+supportedModes:
+    - chat

--- a/providers/openrouter/inclusionai/ling-2.6-flash.yaml
+++ b/providers/openrouter/inclusionai/ling-2.6-flash.yaml
@@ -1,0 +1,21 @@
+costs:
+    - cache_read_input_token_cost: 1.6e-8
+      input_cost_per_token: 8e-8
+      output_cost_per_token: 2.4e-7
+      region: "*"
+features:
+    - function_calling
+    - json_output
+    - prompt_caching
+    - structured_output
+    - tool_choice
+limits:
+    context_window: 262144
+    max_output_tokens: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: chat
+model: inclusionai/ling-2.6-flash

--- a/providers/openrouter/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free.yaml
+++ b/providers/openrouter/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free.yaml
@@ -1,0 +1,26 @@
+costs:
+    - input_cost_per_token: 0.0
+      output_cost_per_token: 0.0
+      region: "*"
+features:
+    - function_calling
+    - tool_choice
+limits:
+    context_window: 256000
+    max_output_tokens: 65536
+modalities:
+    input:
+        - text
+        - audio
+        - image
+        - video
+    output:
+        - text
+mode: chat
+model: nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free
+params:
+    - defaultValue: 0.6
+      key: temperature
+    - defaultValue: 0.95
+      key: top_p
+thinking: true

--- a/providers/openrouter/openrouter/owl-alpha.yaml
+++ b/providers/openrouter/openrouter/owl-alpha.yaml
@@ -16,3 +16,9 @@ modalities:
         - text
 mode: chat
 model: openrouter/owl-alpha
+provisioning: serverless
+sources:
+    - https://openrouter.ai/openrouter/owl-alpha
+status: active
+supportedModes:
+    - chat

--- a/providers/openrouter/openrouter/owl-alpha.yaml
+++ b/providers/openrouter/openrouter/owl-alpha.yaml
@@ -1,0 +1,18 @@
+costs:
+    - input_cost_per_token: 0.0
+      output_cost_per_token: 0.0
+      region: "*"
+features:
+    - function_calling
+    - json_output
+    - structured_output
+limits:
+    context_window: 1048756
+    max_output_tokens: 262144
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: chat
+model: openrouter/owl-alpha

--- a/providers/openrouter/poolside/laguna-m.1:free.yaml
+++ b/providers/openrouter/poolside/laguna-m.1:free.yaml
@@ -1,0 +1,18 @@
+costs:
+    - input_cost_per_token: 0.0
+      output_cost_per_token: 0.0
+      region: "*"
+features:
+    - function_calling
+    - tool_choice
+limits:
+    context_window: 131072
+    max_output_tokens: 8192
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: chat
+model: poolside/laguna-m.1:free
+thinking: true

--- a/providers/openrouter/poolside/laguna-xs.2:free.yaml
+++ b/providers/openrouter/poolside/laguna-xs.2:free.yaml
@@ -1,0 +1,23 @@
+costs:
+    - input_cost_per_token: 0.0
+      output_cost_per_token: 0.0
+      region: "*"
+features:
+    - function_calling
+    - tool_choice
+limits:
+    context_window: 131072
+    max_output_tokens: 8192
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: chat
+model: poolside/laguna-xs.2:free
+params:
+    - defaultValue: 0.7
+      key: temperature
+    - defaultValue: 0.9
+      key: top_p
+thinking: true

--- a/providers/openrouter/x-ai/grok-4.3.yaml
+++ b/providers/openrouter/x-ai/grok-4.3.yaml
@@ -1,0 +1,22 @@
+costs:
+    - cache_read_input_token_cost: 2e-7
+      input_cost_per_token: 1.25e-6
+      output_cost_per_token: 2.5e-6
+      region: "*"
+features:
+    - function_calling
+    - json_output
+    - prompt_caching
+    - structured_output
+    - tool_choice
+limits:
+    context_window: 1000000
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
+mode: chat
+model: x-ai/grok-4.3
+thinking: true

--- a/providers/openrouter/x-ai/grok-4.3.yaml
+++ b/providers/openrouter/x-ai/grok-4.3.yaml
@@ -19,4 +19,10 @@ modalities:
         - text
 mode: chat
 model: x-ai/grok-4.3
+provisioning: serverless
+sources:
+    - https://openrouter.ai/x-ai/grok-4.3
+status: active
+supportedModes:
+    - chat
 thinking: true


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `openrouter`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new OpenRouter model metadata/config YAMLs only, with no runtime logic changes; main risk is incorrect pricing/limits/features values affecting model selection or cost reporting.
> 
> **Overview**
> Adds seven new OpenRouter model definition YAMLs (IBM Granite 4.1 8B, InclusionAI Ling 2.6 Flash, NVIDIA Nemotron-3 Nano Omni reasoning free, OpenRouter Owl Alpha, Poolside Laguna M/XS free, and xAI Grok 4.3) with their declared costs, supported features, modalities, and context/output limits.
> 
> Some new entries also specify `thinking: true` and default sampling params (e.g., `temperature`, `top_p`), plus serverless provisioning/source metadata where applicable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db699c85d8ab3c94232038119a77f7c0d9d6eb8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->