### PR TITLE
feat(google-vertex): add new models [bot]

### DIFF
--- a/providers/google-vertex/internal-test-google/multi-region-test-model.yaml
+++ b/providers/google-vertex/internal-test-google/multi-region-test-model.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: internal-test-google/multi-region-test-model

--- a/providers/google-vertex/moonshotai/kimi-k2-6.yaml
+++ b/providers/google-vertex/moonshotai/kimi-k2-6.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: moonshotai/kimi-k2-6


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `google-vertex`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this only adds new provider model config files with no changes to runtime logic.
> 
> **Overview**
> Adds two new Google Vertex model config YAMLs: `internal-test-google/multi-region-test-model` and `moonshotai/kimi-k2-6`, each declared with `mode: unknown` and their respective `model` identifiers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8812749b937c40802500a8c6b4c75221638ee562. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->