### PR TITLE
feat(cerebras): update model YAMLs [bot]

### DIFF
--- a/providers/cerebras/llama3.1-8b.yaml
+++ b/providers/cerebras/llama3.1-8b.yaml
@@ -2,6 +2,7 @@ costs:
     - input_cost_per_token: 1e-7
       output_cost_per_token: 1e-7
       region: "*"
+deprecationDate: "2026-05-27"
 features:
     - function_calling
     - parallel_function_calling

--- a/providers/cerebras/qwen-3-235b-a22b-instruct-2507.yaml
+++ b/providers/cerebras/qwen-3-235b-a22b-instruct-2507.yaml
@@ -2,6 +2,7 @@ costs:
     - input_cost_per_token: 6e-7
       output_cost_per_token: 0.0000012
       region: "*"
+deprecationDate: "2026-05-27"
 features:
     - function_calling
     - parallel_function_calling
@@ -33,7 +34,6 @@ sources:
     - https://inference-docs.cerebras.ai/capabilities/prompt-caching
     - https://inference-docs.cerebras.ai/capabilities/tool-use
     - https://inference-docs.cerebras.ai/capabilities/structured-outputs
-    - https://www.cerebras.ai/pricing
     - https://inference-docs.cerebras.ai/api-reference/chat-completions
 status: preview
 supportedModes:

--- a/providers/cerebras/zai-glm-4.7.yaml
+++ b/providers/cerebras/zai-glm-4.7.yaml
@@ -7,6 +7,8 @@ features:
     - parallel_function_calling
     - prompt_caching
     - structured_output
+    - system_messages
+    - tool_choice
 limits:
     context_window: 131072
     max_output_tokens: 40000


### PR DESCRIPTION
Auto-generated by poc-agent for provider `cerebras`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to provider model YAML metadata (dates/features/links) and do not affect runtime logic.
> 
> **Overview**
> Adds `deprecationDate: "2026-05-27"` to the Cerebras `llama3.1-8b` and `qwen-3-235b-a22b-instruct-2507` model definitions.
> 
> Updates `zai-glm-4.7` advertised capabilities to include `system_messages` and `tool_choice`, and removes the Cerebras pricing URL from `qwen-3-235b-a22b-instruct-2507` `sources`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70e3c41c46f64e31727b1b70d5cc3b6e4b50fe73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->