### PR TITLE
chore: add mode unsupported

### DIFF
--- a/.github/scripts/autogen/types.ts
+++ b/.github/scripts/autogen/types.ts
@@ -94,7 +94,7 @@ export interface components {
          * @description Canonical mode values for a model
          * @enum {string}
          */
-        Mode: "audio_transcription" | "audio_translation" | "chat" | "completion" | "embedding" | "image" | "moderation" | "realtime" | "rerank" | "responses" | "text_to_speech" | "unknown" | "video";
+        Mode: "audio_transcription" | "audio_translation" | "chat" | "completion" | "embedding" | "image" | "moderation" | "realtime" | "rerank" | "responses" | "text_to_speech" | "unknown" | "unsupported" | "video";
         ModelConfig: {
             /** @description Pricing entries per region; use "*" for global/uniform pricing */
             costs?: components["schemas"]["CostWithRegion"][];

--- a/.github/test/model.cue
+++ b/.github/test/model.cue
@@ -247,6 +247,7 @@ package model
 	"responses" |
 	"text_to_speech" |
 	"unknown" |
+	"unsupported" | // Model is not supported by the gateway
 	"video"
 
 #ModelConfig: {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk schema/type-only change that expands the allowed `Mode` enum; primary risk is downstream code needing to handle the new `unsupported` value.
> 
> **Overview**
> Adds a new canonical model `Mode` value, `unsupported`, to both the generated TypeScript OpenAPI types (`.github/scripts/autogen/types.ts`) and the CUE model schema used in tests (`.github/test/model.cue`). This enables marking models as present in config but not supported by the gateway.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5eb2dcc5ed2380ae3797e99170883fe7274fc625. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->