### PR TITLE
feat(together-ai): update model YAMLs [bot]

### DIFF
--- a/providers/together-ai/MiniMaxAI/MiniMax-M2.5-FP4.yaml
+++ b/providers/together-ai/MiniMaxAI/MiniMax-M2.5-FP4.yaml
@@ -5,10 +5,9 @@ costs:
       region: "*"
 features:
     - function_calling
-    - structured_output
     - json_output
 limits:
-    context_window: 228700
+    context_window: 192000
 modalities:
     input:
         - text
@@ -17,6 +16,8 @@ modalities:
 mode: chat
 model: MiniMaxAI/MiniMax-M2.5-FP4
 provisioning: provisioned
+sources:
+    - https://www.together.ai/models/minimax-m2-5
 status: active
 supportedModes:
     - chat

--- a/providers/together-ai/MiniMaxAI/MiniMax-M2.5.yaml
+++ b/providers/together-ai/MiniMaxAI/MiniMax-M2.5.yaml
@@ -9,7 +9,7 @@ features:
     - prompt_caching
     - json_output
 limits:
-    context_window: 228700
+    context_window: 192000
 modalities:
     input:
         - text
@@ -23,3 +23,4 @@ sources:
 status: active
 supportedModes:
     - chat
+thinking: true

--- a/providers/together-ai/MiniMaxAI/MiniMax-M2.5.yaml
+++ b/providers/together-ai/MiniMaxAI/MiniMax-M2.5.yaml
@@ -17,7 +17,7 @@ modalities:
         - text
 mode: chat
 model: MiniMaxAI/MiniMax-M2.5
-provisioning: serverless
+provisioning: provisioned
 sources:
     - https://www.together.ai/models/minimax-m2-5
 status: active

--- a/providers/together-ai/Qwen/Qwen3-4B-Instruct-2507.yaml
+++ b/providers/together-ai/Qwen/Qwen3-4B-Instruct-2507.yaml
@@ -2,6 +2,10 @@ costs:
     - input_cost_per_token: 0
       output_cost_per_token: 0
       region: "*"
+features:
+    - function_calling
+    - tool_choice
+    - system_messages
 limits:
     context_window: 262144
 messages:
@@ -18,6 +22,9 @@ modalities:
 mode: chat
 model: Qwen/Qwen3-4B-Instruct-2507
 provisioning: provisioned
+sources:
+    - https://www.together.ai/models/qwen3-4b
+    - https://huggingface.co/Qwen/Qwen3-4B-Instruct-2507
 status: active
 supportedModes:
     - chat

--- a/providers/together-ai/Qwen/Qwen3-8B-Lora.yaml
+++ b/providers/together-ai/Qwen/Qwen3-8B-Lora.yaml
@@ -2,6 +2,9 @@ costs:
     - input_cost_per_token: 0
       output_cost_per_token: 0
       region: "*"
+limits:
+    context_window: 40960
+    max_input_tokens: 40960
 modalities:
     input:
         - text
@@ -12,6 +15,8 @@ model: Qwen/Qwen3-8B-Lora
 provisioning: provisioned
 sources:
     - https://docs.together.ai/docs/fine-tuning-models
+    - https://www.together.ai/models/qwen3-8b
 status: active
 supportedModes:
     - chat
+thinking: true

--- a/providers/together-ai/Qwen/Qwen3-Coder-Next-FP8.yaml
+++ b/providers/together-ai/Qwen/Qwen3-Coder-Next-FP8.yaml
@@ -2,6 +2,7 @@ costs:
     - input_cost_per_token: 5e-7
       output_cost_per_token: 0.0000012
       region: "*"
+deprecationDate: "2026-05-14"
 features:
     - function_calling
     - structured_output
@@ -19,7 +20,8 @@ mode: chat
 model: Qwen/Qwen3-Coder-Next-FP8
 provisioning: serverless
 sources:
-    - https://docs.together.ai/docs/serverless-models
+    - https://www.together.ai/models/qwen3-coder-next
+    - https://www.together.ai/pricing
     - https://docs.together.ai/docs/function-calling
     - https://docs.together.ai/docs/json-mode
     - https://huggingface.co/Qwen/Qwen3-Coder-Next

--- a/providers/together-ai/Qwen/Qwen3.5-35B-A3B.yaml
+++ b/providers/together-ai/Qwen/Qwen3.5-35B-A3B.yaml
@@ -20,9 +20,10 @@ mode: chat
 model: Qwen/Qwen3.5-35B-A3B
 provisioning: provisioned
 sources:
-    - https://together.ai/pricing
-    - https://docs.together.ai/docs/serverless-models
+    - https://www.together.ai/pricing
+    - https://docs.together.ai/docs/fine-tuning-models
     - https://huggingface.co/Qwen/Qwen3.5-35B-A3B
+status: active
 supportedModes:
     - chat
 thinking: true

--- a/providers/together-ai/Qwen/Qwen3.5-9B-FP8.yaml
+++ b/providers/together-ai/Qwen/Qwen3.5-9B-FP8.yaml
@@ -12,14 +12,14 @@ modalities:
     input:
         - text
         - image
+        - video
     output:
         - text
 mode: chat
 model: Qwen/Qwen3.5-9B-FP8
 provisioning: provisioned
 sources:
-    - https://together.ai/models
-    - https://docs.together.ai/docs/serverless-models
+    - https://www.together.ai/models/qwen3-5-9b
 status: active
 supportedModes:
     - chat

--- a/providers/together-ai/Qwen/Qwen3.5-9B.yaml
+++ b/providers/together-ai/Qwen/Qwen3.5-9B.yaml
@@ -14,14 +14,15 @@ modalities:
     input:
         - image
         - text
+        - video
     output:
         - text
 mode: chat
 model: Qwen/Qwen3.5-9B
 provisioning: serverless
 sources:
-    - https://docs.together.ai/docs/function-calling
-    - https://docs.together.ai/docs/json-mode
+    - https://www.together.ai/models/qwen3-5-9b
+    - https://www.together.ai/pricing
 status: active
 supportedModes:
     - chat

--- a/providers/together-ai/black-forest-labs/FLUX.2-max.yaml
+++ b/providers/together-ai/black-forest-labs/FLUX.2-max.yaml
@@ -4,12 +4,14 @@ costs:
 modalities:
     input:
         - text
+        - image
     output:
         - image
 mode: image
 model: black-forest-labs/FLUX.2-max
 provisioning: serverless
 sources:
+    - https://www.together.ai/models/flux-2-max
     - https://www.together.ai/pricing
 status: active
 supportedModes:

--- a/providers/together-ai/deepseek-ai/DeepSeek-R1-Original.yaml
+++ b/providers/together-ai/deepseek-ai/DeepSeek-R1-Original.yaml
@@ -1,3 +1,12 @@
+costs:
+    - input_cost_per_token: 0.000003
+      output_cost_per_token: 0.000007
+      region: "*"
+features:
+    - function_calling
+    - json_output
+limits:
+    context_window: 160000
 modalities:
     input:
         - text
@@ -6,6 +15,9 @@ modalities:
 mode: chat
 model: deepseek-ai/DeepSeek-R1-Original
 provisioning: serverless
+sources:
+    - https://www.together.ai/models/deepseek-r1
+    - https://www.together.ai/pricing
 status: active
 supportedModes:
     - chat

--- a/providers/together-ai/deepseek-ai/DeepSeek-R1-Original.yaml
+++ b/providers/together-ai/deepseek-ai/DeepSeek-R1-Original.yaml
@@ -14,7 +14,7 @@ modalities:
         - text
 mode: chat
 model: deepseek-ai/DeepSeek-R1-Original
-provisioning: serverless
+provisioning: provisioned
 sources:
     - https://www.together.ai/models/deepseek-r1
     - https://www.together.ai/pricing

--- a/providers/together-ai/deepseek-ai/DeepSeek-R1.yaml
+++ b/providers/together-ai/deepseek-ai/DeepSeek-R1.yaml
@@ -2,6 +2,7 @@ costs:
     - input_cost_per_token: 0.000003
       output_cost_per_token: 0.000007
       region: "*"
+deprecationDate: "2026-05-14"
 features:
     - function_calling
     - structured_output

--- a/providers/together-ai/deepseek-ai/DeepSeek-V3-0324.yaml
+++ b/providers/together-ai/deepseek-ai/DeepSeek-V3-0324.yaml
@@ -2,6 +2,7 @@ costs:
     - input_cost_per_token: 0.00000125
       output_cost_per_token: 0.00000125
       region: "*"
+deprecationDate: "2026-05-14"
 features:
     - function_calling
     - parallel_function_calling
@@ -24,5 +25,6 @@ sources:
     - https://docs.together.ai/docs/function-calling
     - https://docs.together.ai/docs/json-mode
     - https://docs.together.ai/docs/deepseek-faqs
+status: active
 supportedModes:
     - chat

--- a/providers/together-ai/deepseek-ai/DeepSeek-V3.1.yaml
+++ b/providers/together-ai/deepseek-ai/DeepSeek-V3.1.yaml
@@ -2,6 +2,7 @@ costs:
     - input_cost_per_token: 6e-7
       output_cost_per_token: 0.0000017
       region: "*"
+deprecationDate: "2026-05-14"
 features:
     - function_calling
     - parallel_function_calling
@@ -19,6 +20,7 @@ model: deepseek-ai/DeepSeek-V3.1
 provisioning: serverless
 sources:
     - https://www.together.ai/pricing
+    - https://www.together.ai/models/deepseek-v3-1
     - https://docs.together.ai/docs/function-calling
     - https://docs.together.ai/docs/deepseek-3-1-quickstart
     - https://docs.together.ai/docs/json-mode

--- a/providers/together-ai/deepseek-ai/DeepSeek-V3.yaml
+++ b/providers/together-ai/deepseek-ai/DeepSeek-V3.yaml
@@ -7,6 +7,7 @@ features:
     - tool_choice
     - structured_output
     - json_output
+    - system_messages
 limits:
     context_window: 128000
 modalities:

--- a/providers/together-ai/google/gemini-3-pro-image.yaml
+++ b/providers/together-ai/google/gemini-3-pro-image.yaml
@@ -17,6 +17,8 @@ model: google/gemini-3-pro-image
 provisioning: serverless
 sources:
     - https://www.together.ai/models/nano-banana-pro
+    - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/3-pro-image
 status: active
 supportedModes:
     - image
+thinking: true

--- a/providers/together-ai/google/gemma-4-26B-A4B-it.yaml
+++ b/providers/together-ai/google/gemma-4-26B-A4B-it.yaml
@@ -2,6 +2,9 @@ costs:
     - input_cost_per_token: 0
       output_cost_per_token: 0
       region: "*"
+features:
+    - function_calling
+    - system_messages
 limits:
     context_window: 262144
 modalities:

--- a/providers/together-ai/google/imagen-4.0-preview.yaml
+++ b/providers/together-ai/google/imagen-4.0-preview.yaml
@@ -10,7 +10,8 @@ mode: image
 model: google/imagen-4.0-preview
 provisioning: serverless
 sources:
+    - https://www.together.ai/models/google-imagen-4-0-preview
     - https://www.together.ai/pricing
-status: active
+status: preview
 supportedModes:
     - image

--- a/providers/together-ai/mistralai/Mistral-7B-Instruct-v0.2.yaml
+++ b/providers/together-ai/mistralai/Mistral-7B-Instruct-v0.2.yaml
@@ -15,8 +15,10 @@ mode: chat
 model: mistralai/Mistral-7B-Instruct-v0.2
 provisioning: provisioned
 sources:
+    - https://www.together.ai/models/mistral-7b-instruct-v0-2
     - https://www.together.ai/pricing
     - https://docs.together.ai/docs/function-calling
     - https://docs.together.ai/docs/json-mode
+status: active
 supportedModes:
     - chat

--- a/providers/together-ai/moonshotai/Kimi-K2.5.yaml
+++ b/providers/together-ai/moonshotai/Kimi-K2.5.yaml
@@ -8,9 +8,9 @@ features:
     - tool_choice
     - structured_output
     - json_output
+    - system_messages
 limits:
     context_window: 262144
-    max_input_tokens: 262144
 messages:
     options:
         - system
@@ -20,7 +20,6 @@ modalities:
     input:
         - text
         - image
-        - video
     output:
         - text
 mode: chat
@@ -29,6 +28,7 @@ provisioning: serverless
 sources:
     - https://www.together.ai/models/kimi-k2-5
     - https://together.ai/pricing
+    - https://docs.together.ai/docs/kimi-k2.5-quickstart
     - https://docs.together.ai/docs/vision-overview
     - https://docs.together.ai/docs/function-calling
     - https://docs.together.ai/docs/json-mode

--- a/providers/together-ai/openai/gpt-image-1.5.yaml
+++ b/providers/together-ai/openai/gpt-image-1.5.yaml
@@ -4,11 +4,15 @@ costs:
 modalities:
     input:
         - text
+        - image
     output:
         - image
 mode: image
 model: openai/gpt-image-1.5
 provisioning: serverless
+sources:
+    - https://www.together.ai/models/gpt-image-1-5
+    - https://www.together.ai/pricing
 status: active
 supportedModes:
     - image

--- a/providers/together-ai/openai/gpt-oss-120b.yaml
+++ b/providers/together-ai/openai/gpt-oss-120b.yaml
@@ -19,8 +19,10 @@ mode: chat
 model: openai/gpt-oss-120b
 provisioning: serverless
 sources:
+    - https://www.together.ai/models/gpt-oss-120b
     - https://docs.together.ai/docs/function-calling
     - https://docs.together.ai/docs/json-mode
 status: active
 supportedModes:
     - chat
+thinking: true

--- a/providers/together-ai/zai-org/GLM-5.yaml
+++ b/providers/together-ai/zai-org/GLM-5.yaml
@@ -17,7 +17,10 @@ mode: chat
 model: zai-org/GLM-5
 provisioning: serverless
 sources:
-    - https://together.ai/pricing
+    - https://www.together.ai/models/glm-5
+    - https://www.together.ai/pricing
+    - https://docs.z.ai/guides/llm/glm-5
 status: active
 supportedModes:
     - chat
+thinking: true


### PR DESCRIPTION
Auto-generated by poc-agent for provider `together-ai`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily metadata changes, but updates to `provisioning`, `context_window` limits, and new deprecation dates could affect model selection and runtime routing if consumers rely on these fields.
> 
> **Overview**
> Updates Together.ai provider model YAMLs with refreshed capabilities and lifecycle metadata.
> 
> Notable changes include reduced `context_window` for `MiniMax-M2.5*`, provisioning updates (e.g., `MiniMax-M2.5` and `DeepSeek-R1-Original` to `provisioned`), new `features`/modalities flags (e.g., `system_messages`, video/image inputs), added `deprecationDate` on several Qwen/DeepSeek models, and expanded/normalized `sources` plus a few status/thinking flag adjustments (e.g., `imagen-4.0-preview` to `status: preview`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 438d1185617cf723aa03f6e58c5bfab8ea4e9f08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->