### PR TITLE
feat(aws-bedrock): update model YAMLs [bot]

### DIFF
--- a/providers/aws-bedrock/amazon.nova-2-sonic-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.nova-2-sonic-v1:0.yaml
@@ -34,7 +34,7 @@ modalities:
     output:
         - text
         - audio
-mode: audio_transcription
+mode: realtime
 model: amazon.nova-2-sonic-v1:0
 params:
     - defaultValue: 65536
@@ -51,4 +51,4 @@ sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-amazon-nova-2-sonic.html
 status: active
 supportedModes:
-    - audio_transcription
+    - realtime

--- a/providers/aws-bedrock/eu.anthropic.claude-opus-4-7.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-opus-4-7.yaml
@@ -71,11 +71,13 @@ provisioning: serverless
 removeParams:
     - "n"
     - temperature
+    - top_p
 sources:
-    - https://platform.claude.com/docs/en/docs/about-claude/models
+    - https://platform.claude.com/docs/en/about-claude/models/overview
     - https://platform.claude.com/docs/en/about-claude/pricing
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-4-7.html
     - https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference-support.html
-status: preview
+status: active
 supportedModes:
     - chat
 thinking: true

--- a/providers/aws-bedrock/global.anthropic.claude-opus-4-7.yaml
+++ b/providers/aws-bedrock/global.anthropic.claude-opus-4-7.yaml
@@ -28,7 +28,7 @@ costs:
       cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       output_cost_per_token: 0.000025
-      region: mx-central-1
+      region: me-central-1
     - cache_creation_input_token_cost: 0.00000625
       cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
@@ -88,21 +88,6 @@ costs:
       cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       output_cost_per_token: 0.000025
-      region: ap-southeast-7
-    - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5e-7
-      input_cost_per_token: 0.000005
-      output_cost_per_token: 0.000025
-      region: ap-southeast-6
-    - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5e-7
-      input_cost_per_token: 0.000005
-      output_cost_per_token: 0.000025
-      region: ap-southeast-5
-    - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5e-7
-      input_cost_per_token: 0.000005
-      output_cost_per_token: 0.000025
       region: ap-southeast-4
     - cache_creation_input_token_cost: 0.00000625
       cache_read_input_token_cost: 5e-7
@@ -148,11 +133,6 @@ costs:
       cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
       output_cost_per_token: 0.000025
-      region: ap-east-2
-    - cache_creation_input_token_cost: 0.00000625
-      cache_read_input_token_cost: 5e-7
-      input_cost_per_token: 0.000005
-      output_cost_per_token: 0.000025
       region: af-south-1
 features:
     - function_calling
@@ -170,7 +150,6 @@ modalities:
     input:
         - text
         - image
-        - pdf
     output:
         - text
 mode: chat
@@ -188,7 +167,7 @@ sources:
     - https://platform.claude.com/docs/en/docs/about-claude/models
     - https://platform.claude.com/docs/en/about-claude/pricing
     - https://platform.claude.com/docs/en/build-with-claude/claude-in-amazon-bedrock-research-preview
-status: preview
+status: active
 supportedModes:
     - chat
 thinking: true

--- a/providers/aws-bedrock/jp.anthropic.claude-opus-4-7.yaml
+++ b/providers/aws-bedrock/jp.anthropic.claude-opus-4-7.yaml
@@ -37,16 +37,15 @@ params:
       key: max_tokens
       maxValue: 128000
       minValue: 1
-    - key: top_k
-      minValue: 0
 provisioning: serverless
 removeParams:
     - "n"
     - temperature
+    - top_p
 sources:
-    - https://platform.claude.com/docs/en/docs/about-claude/models
-    - https://platform.claude.com/docs/en/about-claude/pricing
     - https://platform.claude.com/docs/en/build-with-claude/claude-in-amazon-bedrock-research-preview
+    - https://platform.claude.com/docs/en/about-claude/pricing
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-4-7.html
 status: active
 supportedModes:
     - chat

--- a/providers/aws-bedrock/jp.anthropic.claude-sonnet-4-6.yaml
+++ b/providers/aws-bedrock/jp.anthropic.claude-sonnet-4-6.yaml
@@ -46,6 +46,7 @@ sources:
     - https://platform.claude.com/docs/en/about-claude/pricing
     - https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference-support.html
     - https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html
+    - https://aws.amazon.com/blogs/machine-learning/introducing-amazon-bedrock-cross-region-inference-for-claude-sonnet-4-5-and-haiku-4-5-in-japan-and-australia/
 status: active
 supportedModes:
     - chat

--- a/providers/aws-bedrock/minimax.minimax-m2.5.yaml
+++ b/providers/aws-bedrock/minimax.minimax-m2.5.yaml
@@ -1,76 +1,50 @@
 costs:
-    - cache_creation_input_token_cost: 3.75e-7
-      cache_read_input_token_cost: 3e-8
-      input_cost_per_token: 3e-7
+    - input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000012
       region: us-west-2
-    - cache_creation_input_token_cost: 3.75e-7
-      cache_read_input_token_cost: 3e-8
-      input_cost_per_token: 3e-7
+    - input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000012
       region: us-east-2
-    - cache_creation_input_token_cost: 3.75e-7
-      cache_read_input_token_cost: 3e-8
-      input_cost_per_token: 3e-7
+    - input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000012
       region: us-east-1
-    - cache_creation_input_token_cost: 3.75e-7
-      cache_read_input_token_cost: 3e-8
-      input_cost_per_token: 3e-7
-      output_cost_per_token: 0.0000012
+    - input_cost_per_token: 3.6e-7
+      output_cost_per_token: 0.00000144
       region: sa-east-1
-    - cache_creation_input_token_cost: 3.75e-7
-      cache_read_input_token_cost: 3e-8
-      input_cost_per_token: 3e-7
-      output_cost_per_token: 0.0000012
+    - input_cost_per_token: 4.7e-7
+      output_cost_per_token: 0.00000186
       region: eu-west-2
-    - cache_creation_input_token_cost: 3.75e-7
-      cache_read_input_token_cost: 3e-8
-      input_cost_per_token: 3e-7
-      output_cost_per_token: 0.0000012
+    - input_cost_per_token: 3.6e-7
+      output_cost_per_token: 0.00000144
       region: eu-west-1
-    - cache_creation_input_token_cost: 3.75e-7
-      cache_read_input_token_cost: 3e-8
-      input_cost_per_token: 3e-7
-      output_cost_per_token: 0.0000012
+    - input_cost_per_token: 3.6e-7
+      output_cost_per_token: 0.00000144
       region: eu-south-1
-    - cache_creation_input_token_cost: 3.75e-7
-      cache_read_input_token_cost: 3e-8
-      input_cost_per_token: 3e-7
-      output_cost_per_token: 0.0000012
+    - input_cost_per_token: 3.6e-7
+      output_cost_per_token: 0.00000144
       region: eu-north-1
-    - cache_creation_input_token_cost: 3.75e-7
-      cache_read_input_token_cost: 3e-8
-      input_cost_per_token: 3e-7
-      output_cost_per_token: 0.0000012
+    - input_cost_per_token: 3.6e-7
+      output_cost_per_token: 0.00000144
       region: eu-central-1
-    - cache_creation_input_token_cost: 3.75e-7
-      cache_read_input_token_cost: 3e-8
-      input_cost_per_token: 3e-7
-      output_cost_per_token: 0.0000012
+    - input_cost_per_token: 3.6e-7
+      output_cost_per_token: 0.00000144
       region: ap-southeast-3
-    - cache_creation_input_token_cost: 3.75e-7
-      cache_read_input_token_cost: 3e-8
-      input_cost_per_token: 3e-7
-      output_cost_per_token: 0.0000012
+    - input_cost_per_token: 3.1e-7
+      output_cost_per_token: 0.00000124
       region: ap-southeast-2
-    - cache_creation_input_token_cost: 3.75e-7
-      cache_read_input_token_cost: 3e-8
-      input_cost_per_token: 3e-7
-      output_cost_per_token: 0.0000012
+    - input_cost_per_token: 3.6e-7
+      output_cost_per_token: 0.00000144
       region: ap-south-1
-    - cache_creation_input_token_cost: 3.75e-7
-      cache_read_input_token_cost: 3e-8
-      input_cost_per_token: 3e-7
-      output_cost_per_token: 0.0000012
+    - input_cost_per_token: 3.6e-7
+      output_cost_per_token: 0.00000144
       region: ap-northeast-1
 features:
     - function_calling
     - system_messages
     - tool_choice
-    - prompt_caching
+    - structured_output
 limits:
-    context_window: 1000000
+    context_window: 196000
     max_output_tokens: 8000
     max_tokens: 8000
 modalities:
@@ -89,7 +63,6 @@ removeParams:
     - stop
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-minimax-minimax-m2-5.html
-    - https://platform.minimax.io/docs/guides/pricing-paygo
     - https://platform.minimax.io/docs/api-reference/text-anthropic-api
 status: active
 supportedModes:

--- a/providers/aws-bedrock/us.anthropic.claude-opus-4-7.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-opus-4-7.yaml
@@ -32,9 +32,12 @@ costs:
 features:
     - cache_control
     - function_calling
+    - parallel_function_calling
     - prompt_caching
     - system_messages
     - tool_choice
+    - structured_output
+    - assistant_prefill
 limits:
     context_window: 1000000
     max_output_tokens: 128000
@@ -57,13 +60,13 @@ provisioning: serverless
 removeParams:
     - "n"
     - temperature
+    - top_p
 sources:
-    - https://platform.claude.com/docs/en/docs/about-claude/models
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-4-7.html
+    - https://platform.claude.com/docs/en/about-claude/models/overview
     - https://platform.claude.com/docs/en/about-claude/pricing
-    - https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference.html
-    - https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html
-    - https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-claude.html
-status: preview
+    - https://aws.amazon.com/blogs/aws/introducing-anthropics-claude-opus-4-7-model-in-amazon-bedrock/
+status: active
 supportedModes:
     - chat
 thinking: true

--- a/providers/aws-bedrock/us.stability.stable-image-control-sketch-v1:0.yaml
+++ b/providers/aws-bedrock/us.stability.stable-image-control-sketch-v1:0.yaml
@@ -1,9 +1,9 @@
 costs:
-    - input_cost_per_image: 0
+    - input_cost_per_image: 0.07
       region: us-west-2
-    - input_cost_per_image: 0
+    - input_cost_per_image: 0.07
       region: us-east-2
-    - input_cost_per_image: 0
+    - input_cost_per_image: 0.07
       region: us-east-1
 modalities:
     input:

--- a/providers/aws-bedrock/us.stability.stable-image-control-structure-v1:0.yaml
+++ b/providers/aws-bedrock/us.stability.stable-image-control-structure-v1:0.yaml
@@ -1,9 +1,9 @@
 costs:
-    - input_cost_per_image: 0.04
+    - input_cost_per_image: 0.07
       region: us-west-2
-    - input_cost_per_image: 0.04
+    - input_cost_per_image: 0.07
       region: us-east-2
-    - input_cost_per_image: 0.04
+    - input_cost_per_image: 0.07
       region: us-east-1
 modalities:
     input:
@@ -24,6 +24,7 @@ removeParams:
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/stable-image-services.html
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-stability-diffusion.html
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-stability-ai-stable-image-control-structure.html
 status: active
 supportedModes:
     - image

--- a/providers/aws-bedrock/us.stability.stable-image-erase-object-v1:0.yaml
+++ b/providers/aws-bedrock/us.stability.stable-image-erase-object-v1:0.yaml
@@ -1,9 +1,9 @@
 costs:
-    - input_cost_per_image: 0.04
+    - input_cost_per_image: 0.07
       region: us-west-2
-    - input_cost_per_image: 0.04
+    - input_cost_per_image: 0.07
       region: us-east-2
-    - input_cost_per_image: 0.04
+    - input_cost_per_image: 0.07
       region: us-east-1
 modalities:
     input:

--- a/providers/aws-bedrock/us.stability.stable-image-search-recolor-v1:0.yaml
+++ b/providers/aws-bedrock/us.stability.stable-image-search-recolor-v1:0.yaml
@@ -1,9 +1,9 @@
 costs:
-    - input_cost_per_image: 0
+    - output_cost_per_image: 0.07
       region: us-west-2
-    - input_cost_per_image: 0
+    - output_cost_per_image: 0.07
       region: us-east-2
-    - input_cost_per_image: 0
+    - output_cost_per_image: 0.07
       region: us-east-1
 modalities:
     input:

--- a/providers/aws-bedrock/us.stability.stable-image-style-guide-v1:0.yaml
+++ b/providers/aws-bedrock/us.stability.stable-image-style-guide-v1:0.yaml
@@ -1,9 +1,9 @@
 costs:
-    - input_cost_per_image: 0.04
+    - input_cost_per_image: 0.07
       region: us-west-2
-    - input_cost_per_image: 0.04
+    - input_cost_per_image: 0.07
       region: us-east-2
-    - input_cost_per_image: 0.04
+    - input_cost_per_image: 0.07
       region: us-east-1
 modalities:
     input:
@@ -23,6 +23,7 @@ removeParams:
     - stream
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/stable-image-services.html
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-stability-ai-stable-image-style-guide.html
 status: active
 supportedModes:
     - image

--- a/providers/aws-bedrock/us.stability.stable-style-transfer-v1:0.yaml
+++ b/providers/aws-bedrock/us.stability.stable-style-transfer-v1:0.yaml
@@ -1,9 +1,9 @@
 costs:
-    - output_cost_per_image: 0.04
+    - output_cost_per_image: 0.08
       region: us-west-2
-    - output_cost_per_image: 0.04
+    - output_cost_per_image: 0.08
       region: us-east-2
-    - output_cost_per_image: 0.04
+    - output_cost_per_image: 0.08
       region: us-east-1
 modalities:
     input:

--- a/providers/aws-bedrock/zai.glm-5.yaml
+++ b/providers/aws-bedrock/zai.glm-5.yaml
@@ -4,10 +4,33 @@ costs:
       region: us-west-2
     - input_cost_per_token: 0.000001
       output_cost_per_token: 0.0000032
+      region: us-east-2
+    - input_cost_per_token: 0.000001
+      output_cost_per_token: 0.0000032
       region: us-east-1
+    - input_cost_per_token: 0.0000012
+      output_cost_per_token: 0.00000384
+      region: sa-east-1
+    - input_cost_per_token: 0.00000155
+      output_cost_per_token: 0.00000496
+      region: eu-west-2
+    - input_cost_per_token: 0.0000012
+      output_cost_per_token: 0.00000384
+      region: eu-north-1
+    - input_cost_per_token: 0.0000012
+      output_cost_per_token: 0.00000384
+      region: ap-southeast-3
+    - input_cost_per_token: 0.00000103
+      output_cost_per_token: 0.0000033
+      region: ap-southeast-2
+    - input_cost_per_token: 0.0000012
+      output_cost_per_token: 0.00000384
+      region: ap-south-1
+    - input_cost_per_token: 0.0000012
+      output_cost_per_token: 0.00000384
+      region: ap-northeast-1
 features:
     - function_calling
-    - structured_output
 limits:
     context_window: 200000
     max_output_tokens: 128000
@@ -30,6 +53,8 @@ removeParams:
 sources:
     - https://aws.amazon.com/about-aws/whats-new/2026/03/amazon-bedrock-minimax-glm/
     - https://docs.z.ai/guides/llm/glm-5
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-zai-glm-5.html
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/model-cards-zai.html
 status: active
 supportedModes:
     - chat


### PR DESCRIPTION
Auto-generated by poc-agent for provider `aws-bedrock`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates model capability metadata and pricing/region tables used by downstream tooling; incorrect values could affect mode availability or cost calculations, but changes are confined to provider YAML config.
> 
> **Overview**
> Updates multiple `providers/aws-bedrock/*.yaml` model definitions.
> 
> Promotes Anthropic `claude-opus-4-7` (EU/US/Global) from *preview* to **active**, adds/adjusts supported features (e.g., `parallel_function_calling`, `structured_output`, `assistant_prefill`), and expands `removeParams` to include `top_p` in several regions.
> 
> Adjusts model metadata for other offerings: switches `amazon.nova-2-sonic-v1:0` from `audio_transcription` to **`realtime`** mode, updates `global.anthropic.claude-opus-4-7` region/cost entries, revises `minimax.minimax-m2.5` pricing and reduces `context_window` to `196000` while adding `structured_output`, and updates Stability image model per-image costs and documentation sources. Adds multi-region pricing entries and AWS model-card sources for `zai.glm-5`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13b26ed723e4ea78ae16a5567909d463313cfe85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->