### PR TITLE
feat(deepinfra): add new models [bot]

### DIFF
--- a/providers/deepinfra/ByteDance/Seed-2.0-code.yaml
+++ b/providers/deepinfra/ByteDance/Seed-2.0-code.yaml
@@ -1,0 +1,15 @@
+costs:
+    - cache_read_input_token_cost: 1e-7
+      input_cost_per_token: 5e-7
+      output_cost_per_token: 3e-6
+      region: "*"
+features:
+    - prompt_caching
+limits:
+    context_window: 256000
+    max_tokens: 256000
+modalities:
+    input:
+        - image
+mode: unknown
+model: ByteDance/Seed-2.0-code

--- a/providers/deepinfra/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning.yaml
+++ b/providers/deepinfra/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning.yaml
@@ -1,0 +1,12 @@
+costs:
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 8e-7
+      region: "*"
+limits:
+    context_window: 262144
+    max_tokens: 262144
+modalities:
+    input:
+        - image
+mode: unknown
+model: nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `deepinfra`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only adds new DeepInfra model definition YAMLs (pricing/limits/modalities) without changing runtime logic.
> 
> **Overview**
> Adds two new DeepInfra model configuration entries: `ByteDance/Seed-2.0-code` (with `prompt_caching` and cache-read token pricing) and `nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning`.
> 
> Each definition specifies token costs, very large context/max token limits (~256k), and declares image input modality, expanding the set of selectable DeepInfra models.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1849211e6941a05f442dee858af9db9d9cf0d226. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->