### PR TITLE
feat(azure-open-ai): update GPT-5 and GPT-5.1 model configurations

### DIFF
--- a/providers/azure-open-ai/gpt-5-mini.yaml
+++ b/providers/azure-open-ai/gpt-5-mini.yaml
@@ -1,8 +1,20 @@
 costs:
-    - cache_read_input_token_cost: 2.75e-8
-      input_cost_per_token: 2.75e-7
+    - cache_read_input_token_cost: 3e-8
+      input_cost_per_token: 2.5e-7
+      output_cost_per_token: 0.000002
+      region: global
+    - cache_read_input_token_cost: 3e-8
+      input_cost_per_token: 2.8e-7
+      output_cost_per_token: 0.0000022
+      region: datazone_us
+    - cache_read_input_token_cost: 3e-8
+      input_cost_per_token: 2.8e-7
       output_cost_per_token: 0.0000022
       region: datazone_eu
+    - cache_read_input_token_cost: 3e-8
+      input_cost_per_token: 2.5e-7
+      output_cost_per_token: 0.000002
+      region: "*"
 deprecationDate: "2027-02-06"
 features:
     - function_calling

--- a/providers/azure-open-ai/gpt-5.1-chat.yaml
+++ b/providers/azure-open-ai/gpt-5.1-chat.yaml
@@ -34,7 +34,7 @@ mode: chat
 model: gpt-5.1-chat
 params:
     - defaultValue: 128
-      key: max_tokens
+      key: max_completion_tokens
       maxValue: 16384
       minValue: 1
     - defaultValue: none
@@ -44,6 +44,7 @@ removeParams:
     - temperature
     - top_p
     - "n"
+    - max_tokens
     - parallel_tool_calls
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models

--- a/providers/azure-open-ai/gpt-5.1.yaml
+++ b/providers/azure-open-ai/gpt-5.1.yaml
@@ -38,13 +38,18 @@ modalities:
 mode: chat
 model: gpt-5.1
 params:
-    - defaultValue: 128000
-      key: max_tokens
+    - defaultValue: 20000
+      key: max_completion_tokens
       maxValue: 128000
       minValue: 1
     - defaultValue: none
       key: reasoning_effort
       type: string
+removeParams:
+    - temperature
+    - top_p
+    - "n"
+    - max_tokens
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
 status: active


### PR DESCRIPTION
- Adjusted cost parameters in gpt-5-mini.yaml for various regions.
- Renamed 'max_tokens' to 'max_completion_tokens' in gpt-5.1-chat.yaml and gpt-5.1.yaml.
- Removed deprecated parameters: 'temperature', 'top_p', 'n', and 'max_tokens' from gpt-5.1-chat.yaml and gpt-5.1.yaml.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes cost tables (billing/estimation) and request parameter names, which could break callers still sending `max_tokens` or alter default completion limits.
> 
> **Overview**
> Aligns Azure OpenAI `gpt-5-mini`, `gpt-5.1-chat`, and `gpt-5.1` model configs with updated platform expectations.
> 
> Updates `gpt-5-mini` pricing by splitting costs per region (including `global`, `datazone_us`, `datazone_eu`) and adding a wildcard (`"*"`) entry.
> 
> Renames the token limit parameter from `max_tokens` to `max_completion_tokens` for `gpt-5.1-chat` and `gpt-5.1`, and explicitly removes deprecated request params (notably `temperature`, `top_p`, `n`, and `max_tokens`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07e43b97f5844b28c49c992357b4ee7506c94770. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->