### PR TITLE
feat(aws-bedrock): add new models [bot]

### DIFF
--- a/providers/aws-bedrock/au.anthropic.claude-opus-4-7.yaml
+++ b/providers/aws-bedrock/au.anthropic.claude-opus-4-7.yaml
@@ -1,0 +1,5 @@
+costs:
+    - region: ap-southeast-4
+    - region: ap-southeast-2
+mode: unknown
+model: au.anthropic.claude-opus-4-7

--- a/providers/aws-bedrock/au.anthropic.claude-opus-4-7.yaml
+++ b/providers/aws-bedrock/au.anthropic.claude-opus-4-7.yaml
@@ -1,5 +1,48 @@
 costs:
-    - region: ap-southeast-4
-    - region: ap-southeast-2
-mode: unknown
+    - cache_creation_input_token_cost: 0.000006875
+      cache_read_input_token_cost: 5.5e-7
+      input_cost_per_token: 0.0000055
+      output_cost_per_token: 0.0000275
+      region: ap-southeast-4
+    - cache_creation_input_token_cost: 0.000006875
+      cache_read_input_token_cost: 5.5e-7
+      input_cost_per_token: 0.0000055
+      output_cost_per_token: 0.0000275
+      region: ap-southeast-2
+features:
+    - function_calling
+    - parallel_function_calling
+    - tool_choice
+    - prompt_caching
+    - cache_control
+    - system_messages
+    - assistant_prefill
+limits:
+    context_window: 1000000
+    max_output_tokens: 128000
+    max_tokens: 128000
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
+mode: chat
 model: au.anthropic.claude-opus-4-7
+params:
+    - defaultValue: 4096
+      key: max_tokens
+      maxValue: 128000
+      minValue: 1
+provisioning: serverless
+removeParams:
+    - temperature
+    - top_p
+sources:
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-4-7.html
+    - https://platform.claude.com/docs/en/about-claude/pricing
+    - https://platform.claude.com/docs/en/about-claude/models/overview
+status: active
+supportedModes:
+    - chat
+thinking: true


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `aws-bedrock`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new AWS Bedrock model metadata YAML without changing runtime logic; main risk is incorrect pricing/limits/feature flags affecting model selection or cost estimates.
> 
> **Overview**
> Adds a new AWS Bedrock model definition `au.anthropic.claude-opus-4-7.yaml`, enabling the AU Claude Opus 4.7 variant to be discovered/used with declared *token pricing (incl. prompt caching)* for `ap-southeast-2` and `ap-southeast-4`.
> 
> The model config also specifies supported capabilities (tool/function calling, cache controls, system messages, assistant prefill), large context/output limits, and parameter handling (sets `max_tokens` defaults and removes `temperature`/`top_p`), with `thinking: true` and `status: active`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 125101182475bee936e03f2eb4a285bc480f8429. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->