### PR TITLE
set pricing mode for tiered pricing

### DIFF
--- a/providers/aws-bedrock/au.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
+++ b/providers/aws-bedrock/au.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
@@ -19,6 +19,7 @@ costs:
           output:
               - cost_per_token: 0.00002475
                 from: 200000
+          pricing_mode: marginal
     - cache_creation_input_token_cost: 0.000004125
       cache_read_input_token_cost: 3.3e-7
       input_cost_per_token: 0.0000033
@@ -39,6 +40,7 @@ costs:
           output:
               - cost_per_token: 0.00002475
                 from: 200000
+          pricing_mode: marginal
 features:
     - function_calling
     - prompt_caching

--- a/providers/aws-bedrock/global.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
+++ b/providers/aws-bedrock/global.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
@@ -19,6 +19,7 @@ costs:
           output:
               - cost_per_token: 0.0000225
                 from: 200000
+          pricing_mode: marginal
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
@@ -39,6 +40,7 @@ costs:
           output:
               - cost_per_token: 0.0000225
                 from: 200000
+          pricing_mode: marginal
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
@@ -59,6 +61,7 @@ costs:
           output:
               - cost_per_token: 0.0000225
                 from: 200000
+          pricing_mode: marginal
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
@@ -79,6 +82,7 @@ costs:
           output:
               - cost_per_token: 0.0000225
                 from: 200000
+          pricing_mode: marginal
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
@@ -99,6 +103,7 @@ costs:
           output:
               - cost_per_token: 0.0000225
                 from: 200000
+          pricing_mode: marginal
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
@@ -119,6 +124,7 @@ costs:
           output:
               - cost_per_token: 0.0000225
                 from: 200000
+          pricing_mode: marginal
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
@@ -139,6 +145,7 @@ costs:
           output:
               - cost_per_token: 0.0000225
                 from: 200000
+          pricing_mode: marginal
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
@@ -159,6 +166,7 @@ costs:
           output:
               - cost_per_token: 0.0000225
                 from: 200000
+          pricing_mode: marginal
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
@@ -179,6 +187,7 @@ costs:
           output:
               - cost_per_token: 0.0000225
                 from: 200000
+          pricing_mode: marginal
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
@@ -199,6 +208,7 @@ costs:
           output:
               - cost_per_token: 0.0000225
                 from: 200000
+          pricing_mode: marginal
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
@@ -219,6 +229,7 @@ costs:
           output:
               - cost_per_token: 0.0000225
                 from: 200000
+          pricing_mode: marginal
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
@@ -239,6 +250,7 @@ costs:
           output:
               - cost_per_token: 0.0000225
                 from: 200000
+          pricing_mode: marginal
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
@@ -259,6 +271,7 @@ costs:
           output:
               - cost_per_token: 0.0000225
                 from: 200000
+          pricing_mode: marginal
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
@@ -279,6 +292,7 @@ costs:
           output:
               - cost_per_token: 0.0000225
                 from: 200000
+          pricing_mode: marginal
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
@@ -299,6 +313,7 @@ costs:
           output:
               - cost_per_token: 0.0000225
                 from: 200000
+          pricing_mode: marginal
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
@@ -319,6 +334,7 @@ costs:
           output:
               - cost_per_token: 0.0000225
                 from: 200000
+          pricing_mode: marginal
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
@@ -339,6 +355,7 @@ costs:
           output:
               - cost_per_token: 0.0000225
                 from: 200000
+          pricing_mode: marginal
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
@@ -359,6 +376,7 @@ costs:
           output:
               - cost_per_token: 0.0000225
                 from: 200000
+          pricing_mode: marginal
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
@@ -379,6 +397,7 @@ costs:
           output:
               - cost_per_token: 0.0000225
                 from: 200000
+          pricing_mode: marginal
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
@@ -399,6 +418,7 @@ costs:
           output:
               - cost_per_token: 0.0000225
                 from: 200000
+          pricing_mode: marginal
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
@@ -419,6 +439,7 @@ costs:
           output:
               - cost_per_token: 0.0000225
                 from: 200000
+          pricing_mode: marginal
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
@@ -439,6 +460,7 @@ costs:
           output:
               - cost_per_token: 0.0000225
                 from: 200000
+          pricing_mode: marginal
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
@@ -459,6 +481,7 @@ costs:
           output:
               - cost_per_token: 0.0000225
                 from: 200000
+          pricing_mode: marginal
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
@@ -479,6 +502,7 @@ costs:
           output:
               - cost_per_token: 0.0000225
                 from: 200000
+          pricing_mode: marginal
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
@@ -499,6 +523,7 @@ costs:
           output:
               - cost_per_token: 0.0000225
                 from: 200000
+          pricing_mode: marginal
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
@@ -519,6 +544,7 @@ costs:
           output:
               - cost_per_token: 0.0000225
                 from: 200000
+          pricing_mode: marginal
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
@@ -539,6 +565,7 @@ costs:
           output:
               - cost_per_token: 0.0000225
                 from: 200000
+          pricing_mode: marginal
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
@@ -559,6 +586,7 @@ costs:
           output:
               - cost_per_token: 0.0000225
                 from: 200000
+          pricing_mode: marginal
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
@@ -579,6 +607,7 @@ costs:
           output:
               - cost_per_token: 0.0000225
                 from: 200000
+          pricing_mode: marginal
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
@@ -599,6 +628,7 @@ costs:
           output:
               - cost_per_token: 0.0000225
                 from: 200000
+          pricing_mode: marginal
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
@@ -619,6 +649,7 @@ costs:
           output:
               - cost_per_token: 0.0000225
                 from: 200000
+          pricing_mode: marginal
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
@@ -639,6 +670,7 @@ costs:
           output:
               - cost_per_token: 0.0000225
                 from: 200000
+          pricing_mode: marginal
 features:
     - function_calling
     - prompt_caching

--- a/providers/aws-bedrock/jp.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
+++ b/providers/aws-bedrock/jp.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
@@ -19,6 +19,7 @@ costs:
           output:
               - cost_per_token: 0.00002475
                 from: 200000
+          pricing_mode: marginal
     - cache_creation_input_token_cost: 0.000004125
       cache_read_input_token_cost: 3.3e-7
       input_cost_per_token: 0.0000033
@@ -39,6 +40,7 @@ costs:
           output:
               - cost_per_token: 0.00002475
                 from: 200000
+          pricing_mode: marginal
 features:
     - function_calling
     - prompt_caching

--- a/providers/aws-bedrock/us-gov.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
+++ b/providers/aws-bedrock/us-gov.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
@@ -19,6 +19,7 @@ costs:
           output:
               - cost_per_token: 0.000027
                 from: 200000
+          pricing_mode: marginal
     - cache_creation_input_token_cost: 0.0000045
       cache_read_input_token_cost: 3.6e-7
       input_cost_per_token: 0.0000036
@@ -39,6 +40,7 @@ costs:
           output:
               - cost_per_token: 0.000027
                 from: 200000
+          pricing_mode: marginal
 features:
     - function_calling
     - prompt_caching

--- a/providers/azure-open-ai/gpt-5.4-2026-03-05.yaml
+++ b/providers/azure-open-ai/gpt-5.4-2026-03-05.yaml
@@ -13,6 +13,7 @@ costs:
           output:
               - cost_per_token: 0.0000225
                 from: 272000
+          pricing_mode: cumulative
 deprecationDate: "2027-09-05"
 features:
     - function_calling

--- a/providers/azure-open-ai/gpt-5.4-pro-2026-03-05.yaml
+++ b/providers/azure-open-ai/gpt-5.4-pro-2026-03-05.yaml
@@ -13,6 +13,7 @@ costs:
           output:
               - cost_per_token: 0.00027
                 from: 272000
+          pricing_mode: cumulative
 deprecationDate: "2027-09-05"
 features:
     - function_calling

--- a/providers/deepinfra/ByteDance/Seed-1.8.yaml
+++ b/providers/deepinfra/ByteDance/Seed-1.8.yaml
@@ -13,6 +13,7 @@ costs:
           output:
               - cost_per_token: 0.000004
                 from: 128000
+          pricing_mode: marginal
 features:
     - function_calling
     - json_output

--- a/providers/deepinfra/ByteDance/Seed-2.0-mini.yaml
+++ b/providers/deepinfra/ByteDance/Seed-2.0-mini.yaml
@@ -13,6 +13,7 @@ costs:
           output:
               - cost_per_token: 8e-7
                 from: 128000
+          pricing_mode: marginal
 features:
     - function_calling
     - json_output

--- a/providers/deepinfra/ByteDance/Seed-2.0-pro.yaml
+++ b/providers/deepinfra/ByteDance/Seed-2.0-pro.yaml
@@ -13,6 +13,7 @@ costs:
           output:
               - cost_per_token: 0.000006
                 from: 128000
+          pricing_mode: marginal
 features:
     - function_calling
     - prompt_caching

--- a/providers/deepinfra/Qwen/Qwen3-Max-Thinking.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Max-Thinking.yaml
@@ -19,6 +19,7 @@ costs:
                 from: 32000
               - cost_per_token: 0.000015
                 from: 128000
+          pricing_mode: marginal
 features:
     - function_calling
     - json_output

--- a/providers/deepinfra/Qwen/Qwen3-Max.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-Max.yaml
@@ -19,6 +19,7 @@ costs:
                 from: 32000
               - cost_per_token: 0.000015
                 from: 128000
+          pricing_mode: marginal
 features:
     - function_calling
     - json_output

--- a/providers/deepinfra/google/gemini-2.5-pro.yaml
+++ b/providers/deepinfra/google/gemini-2.5-pro.yaml
@@ -16,6 +16,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
+          pricing_mode: marginal
 features:
     - function_calling
     - json_output

--- a/providers/google-gemini/deep-research-max-preview-04-2026.yaml
+++ b/providers/google-gemini/deep-research-max-preview-04-2026.yaml
@@ -16,7 +16,7 @@ costs:
           output:
               - cost_per_token: 0.000018
                 from: 200000
-          pricing_mode: marginal
+          pricing_mode: cumulative
 features:
     - function_calling
     - system_messages

--- a/providers/google-gemini/deep-research-max-preview-04-2026.yaml
+++ b/providers/google-gemini/deep-research-max-preview-04-2026.yaml
@@ -16,6 +16,7 @@ costs:
           output:
               - cost_per_token: 0.000018
                 from: 200000
+          pricing_mode: marginal
 features:
     - function_calling
     - system_messages

--- a/providers/google-gemini/deep-research-preview-04-2026.yaml
+++ b/providers/google-gemini/deep-research-preview-04-2026.yaml
@@ -16,7 +16,7 @@ costs:
           output:
               - cost_per_token: 0.000018
                 from: 200000
-          pricing_mode: marginal
+          pricing_mode: cumulative
 features:
     - function_calling
     - system_messages

--- a/providers/google-gemini/deep-research-preview-04-2026.yaml
+++ b/providers/google-gemini/deep-research-preview-04-2026.yaml
@@ -16,6 +16,7 @@ costs:
           output:
               - cost_per_token: 0.000018
                 from: 200000
+          pricing_mode: marginal
 features:
     - function_calling
     - system_messages

--- a/providers/google-gemini/deep-research-pro-preview-12-2025.yaml
+++ b/providers/google-gemini/deep-research-pro-preview-12-2025.yaml
@@ -16,7 +16,7 @@ costs:
           output:
               - cost_per_token: 0.000018
                 from: 200000
-          pricing_mode: marginal
+          pricing_mode: cumulative
 features:
     - system_messages
 limits:

--- a/providers/google-gemini/deep-research-pro-preview-12-2025.yaml
+++ b/providers/google-gemini/deep-research-pro-preview-12-2025.yaml
@@ -16,6 +16,7 @@ costs:
           output:
               - cost_per_token: 0.000018
                 from: 200000
+          pricing_mode: marginal
 features:
     - system_messages
 limits:

--- a/providers/google-gemini/gemini-2.5-computer-use-preview-10-2025.yaml
+++ b/providers/google-gemini/gemini-2.5-computer-use-preview-10-2025.yaml
@@ -9,6 +9,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
+          pricing_mode: marginal
 features:
     - function_calling
     - parallel_function_calling

--- a/providers/google-gemini/gemini-2.5-computer-use-preview-10-2025.yaml
+++ b/providers/google-gemini/gemini-2.5-computer-use-preview-10-2025.yaml
@@ -9,7 +9,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
-          pricing_mode: marginal
+          pricing_mode: cumulative
 features:
     - function_calling
     - parallel_function_calling

--- a/providers/google-gemini/gemini-3.1-pro-preview-customtools.yaml
+++ b/providers/google-gemini/gemini-3.1-pro-preview-customtools.yaml
@@ -16,7 +16,7 @@ costs:
           output:
               - cost_per_token: 0.000018
                 from: 200000
-          pricing_mode: marginal
+          pricing_mode: cumulative
 features:
     - function_calling
     - system_messages

--- a/providers/google-gemini/gemini-3.1-pro-preview-customtools.yaml
+++ b/providers/google-gemini/gemini-3.1-pro-preview-customtools.yaml
@@ -16,6 +16,7 @@ costs:
           output:
               - cost_per_token: 0.000018
                 from: 200000
+          pricing_mode: marginal
 features:
     - function_calling
     - system_messages

--- a/providers/google-gemini/gemini-3.1-pro-preview.yaml
+++ b/providers/google-gemini/gemini-3.1-pro-preview.yaml
@@ -16,7 +16,7 @@ costs:
           output:
               - cost_per_token: 0.000018
                 from: 200000
-          pricing_mode: marginal
+          pricing_mode: cumulative
 features:
     - function_calling
     - parallel_function_calling

--- a/providers/google-gemini/gemini-3.1-pro-preview.yaml
+++ b/providers/google-gemini/gemini-3.1-pro-preview.yaml
@@ -16,6 +16,7 @@ costs:
           output:
               - cost_per_token: 0.000018
                 from: 200000
+          pricing_mode: marginal
 features:
     - function_calling
     - parallel_function_calling

--- a/providers/google-vertex/anthropic/claude-sonnet-4-5.yaml
+++ b/providers/google-vertex/anthropic/claude-sonnet-4-5.yaml
@@ -17,6 +17,7 @@ costs:
           output:
               - cost_per_token: 0.00002475
                 from: 200000
+          pricing_mode: marginal
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
@@ -37,6 +38,7 @@ costs:
           output:
               - cost_per_token: 0.0000225
                 from: 200000
+          pricing_mode: marginal
     - cache_creation_input_token_cost: 0.000004125
       cache_read_input_token_cost: 3.3e-7
       input_cost_per_token: 0.0000033
@@ -55,6 +57,7 @@ costs:
           output:
               - cost_per_token: 0.00002475
                 from: 200000
+          pricing_mode: marginal
     - cache_creation_input_token_cost: 0.000004125
       cache_read_input_token_cost: 3.3e-7
       input_cost_per_token: 0.0000033
@@ -73,6 +76,7 @@ costs:
           output:
               - cost_per_token: 0.00002475
                 from: 200000
+          pricing_mode: marginal
 features:
     - function_calling
     - cache_control

--- a/providers/google-vertex/anthropic/claude-sonnet-4-5@20250929.yaml
+++ b/providers/google-vertex/anthropic/claude-sonnet-4-5@20250929.yaml
@@ -17,6 +17,7 @@ costs:
           output:
               - cost_per_token: 0.00002475
                 from: 200000
+          pricing_mode: marginal
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
@@ -37,6 +38,7 @@ costs:
           output:
               - cost_per_token: 0.0000225
                 from: 200000
+          pricing_mode: marginal
     - cache_creation_input_token_cost: 0.000004125
       cache_read_input_token_cost: 3.3e-7
       input_cost_per_token: 0.0000033
@@ -55,6 +57,7 @@ costs:
           output:
               - cost_per_token: 0.00002475
                 from: 200000
+          pricing_mode: marginal
     - cache_creation_input_token_cost: 0.000004125
       cache_read_input_token_cost: 3.3e-7
       input_cost_per_token: 0.0000033
@@ -73,6 +76,7 @@ costs:
           output:
               - cost_per_token: 0.00002475
                 from: 200000
+          pricing_mode: marginal
 features:
     - function_calling
     - system_messages

--- a/providers/google-vertex/anthropic/claude-sonnet-4.yaml
+++ b/providers/google-vertex/anthropic/claude-sonnet-4.yaml
@@ -19,6 +19,7 @@ costs:
           output:
               - cost_per_token: 0.0000225
                 from: 200000
+          pricing_mode: marginal
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
@@ -39,6 +40,7 @@ costs:
           output:
               - cost_per_token: 0.0000225
                 from: 200000
+          pricing_mode: marginal
     - cache_creation_input_token_cost: 0.00000375
       cache_read_input_token_cost: 3e-7
       input_cost_per_token: 0.000003
@@ -59,6 +61,7 @@ costs:
           output:
               - cost_per_token: 0.0000225
                 from: 200000
+          pricing_mode: marginal
 features:
     - function_calling
     - tool_choice

--- a/providers/google-vertex/gemini-2.5-computer-use-preview-10-2025.yaml
+++ b/providers/google-vertex/gemini-2.5-computer-use-preview-10-2025.yaml
@@ -9,6 +9,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
+          pricing_mode: marginal
 features:
     - function_calling
     - parallel_function_calling

--- a/providers/google-vertex/gemini-2.5-computer-use-preview-10-2025.yaml
+++ b/providers/google-vertex/gemini-2.5-computer-use-preview-10-2025.yaml
@@ -9,7 +9,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
-          pricing_mode: marginal
+          pricing_mode: cumulative
 features:
     - function_calling
     - parallel_function_calling

--- a/providers/google-vertex/gemini-2.5-pro.yaml
+++ b/providers/google-vertex/gemini-2.5-pro.yaml
@@ -15,6 +15,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
+          pricing_mode: marginal
     - cache_read_input_token_cost: 1.25e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -31,6 +32,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
+          pricing_mode: marginal
     - cache_read_input_token_cost: 1.25e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -47,6 +49,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
+          pricing_mode: marginal
     - cache_read_input_token_cost: 1.25e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -63,6 +66,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
+          pricing_mode: marginal
     - cache_read_input_token_cost: 1.25e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -79,6 +83,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
+          pricing_mode: marginal
     - cache_read_input_token_cost: 1.25e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -95,6 +100,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
+          pricing_mode: marginal
     - cache_read_input_token_cost: 1.25e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -111,6 +117,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
+          pricing_mode: marginal
     - cache_read_input_token_cost: 1.25e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -127,6 +134,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
+          pricing_mode: marginal
     - cache_read_input_token_cost: 1.25e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -143,6 +151,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
+          pricing_mode: marginal
     - cache_read_input_token_cost: 1.25e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -159,6 +168,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
+          pricing_mode: marginal
     - cache_read_input_token_cost: 1.25e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -175,6 +185,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
+          pricing_mode: marginal
     - cache_read_input_token_cost: 1.25e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -191,6 +202,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
+          pricing_mode: marginal
     - cache_read_input_token_cost: 1.25e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -207,6 +219,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
+          pricing_mode: marginal
     - cache_read_input_token_cost: 1.25e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -223,6 +236,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
+          pricing_mode: marginal
     - cache_read_input_token_cost: 1.25e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -239,6 +253,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
+          pricing_mode: marginal
     - cache_read_input_token_cost: 1.25e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -255,6 +270,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
+          pricing_mode: marginal
     - cache_read_input_token_cost: 1.25e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -271,6 +287,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
+          pricing_mode: marginal
 deprecationDate: "2026-10-16"
 features:
     - function_calling

--- a/providers/google-vertex/gemini-2.5-pro.yaml
+++ b/providers/google-vertex/gemini-2.5-pro.yaml
@@ -15,7 +15,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
-          pricing_mode: marginal
+          pricing_mode: cumulative
     - cache_read_input_token_cost: 1.25e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -32,7 +32,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
-          pricing_mode: marginal
+          pricing_mode: cumulative
     - cache_read_input_token_cost: 1.25e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -49,7 +49,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
-          pricing_mode: marginal
+          pricing_mode: cumulative
     - cache_read_input_token_cost: 1.25e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -66,7 +66,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
-          pricing_mode: marginal
+          pricing_mode: cumulative
     - cache_read_input_token_cost: 1.25e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -83,7 +83,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
-          pricing_mode: marginal
+          pricing_mode: cumulative
     - cache_read_input_token_cost: 1.25e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -100,7 +100,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
-          pricing_mode: marginal
+          pricing_mode: cumulative
     - cache_read_input_token_cost: 1.25e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -117,7 +117,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
-          pricing_mode: marginal
+          pricing_mode: cumulative
     - cache_read_input_token_cost: 1.25e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -134,7 +134,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
-          pricing_mode: marginal
+          pricing_mode: cumulative
     - cache_read_input_token_cost: 1.25e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -151,7 +151,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
-          pricing_mode: marginal
+          pricing_mode: cumulative
     - cache_read_input_token_cost: 1.25e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -168,7 +168,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
-          pricing_mode: marginal
+          pricing_mode: cumulative
     - cache_read_input_token_cost: 1.25e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -185,7 +185,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
-          pricing_mode: marginal
+          pricing_mode: cumulative
     - cache_read_input_token_cost: 1.25e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -202,7 +202,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
-          pricing_mode: marginal
+          pricing_mode: cumulative
     - cache_read_input_token_cost: 1.25e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -219,7 +219,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
-          pricing_mode: marginal
+          pricing_mode: cumulative
     - cache_read_input_token_cost: 1.25e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -236,7 +236,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
-          pricing_mode: marginal
+          pricing_mode: cumulative
     - cache_read_input_token_cost: 1.25e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -253,7 +253,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
-          pricing_mode: marginal
+          pricing_mode: cumulative
     - cache_read_input_token_cost: 1.25e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -270,7 +270,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
-          pricing_mode: marginal
+          pricing_mode: cumulative
     - cache_read_input_token_cost: 1.25e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -287,7 +287,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
-          pricing_mode: marginal
+          pricing_mode: cumulative
 deprecationDate: "2026-10-16"
 features:
     - function_calling

--- a/providers/google-vertex/gemini-3.1-pro-preview.yaml
+++ b/providers/google-vertex/gemini-3.1-pro-preview.yaml
@@ -15,7 +15,7 @@ costs:
           output:
               - cost_per_token: 0.000018
                 from: 200000
-          pricing_mode: marginal
+          pricing_mode: cumulative
 features:
     - function_calling
     - parallel_function_calling

--- a/providers/google-vertex/gemini-3.1-pro-preview.yaml
+++ b/providers/google-vertex/gemini-3.1-pro-preview.yaml
@@ -15,6 +15,7 @@ costs:
           output:
               - cost_per_token: 0.000018
                 from: 200000
+          pricing_mode: marginal
 features:
     - function_calling
     - parallel_function_calling

--- a/providers/google-vertex/google/gemini-2.5-computer-use-preview-10-2025.yaml
+++ b/providers/google-vertex/google/gemini-2.5-computer-use-preview-10-2025.yaml
@@ -9,6 +9,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
+          pricing_mode: marginal
 features:
     - function_calling
     - parallel_function_calling

--- a/providers/google-vertex/google/gemini-2.5-computer-use-preview-10-2025.yaml
+++ b/providers/google-vertex/google/gemini-2.5-computer-use-preview-10-2025.yaml
@@ -9,7 +9,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
-          pricing_mode: marginal
+          pricing_mode: cumulative
 features:
     - function_calling
     - parallel_function_calling

--- a/providers/google-vertex/google/gemini-2.5-pro.yaml
+++ b/providers/google-vertex/google/gemini-2.5-pro.yaml
@@ -15,6 +15,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
+          pricing_mode: marginal
     - cache_read_input_token_cost: 1.3e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -31,6 +32,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
+          pricing_mode: marginal
     - cache_read_input_token_cost: 1.3e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -47,6 +49,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
+          pricing_mode: marginal
     - cache_read_input_token_cost: 1.3e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -63,6 +66,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
+          pricing_mode: marginal
     - cache_read_input_token_cost: 1.3e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -79,6 +83,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
+          pricing_mode: marginal
     - cache_read_input_token_cost: 1.3e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -95,6 +100,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
+          pricing_mode: marginal
     - cache_read_input_token_cost: 1.3e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -111,6 +117,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
+          pricing_mode: marginal
     - cache_read_input_token_cost: 1.3e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -127,6 +134,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
+          pricing_mode: marginal
     - cache_read_input_token_cost: 1.3e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -143,6 +151,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
+          pricing_mode: marginal
     - cache_read_input_token_cost: 1.3e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -159,6 +168,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
+          pricing_mode: marginal
     - cache_read_input_token_cost: 1.3e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -175,6 +185,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
+          pricing_mode: marginal
     - cache_read_input_token_cost: 1.3e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -191,6 +202,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
+          pricing_mode: marginal
     - cache_read_input_token_cost: 1.3e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -207,6 +219,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
+          pricing_mode: marginal
     - cache_read_input_token_cost: 1.3e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -223,6 +236,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
+          pricing_mode: marginal
     - cache_read_input_token_cost: 1.3e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -239,6 +253,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
+          pricing_mode: marginal
     - cache_read_input_token_cost: 1.3e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -255,6 +270,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
+          pricing_mode: marginal
     - cache_read_input_token_cost: 1.3e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -271,6 +287,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
+          pricing_mode: marginal
 features:
     - function_calling
     - system_messages

--- a/providers/google-vertex/google/gemini-2.5-pro.yaml
+++ b/providers/google-vertex/google/gemini-2.5-pro.yaml
@@ -15,7 +15,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
-          pricing_mode: marginal
+          pricing_mode: cumulative
     - cache_read_input_token_cost: 1.3e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -32,7 +32,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
-          pricing_mode: marginal
+          pricing_mode: cumulative
     - cache_read_input_token_cost: 1.3e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -49,7 +49,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
-          pricing_mode: marginal
+          pricing_mode: cumulative
     - cache_read_input_token_cost: 1.3e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -66,7 +66,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
-          pricing_mode: marginal
+          pricing_mode: cumulative
     - cache_read_input_token_cost: 1.3e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -83,7 +83,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
-          pricing_mode: marginal
+          pricing_mode: cumulative
     - cache_read_input_token_cost: 1.3e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -100,7 +100,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
-          pricing_mode: marginal
+          pricing_mode: cumulative
     - cache_read_input_token_cost: 1.3e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -117,7 +117,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
-          pricing_mode: marginal
+          pricing_mode: cumulative
     - cache_read_input_token_cost: 1.3e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -134,7 +134,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
-          pricing_mode: marginal
+          pricing_mode: cumulative
     - cache_read_input_token_cost: 1.3e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -151,7 +151,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
-          pricing_mode: marginal
+          pricing_mode: cumulative
     - cache_read_input_token_cost: 1.3e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -168,7 +168,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
-          pricing_mode: marginal
+          pricing_mode: cumulative
     - cache_read_input_token_cost: 1.3e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -185,7 +185,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
-          pricing_mode: marginal
+          pricing_mode: cumulative
     - cache_read_input_token_cost: 1.3e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -202,7 +202,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
-          pricing_mode: marginal
+          pricing_mode: cumulative
     - cache_read_input_token_cost: 1.3e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -219,7 +219,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
-          pricing_mode: marginal
+          pricing_mode: cumulative
     - cache_read_input_token_cost: 1.3e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -236,7 +236,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
-          pricing_mode: marginal
+          pricing_mode: cumulative
     - cache_read_input_token_cost: 1.3e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -253,7 +253,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
-          pricing_mode: marginal
+          pricing_mode: cumulative
     - cache_read_input_token_cost: 1.3e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -270,7 +270,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
-          pricing_mode: marginal
+          pricing_mode: cumulative
     - cache_read_input_token_cost: 1.3e-7
       input_cost_per_token: 0.00000125
       input_cost_per_token_batches: 6.25e-7
@@ -287,7 +287,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
-          pricing_mode: marginal
+          pricing_mode: cumulative
 features:
     - function_calling
     - system_messages

--- a/providers/google-vertex/google/gemini-3.1-pro-preview.yaml
+++ b/providers/google-vertex/google/gemini-3.1-pro-preview.yaml
@@ -15,6 +15,7 @@ costs:
           output:
               - cost_per_token: 0.000018
                 from: 200000
+          pricing_mode: marginal
 features:
     - function_calling
     - system_messages

--- a/providers/google-vertex/google/gemini-3.1-pro-preview.yaml
+++ b/providers/google-vertex/google/gemini-3.1-pro-preview.yaml
@@ -15,7 +15,7 @@ costs:
           output:
               - cost_per_token: 0.000018
                 from: 200000
-          pricing_mode: marginal
+          pricing_mode: cumulative
 features:
     - function_calling
     - system_messages

--- a/providers/openai/gpt-5.1.yaml
+++ b/providers/openai/gpt-5.1.yaml
@@ -15,6 +15,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 272000
+          pricing_mode: cumulative
 features:
     - function_calling
     - parallel_function_calling

--- a/providers/openai/gpt-5.4-2026-03-05.yaml
+++ b/providers/openai/gpt-5.4-2026-03-05.yaml
@@ -15,6 +15,7 @@ costs:
           output:
               - cost_per_token: 0.0000225
                 from: 272000
+          pricing_mode: cumulative
 features:
     - function_calling
     - parallel_function_calling

--- a/providers/openai/gpt-5.4-pro-2026-03-05.yaml
+++ b/providers/openai/gpt-5.4-pro-2026-03-05.yaml
@@ -11,6 +11,7 @@ costs:
           output:
               - cost_per_token: 0.00027
                 from: 272000
+          pricing_mode: cumulative
 features:
     - function_calling
     - system_messages

--- a/providers/openai/gpt-5.4-pro.yaml
+++ b/providers/openai/gpt-5.4-pro.yaml
@@ -11,6 +11,7 @@ costs:
           output:
               - cost_per_token: 0.00027
                 from: 272000
+          pricing_mode: cumulative
 features:
     - function_calling
     - tool_choice

--- a/providers/openai/gpt-5.4.yaml
+++ b/providers/openai/gpt-5.4.yaml
@@ -15,6 +15,7 @@ costs:
           output:
               - cost_per_token: 0.0000225
                 from: 272000
+          pricing_mode: cumulative
 features:
     - function_calling
     - parallel_function_calling

--- a/providers/openai/gpt-5.5-2026-04-23.yaml
+++ b/providers/openai/gpt-5.5-2026-04-23.yaml
@@ -15,6 +15,7 @@ costs:
           output:
               - cost_per_token: 0.000045
                 from: 272000
+          pricing_mode: cumulative
 features:
     - function_calling
     - parallel_function_calling

--- a/providers/openai/gpt-5.5.yaml
+++ b/providers/openai/gpt-5.5.yaml
@@ -15,6 +15,7 @@ costs:
           output:
               - cost_per_token: 0.000045
                 from: 272000
+          pricing_mode: cumulative
 features:
     - function_calling
     - parallel_function_calling

--- a/providers/openrouter/anthropic/claude-sonnet-4.5.yaml
+++ b/providers/openrouter/anthropic/claude-sonnet-4.5.yaml
@@ -17,6 +17,7 @@ costs:
           output:
               - cost_per_token: 0.0000225
                 from: 200000
+          pricing_mode: marginal
 features:
     - function_calling
     - json_output

--- a/providers/openrouter/anthropic/claude-sonnet-4.yaml
+++ b/providers/openrouter/anthropic/claude-sonnet-4.yaml
@@ -17,6 +17,7 @@ costs:
           output:
               - cost_per_token: 0.0000225
                 from: 200000
+          pricing_mode: marginal
 features:
     - function_calling
     - prompt_caching

--- a/providers/openrouter/bytedance-seed/seed-1.6-flash.yaml
+++ b/providers/openrouter/bytedance-seed/seed-1.6-flash.yaml
@@ -9,6 +9,7 @@ costs:
           output:
               - cost_per_token: 8e-7
                 from: 128000
+          pricing_mode: marginal
 features:
     - function_calling
     - json_output

--- a/providers/openrouter/bytedance-seed/seed-1.6.yaml
+++ b/providers/openrouter/bytedance-seed/seed-1.6.yaml
@@ -9,6 +9,7 @@ costs:
           output:
               - cost_per_token: 0.000004
                 from: 128000
+          pricing_mode: marginal
 features:
     - function_calling
     - json_output

--- a/providers/openrouter/bytedance-seed/seed-2.0-lite.yaml
+++ b/providers/openrouter/bytedance-seed/seed-2.0-lite.yaml
@@ -9,6 +9,7 @@ costs:
           output:
               - cost_per_token: 0.000004
                 from: 128000
+          pricing_mode: marginal
 features:
     - function_calling
     - json_output

--- a/providers/openrouter/bytedance-seed/seed-2.0-mini.yaml
+++ b/providers/openrouter/bytedance-seed/seed-2.0-mini.yaml
@@ -9,6 +9,7 @@ costs:
           output:
               - cost_per_token: 8e-7
                 from: 128000
+          pricing_mode: marginal
 features:
     - function_calling
     - json_output

--- a/providers/openrouter/google/gemini-2.5-pro-preview-05-06.yaml
+++ b/providers/openrouter/google/gemini-2.5-pro-preview-05-06.yaml
@@ -18,6 +18,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
+          pricing_mode: marginal
 features:
     - function_calling
     - json_output

--- a/providers/openrouter/google/gemini-2.5-pro-preview-05-06.yaml
+++ b/providers/openrouter/google/gemini-2.5-pro-preview-05-06.yaml
@@ -18,7 +18,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
-          pricing_mode: marginal
+          pricing_mode: cumulative
 features:
     - function_calling
     - json_output

--- a/providers/openrouter/google/gemini-2.5-pro-preview.yaml
+++ b/providers/openrouter/google/gemini-2.5-pro-preview.yaml
@@ -18,6 +18,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
+          pricing_mode: marginal
 features:
     - function_calling
     - json_output

--- a/providers/openrouter/google/gemini-2.5-pro-preview.yaml
+++ b/providers/openrouter/google/gemini-2.5-pro-preview.yaml
@@ -18,7 +18,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
-          pricing_mode: marginal
+          pricing_mode: cumulative
 features:
     - function_calling
     - json_output

--- a/providers/openrouter/google/gemini-2.5-pro.yaml
+++ b/providers/openrouter/google/gemini-2.5-pro.yaml
@@ -21,6 +21,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
+          pricing_mode: marginal
 features:
     - function_calling
     - json_output

--- a/providers/openrouter/google/gemini-2.5-pro.yaml
+++ b/providers/openrouter/google/gemini-2.5-pro.yaml
@@ -21,7 +21,7 @@ costs:
           output:
               - cost_per_token: 0.000015
                 from: 200000
-          pricing_mode: marginal
+          pricing_mode: cumulative
 features:
     - function_calling
     - json_output

--- a/providers/openrouter/google/gemini-3.1-pro-preview-customtools.yaml
+++ b/providers/openrouter/google/gemini-3.1-pro-preview-customtools.yaml
@@ -17,6 +17,7 @@ costs:
           output:
               - cost_per_token: 0.000018
                 from: 200000
+          pricing_mode: marginal
 features:
     - function_calling
     - json_output

--- a/providers/openrouter/google/gemini-3.1-pro-preview-customtools.yaml
+++ b/providers/openrouter/google/gemini-3.1-pro-preview-customtools.yaml
@@ -17,7 +17,7 @@ costs:
           output:
               - cost_per_token: 0.000018
                 from: 200000
-          pricing_mode: marginal
+          pricing_mode: cumulative
 features:
     - function_calling
     - json_output

--- a/providers/openrouter/google/gemini-3.1-pro-preview.yaml
+++ b/providers/openrouter/google/gemini-3.1-pro-preview.yaml
@@ -15,6 +15,7 @@ costs:
           output:
               - cost_per_token: 0.000018
                 from: 200000
+          pricing_mode: marginal
 features:
     - function_calling
     - json_output

--- a/providers/openrouter/google/gemini-3.1-pro-preview.yaml
+++ b/providers/openrouter/google/gemini-3.1-pro-preview.yaml
@@ -15,7 +15,7 @@ costs:
           output:
               - cost_per_token: 0.000018
                 from: 200000
-          pricing_mode: marginal
+          pricing_mode: cumulative
 features:
     - function_calling
     - json_output

--- a/providers/openrouter/minimax/minimax-m1.yaml
+++ b/providers/openrouter/minimax/minimax-m1.yaml
@@ -6,6 +6,7 @@ costs:
           input:
               - cost_per_token: 0.0000013
                 from: 200000
+          pricing_mode: marginal
 features:
     - function_calling
     - tool_choice

--- a/providers/openrouter/openai/gpt-5.4-pro.yaml
+++ b/providers/openrouter/openai/gpt-5.4-pro.yaml
@@ -9,6 +9,7 @@ costs:
           output:
               - cost_per_token: 0.00027
                 from: 272000
+          pricing_mode: cumulative
 features:
     - function_calling
     - json_output

--- a/providers/openrouter/openai/gpt-5.4.yaml
+++ b/providers/openrouter/openai/gpt-5.4.yaml
@@ -13,6 +13,7 @@ costs:
           output:
               - cost_per_token: 0.0000225
                 from: 272000
+          pricing_mode: cumulative
 features:
     - function_calling
     - json_output

--- a/providers/openrouter/qwen/qwen-plus-2025-07-28.yaml
+++ b/providers/openrouter/qwen/qwen-plus-2025-07-28.yaml
@@ -17,6 +17,7 @@ costs:
           output:
               - cost_per_token: 0.00000234
                 from: 256000
+          pricing_mode: marginal
 features:
     - function_calling
     - json_output

--- a/providers/openrouter/qwen/qwen-plus-2025-07-28:thinking.yaml
+++ b/providers/openrouter/qwen/qwen-plus-2025-07-28:thinking.yaml
@@ -17,6 +17,7 @@ costs:
           output:
               - cost_per_token: 0.00000234
                 from: 256000
+          pricing_mode: marginal
 features:
     - function_calling
     - json_output

--- a/providers/openrouter/qwen/qwen-plus.yaml
+++ b/providers/openrouter/qwen/qwen-plus.yaml
@@ -17,6 +17,7 @@ costs:
           output:
               - cost_per_token: 0.00000234
                 from: 256000
+          pricing_mode: marginal
 features:
     - function_calling
     - json_output

--- a/providers/openrouter/qwen/qwen3-coder-flash.yaml
+++ b/providers/openrouter/qwen/qwen3-coder-flash.yaml
@@ -14,6 +14,7 @@ costs:
                 from: 32000
               - cost_per_token: 0.0000026
                 from: 128000
+          pricing_mode: marginal
 features:
     - function_calling
     - json_output

--- a/providers/openrouter/qwen/qwen3-coder-plus.yaml
+++ b/providers/openrouter/qwen/qwen3-coder-plus.yaml
@@ -19,6 +19,7 @@ costs:
                 from: 32000
               - cost_per_token: 0.00000975
                 from: 128000
+          pricing_mode: marginal
 features:
     - function_calling
     - json_output

--- a/providers/openrouter/qwen/qwen3-max-thinking.yaml
+++ b/providers/openrouter/qwen/qwen3-max-thinking.yaml
@@ -13,6 +13,7 @@ costs:
                 from: 32000
               - cost_per_token: 0.00000975
                 from: 128000
+          pricing_mode: marginal
 features:
     - function_calling
     - json_output

--- a/providers/openrouter/qwen/qwen3-max.yaml
+++ b/providers/openrouter/qwen/qwen3-max.yaml
@@ -15,6 +15,7 @@ costs:
                 from: 32000
               - cost_per_token: 0.00000975
                 from: 128000
+          pricing_mode: marginal
 features:
     - function_calling
     - json_output

--- a/providers/openrouter/qwen/qwen3.5-plus-02-15.yaml
+++ b/providers/openrouter/qwen/qwen3.5-plus-02-15.yaml
@@ -9,6 +9,7 @@ costs:
           output:
               - cost_per_token: 0.00000195
                 from: 256000
+          pricing_mode: marginal
 features:
     - function_calling
     - json_output

--- a/providers/openrouter/qwen/qwen3.6-plus.yaml
+++ b/providers/openrouter/qwen/qwen3.6-plus.yaml
@@ -9,6 +9,7 @@ costs:
           output:
               - cost_per_token: 0.0000039
                 from: 256000
+          pricing_mode: marginal
 features:
     - function_calling
     - json_output

--- a/providers/openrouter/x-ai/grok-4-fast.yaml
+++ b/providers/openrouter/x-ai/grok-4-fast.yaml
@@ -10,6 +10,7 @@ costs:
           output:
               - cost_per_token: 0.000001
                 from: 128000
+          pricing_mode: marginal
 deprecationDate: "2026-06-01"
 features:
     - function_calling

--- a/providers/openrouter/x-ai/grok-4.1-fast.yaml
+++ b/providers/openrouter/x-ai/grok-4.1-fast.yaml
@@ -10,6 +10,7 @@ costs:
           output:
               - cost_per_token: 0.000001
                 from: 128000
+          pricing_mode: marginal
 deprecationDate: "2026-06-01"
 features:
     - function_calling

--- a/providers/openrouter/x-ai/grok-4.20-multi-agent.yaml
+++ b/providers/openrouter/x-ai/grok-4.20-multi-agent.yaml
@@ -15,6 +15,7 @@ costs:
           output:
               - cost_per_token: 0.000012
                 from: 200000
+          pricing_mode: marginal
 features:
     - json_output
     - prompt_caching

--- a/providers/openrouter/x-ai/grok-4.20.yaml
+++ b/providers/openrouter/x-ai/grok-4.20.yaml
@@ -13,6 +13,7 @@ costs:
           output:
               - cost_per_token: 0.000012
                 from: 200000
+          pricing_mode: marginal
 features:
     - function_calling
     - json_output

--- a/providers/openrouter/x-ai/grok-4.yaml
+++ b/providers/openrouter/x-ai/grok-4.yaml
@@ -10,6 +10,7 @@ costs:
           output:
               - cost_per_token: 0.00003
                 from: 128000
+          pricing_mode: marginal
 deprecationDate: "2026-06-01"
 features:
     - function_calling

--- a/providers/openrouter/xiaomi/mimo-v2-pro.yaml
+++ b/providers/openrouter/xiaomi/mimo-v2-pro.yaml
@@ -13,6 +13,7 @@ costs:
           output:
               - cost_per_token: 0.000006
                 from: 256000
+          pricing_mode: marginal
 features:
     - function_calling
     - json_output

--- a/providers/xai/grok-4-1-fast-non-reasoning-latest.yaml
+++ b/providers/xai/grok-4-1-fast-non-reasoning-latest.yaml
@@ -15,6 +15,7 @@ costs:
           output:
               - cost_per_token: 1e-6
                 from: 128000
+          pricing_mode: marginal
 features:
     - function_calling
     - tool_choice

--- a/providers/xai/grok-4-1-fast-non-reasoning.yaml
+++ b/providers/xai/grok-4-1-fast-non-reasoning.yaml
@@ -12,6 +12,7 @@ costs:
           output:
               - cost_per_token: 1e-6
                 from: 128000
+          pricing_mode: marginal
 features:
     - function_calling
     - structured_output

--- a/providers/xai/grok-4-1-fast-reasoning-latest.yaml
+++ b/providers/xai/grok-4-1-fast-reasoning-latest.yaml
@@ -15,6 +15,7 @@ costs:
           output:
               - cost_per_token: 1e-6
                 from: 128000
+          pricing_mode: marginal
 features:
     - function_calling
     - tool_choice

--- a/providers/xai/grok-4-1-fast.yaml
+++ b/providers/xai/grok-4-1-fast.yaml
@@ -12,6 +12,7 @@ costs:
           output:
               - cost_per_token: 1e-6
                 from: 128000
+          pricing_mode: marginal
 features:
     - function_calling
     - tool_choice

--- a/providers/xai/grok-4-fast-non-reasoning-latest.yaml
+++ b/providers/xai/grok-4-fast-non-reasoning-latest.yaml
@@ -15,6 +15,7 @@ costs:
           output:
               - cost_per_token: 1e-6
                 from: 128000
+          pricing_mode: marginal
 features:
     - function_calling
     - structured_output

--- a/providers/xai/grok-4-fast-non-reasoning.yaml
+++ b/providers/xai/grok-4-fast-non-reasoning.yaml
@@ -12,6 +12,7 @@ costs:
           output:
               - cost_per_token: 1e-6
                 from: 128000
+          pricing_mode: marginal
 features:
     - function_calling
     - tool_choice

--- a/providers/xai/grok-4-fast-reasoning-latest.yaml
+++ b/providers/xai/grok-4-fast-reasoning-latest.yaml
@@ -12,6 +12,7 @@ costs:
           output:
               - cost_per_token: 1e-6
                 from: 128000
+          pricing_mode: marginal
 features:
     - function_calling
     - structured_output

--- a/providers/xai/grok-4-fast.yaml
+++ b/providers/xai/grok-4-fast.yaml
@@ -15,6 +15,7 @@ costs:
           output:
               - cost_per_token: 1e-6
                 from: 128000
+          pricing_mode: marginal
 features:
     - function_calling
     - structured_output

--- a/providers/xai/grok-4.yaml
+++ b/providers/xai/grok-4.yaml
@@ -12,6 +12,7 @@ costs:
           output:
               - cost_per_token: 0.00003
                 from: 128000
+          pricing_mode: marginal
 features:
     - function_calling
     - structured_output


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes cost configuration semantics by explicitly setting `tiered_pricing.pricing_mode` for many models, which could alter token-cost calculations and downstream billing/estimation behavior if consumers assume a different default.
> 
> **Overview**
> **Adds explicit `pricing_mode` to `tiered_pricing` across many provider model YAMLs** to disambiguate how tier thresholds are applied.
> 
> Anthropic/Bedrock, Vertex Claude, DeepInfra, OpenRouter (Qwen/xAI/etc.) are set to `marginal`, while OpenAI/Azure OpenAI and multiple Gemini configs are set to `cumulative`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d3003b2dc41ed54253691c20c688411553cf93a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->