### PR TITLE
chore: add databricks anthropic models

### DIFF
--- a/providers/databricks/databricks-claude-opus-4-6.yaml
+++ b/providers/databricks/databricks-claude-opus-4-6.yaml
@@ -1,0 +1,40 @@
+costs:
+    - cache_creation_input_token_cost: 0.00000625
+      cache_creation_input_token_cost_per_hour: 0.00001
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 0.000005
+      input_cost_per_token_batches: 0.0000025
+      output_cost_per_token: 0.000025
+      output_cost_per_token_batches: 0.0000125
+      region: "*"
+deprecationDate: "2027-02-05"
+features:
+    - function_calling
+    - tool_choice
+    - prompt_caching
+    - structured_output
+    - cache_control
+    - assistant_prefill
+limits:
+    context_window: 1000000
+    max_input_tokens: 1000000
+    max_output_tokens: 128000
+    max_tokens: 128000
+    tool_use_system_prompt_tokens: 346
+modalities:
+    input:
+        - text
+        - image
+        - pdf
+    output:
+        - text
+mode: chat
+model: databricks-claude-opus-4-6
+params:
+    - key: max_tokens
+      maxValue: 128000
+provisioning: serverless
+status: active
+supportedModes:
+    - chat
+thinking: true

--- a/providers/databricks/databricks-claude-opus-4-7.yaml
+++ b/providers/databricks/databricks-claude-opus-4-7.yaml
@@ -1,0 +1,48 @@
+costs:
+    - cache_creation_input_token_cost: 0.00000625
+      cache_creation_input_token_cost_per_hour: 0.00001
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 0.000005
+      input_cost_per_token_batches: 0.0000025
+      output_cost_per_token: 0.000025
+      output_cost_per_token_batches: 0.0000125
+      region: "*"
+features:
+    - function_calling
+    - parallel_function_calling
+    - cache_control
+    - system_messages
+    - tool_choice
+    - prompt_caching
+    - assistant_prefill
+    - structured_output
+    - code_execution
+limits:
+    context_window: 1000000
+    max_input_tokens: 1000000
+    max_output_tokens: 128000
+    max_tokens: 128000
+    tool_use_system_prompt_tokens: 346
+modalities:
+    input:
+        - text
+        - image
+        - pdf
+    output:
+        - text
+mode: chat
+model: databricks-claude-opus-4-7
+params:
+    - defaultValue: 256
+      key: max_tokens
+      maxValue: 128000
+      minValue: 1
+provisioning: serverless
+removeParams:
+    - temperature
+    - top_p
+    - top_k
+status: active
+supportedModes:
+    - chat
+thinking: true

--- a/providers/databricks/databricks-claude-sonnet-4-6.yaml
+++ b/providers/databricks/databricks-claude-sonnet-4-6.yaml
@@ -1,0 +1,42 @@
+costs:
+    - cache_creation_input_token_cost: 0.00000375
+      cache_creation_input_token_cost_per_hour: 0.000006
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 0.000003
+      input_cost_per_token_batches: 0.0000015
+      output_cost_per_token: 0.000015
+      output_cost_per_token_batches: 0.0000075
+      region: "*"
+features:
+    - function_calling
+    - parallel_function_calling
+    - tool_choice
+    - prompt_caching
+    - cache_control
+    - structured_output
+    - assistant_prefill
+    - system_messages
+limits:
+    context_window: 1000000
+    max_output_tokens: 64000
+    max_tokens: 64000
+    tool_use_system_prompt_tokens: 346
+modalities:
+    input:
+        - text
+        - image
+        - pdf
+    output:
+        - text
+mode: chat
+model: databricks-claude-sonnet-4-6
+params:
+    - defaultValue: 256
+      key: max_tokens
+      maxValue: 64000
+      minValue: 1
+provisioning: serverless
+status: active
+supportedModes:
+    - chat
+thinking: true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: adds new Databricks model YAML definitions only; main risk is misconfigured pricing/limits/feature flags affecting model selection or billing calculations.
> 
> **Overview**
> Adds three new Databricks model definition YAMLs for `databricks-claude-opus-4-6`, `databricks-claude-opus-4-7`, and `databricks-claude-sonnet-4-6`, including pricing, supported features, modalities (text/image/pdf where applicable), and token limits up to a 1M context window.
> 
> The configs also introduce model-specific parameter handling (e.g., `max_tokens` defaults/ranges and `removeParams` for `temperature`/`top_p`/`top_k` on `opus-4-7`) and set status/provisioning metadata (plus a deprecation date for `opus-4-6`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7f8ac9f6641e3781b0313595e3f34d965661cc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->