### PR TITLE
feat(google-vertex): add new models [bot]

### DIFF
--- a/providers/google-vertex/internal-test-google/multi-region-test-model.yaml
+++ b/providers/google-vertex/internal-test-google/multi-region-test-model.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: internal-test-google/multi-region-test-model

--- a/providers/google-vertex/moonshotai/kimi-k2-6.yaml
+++ b/providers/google-vertex/moonshotai/kimi-k2-6.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: moonshotai/kimi-k2-6


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `google-vertex`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds two new `google-vertex` model definition YAMLs without modifying runtime logic or shared code paths.
> 
> **Overview**
> Adds two new `google-vertex` model definition YAMLs: `internal-test-google/multi-region-test-model` and `moonshotai/kimi-k2-6`, each declared with `mode: unknown` and its `model` identifier.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa12b286c4330ffd62099efbc7a3e135d25071d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->