### PR TITLE
feat(deepinfra): add new models [bot]

### DIFF
--- a/providers/deepinfra/ByteDance/Seed-2.0-code.yaml
+++ b/providers/deepinfra/ByteDance/Seed-2.0-code.yaml
@@ -1,0 +1,15 @@
+costs:
+    - cache_read_input_token_cost: 1e-7
+      input_cost_per_token: 5e-7
+      output_cost_per_token: 3e-6
+      region: "*"
+features:
+    - prompt_caching
+limits:
+    context_window: 256000
+    max_tokens: 256000
+modalities:
+    input:
+        - image
+mode: unknown
+model: ByteDance/Seed-2.0-code

--- a/providers/deepinfra/Qwen/Qwen3.6-27B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3.6-27B.yaml
@@ -1,0 +1,13 @@
+costs:
+    - input_cost_per_token: 3.2e-7
+      output_cost_per_token: 3.2e-6
+      region: "*"
+limits:
+    context_window: 262144
+    max_tokens: 262144
+modalities:
+    input:
+        - image
+mode: unknown
+model: Qwen/Qwen3.6-27B
+thinking: true

--- a/providers/deepinfra/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning.yaml
+++ b/providers/deepinfra/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning.yaml
@@ -1,0 +1,12 @@
+costs:
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 8e-7
+      region: "*"
+limits:
+    context_window: 262144
+    max_tokens: 262144
+modalities:
+    input:
+        - image
+mode: unknown
+model: nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `deepinfra`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds three new `deepinfra` model metadata YAMLs (pricing/limits/capabilities) without changing runtime logic.
> 
> **Overview**
> Adds three new `deepinfra` provider model definition files for `ByteDance/Seed-2.0-code`, `Qwen/Qwen3.6-27B` (marked `thinking: true`), and `nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning`.
> 
> Each config includes token pricing, large context/token limits (~256k), and image input modality support; `Seed-2.0-code` also declares `prompt_caching` with a cache read token cost.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3eecf80e344aeddb690f83e511d75a5f95750a03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->