### PR TITLE
feat(deepinfra): add new models [bot]

### DIFF
--- a/providers/deepinfra/ByteDance/Seed-2.0-code.yaml
+++ b/providers/deepinfra/ByteDance/Seed-2.0-code.yaml
@@ -1,0 +1,15 @@
+costs:
+    - cache_read_input_token_cost: 1e-7
+      input_cost_per_token: 5e-7
+      output_cost_per_token: 3e-6
+      region: "*"
+features:
+    - prompt_caching
+limits:
+    context_window: 256000
+    max_tokens: 256000
+modalities:
+    input:
+        - image
+mode: unknown
+model: ByteDance/Seed-2.0-code

--- a/providers/deepinfra/Qwen/Qwen3.6-27B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3.6-27B.yaml
@@ -2,12 +2,24 @@ costs:
     - input_cost_per_token: 3.2e-7
       output_cost_per_token: 3.2e-6
       region: "*"
+features:
+    - function_calling
+    - json_output
 limits:
     context_window: 262144
     max_tokens: 262144
 modalities:
     input:
+        - text
         - image
-mode: unknown
+    output:
+        - text
+mode: chat
 model: Qwen/Qwen3.6-27B
+provisioning: serverless
+sources:
+    - https://deepinfra.com/Qwen/Qwen3.6-27B
+status: active
+supportedModes:
+    - chat
 thinking: true

--- a/providers/deepinfra/Qwen/Qwen3.6-27B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3.6-27B.yaml
@@ -1,0 +1,13 @@
+costs:
+    - input_cost_per_token: 3.2e-7
+      output_cost_per_token: 3.2e-6
+      region: "*"
+limits:
+    context_window: 262144
+    max_tokens: 262144
+modalities:
+    input:
+        - image
+mode: unknown
+model: Qwen/Qwen3.6-27B
+thinking: true

--- a/providers/deepinfra/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning.yaml
+++ b/providers/deepinfra/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning.yaml
@@ -1,0 +1,12 @@
+costs:
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 8e-7
+      region: "*"
+limits:
+    context_window: 262144
+    max_tokens: 262144
+modalities:
+    input:
+        - image
+mode: unknown
+model: nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `deepinfra`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds three new DeepInfra model metadata YAMLs (pricing, limits, modalities, and feature flags) without changing any runtime logic.
> 
> **Overview**
> Adds three new model configuration entries under `providers/deepinfra` for `ByteDance/Seed-2.0-code`, `Qwen/Qwen3.6-27B`, and `nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning`.
> 
> Each YAML introduces pricing, context/max token limits (~256k), and declared modalities/features (e.g., `prompt_caching` for Seed, `function_calling`/`json_output` and `thinking` for Qwen), expanding the DeepInfra model registry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 340e2ba83511f6cafd57f022c493dd2695681a83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->