### PR TITLE
feat(google-vertex): add new models [bot]

### DIFF
--- a/providers/google-vertex/internal-test-google/multi-region-test-model.yaml
+++ b/providers/google-vertex/internal-test-google/multi-region-test-model.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: internal-test-google/multi-region-test-model

--- a/providers/google-vertex/moonshotai/kimi-k2-6.yaml
+++ b/providers/google-vertex/moonshotai/kimi-k2-6.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: moonshotai/kimi-k2-6


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `google-vertex`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds two new `google-vertex` model definition YAMLs without modifying runtime logic; main risk is misconfiguration or unintended exposure of an internal test model entry.
> 
> **Overview**
> Adds two new `google-vertex` model definition files: `internal-test-google/multi-region-test-model` and `moonshotai/kimi-k2-6`, both registered with `mode: unknown` and their respective `model` identifiers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17322053cbb6c166f6671560abad724654c9202a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->