### PR TITLE
feat: 1hr cache creation cost and pricing mode

### DIFF
--- a/.github/scripts/autogen/types.ts
+++ b/.github/scripts/autogen/types.ts
@@ -17,9 +17,9 @@ export interface components {
         Cost: {
             cache_creation_input_audio_token_cost?: number;
             cache_creation_input_token_cost?: number;
+            cache_creation_input_token_cost_per_hour?: number;
             cache_read_input_audio_token_cost?: number;
             cache_read_input_token_cost?: number;
-            cache_storage_cost_per_token_per_hour?: number;
             input_cost_per_annotated_page?: number;
             input_cost_per_audio_token?: number;
             input_cost_per_character?: number;
@@ -136,6 +136,14 @@ export interface components {
         ModelParamKey: "json_schema" | "max_completion_tokens" | "max_tokens" | "min_tokens" | "n" | "parallel_tool_calls" | "reasoning" | "reasoning_effort" | "response_format" | "seed" | "stop" | "stream" | "temperature" | "thinking" | "tool_choice" | "top_k" | "top_p" | "verbosity";
         /** @enum {string} */
         ModelParamType: "array-of-strings" | "boolean" | "json" | "number" | "string";
+        /**
+         * @description How the model prices long context tokens
+         *     marginal: remaining tokens after long context are priced under long context pricing
+         *     cumulative: all input tokens are priced under long context pricing
+         * @default marginal
+         * @enum {string}
+         */
+        PricingMode: "marginal" | "cumulative";
         PricingTier: {
             cost_per_token: number;
             from: number;
@@ -155,6 +163,7 @@ export interface components {
             cache_write?: components["schemas"]["PricingTier"][];
             input?: components["schemas"]["PricingTier"][];
             output?: components["schemas"]["PricingTier"][];
+            pricing_mode?: components["schemas"]["PricingMode"];
         };
         /**
          * @description Vertex region identifiers
@@ -188,6 +197,7 @@ export type ModelConfig = components['schemas']['ModelConfig'];
 export type ModelParam = components['schemas']['ModelParam'];
 export type ModelParamKey = components['schemas']['ModelParamKey'];
 export type ModelParamType = components['schemas']['ModelParamType'];
+export type PricingMode = components['schemas']['PricingMode'];
 export type PricingTier = components['schemas']['PricingTier'];
 export type Provisioning = components['schemas']['Provisioning'];
 export type Status = components['schemas']['Status'];

--- a/.github/test/model.cue
+++ b/.github/test/model.cue
@@ -104,11 +104,11 @@ package model
 	"global"
 
 #Cost: {
-	cache_creation_input_audio_token_cost?: number & >= 0
-	cache_creation_input_token_cost?:       number & >= 0
-	cache_read_input_audio_token_cost?:     number & >= 0
-	cache_read_input_token_cost?:           number & >= 0
-	cache_storage_cost_per_token_per_hour?: number & >= 0
+	cache_creation_input_audio_token_cost?:    number & >= 0
+	cache_creation_input_token_cost?:          number & >= 0
+	cache_creation_input_token_cost_per_hour?: number & >= 0
+	cache_read_input_audio_token_cost?:        number & >= 0
+	cache_read_input_token_cost?:              number & >= 0
 	input_cost_per_annotated_page?:         number & >= 0
 	input_cost_per_audio_token?:            number & >= 0
 	input_cost_per_character?:              number & >= 0
@@ -291,6 +291,13 @@ package model
 	from:           int & >= 0
 }
 
+// How the model prices long context tokens
+// marginal: remaining tokens after long context are priced under long context pricing
+// cumulative: all input tokens are priced under long context pricing
+#PricingMode:
+	*"marginal" | "cumulative"
+	// defaults to "marginal"
+
 // How the model is made available to callers
 #Provisioning:
 	"serverless" |   // Managed API, pay-per-token/request
@@ -308,4 +315,5 @@ package model
 	cache_write?: [...#PricingTier]
 	input?:       [...#PricingTier]
 	output?:      [...#PricingTier]
+	pricing_mode?: #PricingMode
 }

--- a/providers/deepinfra/google/gemini-2.5-pro.yaml
+++ b/providers/deepinfra/google/gemini-2.5-pro.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 1.25e-7
-      cache_storage_cost_per_token_per_hour: 0.0000045
+    - cache_creation_input_token_cost_per_hour: 0.0000045
+      cache_read_input_token_cost: 1.25e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
       output_cost_per_token: 0.00001

--- a/providers/google-gemini/deep-research-max-preview-04-2026.yaml
+++ b/providers/google-gemini/deep-research-max-preview-04-2026.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 2e-7
-      cache_storage_cost_per_token_per_hour: 0.0000045
+    - cache_creation_input_token_cost_per_hour: 0.0000045
+      cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000012

--- a/providers/google-gemini/deep-research-preview-04-2026.yaml
+++ b/providers/google-gemini/deep-research-preview-04-2026.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 2e-7
-      cache_storage_cost_per_token_per_hour: 0.0000045
+    - cache_creation_input_token_cost_per_hour: 0.0000045
+      cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000012

--- a/providers/google-gemini/deep-research-pro-preview-12-2025.yaml
+++ b/providers/google-gemini/deep-research-pro-preview-12-2025.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 2e-7
-      cache_storage_cost_per_token_per_hour: 0.0000045
+    - cache_creation_input_token_cost_per_hour: 0.0000045
+      cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000012

--- a/providers/google-gemini/gemini-2.0-flash-001.yaml
+++ b/providers/google-gemini/gemini-2.0-flash-001.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_audio_token_cost: 1.75e-7
+    - cache_creation_input_token_cost_per_hour: 0.000001
+      cache_read_input_audio_token_cost: 1.75e-7
       cache_read_input_token_cost: 2.5e-8
-      cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 7e-7
       input_cost_per_token: 1e-7
       input_cost_per_token_batches: 5e-8

--- a/providers/google-gemini/gemini-2.0-flash.yaml
+++ b/providers/google-gemini/gemini-2.0-flash.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_audio_token_cost: 1.75e-7
+    - cache_creation_input_token_cost_per_hour: 0.000001
+      cache_read_input_audio_token_cost: 1.75e-7
       cache_read_input_token_cost: 2.5e-8
-      cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 7e-7
       input_cost_per_token: 1e-7
       input_cost_per_token_batches: 5e-8

--- a/providers/google-gemini/gemini-2.5-flash-image.yaml
+++ b/providers/google-gemini/gemini-2.5-flash-image.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 3e-8
-      cache_storage_cost_per_token_per_hour: 0.000001
+    - cache_creation_input_token_cost_per_hour: 0.000001
+      cache_read_input_token_cost: 3e-8
       input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_image_1k: 0.039

--- a/providers/google-gemini/gemini-2.5-flash-lite-preview-09-2025.yaml
+++ b/providers/google-gemini/gemini-2.5-flash-lite-preview-09-2025.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_audio_token_cost: 3e-8
+    - cache_creation_input_token_cost_per_hour: 0.000001
+      cache_read_input_audio_token_cost: 3e-8
       cache_read_input_token_cost: 1e-8
-      cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 3e-7
       input_cost_per_token: 1e-7
       input_cost_per_token_batches: 5e-8

--- a/providers/google-gemini/gemini-2.5-flash-lite.yaml
+++ b/providers/google-gemini/gemini-2.5-flash-lite.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_audio_token_cost: 3e-8
+    - cache_creation_input_token_cost_per_hour: 0.000001
+      cache_read_input_audio_token_cost: 3e-8
       cache_read_input_token_cost: 1e-8
-      cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 3e-7
       input_cost_per_token: 1e-7
       input_cost_per_token_batches: 5e-8

--- a/providers/google-gemini/gemini-2.5-flash-preview-09-2025.yaml
+++ b/providers/google-gemini/gemini-2.5-flash-preview-09-2025.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_audio_token_cost: 1e-7
+    - cache_creation_input_token_cost_per_hour: 0.000001
+      cache_read_input_audio_token_cost: 1e-7
       cache_read_input_token_cost: 3e-8
-      cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
       input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7

--- a/providers/google-gemini/gemini-2.5-flash.yaml
+++ b/providers/google-gemini/gemini-2.5-flash.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_audio_token_cost: 1e-7
+    - cache_creation_input_token_cost_per_hour: 0.000001
+      cache_read_input_audio_token_cost: 1e-7
       cache_read_input_token_cost: 3e-8
-      cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
       input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7

--- a/providers/google-gemini/gemini-2.5-pro.yaml
+++ b/providers/google-gemini/gemini-2.5-pro.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 1.25e-7
-      cache_storage_cost_per_token_per_hour: 0.0000045
+    - cache_creation_input_token_cost_per_hour: 0.0000045
+      cache_read_input_token_cost: 1.25e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
       output_cost_per_token: 0.00001

--- a/providers/google-gemini/gemini-3-flash-preview.yaml
+++ b/providers/google-gemini/gemini-3-flash-preview.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_audio_token_cost: 1e-7
+    - cache_creation_input_token_cost_per_hour: 0.000001
+      cache_read_input_audio_token_cost: 1e-7
       cache_read_input_token_cost: 5e-8
-      cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
       input_cost_per_token: 5e-7
       input_cost_per_token_batches: 2.5e-7

--- a/providers/google-gemini/gemini-3-pro-preview.yaml
+++ b/providers/google-gemini/gemini-3-pro-preview.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 2e-7
-      cache_storage_cost_per_token_per_hour: 0.0000045
+    - cache_creation_input_token_cost_per_hour: 0.0000045
+      cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000012

--- a/providers/google-gemini/gemini-3.1-flash-lite-preview.yaml
+++ b/providers/google-gemini/gemini-3.1-flash-lite-preview.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_audio_token_cost: 5e-8
+    - cache_creation_input_token_cost_per_hour: 0.000001
+      cache_read_input_audio_token_cost: 5e-8
       cache_read_input_token_cost: 2.5e-8
-      cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 5e-7
       input_cost_per_token: 2.5e-7
       input_cost_per_token_batches: 1.25e-7

--- a/providers/google-gemini/gemini-3.1-flash-lite.yaml
+++ b/providers/google-gemini/gemini-3.1-flash-lite.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_audio_token_cost: 5e-8
+    - cache_creation_input_token_cost_per_hour: 0.000001
+      cache_read_input_audio_token_cost: 5e-8
       cache_read_input_token_cost: 2.5e-8
-      cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 5e-7
       input_cost_per_token: 2.5e-7
       input_cost_per_token_batches: 1.25e-7

--- a/providers/google-gemini/gemini-3.1-pro-preview-customtools.yaml
+++ b/providers/google-gemini/gemini-3.1-pro-preview-customtools.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 2e-7
-      cache_storage_cost_per_token_per_hour: 0.0000045
+    - cache_creation_input_token_cost_per_hour: 0.0000045
+      cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000012

--- a/providers/google-gemini/gemini-3.1-pro-preview.yaml
+++ b/providers/google-gemini/gemini-3.1-pro-preview.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 2e-7
-      cache_storage_cost_per_token_per_hour: 0.0000045
+    - cache_creation_input_token_cost_per_hour: 0.0000045
+      cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000012

--- a/providers/google-gemini/gemini-flash-latest.yaml
+++ b/providers/google-gemini/gemini-flash-latest.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_audio_token_cost: 1e-7
+    - cache_creation_input_token_cost_per_hour: 0.000001
+      cache_read_input_audio_token_cost: 1e-7
       cache_read_input_token_cost: 5e-8
-      cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
       input_cost_per_token: 5e-7
       input_cost_per_token_batches: 2.5e-7

--- a/providers/google-gemini/gemini-flash-lite-latest.yaml
+++ b/providers/google-gemini/gemini-flash-lite-latest.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_audio_token_cost: 3e-8
+    - cache_creation_input_token_cost_per_hour: 0.000001
+      cache_read_input_audio_token_cost: 3e-8
       cache_read_input_token_cost: 1e-8
-      cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 3e-7
       input_cost_per_token: 1e-7
       input_cost_per_token_batches: 5e-8

--- a/providers/google-gemini/gemini-pro-latest.yaml
+++ b/providers/google-gemini/gemini-pro-latest.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 2e-7
-      cache_storage_cost_per_token_per_hour: 0.0000045
+    - cache_creation_input_token_cost_per_hour: 0.0000045
+      cache_read_input_token_cost: 2e-7
       input_cost_per_token: 0.000002
       input_cost_per_token_batches: 0.000001
       output_cost_per_token: 0.000012

--- a/providers/google-gemini/gemma-3-27b-it.yaml
+++ b/providers/google-gemini/gemma-3-27b-it.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_creation_input_token_cost: 0
+      cache_creation_input_token_cost_per_hour: 0
       cache_read_input_token_cost: 0
-      cache_storage_cost_per_token_per_hour: 0
       input_cost_per_character: 0
       input_cost_per_image: 0
       input_cost_per_token: 0

--- a/providers/google-gemini/gemma-3n-e2b-it.yaml
+++ b/providers/google-gemini/gemma-3n-e2b-it.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 0
-      cache_storage_cost_per_token_per_hour: 0
+    - cache_creation_input_token_cost_per_hour: 0
+      cache_read_input_token_cost: 0
       input_cost_per_token: 0
       output_cost_per_token: 0
       region: "*"

--- a/providers/google-vertex/gemini-2.5-flash-lite-preview-09-2025.yaml
+++ b/providers/google-vertex/gemini-2.5-flash-lite-preview-09-2025.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_audio_token_cost: 3e-8
+    - cache_creation_input_token_cost_per_hour: 0.000001
+      cache_read_input_audio_token_cost: 3e-8
       cache_read_input_token_cost: 1e-8
-      cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 3e-7
       input_cost_per_token: 1e-7
       input_cost_per_token_batches: 5e-8

--- a/providers/google-vertex/gemini-2.5-flash-preview-09-2025.yaml
+++ b/providers/google-vertex/gemini-2.5-flash-preview-09-2025.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 3e-8
-      cache_storage_cost_per_token_per_hour: 0.000001
+    - cache_creation_input_token_cost_per_hour: 0.000001
+      cache_read_input_token_cost: 3e-8
       input_cost_per_audio_token: 0.000001
       input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000025

--- a/providers/google-vertex/gemini-2.5-flash.yaml
+++ b/providers/google-vertex/gemini-2.5-flash.yaml
@@ -1,214 +1,214 @@
 costs:
-    - cache_read_input_audio_token_cost: 1e-7
+    - cache_creation_input_token_cost_per_hour: 0.000001
+      cache_read_input_audio_token_cost: 1e-7
       cache_read_input_token_cost: 3e-8
-      cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
       input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: us-west4
-    - cache_read_input_audio_token_cost: 1e-7
+    - cache_creation_input_token_cost_per_hour: 0.000001
+      cache_read_input_audio_token_cost: 1e-7
       cache_read_input_token_cost: 3e-8
-      cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
       input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: us-west1
-    - cache_read_input_audio_token_cost: 1e-7
+    - cache_creation_input_token_cost_per_hour: 0.000001
+      cache_read_input_audio_token_cost: 1e-7
       cache_read_input_token_cost: 3e-8
-      cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
       input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: us-south1
-    - cache_read_input_audio_token_cost: 1e-7
+    - cache_creation_input_token_cost_per_hour: 0.000001
+      cache_read_input_audio_token_cost: 1e-7
       cache_read_input_token_cost: 3e-8
-      cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
       input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: us-east5
-    - cache_read_input_audio_token_cost: 1e-7
+    - cache_creation_input_token_cost_per_hour: 0.000001
+      cache_read_input_audio_token_cost: 1e-7
       cache_read_input_token_cost: 3e-8
-      cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
       input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: us-east4
-    - cache_read_input_audio_token_cost: 1e-7
+    - cache_creation_input_token_cost_per_hour: 0.000001
+      cache_read_input_audio_token_cost: 1e-7
       cache_read_input_token_cost: 3e-8
-      cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
       input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: us-east1
-    - cache_read_input_audio_token_cost: 1e-7
+    - cache_creation_input_token_cost_per_hour: 0.000001
+      cache_read_input_audio_token_cost: 1e-7
       cache_read_input_token_cost: 3e-8
-      cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
       input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: us-central1
-    - cache_read_input_audio_token_cost: 1e-7
+    - cache_creation_input_token_cost_per_hour: 0.000001
+      cache_read_input_audio_token_cost: 1e-7
       cache_read_input_token_cost: 3e-8
-      cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
       input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: southamerica-east1
-    - cache_read_input_audio_token_cost: 1e-7
+    - cache_creation_input_token_cost_per_hour: 0.000001
+      cache_read_input_audio_token_cost: 1e-7
       cache_read_input_token_cost: 3e-8
-      cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
       input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: northamerica-northeast1
-    - cache_read_input_audio_token_cost: 1e-7
+    - cache_creation_input_token_cost_per_hour: 0.000001
+      cache_read_input_audio_token_cost: 1e-7
       cache_read_input_token_cost: 3e-8
-      cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
       input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: global
-    - cache_read_input_audio_token_cost: 1e-7
+    - cache_creation_input_token_cost_per_hour: 0.000001
+      cache_read_input_audio_token_cost: 1e-7
       cache_read_input_token_cost: 3e-8
-      cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
       input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: europe-west9
-    - cache_read_input_audio_token_cost: 1e-7
+    - cache_creation_input_token_cost_per_hour: 0.000001
+      cache_read_input_audio_token_cost: 1e-7
       cache_read_input_token_cost: 3e-8
-      cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
       input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: europe-west8
-    - cache_read_input_audio_token_cost: 1e-7
+    - cache_creation_input_token_cost_per_hour: 0.000001
+      cache_read_input_audio_token_cost: 1e-7
       cache_read_input_token_cost: 3e-8
-      cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
       input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: europe-west4
-    - cache_read_input_audio_token_cost: 1e-7
+    - cache_creation_input_token_cost_per_hour: 0.000001
+      cache_read_input_audio_token_cost: 1e-7
       cache_read_input_token_cost: 3e-8
-      cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
       input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: europe-west3
-    - cache_read_input_audio_token_cost: 1e-7
+    - cache_creation_input_token_cost_per_hour: 0.000001
+      cache_read_input_audio_token_cost: 1e-7
       cache_read_input_token_cost: 3e-8
-      cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
       input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: europe-west2
-    - cache_read_input_audio_token_cost: 1e-7
+    - cache_creation_input_token_cost_per_hour: 0.000001
+      cache_read_input_audio_token_cost: 1e-7
       cache_read_input_token_cost: 3e-8
-      cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
       input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: europe-west1
-    - cache_read_input_audio_token_cost: 1e-7
+    - cache_creation_input_token_cost_per_hour: 0.000001
+      cache_read_input_audio_token_cost: 1e-7
       cache_read_input_token_cost: 3e-8
-      cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
       input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: europe-southwest1
-    - cache_read_input_audio_token_cost: 1e-7
+    - cache_creation_input_token_cost_per_hour: 0.000001
+      cache_read_input_audio_token_cost: 1e-7
       cache_read_input_token_cost: 3e-8
-      cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
       input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: europe-north1
-    - cache_read_input_audio_token_cost: 1e-7
+    - cache_creation_input_token_cost_per_hour: 0.000001
+      cache_read_input_audio_token_cost: 1e-7
       cache_read_input_token_cost: 3e-8
-      cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
       input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: europe-central2
-    - cache_read_input_audio_token_cost: 1e-7
+    - cache_creation_input_token_cost_per_hour: 0.000001
+      cache_read_input_audio_token_cost: 1e-7
       cache_read_input_token_cost: 3e-8
-      cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
       input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: australia-southeast1
-    - cache_read_input_audio_token_cost: 1e-7
+    - cache_creation_input_token_cost_per_hour: 0.000001
+      cache_read_input_audio_token_cost: 1e-7
       cache_read_input_token_cost: 3e-8
-      cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
       input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: asia-southeast1
-    - cache_read_input_audio_token_cost: 1e-7
+    - cache_creation_input_token_cost_per_hour: 0.000001
+      cache_read_input_audio_token_cost: 1e-7
       cache_read_input_token_cost: 3e-8
-      cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
       input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: asia-south1
-    - cache_read_input_audio_token_cost: 1e-7
+    - cache_creation_input_token_cost_per_hour: 0.000001
+      cache_read_input_audio_token_cost: 1e-7
       cache_read_input_token_cost: 3e-8
-      cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
       input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_token: 0.0000025
       output_cost_per_token_batches: 0.00000125
       region: asia-northeast3
-    - cache_read_input_audio_token_cost: 1e-7
+    - cache_creation_input_token_cost_per_hour: 0.000001
+      cache_read_input_audio_token_cost: 1e-7
       cache_read_input_token_cost: 3e-8
-      cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 0.000001
       input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7

--- a/providers/google-vertex/google/gemini-2.5-flash-lite-preview-09-2025.yaml
+++ b/providers/google-vertex/google/gemini-2.5-flash-lite-preview-09-2025.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_audio_token_cost: 3e-8
+    - cache_creation_input_token_cost_per_hour: 0.000001
+      cache_read_input_audio_token_cost: 3e-8
       cache_read_input_token_cost: 1e-8
-      cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 3e-7
       input_cost_per_token: 1e-7
       input_cost_per_token_batches: 5e-8

--- a/providers/google-vertex/google/gemini-2.5-flash-preview-09-2025.yaml
+++ b/providers/google-vertex/google/gemini-2.5-flash-preview-09-2025.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 3e-8
-      cache_storage_cost_per_token_per_hour: 0.000001
+    - cache_creation_input_token_cost_per_hour: 0.000001
+      cache_read_input_token_cost: 3e-8
       input_cost_per_audio_token: 0.000001
       input_cost_per_token: 3e-7
       output_cost_per_token: 0.0000025

--- a/providers/openrouter/gemini-2.5-flash-lite.yaml
+++ b/providers/openrouter/gemini-2.5-flash-lite.yaml
@@ -1,7 +1,7 @@
 costs:
-    - cache_read_input_audio_token_cost: 3e-8
+    - cache_creation_input_token_cost_per_hour: 0.000001
+      cache_read_input_audio_token_cost: 3e-8
       cache_read_input_token_cost: 1e-8
-      cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 3e-7
       input_cost_per_image_token: 1e-7
       input_cost_per_token: 1e-7

--- a/providers/openrouter/google/gemini-2.0-flash-001.yaml
+++ b/providers/openrouter/google/gemini-2.0-flash-001.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_creation_input_token_cost: 8.333333333333334e-8
+      cache_creation_input_token_cost_per_hour: 0.000001
       cache_read_input_token_cost: 2.5e-8
-      cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 7e-7
       input_cost_per_token: 1e-7
       output_cost_per_token: 4e-7

--- a/providers/openrouter/google/gemini-2.5-flash-lite-preview-09-2025.yaml
+++ b/providers/openrouter/google/gemini-2.5-flash-lite-preview-09-2025.yaml
@@ -1,8 +1,8 @@
 costs:
     - cache_creation_input_token_cost: 8.33e-8
+      cache_creation_input_token_cost_per_hour: 0.000001
       cache_read_input_audio_token_cost: 3e-8
       cache_read_input_token_cost: 1e-8
-      cache_storage_cost_per_token_per_hour: 0.000001
       input_cost_per_audio_token: 3e-7
       input_cost_per_token: 1e-7
       output_cost_per_token: 4e-7

--- a/providers/openrouter/google/gemini-2.5-pro.yaml
+++ b/providers/openrouter/google/gemini-2.5-pro.yaml
@@ -1,7 +1,7 @@
 costs:
     - cache_creation_input_token_cost: 3.75e-7
+      cache_creation_input_token_cost_per_hour: 0.0000045
       cache_read_input_token_cost: 1.25e-7
-      cache_storage_cost_per_token_per_hour: 0.0000045
       input_cost_per_audio_token: 0.00000125
       input_cost_per_image_token: 0.00000125
       input_cost_per_token: 0.00000125

--- a/providers/openrouter/google/gemini-3.1-pro-preview-customtools.yaml
+++ b/providers/openrouter/google/gemini-3.1-pro-preview-customtools.yaml
@@ -1,8 +1,8 @@
 costs:
     - cache_creation_input_token_cost: 3.75e-7
+      cache_creation_input_token_cost_per_hour: 0.0000045
       cache_read_input_audio_token_cost: 2e-7
       cache_read_input_token_cost: 2e-7
-      cache_storage_cost_per_token_per_hour: 0.0000045
       input_cost_per_audio_token: 0.000002
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000012

--- a/providers/openrouter/google/gemini-3.1-pro-preview.yaml
+++ b/providers/openrouter/google/gemini-3.1-pro-preview.yaml
@@ -1,6 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 2e-7
-      cache_storage_cost_per_token_per_hour: 0.0000045
+    - cache_creation_input_token_cost_per_hour: 0.0000045
+      cache_read_input_token_cost: 2e-7
       input_cost_per_audio_token: 0.000002
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000012


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Updates pricing schema and many provider model YAMLs, which could affect downstream cost calculations and validation if any consumers still expect the removed cache storage field or don’t handle the new pricing mode.
> 
> **Overview**
> Adds schema support for hourly cache creation pricing and long-context tier pricing behavior.
> 
> Replaces `cache_storage_cost_per_token_per_hour` with `cache_creation_input_token_cost_per_hour` in the generated TS OpenAPI types, the CUE validation schema, and a broad set of Gemini model pricing YAMLs across providers (Google Gemini, Vertex, OpenRouter, DeepInfra).
> 
> Introduces a new `PricingMode` enum (`marginal`/`cumulative`) and a `tiered_pricing.pricing_mode` field to describe how long-context tokens are priced.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 950be94b1b5b5375b08acd5baf009737977215e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->