### PR TITLE
feat(aws-bedrock): add new models [bot]

### DIFF
--- a/providers/aws-bedrock/au.anthropic.claude-opus-4-7.yaml
+++ b/providers/aws-bedrock/au.anthropic.claude-opus-4-7.yaml
@@ -1,0 +1,5 @@
+costs:
+    - region: ap-southeast-4
+    - region: ap-southeast-2
+mode: unknown
+model: au.anthropic.claude-opus-4-7


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `aws-bedrock`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new AWS Bedrock model metadata YAML entry without changing runtime logic.
> 
> **Overview**
> Adds a new AWS Bedrock model definition file, `au.anthropic.claude-opus-4-7.yaml`, registering the model with region cost entries for `ap-southeast-4` and `ap-southeast-2` and marking its `mode` as `unknown`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36363ac9fd9cea010955dd3928de67575d9c77e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->