### PR TITLE
feat(together-ai): add new models [bot]

### DIFF
--- a/providers/together-ai/Qwen/Qwen3.6-Plus.yaml
+++ b/providers/together-ai/Qwen/Qwen3.6-Plus.yaml
@@ -1,0 +1,10 @@
+costs:
+    - input_cost_per_token: 5e-7
+      output_cost_per_token: 3e-6
+      region: "*"
+limits:
+    context_window: 1000000
+mode: unknown
+model: Qwen/Qwen3.6-Plus
+supportedModes:
+    - chat

--- a/providers/together-ai/deepseek-ai/DeepSeek-V4-Pro.yaml
+++ b/providers/together-ai/deepseek-ai/DeepSeek-V4-Pro.yaml
@@ -1,0 +1,11 @@
+costs:
+    - cache_read_input_token_cost: 2e-7
+      input_cost_per_token: 2.1e-6
+      output_cost_per_token: 4.4e-6
+      region: "*"
+limits:
+    context_window: 512000
+mode: unknown
+model: deepseek-ai/DeepSeek-V4-Pro
+supportedModes:
+    - chat

--- a/providers/together-ai/mistralai/Voxtral-Mini-3B-2507.yaml
+++ b/providers/together-ai/mistralai/Voxtral-Mini-3B-2507.yaml
@@ -1,0 +1,8 @@
+costs:
+    - input_cost_per_token: 2.7e-7
+      output_cost_per_token: 8.5e-7
+      region: "*"
+mode: unknown
+model: mistralai/Voxtral-Mini-3B-2507
+supportedModes:
+    - audio_transcription

--- a/providers/together-ai/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning-fp8.yaml
+++ b/providers/together-ai/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning-fp8.yaml
@@ -1,0 +1,10 @@
+costs:
+    - input_cost_per_token: 0.0
+      output_cost_per_token: 0.0
+      region: "*"
+limits:
+    context_window: 131072
+mode: unknown
+model: nvidia/nemotron-3-nano-omni-30b-a3b-reasoning-fp8
+supportedModes:
+    - chat


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `together-ai`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only adds new Together.ai model metadata (pricing/limits/modes) without changing runtime logic. Main risk is incorrect cost/context-window values affecting billing or model selection.
> 
> **Overview**
> Adds four new Together.ai model definition YAMLs to the provider catalog: `Qwen/Qwen3.6-Plus`, `deepseek-ai/DeepSeek-V4-Pro`, `mistralai/Voxtral-Mini-3B-2507`, and `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning-fp8`.
> 
> Each entry specifies token pricing (including `cache_read_input_token_cost` for DeepSeek), supported mode (`chat` or `audio_transcription`), and where applicable a `context_window` limit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c8d77a07decc67327699361723f4bc28a0cd6b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->