### PR TITLE
feat(together-ai): add new models [bot]

### DIFF
--- a/providers/together-ai/pixverse/pixverse-v6.yaml
+++ b/providers/together-ai/pixverse/pixverse-v6.yaml
@@ -1,8 +1,17 @@
 costs:
-    - input_cost_per_token: 0.0
-      output_cost_per_token: 0.0
+    - input_cost_per_token: 0.0 # not found in official docs
+      output_cost_per_token: 0.0 # not found in official docs
       region: "*"
-mode: unknown
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - video
+        - audio
+mode: video
 model: pixverse/pixverse-v6
+provisioning: serverless
+status: active
 supportedModes:
     - video

--- a/providers/together-ai/pixverse/pixverse-v6.yaml
+++ b/providers/together-ai/pixverse/pixverse-v6.yaml
@@ -1,0 +1,8 @@
+costs:
+    - input_cost_per_token: 0.0
+      output_cost_per_token: 0.0
+      region: "*"
+mode: unknown
+model: pixverse/pixverse-v6
+supportedModes:
+    - video

--- a/providers/together-ai/xai/grok-imagine-image-pro.yaml
+++ b/providers/together-ai/xai/grok-imagine-image-pro.yaml
@@ -1,0 +1,8 @@
+costs:
+    - input_cost_per_token: 0.0
+      output_cost_per_token: 0.0
+      region: "*"
+mode: unknown
+model: xai/grok-imagine-image-pro
+supportedModes:
+    - image

--- a/providers/together-ai/xai/grok-imagine-image-pro.yaml
+++ b/providers/together-ai/xai/grok-imagine-image-pro.yaml
@@ -2,7 +2,13 @@ costs:
     - input_cost_per_token: 0.0
       output_cost_per_token: 0.0
       region: "*"
-mode: unknown
+modalities:
+    input:
+        - text
+    output:
+        - image
+mode: image
 model: xai/grok-imagine-image-pro
+provisioning: serverless
 supportedModes:
     - image


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `together-ai`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds new Together AI model definition YAMLs with metadata and placeholder (0.0) token costs; no runtime logic changes.
> 
> **Overview**
> Adds two new Together AI model definition YAMLs: `pixverse/pixverse-v6` (text+image to video/audio, `mode: video`, `status: active`) and `xai/grok-imagine-image-pro` (text to image, `mode: image`). Both are marked `serverless` and include region-wide cost stubs (0.0) for token pricing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50501e07d7aff3ae7312555844b4929ab7039738. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->