### PR TITLE
feat(deepinfra): update model YAMLs [bot]

### DIFF
--- a/providers/deepinfra/BAAI/bge-base-en-v1.5.yaml
+++ b/providers/deepinfra/BAAI/bge-base-en-v1.5.yaml
@@ -1,5 +1,5 @@
 costs:
-    - input_cost_per_token: 1e-8
+    - input_cost_per_token: 5e-9
       region: "*"
 limits:
     max_input_tokens: 512

--- a/providers/deepinfra/BAAI/bge-en-icl.yaml
+++ b/providers/deepinfra/BAAI/bge-en-icl.yaml
@@ -4,7 +4,6 @@ costs:
 modalities:
     input:
         - text
-        - image
     output:
         - embedding
 mode: embedding

--- a/providers/deepinfra/Bria/fibo.yaml
+++ b/providers/deepinfra/Bria/fibo.yaml
@@ -4,7 +4,6 @@ costs:
 modalities:
     input:
         - text
-        - image
     output:
         - image
 mode: image

--- a/providers/deepinfra/Bria/replace_background.yaml
+++ b/providers/deepinfra/Bria/replace_background.yaml
@@ -4,6 +4,7 @@ costs:
 modalities:
     input:
         - image
+        - text
     output:
         - image
 mode: image

--- a/providers/deepinfra/MiniMaxAI/MiniMax-M2.5.yaml
+++ b/providers/deepinfra/MiniMaxAI/MiniMax-M2.5.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_read_input_token_cost: 3e-8
-      input_cost_per_token: 2.7e-7
-      output_cost_per_token: 9.5e-7
+      input_cost_per_token: 1.5e-7
+      output_cost_per_token: 1.15e-6
       region: "*"
 features:
     - function_calling

--- a/providers/deepinfra/PaddlePaddle/PaddleOCR-VL-0.9B.yaml
+++ b/providers/deepinfra/PaddlePaddle/PaddleOCR-VL-0.9B.yaml
@@ -2,6 +2,7 @@ costs:
     - input_cost_per_token: 1.4e-7
       output_cost_per_token: 8e-7
       region: "*"
+deprecationDate: "2026-05-07"
 features:
     - json_output
     - prompt_caching

--- a/providers/deepinfra/PaddlePaddle/PaddleOCR-VL-0.9B.yaml
+++ b/providers/deepinfra/PaddlePaddle/PaddleOCR-VL-0.9B.yaml
@@ -4,7 +4,6 @@ costs:
       region: "*"
 deprecationDate: "2026-05-07"
 features:
-    - json_output
     - prompt_caching
 limits:
     context_window: 16384

--- a/providers/deepinfra/Qwen/Qwen3.5-35B-A3B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3.5-35B-A3B.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_read_input_token_cost: 1e-7
-      input_cost_per_token: 2e-7
-      output_cost_per_token: 9.5e-7
+      input_cost_per_token: 1.8e-7
+      output_cost_per_token: 1e-6
       region: "*"
 features:
     - function_calling
@@ -14,6 +14,7 @@ modalities:
     input:
         - text
         - image
+        - video
     output:
         - text
 mode: chat

--- a/providers/deepinfra/Qwen/Qwen3.5-397B-A17B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3.5-397B-A17B.yaml
@@ -14,6 +14,7 @@ modalities:
     input:
         - text
         - image
+        - video
     output:
         - text
 mode: chat

--- a/providers/deepinfra/Qwen/Qwen3.5-4B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3.5-4B.yaml
@@ -14,6 +14,7 @@ modalities:
     input:
         - text
         - image
+        - video
     output:
         - text
 mode: chat

--- a/providers/deepinfra/black-forest-labs/FLUX-1.1-pro.yaml
+++ b/providers/deepinfra/black-forest-labs/FLUX-1.1-pro.yaml
@@ -11,5 +11,6 @@ model: black-forest-labs/FLUX-1.1-pro
 provisioning: serverless
 sources:
     - https://deepinfra.com/black-forest-labs/FLUX-1.1-pro
+status: active
 supportedModes:
     - image

--- a/providers/deepinfra/black-forest-labs/FLUX-2-pro.yaml
+++ b/providers/deepinfra/black-forest-labs/FLUX-2-pro.yaml
@@ -1,5 +1,6 @@
 costs:
     - input_cost_per_image: 0.015
+      output_cost_per_image: 0.03
       region: "*"
 modalities:
     input:

--- a/providers/deepinfra/sentence-transformers/multi-qa-mpnet-base-dot-v1.yaml
+++ b/providers/deepinfra/sentence-transformers/multi-qa-mpnet-base-dot-v1.yaml
@@ -7,7 +7,6 @@ limits:
 modalities:
     input:
         - text
-        - image
     output:
         - embedding
 mode: embedding

--- a/providers/deepinfra/shibing624/text2vec-base-chinese.yaml
+++ b/providers/deepinfra/shibing624/text2vec-base-chinese.yaml
@@ -7,7 +7,6 @@ limits:
 modalities:
     input:
         - text
-        - image
     output:
         - embedding
 mode: embedding

--- a/providers/deepinfra/stabilityai/sdxl-turbo.yaml
+++ b/providers/deepinfra/stabilityai/sdxl-turbo.yaml
@@ -1,10 +1,9 @@
 costs:
-    - output_cost_per_image: 0.001
+    - output_cost_per_image: 0.0002
       region: "*"
 modalities:
     input:
         - text
-        - image
     output:
         - image
 mode: image
@@ -12,5 +11,6 @@ model: stabilityai/sdxl-turbo
 provisioning: serverless
 sources:
     - https://deepinfra.com/stabilityai/sdxl-turbo
+status: active
 supportedModes:
     - image

--- a/providers/deepinfra/stepfun-ai/Step-3.5-Flash.yaml
+++ b/providers/deepinfra/stepfun-ai/Step-3.5-Flash.yaml
@@ -5,7 +5,6 @@ costs:
       region: "*"
 features:
     - function_calling
-    - json_output
     - prompt_caching
 limits:
     context_window: 262144

--- a/providers/deepinfra/stepfun-ai/Step-3.5-Flash.yaml
+++ b/providers/deepinfra/stepfun-ai/Step-3.5-Flash.yaml
@@ -5,6 +5,7 @@ costs:
       region: "*"
 features:
     - function_calling
+    - json_output
     - prompt_caching
 limits:
     context_window: 262144


### PR DESCRIPTION
Auto-generated by poc-agent for provider `deepinfra`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates model metadata that affects advertised modalities and per-token/per-image pricing, which can change request routing/validation and cost estimation. No code changes, but mis-specified YAML values could impact downstream billing and capability checks.
> 
> **Overview**
> Updates multiple DeepInfra model YAMLs to reflect **new pricing** (token/image rates, including adding `output_cost_per_image` for `FLUX-2-pro` and lowering `sdxl-turbo` image cost).
> 
> Adjusts **capability metadata** by removing erroneous `image` input modalities from several embedding/image models, adding `text` input to `Bria/replace_background`, and adding `video` input support to several `Qwen3.5` chat models. Also marks some models explicitly `status: active` and adds a `deprecationDate` to `PaddleOCR-VL-0.9B`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8743ec91823fdd4a8a778fc8524e452b46236d33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->