### PR TITLE
chore: deprecate models

### DIFF
--- a/providers/databricks/databricks-claude-opus-4.yaml
+++ b/providers/databricks/databricks-claude-opus-4.yaml
@@ -15,6 +15,7 @@ features:
     - system_messages
     - prompt_caching
     - cache_control
+isDeprecated: true
 limits:
     context_window: 200000
     max_input_tokens: 200000
@@ -34,7 +35,7 @@ sources:
     - https://platform.claude.com/docs/en/about-claude/pricing
     - https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/limits
     - https://platform.claude.com/docs/en/about-claude/model-deprecations
-status: active
+status: deprecated
 supportedModes:
     - chat
 thinking: true

--- a/providers/databricks/databricks-claude-sonnet-4-1.yaml
+++ b/providers/databricks/databricks-claude-sonnet-4-1.yaml
@@ -7,6 +7,7 @@ features:
     - function_calling
     - tool_choice
     - assistant_prefill
+isDeprecated: true
 limits:
     context_window: 200000
     max_input_tokens: 200000
@@ -23,7 +24,7 @@ model: databricks-claude-sonnet-4-1
 provisioning: serverless
 sources:
     - https://platform.claude.com/docs/en/about-claude/models
-status: active
+status: deprecated
 supportedModes:
     - chat
 thinking: true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk config-only change that marks two Databricks model definitions as deprecated; main risk is unintended downstream filtering/selection if consumers treat `status`/`isDeprecated` as gating flags.
> 
> **Overview**
> Marks Databricks models `databricks-claude-opus-4` and `databricks-claude-sonnet-4-1` as **deprecated** by setting `status: deprecated` and adding `isDeprecated: true` (with `deprecationDate` already present).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8899037f056e37fce3c9dfd4c17e5ced1053f08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->