### PR TITLE
fix: revert premature deprecations

### DIFF
--- a/providers/aws-bedrock/amazon.nova-canvas-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.nova-canvas-v1:0.yaml
@@ -6,7 +6,6 @@ costs:
     - output_cost_per_image: 0.06
       region: ap-northeast-1
 deprecationDate: "2026-09-30"
-isDeprecated: true
 modalities:
     input:
         - text

--- a/providers/aws-bedrock/apac.anthropic.claude-sonnet-4-20250514-v1:0.yaml
+++ b/providers/aws-bedrock/apac.anthropic.claude-sonnet-4-20250514-v1:0.yaml
@@ -84,7 +84,6 @@ features:
     - system_messages
     - tool_choice
     - assistant_prefill
-isDeprecated: true
 limits:
     context_window: 200000
     max_input_tokens: 200000

--- a/providers/aws-bedrock/eu.anthropic.claude-3-haiku-20240307-v1:0.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-3-haiku-20240307-v1:0.yaml
@@ -17,7 +17,6 @@ costs:
 deprecationDate: "2026-09-10"
 features:
     - function_calling
-isDeprecated: true
 limits:
     context_window: 200000
     max_input_tokens: 200000

--- a/providers/aws-bedrock/eu.anthropic.claude-sonnet-4-20250514-v1:0.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-sonnet-4-20250514-v1:0.yaml
@@ -116,7 +116,6 @@ features:
     - cache_control
     - prompt_caching
     - assistant_prefill
-isDeprecated: true
 limits:
     context_window: 200000
     max_input_tokens: 200000

--- a/providers/aws-bedrock/global.anthropic.claude-sonnet-4-20250514-v1:0.yaml
+++ b/providers/aws-bedrock/global.anthropic.claude-sonnet-4-20250514-v1:0.yaml
@@ -40,7 +40,6 @@ features:
     - system_messages
     - tool_choice
     - assistant_prefill
-isDeprecated: true
 limits:
     context_window: 200000
     max_input_tokens: 200000

--- a/providers/aws-bedrock/us-gov.anthropic.claude-3-haiku-20240307-v1:0.yaml
+++ b/providers/aws-bedrock/us-gov.anthropic.claude-3-haiku-20240307-v1:0.yaml
@@ -5,7 +5,6 @@ costs:
 deprecationDate: "2026-09-10"
 features:
     - function_calling
-isDeprecated: true
 limits:
     context_window: 200000
     max_input_tokens: 200000

--- a/providers/aws-bedrock/us.amazon.nova-premier-v1:0.yaml
+++ b/providers/aws-bedrock/us.amazon.nova-premier-v1:0.yaml
@@ -23,7 +23,6 @@ features:
     - system_messages
     - tool_choice
     - prompt_caching
-isDeprecated: true
 limits:
     context_window: 1000000
     max_input_tokens: 1000000

--- a/providers/aws-bedrock/us.amazon.nova-pro-v1:0.yaml
+++ b/providers/aws-bedrock/us.amazon.nova-pro-v1:0.yaml
@@ -19,7 +19,6 @@ features:
     - function_calling
     - prompt_caching
     - system_messages
-isDeprecated: true
 limits:
     context_window: 300000
     max_input_tokens: 300000

--- a/providers/aws-bedrock/us.anthropic.claude-opus-4-20250514-v1:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-opus-4-20250514-v1:0.yaml
@@ -27,7 +27,6 @@ features:
     - tool_choice
     - prompt_caching
     - assistant_prefill
-isDeprecated: true
 limits:
     context_window: 200000
     max_input_tokens: 200000

--- a/providers/aws-bedrock/us.anthropic.claude-sonnet-4-20250514-v1:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-sonnet-4-20250514-v1:0.yaml
@@ -35,7 +35,6 @@ features:
     - system_messages
     - tool_choice
     - assistant_prefill
-isDeprecated: true
 limits:
     context_window: 200000
     max_input_tokens: 200000

--- a/providers/aws-bedrock/writer.palmyra-vision-7b.yaml
+++ b/providers/aws-bedrock/writer.palmyra-vision-7b.yaml
@@ -11,7 +11,6 @@ costs:
 deprecationDate: "2026-07-13"
 features:
     - system_messages
-isDeprecated: true
 limits:
     context_window: 8000
     max_output_tokens: 4096

--- a/providers/azure-open-ai/azure-tts-hd.yaml
+++ b/providers/azure-open-ai/azure-tts-hd.yaml
@@ -2,6 +2,5 @@ costs:
     - input_cost_per_character: 0.00003
       region: "*"
 deprecationDate: "2026-06-18"
-isDeprecated: true
 mode: text_to_speech
 model: azure-tts-hd

--- a/providers/azure-open-ai/gpt-4o-mini-2024-07-18.yaml
+++ b/providers/azure-open-ai/gpt-4o-mini-2024-07-18.yaml
@@ -40,6 +40,6 @@ params:
       maxValue: 16384
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
-status: deprecated
+status: active
 supportedModes:
     - chat

--- a/providers/azure-open-ai/o3-mini.yaml
+++ b/providers/azure-open-ai/o3-mini.yaml
@@ -21,7 +21,6 @@ features:
     - tool_choice
     - prompt_caching
     - structured_output
-isDeprecated: true
 limits:
     context_window: 200000
     max_input_tokens: 200000

--- a/providers/azure-open-ai/tts-1-hd.yaml
+++ b/providers/azure-open-ai/tts-1-hd.yaml
@@ -2,7 +2,6 @@ costs:
     - input_cost_per_character: 0.00003
       region: "*"
 deprecationDate: "2026-06-18"
-isDeprecated: true
 limits:
     max_tokens: 4096
 mode: text_to_speech

--- a/providers/databricks/databricks-claude-opus-4.yaml
+++ b/providers/databricks/databricks-claude-opus-4.yaml
@@ -7,7 +7,6 @@ features:
     - function_calling
     - tool_choice
     - assistant_prefill
-isDeprecated: true
 limits:
     context_window: 200000
     max_input_tokens: 200000
@@ -25,7 +24,7 @@ provisioning: serverless
 sources:
     - https://platform.claude.com/docs/en/docs/about-claude/models
     - https://platform.claude.com/docs/en/about-claude/pricing
-status: deprecated
+status: active
 supportedModes:
     - chat
 thinking: true

--- a/providers/databricks/databricks-claude-sonnet-4-1.yaml
+++ b/providers/databricks/databricks-claude-sonnet-4-1.yaml
@@ -7,7 +7,6 @@ features:
     - function_calling
     - tool_choice
     - assistant_prefill
-isDeprecated: true
 limits:
     context_window: 200000
     max_input_tokens: 200000

--- a/providers/google-vertex/gemini-2.0-flash-001.yaml
+++ b/providers/google-vertex/gemini-2.0-flash-001.yaml
@@ -168,4 +168,4 @@ params:
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-0-flash
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/context-cache/context-cache-overview
-status: deprecated
+status: active

--- a/providers/google-vertex/gemini-2.0-flash-lite-001.yaml
+++ b/providers/google-vertex/gemini-2.0-flash-lite-001.yaml
@@ -220,4 +220,4 @@ params:
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-0-flash-lite
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/locations
-status: deprecated
+status: active

--- a/providers/google-vertex/gemini-2.0-flash-lite.yaml
+++ b/providers/google-vertex/gemini-2.0-flash-lite.yaml
@@ -97,7 +97,6 @@ features:
     - tool_choice
     - prompt_caching
     - structured_output
-isDeprecated: true
 limits:
     context_window: 1048576
     max_input_tokens: 1048576

--- a/providers/google-vertex/gemini-2.0-flash.yaml
+++ b/providers/google-vertex/gemini-2.0-flash.yaml
@@ -166,4 +166,4 @@ params:
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-0-flash
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/context-cache/context-cache-overview
-status: deprecated
+status: active

--- a/providers/google-vertex/google/gemini-2.0-flash-001.yaml
+++ b/providers/google-vertex/google/gemini-2.0-flash-001.yaml
@@ -1,4 +1,3 @@
 deprecationDate: "2026-06-01"
-isDeprecated: true
 mode: unknown
 model: google/gemini-2.0-flash-001

--- a/providers/google-vertex/google/gemini-2.0-flash-lite-001.yaml
+++ b/providers/google-vertex/google/gemini-2.0-flash-lite-001.yaml
@@ -120,4 +120,4 @@ params:
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-0-flash-lite
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/model-versions
-status: deprecated
+status: active

--- a/providers/google-vertex/google/imagen-3.0-generate-002.yaml
+++ b/providers/google-vertex/google/imagen-3.0-generate-002.yaml
@@ -1,4 +1,3 @@
 deprecationDate: "2026-06-30"
-isDeprecated: true
 mode: unknown
 model: google/imagen-3.0-generate-002

--- a/providers/google-vertex/imagen-3.0-fast-generate-001.yaml
+++ b/providers/google-vertex/imagen-3.0-fast-generate-001.yaml
@@ -60,7 +60,6 @@ costs:
     - output_cost_per_image: 0.02
       region: asia-east1
 deprecationDate: "2026-06-30"
-isDeprecated: true
 modalities:
     input:
         - text

--- a/providers/google-vertex/imagen-3.0-generate-002.yaml
+++ b/providers/google-vertex/imagen-3.0-generate-002.yaml
@@ -60,7 +60,6 @@ costs:
     - output_cost_per_image: 0.04
       region: asia-east1
 deprecationDate: "2026-06-30"
-isDeprecated: true
 modalities:
     input:
         - text

--- a/providers/google-vertex/imagen-4.0-generate-001.yaml
+++ b/providers/google-vertex/imagen-4.0-generate-001.yaml
@@ -81,4 +81,4 @@ sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/model-reference/imagen-api
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/image/generate-images
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/image/overview
-status: deprecated
+status: active

--- a/providers/google-vertex/imagen-4.0-ultra-generate-001.yaml
+++ b/providers/google-vertex/imagen-4.0-ultra-generate-001.yaml
@@ -60,7 +60,6 @@ costs:
     - output_cost_per_image: 0.06
       region: asia-east1
 deprecationDate: "2026-06-30"
-isDeprecated: true
 modalities:
     input:
         - text

--- a/providers/mistral-ai/devstral-medium-2507.yaml
+++ b/providers/mistral-ai/devstral-medium-2507.yaml
@@ -5,7 +5,6 @@ costs:
 deprecationDate: "2026-05-31"
 features:
     - function_calling
-isDeprecated: true
 limits:
     context_window: 131072
 mode: chat

--- a/providers/mistral-ai/devstral-small-2507.yaml
+++ b/providers/mistral-ai/devstral-small-2507.yaml
@@ -5,7 +5,6 @@ costs:
 deprecationDate: "2026-05-31"
 features:
     - function_calling
-isDeprecated: true
 limits:
     context_window: 131072
 mode: chat

--- a/providers/mistral-ai/mistral-large-2411.yaml
+++ b/providers/mistral-ai/mistral-large-2411.yaml
@@ -5,7 +5,6 @@ costs:
 deprecationDate: "2026-05-31"
 features:
     - function_calling
-isDeprecated: true
 limits:
     context_window: 131072
 mode: chat

--- a/providers/mistral-ai/mistral-large-pixtral-2411.yaml
+++ b/providers/mistral-ai/mistral-large-pixtral-2411.yaml
@@ -1,7 +1,6 @@
 deprecationDate: "2026-05-31"
 features:
     - function_calling
-isDeprecated: true
 limits:
     context_window: 131072
 modalities:

--- a/providers/mistral-ai/mistral-moderation-2411.yaml
+++ b/providers/mistral-ai/mistral-moderation-2411.yaml
@@ -3,7 +3,6 @@ costs:
       output_cost_per_token: 1e-7
       region: "*"
 deprecationDate: "2026-06-30"
-isDeprecated: true
 limits:
     context_window: 8192
 mode: moderation

--- a/providers/mistral-ai/mistral-ocr-2505.yaml
+++ b/providers/mistral-ai/mistral-ocr-2505.yaml
@@ -5,7 +5,6 @@ costs:
 deprecationDate: "2026-05-31"
 features:
     - function_calling
-isDeprecated: true
 limits:
     context_window: 16384
 modalities:

--- a/providers/mistral-ai/pixtral-large-2411.yaml
+++ b/providers/mistral-ai/pixtral-large-2411.yaml
@@ -5,7 +5,6 @@ costs:
 deprecationDate: "2026-05-31"
 features:
     - function_calling
-isDeprecated: true
 limits:
     context_window: 131072
 modalities:

--- a/providers/mistral-ai/pixtral-large-latest.yaml
+++ b/providers/mistral-ai/pixtral-large-latest.yaml
@@ -5,7 +5,6 @@ costs:
 deprecationDate: "2026-05-31"
 features:
     - function_calling
-isDeprecated: true
 limits:
     context_window: 131072
 modalities:

--- a/providers/mistral-ai/voxtral-mini-2507.yaml
+++ b/providers/mistral-ai/voxtral-mini-2507.yaml
@@ -4,7 +4,6 @@ costs:
       output_cost_per_token: 4e-8
       region: "*"
 deprecationDate: "2026-05-31"
-isDeprecated: true
 limits:
     context_window: 16384
 mode: audio_transcription

--- a/providers/mistral-ai/voxtral-mini-transcribe-2507.yaml
+++ b/providers/mistral-ai/voxtral-mini-transcribe-2507.yaml
@@ -2,7 +2,6 @@ costs:
     - input_cost_per_second: 0.0000333333
       region: "*"
 deprecationDate: "2026-05-31"
-isDeprecated: true
 limits:
     context_window: 16384
 mode: audio_transcription

--- a/providers/openai/gpt-3.5-turbo-instruct.yaml
+++ b/providers/openai/gpt-3.5-turbo-instruct.yaml
@@ -3,7 +3,6 @@ costs:
       output_cost_per_token: 0.000002
       region: "*"
 deprecationDate: "2026-09-28"
-isDeprecated: true
 limits:
     context_window: 4096
     max_output_tokens: 4096

--- a/providers/openai/gpt-realtime-mini-2025-10-06.yaml
+++ b/providers/openai/gpt-realtime-mini-2025-10-06.yaml
@@ -12,7 +12,6 @@ features:
     - system_messages
     - tool_choice
     - prompt_caching
-isDeprecated: true
 limits:
     context_window: 32000
     max_output_tokens: 4096
@@ -30,6 +29,6 @@ model: gpt-realtime-mini-2025-10-06
 provisioning: serverless
 sources:
     - https://developers.openai.com/api/docs/models/gpt-realtime-mini
-status: deprecated
+status: active
 supportedModes:
     - realtime

--- a/providers/openai/sora-2.yaml
+++ b/providers/openai/sora-2.yaml
@@ -2,7 +2,6 @@ costs:
     - output_cost_per_second: 0.1
       region: "*"
 deprecationDate: "2026-09-24"
-isDeprecated: true
 messages:
     options: []
 modalities:

--- a/providers/openrouter/google/gemini-2.0-flash-001.yaml
+++ b/providers/openrouter/google/gemini-2.0-flash-001.yaml
@@ -32,4 +32,4 @@ mode: chat
 model: google/gemini-2.0-flash-001
 sources:
     - https://openrouter.ai/google/gemini-2.0-flash-001/api
-status: deprecated
+status: active


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Updates provider model metadata that controls availability/deprecation state; incorrect flags could cause clients to use models that should be retired (or vice versa). Changes are config-only but affect runtime model selection and billing metadata.
> 
> **Overview**
> Reverts a set of **premature deprecations** across multiple provider model YAMLs by removing `isDeprecated: true` flags and flipping several models’ `status` from `deprecated` back to `active` (notably some Azure OpenAI, Databricks, Google Vertex, OpenAI Realtime, and OpenRouter entries).
> 
> Keeps `deprecationDate` values while restoring models to active service, adjusting related metadata only (no code changes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c6a70ddac7ff237aa1f1b062d7fc5b038829cc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->