### PR TITLE
feat(xai): add new models [bot]

### DIFF
--- a/providers/xai/grok-imagine-image-quality-20260403.yaml
+++ b/providers/xai/grok-imagine-image-quality-20260403.yaml
@@ -9,3 +9,7 @@ modalities:
         - image
 mode: image
 model: grok-imagine-image-quality-20260403
+provisioning: serverless
+status: active
+supportedModes:
+    - image

--- a/providers/xai/grok-imagine-image-quality-20260403.yaml
+++ b/providers/xai/grok-imagine-image-quality-20260403.yaml
@@ -1,5 +1,6 @@
 costs:
-    - output_cost_per_image: 4000000.0
+    - input_cost_per_image: 0.01
+      output_cost_per_image: 0.04
       region: "*"
 modalities:
     input:
@@ -11,5 +12,7 @@ mode: image
 model: grok-imagine-image-quality-20260403
 provisioning: serverless
 status: active
+sources: 
+    - https://docs.x.ai/developers/models/grok-imagine-image-quality
 supportedModes:
     - image

--- a/providers/xai/grok-imagine-image-quality-20260403.yaml
+++ b/providers/xai/grok-imagine-image-quality-20260403.yaml
@@ -11,8 +11,9 @@ modalities:
 mode: image
 model: grok-imagine-image-quality-20260403
 provisioning: serverless
-status: active
 sources: 
     - https://docs.x.ai/developers/models/grok-imagine-image-quality
+status: active
 supportedModes:
     - image
+

--- a/providers/xai/grok-imagine-image-quality-20260403.yaml
+++ b/providers/xai/grok-imagine-image-quality-20260403.yaml
@@ -1,0 +1,11 @@
+costs:
+    - output_cost_per_image: 4000000.0
+      region: "*"
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - image
+mode: image
+model: grok-imagine-image-quality-20260403

--- a/providers/xai/grok-imagine-image-quality-20260403.yaml
+++ b/providers/xai/grok-imagine-image-quality-20260403.yaml
@@ -16,4 +16,3 @@ sources:
 status: active
 supportedModes:
     - image
-

--- a/providers/xai/grok-imagine-image-quality-20260403.yaml
+++ b/providers/xai/grok-imagine-image-quality-20260403.yaml
@@ -11,7 +11,7 @@ modalities:
 mode: image
 model: grok-imagine-image-quality-20260403
 provisioning: serverless
-sources: 
+sources:
     - https://docs.x.ai/developers/models/grok-imagine-image-quality
 status: active
 supportedModes:

--- a/providers/xai/grok-imagine-image-quality.yaml
+++ b/providers/xai/grok-imagine-image-quality.yaml
@@ -11,8 +11,9 @@ modalities:
 mode: image
 model: grok-imagine-image-quality
 provisioning: serverless
-status: active
 sources:
     - https://docs.x.ai/developers/models/grok-imagine-image-quality
+status: active
 supportedModes:
     - image
+

--- a/providers/xai/grok-imagine-image-quality.yaml
+++ b/providers/xai/grok-imagine-image-quality.yaml
@@ -1,5 +1,6 @@
 costs:
-    - output_cost_per_image: 4000000.0
+    - input_cost_per_image: 0.01
+      output_cost_per_image: 0.04
       region: "*"
 modalities:
     input:
@@ -11,5 +12,7 @@ mode: image
 model: grok-imagine-image-quality
 provisioning: serverless
 status: active
+sources:
+    - https://docs.x.ai/developers/models/grok-imagine-image-quality
 supportedModes:
     - image

--- a/providers/xai/grok-imagine-image-quality.yaml
+++ b/providers/xai/grok-imagine-image-quality.yaml
@@ -1,0 +1,11 @@
+costs:
+    - output_cost_per_image: 4000000.0
+      region: "*"
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - image
+mode: image
+model: grok-imagine-image-quality

--- a/providers/xai/grok-imagine-image-quality.yaml
+++ b/providers/xai/grok-imagine-image-quality.yaml
@@ -16,4 +16,3 @@ sources:
 status: active
 supportedModes:
     - image
-

--- a/providers/xai/grok-imagine-image-quality.yaml
+++ b/providers/xai/grok-imagine-image-quality.yaml
@@ -9,3 +9,7 @@ modalities:
         - image
 mode: image
 model: grok-imagine-image-quality
+provisioning: serverless
+status: active
+supportedModes:
+    - image


### PR DESCRIPTION
Auto-generated by model-addition-agent for provider `xai`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds two new provider model metadata YAML entries; change is isolated to configuration and does not modify runtime logic.
> 
> **Overview**
> Adds two new xAI model definition YAMLs for the image-generation model `grok-imagine-image-quality`, including a dated variant `grok-imagine-image-quality-20260403`.
> 
> Each entry defines image mode/modalities plus per-image input/output pricing, marks the models as `active`, and links to the upstream xAI model docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eafa7b58c7eeb207f2e4fe2579c84120e3aed64c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->