### PR TITLE
feat(google-vertex): update model YAMLs [bot]

### DIFF
--- a/providers/google-vertex/anthropic/claude-opus-4-7.yaml
+++ b/providers/google-vertex/anthropic/claude-opus-4-7.yaml
@@ -1,4 +1,11 @@
 costs:
+    - cache_creation_input_token_cost: 0.000006875
+      cache_read_input_token_cost: 5.5e-7
+      input_cost_per_token: 0.0000055
+      input_cost_per_token_batches: 0.00000275
+      output_cost_per_token: 0.0000275
+      output_cost_per_token_batches: 0.00001375
+      region: us
     - cache_creation_input_token_cost: 0.00000625
       cache_read_input_token_cost: 5e-7
       input_cost_per_token: 0.000005
@@ -6,6 +13,13 @@ costs:
       output_cost_per_token: 0.000025
       output_cost_per_token_batches: 0.0000125
       region: global
+    - cache_creation_input_token_cost: 0.000006875
+      cache_read_input_token_cost: 5.5e-7
+      input_cost_per_token: 0.0000055
+      input_cost_per_token_batches: 0.00000275
+      output_cost_per_token: 0.0000275
+      output_cost_per_token_batches: 0.00001375
+      region: eu
 features:
     - assistant_prefill
     - cache_control
@@ -37,7 +51,6 @@ removeParams:
     - temperature
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude/opus-4-7
-    - https://platform.claude.com/docs/en/docs/about-claude/models
     - https://platform.claude.com/docs/en/docs/about-claude/pricing
 status: active
 supportedModes:


### PR DESCRIPTION
Auto-generated by poc-agent for provider `google-vertex`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that updates cost metadata and documentation links; main impact is on billing/estimation logic that consumes these YAML prices.
> 
> **Overview**
> Updates `providers/google-vertex/anthropic/claude-opus-4-7.yaml` to add **region-specific pricing entries** for `us` and `eu` (including cache creation/read and batch token rates) alongside the existing `global` costs.
> 
> Removes an outdated Claude model documentation source link, keeping the Vertex model doc and Claude pricing reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b70409f10a99f395c79026b2a1ad541fa281a3e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->