### PR TITLE
feat(deepinfra): add new models [bot]

### DIFF
--- a/providers/deepinfra/ByteDance/Seed-2.0-code.yaml
+++ b/providers/deepinfra/ByteDance/Seed-2.0-code.yaml
@@ -1,0 +1,15 @@
+costs:
+    - cache_read_input_token_cost: 1e-7
+      input_cost_per_token: 5e-7
+      output_cost_per_token: 3e-6
+      region: "*"
+features:
+    - prompt_caching
+limits:
+    context_window: 256000
+    max_tokens: 256000
+modalities:
+    input:
+        - image
+mode: unknown
+model: ByteDance/Seed-2.0-code

--- a/providers/deepinfra/Qwen/Qwen3.6-27B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3.6-27B.yaml
@@ -1,0 +1,13 @@
+costs:
+    - input_cost_per_token: 3.2e-7
+      output_cost_per_token: 3.2e-6
+      region: "*"
+limits:
+    context_window: 262144
+    max_tokens: 262144
+modalities:
+    input:
+        - image
+mode: unknown
+model: Qwen/Qwen3.6-27B
+thinking: true

--- a/providers/deepinfra/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning.yaml
+++ b/providers/deepinfra/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning.yaml
@@ -1,0 +1,12 @@
+costs:
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 8e-7
+      region: "*"
+limits:
+    context_window: 262144
+    max_tokens: 262144
+modalities:
+    input:
+        - image
+mode: unknown
+model: nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `deepinfra`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk data-only change: it adds three new DeepInfra model definition YAMLs (pricing/limits/modalities) without touching runtime code; main risk is mis-specified metadata (e.g., `mode: unknown`, token limits, costs) affecting model listing or billing.
> 
> **Overview**
> Adds three new DeepInfra model definition YAMLs for `ByteDance/Seed-2.0-code`, `Qwen/Qwen3.6-27B` (marked `thinking: true`), and `nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning`.
> 
> Each model config introduces **pricing**, **token/context limits (~256k)**, and **image input modality** metadata, with `Seed-2.0-code` also advertising `prompt_caching` costs/feature support.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1faef356f6b57a5982df6cb3cded9560d8a73ee9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->