### PR TITLE
feat(deepinfra): add new models [bot]

### DIFF
--- a/providers/deepinfra/XiaomiMiMo/MiMo-V2.5-Pro.yaml
+++ b/providers/deepinfra/XiaomiMiMo/MiMo-V2.5-Pro.yaml
@@ -1,0 +1,12 @@
+costs:
+    - cache_read_input_token_cost: 2e-7
+      input_cost_per_token: 1e-6
+      output_cost_per_token: 3e-6
+      region: "*"
+features:
+    - prompt_caching
+limits:
+    context_window: 1048576
+    max_tokens: 1048576
+mode: unknown
+model: XiaomiMiMo/MiMo-V2.5-Pro

--- a/providers/deepinfra/XiaomiMiMo/MiMo-V2.5-Pro.yaml
+++ b/providers/deepinfra/XiaomiMiMo/MiMo-V2.5-Pro.yaml
@@ -5,8 +5,21 @@ costs:
       region: "*"
 features:
     - prompt_caching
+    - function_calling
+    - json_output
 limits:
     context_window: 1048576
     max_tokens: 1048576
-mode: unknown
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: chat
 model: XiaomiMiMo/MiMo-V2.5-Pro
+provisioning: serverless
+sources:
+    - https://deepinfra.com/XiaomiMiMo/MiMo-V2.5-Pro
+status: active
+supportedModes:
+    - chat

--- a/providers/deepinfra/XiaomiMiMo/MiMo-V2.5.yaml
+++ b/providers/deepinfra/XiaomiMiMo/MiMo-V2.5.yaml
@@ -5,8 +5,24 @@ costs:
       region: "*"
 features:
     - prompt_caching
+    - function_calling
+    - json_output
 limits:
     context_window: 262144
     max_tokens: 262144
-mode: unknown
+modalities:
+    input:
+        - text
+        - image
+        - video
+        - audio
+    output:
+        - text
+mode: chat
 model: XiaomiMiMo/MiMo-V2.5
+provisioning: serverless
+sources:
+    - https://deepinfra.com/XiaomiMiMo/MiMo-V2.5
+status: active
+supportedModes:
+    - chat

--- a/providers/deepinfra/XiaomiMiMo/MiMo-V2.5.yaml
+++ b/providers/deepinfra/XiaomiMiMo/MiMo-V2.5.yaml
@@ -1,0 +1,12 @@
+costs:
+    - cache_read_input_token_cost: 8e-8
+      input_cost_per_token: 4e-7
+      output_cost_per_token: 2e-6
+      region: "*"
+features:
+    - prompt_caching
+limits:
+    context_window: 262144
+    max_tokens: 262144
+mode: unknown
+model: XiaomiMiMo/MiMo-V2.5


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `deepinfra`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only adds new DeepInfra model metadata YAMLs (costs/limits/features/modalities) with no runtime logic changes.
> 
> **Overview**
> Adds two new DeepInfra model definitions: `XiaomiMiMo/MiMo-V2.5` and `XiaomiMiMo/MiMo-V2.5-Pro`.
> 
> Each YAML registers pricing, supported features (prompt caching, function calling, JSON output), modality support, and large context/max token limits, and marks the models as active for `chat` mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e278ad1bd63c973741d6c0181b5db0d96784aee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->