### PR TITLE
refactor(azure-open-ai): change mode from 'chat' to 'responses' in GPT-5.2 and GPT-5.3 model YAMLs

### DIFF
--- a/providers/azure-open-ai/gpt-5.2-codex-2026-01-14.yaml
+++ b/providers/azure-open-ai/gpt-5.2-codex-2026-01-14.yaml
@@ -23,7 +23,7 @@ modalities:
         - pdf
     output:
         - text
-mode: chat
+mode: responses
 model: gpt-5.2-codex-2026-01-14
 params:
     - defaultValue: 128
@@ -35,5 +35,5 @@ sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/foundry-models/concepts/models-sold-directly-by-azure
 status: active
 supportedModes:
-    - chat
+    - responses
 thinking: true

--- a/providers/azure-open-ai/gpt-5.3-codex-2026-02-20.yaml
+++ b/providers/azure-open-ai/gpt-5.3-codex-2026-02-20.yaml
@@ -22,7 +22,7 @@ modalities:
         - pdf
     output:
         - text
-mode: chat
+mode: responses
 model: gpt-5.3-codex-2026-02-20
 params:
     - defaultValue: 128
@@ -37,5 +37,5 @@ sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/model-retirements
 status: active
 supportedModes:
-    - chat
+    - responses
 thinking: true

--- a/providers/azure-open-ai/gpt-5.3-codex-2026-02-24.yaml
+++ b/providers/azure-open-ai/gpt-5.3-codex-2026-02-24.yaml
@@ -23,7 +23,7 @@ modalities:
         - pdf
     output:
         - text
-mode: chat
+mode: responses
 model: gpt-5.3-codex-2026-02-24
 params:
     - defaultValue: 128
@@ -37,5 +37,5 @@ sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
 status: active
 supportedModes:
-    - chat
+    - responses
 thinking: true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Config-only change confined to model metadata; main risk is incompatibility if any callers still assume `chat` for these specific models.
> 
> **Overview**
> Switches the Azure OpenAI model YAMLs for `gpt-5.2-codex-2026-01-14`, `gpt-5.3-codex-2026-02-20`, and `gpt-5.3-codex-2026-02-24` from `mode: chat` to `mode: responses`.
> 
> Updates `supportedModes` accordingly by removing `chat` and listing only `responses`, aligning these model configs with the expected invocation mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10f163c143f1af881380a6f5ba3f7cd45cc5d1dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->