### PR TITLE
feat(google-gemini): update model YAMLs [bot]

### DIFF
--- a/providers/google-gemini/gemini-robotics-er-1.5-preview.yaml
+++ b/providers/google-gemini/gemini-robotics-er-1.5-preview.yaml
@@ -1,13 +1,14 @@
 costs:
-    - input_cost_per_audio_token: 0.000001
+    - input_cost_per_audio_token: 1e-6
       input_cost_per_token: 3e-7
-      output_cost_per_token: 0.0000025
+      output_cost_per_token: 2.5e-6
       region: "*"
 deprecationDate: "2026-04-30"
 features:
     - function_calling
     - structured_output
     - code_execution
+isDeprecated: true
 limits:
     context_window: 1048576
     max_input_tokens: 1048576
@@ -29,7 +30,7 @@ params:
 provisioning: serverless
 sources:
     - https://ai.google.dev/gemini-api/docs/robotics-overview
-status: preview
+status: retired
 supportedModes:
     - chat
 thinking: true

--- a/providers/google-gemini/veo-3.1-generate-preview.yaml
+++ b/providers/google-gemini/veo-3.1-generate-preview.yaml
@@ -26,6 +26,7 @@ removeParams:
     - tool_choice
 sources:
     - https://ai.google.dev/gemini-api/docs/video
+    - https://ai.google.dev/gemini-api/docs/models/veo-3.1-generate-preview
 status: preview
 supportedModes:
     - video

--- a/providers/google-gemini/veo-3.1-generate-preview.yaml
+++ b/providers/google-gemini/veo-3.1-generate-preview.yaml
@@ -10,7 +10,6 @@ modalities:
     input:
         - text
         - image
-        - video
     output:
         - video
         - audio
@@ -27,7 +26,6 @@ removeParams:
     - tool_choice
 sources:
     - https://ai.google.dev/gemini-api/docs/video
-    - https://ai.google.dev/gemini-api/docs/models/veo-3.1-generate-preview
 status: preview
 supportedModes:
     - video


### PR DESCRIPTION
Auto-generated by poc-agent for provider `google-gemini`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk metadata-only changes to provider model configuration YAMLs (status flags, cost formatting, and declared modalities) with no code logic changes.
> 
> **Overview**
> Marks `gemini-robotics-er-1.5-preview` as **deprecated/retired** by adding `isDeprecated: true`, changing `status` from `preview` to `retired`, and normalizing cost values to scientific notation.
> 
> Updates `veo-3.1-generate-preview` modality declarations by removing `video` from the `modalities.input` list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d26b6c38bae14bc3b0c8679d0e6442b7b129d686. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->