### PR TITLE
feat(openrouter): add new models [bot]

### DIFF
--- a/providers/openrouter/microsoft/phi-4-mini-instruct.yaml
+++ b/providers/openrouter/microsoft/phi-4-mini-instruct.yaml
@@ -1,0 +1,19 @@
+costs:
+    - cache_read_input_token_cost: 8e-8
+      input_cost_per_token: 8e-8
+      output_cost_per_token: 3.5e-7
+      region: "*"
+features:
+    - json_output
+    - prompt_caching
+    - structured_output
+limits:
+    context_window: 128000
+    max_output_tokens: 128000
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: chat
+model: microsoft/phi-4-mini-instruct

--- a/providers/openrouter/microsoft/phi-4-mini-instruct.yaml
+++ b/providers/openrouter/microsoft/phi-4-mini-instruct.yaml
@@ -17,3 +17,9 @@ modalities:
         - text
 mode: chat
 model: microsoft/phi-4-mini-instruct
+provisioning: serverless
+sources:
+    - https://openrouter.ai/microsoft/phi-4-mini-instruct
+status: active
+supportedModes:
+    - chat

--- a/providers/openrouter/openai/gpt-chat-latest.yaml
+++ b/providers/openrouter/openai/gpt-chat-latest.yaml
@@ -1,0 +1,23 @@
+costs:
+    - cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 5e-6
+      output_cost_per_token: 3e-5
+      region: "*"
+features:
+    - function_calling
+    - json_output
+    - prompt_caching
+    - structured_output
+    - tool_choice
+limits:
+    context_window: 400000
+    max_output_tokens: 128000
+modalities:
+    input:
+        - text
+        - image
+        - pdf
+    output:
+        - text
+mode: chat
+model: openai/gpt-chat-latest

--- a/providers/openrouter/openai/gpt-chat-latest.yaml
+++ b/providers/openrouter/openai/gpt-chat-latest.yaml
@@ -21,3 +21,9 @@ modalities:
         - text
 mode: chat
 model: openai/gpt-chat-latest
+provisioning: serverless
+sources:
+    - https://openrouter.ai/openai/gpt-chat-latest
+status: active
+supportedModes:
+    - chat


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `openrouter`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only adds new OpenRouter model definition YAMLs (pricing/limits/features) without changing runtime code paths.
> 
> **Overview**
> Adds two new OpenRouter model configuration entries: `microsoft/phi-4-mini-instruct` and `openai/gpt-chat-latest`.
> 
> Each YAML defines token pricing (including cached reads), supported features (e.g., structured output/function calling), modality support, and large context/output limits for serverless chat provisioning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3540ea708c16610503df9b9656780a6ebff1a29a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->