### PR TITLE
feat(mistral-ai): update model YAMLs [bot]

### DIFF
--- a/providers/mistral-ai/codestral-2508.yaml
+++ b/providers/mistral-ai/codestral-2508.yaml
@@ -6,6 +6,9 @@ features:
     - function_calling
     - structured_output
     - json_output
+    - system_messages
+    - tool_choice
+    - assistant_prefill
 limits:
     context_window: 256000
 modalities:

--- a/providers/mistral-ai/codestral-latest.yaml
+++ b/providers/mistral-ai/codestral-latest.yaml
@@ -8,6 +8,13 @@ features:
     - json_output
 limits:
     context_window: 256000
+modalities:
+    input:
+        - text
+        - code
+    output:
+        - text
+        - code
 mode: chat
 model: codestral-latest
 params:

--- a/providers/mistral-ai/devstral-latest.yaml
+++ b/providers/mistral-ai/devstral-latest.yaml
@@ -8,12 +8,15 @@ features:
     - function_calling
     - json_output
     - structured_output
+    - system_messages
+    - tool_choice
 limits:
     context_window: 262144
 modalities:
     input:
         - text
         - image
+        - doc
     output:
         - text
 mode: chat

--- a/providers/mistral-ai/magistral-small-2509.yaml
+++ b/providers/mistral-ai/magistral-small-2509.yaml
@@ -1,11 +1,12 @@
 costs:
     - input_cost_per_token: 5e-7
-      output_cost_per_token: 0.0000015
+      output_cost_per_token: 1.5e-6
       region: "*"
 features:
     - function_calling
     - structured_output
     - json_output
+isDeprecated: true
 limits:
     context_window: 131072
 modalities:
@@ -26,7 +27,7 @@ removeParams:
 sources:
     - https://docs.mistral.ai/models/magistral-small-1-2-25-09
     - https://docs.mistral.ai/capabilities/reasoning/native
-status: active
+status: deprecated
 supportedModes:
     - chat
 thinking: true

--- a/providers/mistral-ai/magistral-small-latest.yaml
+++ b/providers/mistral-ai/magistral-small-latest.yaml
@@ -1,12 +1,13 @@
 costs:
     - input_cost_per_token: 5e-7
-      output_cost_per_token: 0.0000015
+      output_cost_per_token: 1.5e-6
       region: "*"
 features:
     - function_calling
     - structured_output
     - json_output
     - tool_choice
+isDeprecated: true
 limits:
     context_window: 131072
 modalities:
@@ -27,7 +28,7 @@ sources:
     - https://docs.mistral.ai/models/magistral-small-1-2-25-09
     - https://docs.mistral.ai/capabilities/reasoning
     - https://mistral.ai/news/magistral
-status: active
+status: deprecated
 supportedModes:
     - chat
 thinking: true

--- a/providers/mistral-ai/mistral-moderation-latest.yaml
+++ b/providers/mistral-ai/mistral-moderation-latest.yaml
@@ -5,6 +5,9 @@ costs:
 deprecationDate: "2026-06-30"
 limits:
     context_window: 8192
+modalities:
+    input:
+        - text
 mode: moderation
 model: mistral-moderation-latest
 removeParams:

--- a/providers/mistral-ai/mistral-small-2506.yaml
+++ b/providers/mistral-ai/mistral-small-2506.yaml
@@ -8,6 +8,7 @@ features:
     - structured_output
     - json_output
     - tool_choice
+isDeprecated: true
 limits:
     context_window: 131072
 modalities:
@@ -32,7 +33,7 @@ sources:
     - https://docs.mistral.ai/capabilities/reasoning
     - https://docs.mistral.ai/capabilities/structured_output/json_mode
     - https://docs.mistral.ai/capabilities/batch
-status: active
+status: deprecated
 supportedModes:
     - chat
 thinking: true

--- a/providers/mistral-ai/mistral-vibe-cli-latest.yaml
+++ b/providers/mistral-ai/mistral-vibe-cli-latest.yaml
@@ -1,7 +1,20 @@
+costs:
+    - input_cost_per_token: 0.0000015
+      output_cost_per_token: 0.0000075
+      region: "*"
 features:
     - function_calling
+    - structured_output
+    - system_messages
+    - tool_choice
 limits:
     context_window: 262144
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
 mode: chat
 model: mistral-vibe-cli-latest
 params:
@@ -10,6 +23,9 @@ params:
 provisioning: serverless
 sources:
     - https://docs.mistral.ai/mistral-vibe/introduction
+    - https://mistral.ai/news/devstral-2-vibe-cli
+    - https://mistral.ai/news/vibe-remote-agents-mistral-medium-3-5
 status: active
 supportedModes:
     - chat
+thinking: true


### PR DESCRIPTION
Auto-generated by poc-agent for provider `mistral-ai`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk metadata-only changes, but marking models as `deprecated`/`isDeprecated` can affect model discovery/selection in downstream tooling.
> 
> **Overview**
> Refreshes several `mistral-ai` model YAML definitions to reflect updated capabilities and IO support (e.g., adds `system_messages`, `tool_choice`, `assistant_prefill`, and new `modalities` entries).
> 
> Marks `magistral-small-*` and `mistral-small-2506` as **deprecated** (adds `isDeprecated: true` and changes `status`), and updates `mistral-vibe-cli-latest` metadata with explicit costs, modalities, extra sources, and `thinking: true`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57be7b9a7df2b7ce66d4e73d225ce1ed4ce30ed5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->