### PR TITLE
feat(cohere): update model YAMLs [bot]

### DIFF
--- a/providers/cohere/command-a-translate-08-2025.yaml
+++ b/providers/cohere/command-a-translate-08-2025.yaml
@@ -5,6 +5,8 @@ costs:
 features:
     - structured_output
     - function_calling
+    - system_messages
+    - tool_choice
 limits:
     context_window: 16000
     max_input_tokens: 8000

--- a/providers/cohere/command-a-vision-07-2025.yaml
+++ b/providers/cohere/command-a-vision-07-2025.yaml
@@ -4,6 +4,7 @@ costs:
       region: "*"
 features:
     - structured_output
+    - system_messages
 limits:
     context_window: 128000
     max_output_tokens: 8000

--- a/providers/cohere/command-r-08-2024.yaml
+++ b/providers/cohere/command-r-08-2024.yaml
@@ -6,6 +6,7 @@ features:
     - function_calling
     - structured_output
     - tool_choice
+    - system_messages
 limits:
     context_window: 128000
     max_output_tokens: 4000

--- a/providers/cohere/command-r7b-12-2024.yaml
+++ b/providers/cohere/command-r7b-12-2024.yaml
@@ -6,6 +6,7 @@ features:
     - function_calling
     - json_output
     - structured_output
+    - system_messages
     - tool_choice
 limits:
     context_window: 128000

--- a/providers/cohere/rerank-v4.0-pro.yaml
+++ b/providers/cohere/rerank-v4.0-pro.yaml
@@ -3,6 +3,11 @@ costs:
       region: "*"
 limits:
     context_window: 32768
+modalities:
+    input:
+        - text
+    output:
+        - text
 mode: rerank
 model: rerank-v4.0-pro
 provisioning: serverless


### PR DESCRIPTION
Auto-generated by poc-agent for provider `cohere`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk metadata-only updates to Cohere model definitions; main risk is incorrect capability flags affecting routing/validation for these models.
> 
> **Overview**
> Updates several Cohere chat model YAMLs to advertise new capabilities: adds `system_messages` to `command-a-vision-07-2025`, `command-r-08-2024`, and `command-r7b-12-2024`, and adds both `system_messages` and `tool_choice` to `command-a-translate-08-2025`.
> 
> Adds explicit `modalities` (text in/out) to `rerank-v4.0-pro` so the rerank model declares its input/output types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf80d6c7ef17ac9c13d25d05d11228e5c1f9fd8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->