### PR TITLE
feat(openai): add new models [bot]

### DIFF
--- a/providers/openai/chat-latest.yaml
+++ b/providers/openai/chat-latest.yaml
@@ -1,2 +1,37 @@
-mode: unknown
+costs:
+    - cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.00003
+      region: "*"
+features:
+    - function_calling
+    - parallel_function_calling
+    - tool_choice
+    - system_messages
+    - structured_output
+    - json_output
+    - prompt_caching
+limits:
+    context_window: 400000
+    max_output_tokens: 128000
+    max_tokens: 128000
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
+mode: chat
 model: chat-latest
+params:
+    - defaultValue: 128
+      key: max_tokens
+      maxValue: 128000
+      minValue: 1
+provisioning: serverless
+sources:
+    - https://developers.openai.com/api/docs/models/chat-latest
+status: active
+supportedModes:
+    - chat
+    - responses

--- a/providers/openai/chat-latest.yaml
+++ b/providers/openai/chat-latest.yaml
@@ -1,0 +1,2 @@
+mode: unknown
+model: chat-latest

--- a/providers/openai/chat-latest.yaml
+++ b/providers/openai/chat-latest.yaml
@@ -26,6 +26,7 @@ model: chat-latest
 provisioning: serverless
 removeParams:
     - max_tokens
+    - temperature
 sources:
     - https://developers.openai.com/api/docs/models/chat-latest
 status: active

--- a/providers/openai/chat-latest.yaml
+++ b/providers/openai/chat-latest.yaml
@@ -23,12 +23,10 @@ modalities:
         - text
 mode: chat
 model: chat-latest
-params:
-    - defaultValue: 128
-      key: max_tokens
-      maxValue: 128000
-      minValue: 1
 provisioning: serverless
+removeParams: 
+    - max_tokens
+    - max_output_tokens
 sources:
     - https://developers.openai.com/api/docs/models/chat-latest
 status: active

--- a/providers/openai/chat-latest.yaml
+++ b/providers/openai/chat-latest.yaml
@@ -24,9 +24,8 @@ modalities:
 mode: chat
 model: chat-latest
 provisioning: serverless
-removeParams: 
+removeParams:
     - max_tokens
-    - max_output_tokens
 sources:
     - https://developers.openai.com/api/docs/models/chat-latest
 status: active


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `openai`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only adds a new OpenAI model metadata/config YAML and does not change runtime logic.
> 
> **Overview**
> Adds a new OpenAI model definition `providers/openai/chat-latest.yaml` for `chat-latest`, including token pricing, supported features (tools/function calling, structured/JSON output, prompt caching), multimodal inputs (text+image), and updated limits (400k context, 128k output).
> 
> Marks the model as **active**, serverless-provisioned, usable in `chat` and `responses` modes, and strips unsupported request params via `removeParams`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d77214d168533f1e7c1088159f9adbda9407387. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->