### PR TITLE
feat(anthropic): update model YAMLs [bot]

### DIFF
--- a/providers/anthropic/claude-haiku-4-5.yaml
+++ b/providers/anthropic/claude-haiku-4-5.yaml
@@ -8,11 +8,13 @@ costs:
       region: "*"
 features:
     - function_calling
+    - parallel_function_calling
     - tool_choice
     - prompt_caching
     - cache_control
     - structured_output
     - assistant_prefill
+    - system_messages
 limits:
     context_window: 200000
     max_input_tokens: 200000

--- a/providers/anthropic/claude-opus-4-1-20250805.yaml
+++ b/providers/anthropic/claude-opus-4-1-20250805.yaml
@@ -8,10 +8,12 @@ costs:
       region: "*"
 features:
     - function_calling
+    - parallel_function_calling
     - tool_choice
     - cache_control
     - prompt_caching
     - assistant_prefill
+    - system_messages
 limits:
     context_window: 200000
     max_input_tokens: 200000

--- a/providers/anthropic/claude-sonnet-4-5-20250929.yaml
+++ b/providers/anthropic/claude-sonnet-4-5-20250929.yaml
@@ -6,19 +6,6 @@ costs:
       output_cost_per_token: 0.000015
       output_cost_per_token_batches: 0.0000075
       region: "*"
-      tiered_pricing:
-          cache_read:
-              - cost_per_token: 6e-7
-                from: 200000
-          cache_write:
-              - cost_per_token: 0.0000075
-                from: 200000
-          input:
-              - cost_per_token: 0.000006
-                from: 200000
-          output:
-              - cost_per_token: 0.0000225
-                from: 200000
 features:
     - function_calling
     - tool_choice

--- a/providers/anthropic/claude-sonnet-4-5.yaml
+++ b/providers/anthropic/claude-sonnet-4-5.yaml
@@ -8,10 +8,13 @@ costs:
       region: "*"
 features:
     - function_calling
+    - parallel_function_calling
     - tool_choice
     - prompt_caching
+    - cache_control
     - structured_output
     - assistant_prefill
+    - system_messages
 limits:
     context_window: 200000
     max_input_tokens: 200000


### PR DESCRIPTION
Auto-generated by poc-agent for provider `anthropic`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only changes that adjust advertised model features and pricing metadata; main risk is downstream consumers enabling `parallel_function_calling`/`system_messages` based on these flags.
> 
> **Overview**
> Updates Anthropic model YAML metadata to advertise additional capabilities for `claude-haiku-4-5`, `claude-opus-4-1-20250805`, and `claude-sonnet-4-5` (adds `parallel_function_calling` and `system_messages`, and ensures `cache_control` is listed where applicable).
> 
> Simplifies `claude-sonnet-4-5-20250929` pricing by removing the `tiered_pricing` block, leaving only the base per-token costs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bef426f7b0d13f4c86c2221b1061267f3548c99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->