### PR TITLE
Test run fixes

### DIFF
--- a/providers/aws-bedrock/us.amazon.nova-pro-v1:0.yaml
+++ b/providers/aws-bedrock/us.amazon.nova-pro-v1:0.yaml
@@ -19,7 +19,6 @@ features:
     - prompt_caching
     - system_messages
     - tool_choice
-    - structured_output
 limits:
     context_window: 300000
     max_input_tokens: 300000

--- a/providers/deepinfra/stepfun-ai/Step-3.5-Flash.yaml
+++ b/providers/deepinfra/stepfun-ai/Step-3.5-Flash.yaml
@@ -5,7 +5,7 @@ costs:
       region: "*"
 features:
     - function_calling
-    - json_output
+    # - json_output // json_output is not supported by this model
     - prompt_caching
 limits:
     context_window: 262144

--- a/providers/google-gemini/gemini-embedding-2.yaml
+++ b/providers/google-gemini/gemini-embedding-2.yaml
@@ -3,7 +3,17 @@ costs:
       input_cost_per_image_token: 4.5e-7
       input_cost_per_token: 2e-7
       input_cost_per_video_token: 1.2e-5
-      region: "*"
+      region: us
+    - input_cost_per_audio_token: 6.5e-6
+      input_cost_per_image_token: 4.5e-7
+      input_cost_per_token: 2e-7
+      input_cost_per_video_token: 1.2e-5
+      region: global
+    - input_cost_per_audio_token: 6.5e-6
+      input_cost_per_image_token: 4.5e-7
+      input_cost_per_token: 2e-7
+      input_cost_per_video_token: 1.2e-5
+      region: eu
 limits:
     context_window: 8192
     max_input_tokens: 8192

--- a/providers/google-gemini/gemma-3-12b-it.yaml
+++ b/providers/google-gemini/gemma-3-12b-it.yaml
@@ -19,7 +19,7 @@ model: gemma-3-12b-it
 params:
     - key: max_tokens
       maxValue: 8192
-provisioning: serverless
+provisioning: provisioned
 sources:
     - https://huggingface.co/google/gemma-3-12b-it
     - https://ai.google.dev/gemma/docs/core/model_card_3

--- a/providers/google-gemini/gemma-3-1b-it.yaml
+++ b/providers/google-gemini/gemma-3-1b-it.yaml
@@ -22,7 +22,7 @@ model: gemma-3-1b-it
 params:
     - key: max_tokens
       maxValue: 8192
-provisioning: serverless
+provisioning: provisioned
 sources:
     - https://ai.google.dev/gemma/docs/core
     - https://ai.google.dev/gemma/docs/core/model_card_3

--- a/providers/google-gemini/gemma-3-27b-it.yaml
+++ b/providers/google-gemini/gemma-3-27b-it.yaml
@@ -26,7 +26,7 @@ model: gemma-3-27b-it
 params:
     - key: max_tokens
       maxValue: 8192
-provisioning: serverless
+provisioning: provisioned
 sources:
     - https://ai.google.dev/gemma/docs/core
     - https://ai.google.dev/gemma/docs/core/model_card_3

--- a/providers/google-gemini/gemma-3-4b-it.yaml
+++ b/providers/google-gemini/gemma-3-4b-it.yaml
@@ -22,7 +22,7 @@ params:
       key: max_tokens
       maxValue: 8192
       minValue: 1
-provisioning: serverless
+provisioning: provisioned
 sources:
     - https://ai.google.dev/gemma/docs/core
     - https://ai.google.dev/gemma/docs/core/model_card_3

--- a/providers/google-gemini/gemma-3n-e2b-it.yaml
+++ b/providers/google-gemini/gemma-3n-e2b-it.yaml
@@ -21,7 +21,7 @@ modalities:
         - text
 mode: chat
 model: gemma-3n-e2b-it
-provisioning: serverless
+provisioning: provisioned
 removeParams:
     - tool_choice
 sources:

--- a/providers/google-gemini/gemma-3n-e4b-it.yaml
+++ b/providers/google-gemini/gemma-3n-e4b-it.yaml
@@ -24,7 +24,7 @@ params:
       key: max_tokens
       maxValue: 32000
       minValue: 1
-provisioning: serverless
+provisioning: provisioned
 removeParams:
     - tool_choice
 sources:

--- a/providers/google-vertex/google/gemma4.yaml
+++ b/providers/google-vertex/google/gemma4.yaml
@@ -21,7 +21,7 @@ modalities:
         - text
 mode: chat
 model: google/gemma4
-provisioning: serverless
+provisioning: provisioned
 sources:
     - https://ai.google.dev/gemma/docs/core
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/open-models/use-gemma

--- a/providers/google-vertex/minimaxai/minimax-m2.yaml
+++ b/providers/google-vertex/minimaxai/minimax-m2.yaml
@@ -20,7 +20,7 @@ model: minimaxai/minimax-m2
 params:
     - key: max_tokens
       maxValue: 196608
-provisioning: serverless
+provisioning: provisioned
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/minimax/minimax-m2
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/minimax

--- a/providers/google-vertex/openai/gpt-oss.yaml
+++ b/providers/google-vertex/openai/gpt-oss.yaml
@@ -19,7 +19,7 @@ modalities:
         - text
 mode: chat
 model: openai/gpt-oss
-provisioning: serverless
+provisioning: provisioned
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/openai/gpt-oss-120b
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/openai/gpt-oss-20b

--- a/providers/google-vertex/zai-org/glm-4.7.yaml
+++ b/providers/google-vertex/zai-org/glm-4.7.yaml
@@ -20,7 +20,7 @@ model: zai-org/glm-4.7
 params:
     - key: max_tokens
       maxValue: 128000
-provisioning: serverless
+provisioning: provisioned
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/zaiorg/glm-47
     - https://cloud.google.com/vertex-ai/generative-ai/pricing#glm-models

--- a/providers/openrouter/openai/gpt-3.5-turbo-16k.yaml
+++ b/providers/openrouter/openai/gpt-3.5-turbo-16k.yaml
@@ -5,7 +5,6 @@ costs:
 features:
     - function_calling
     - json_output
-    - structured_output
     - tool_choice
 limits:
     context_window: 16385

--- a/providers/openrouter/openai/gpt-4o-audio-preview.yaml
+++ b/providers/openrouter/openai/gpt-4o-audio-preview.yaml
@@ -7,6 +7,7 @@ costs:
 features:
     - function_calling
     - tool_choice
+isDeprecated: true
 limits:
     context_window: 128000
     max_output_tokens: 16384
@@ -24,6 +25,6 @@ provisioning: serverless
 sources:
     - https://openrouter.ai/openai/gpt-4o-audio-preview
     - https://openrouter.ai/openai/gpt-4o-audio-preview/api
-status: active
+status: deprecated
 supportedModes:
     - chat

--- a/providers/sambanova/MiniMax-M2.5.yaml
+++ b/providers/sambanova/MiniMax-M2.5.yaml
@@ -8,6 +8,7 @@ features:
     - system_messages
     - json_output
     - structured_output
+isDeprecated: true
 limits:
     context_window: 160000
 modalities:
@@ -22,6 +23,6 @@ sources:
     - https://cloud.sambanova.ai/playground?model=MiniMax-M2.5
     - https://docs.sambanova.ai/docs/en/features/function-calling
     - https://sambanova-systems.mintlify.dev/docs/api-reference/chat-completions/create-chat-based-completion.md
-status: active
+status: deprecated
 supportedModes:
     - chat

--- a/providers/together-ai/google/gemma-4-31B-it-lora.yaml
+++ b/providers/together-ai/google/gemma-4-31B-it-lora.yaml
@@ -16,7 +16,7 @@ modalities:
         - text
 mode: chat
 model: google/gemma-4-31B-it-lora
-provisioning: serverless
+provisioning: provisioned
 sources:
     - https://www.together.ai/models/gemma-4-31b
     - https://docs.together.ai/docs/lora-inference


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes update model capability flags, provisioning mode, and regional pricing metadata, which can affect model selection/availability and cost calculations at runtime.
> 
> **Overview**
> Updates multiple provider model YAMLs to **correct advertised capabilities and lifecycle state**.
> 
> Removes unsupported feature flags (e.g., `structured_output`/`json_output`) for specific models, marks `openai/gpt-4o-audio-preview` (OpenRouter) and `MiniMax-M2.5` (SambaNova) as **deprecated** via `isDeprecated: true` + `status: deprecated`, and switches several Gemini/Vertex/Together model entries from `provisioning: serverless` to `provisioning: provisioned`.
> 
> Also refines pricing metadata by splitting `gemini-embedding-2` costs into explicit `us`/`global`/`eu` regions (instead of `*`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7c9ca222ab92f1162f1a2f184559abac718915b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->