### PR TITLE
Revert "Remove unsupported nova sonic realtime model"

### DIFF
--- a/providers/aws-bedrock/amazon.nova-2-sonic-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.nova-2-sonic-v1:0.yaml
@@ -1,0 +1,54 @@
+costs:
+    - input_cost_per_audio_token: 0.000003
+      input_cost_per_token: 3.19e-7
+      output_cost_per_audio_token: 0.000012
+      output_cost_per_token: 0.000002651
+      region: us-west-2
+    - input_cost_per_audio_token: 0.000003
+      input_cost_per_token: 3.3e-7
+      output_cost_per_audio_token: 0.000012
+      output_cost_per_token: 0.00000275
+      region: us-east-1
+    - input_cost_per_audio_token: 0.00000291
+      input_cost_per_token: 3.63e-7
+      output_cost_per_audio_token: 0.00001165
+      output_cost_per_token: 0.00000292
+      region: eu-north-1
+    - input_cost_per_audio_token: 0.00000363
+      input_cost_per_token: 3.96e-7
+      output_cost_per_audio_token: 0.00001452
+      output_cost_per_token: 0.000003311
+      region: ap-northeast-1
+features:
+    - function_calling
+    - system_messages
+    - tool_choice
+limits:
+    context_window: 1000000
+    max_output_tokens: 65536
+    max_tokens: 65536
+modalities:
+    input:
+        - text
+        - audio
+    output:
+        - text
+        - audio
+mode: realtime
+model: amazon.nova-2-sonic-v1:0
+params:
+    - defaultValue: 65536
+      key: max_tokens
+      maxValue: 65536
+      minValue: 1
+provisioning: serverless
+sources:
+    - https://aws.amazon.com/nova/models/
+    - https://docs.aws.amazon.com/nova/latest/nova2-userguide/what-is-nova-2.html
+    - https://docs.aws.amazon.com/nova/latest/nova2-userguide/using-conversational-speech.html
+    - https://docs.aws.amazon.com/ai/responsible-ai/nova-2-sonic/overview.html
+    - https://aws.amazon.com/nova/pricing/
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-amazon-nova-2-sonic.html
+status: active
+supportedModes:
+    - realtime

--- a/providers/aws-bedrock/amazon.nova-2-sonic-v1:0.yaml
+++ b/providers/aws-bedrock/amazon.nova-2-sonic-v1:0.yaml
@@ -34,7 +34,7 @@ modalities:
     output:
         - text
         - audio
-mode: realtime
+mode: unsupported # (realtime not supported)
 model: amazon.nova-2-sonic-v1:0
 params:
     - defaultValue: 65536
@@ -43,10 +43,6 @@ params:
       minValue: 1
 provisioning: serverless
 sources:
-    - https://aws.amazon.com/nova/models/
-    - https://docs.aws.amazon.com/nova/latest/nova2-userguide/what-is-nova-2.html
-    - https://docs.aws.amazon.com/nova/latest/nova2-userguide/using-conversational-speech.html
-    - https://docs.aws.amazon.com/ai/responsible-ai/nova-2-sonic/overview.html
     - https://aws.amazon.com/nova/pricing/
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-amazon-nova-2-sonic.html
 status: active


### PR DESCRIPTION
Reverts truefoundry/models#1124

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only adds a provider model metadata YAML (pricing/limits/features) and does not change runtime code paths.
> 
> **Overview**
> Re-adds the AWS Bedrock model definition for `amazon.nova-2-sonic-v1:0`, including per-region pricing, supported modalities (text/audio), feature flags, and token limits.
> 
> Marks the model `status: active` with `supportedModes: [realtime]` while setting `mode: unsupported` (noting realtime isn’t supported), effectively reverting the prior removal of this model entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35bd3b68c08d74aa8e561de9e0064abaddb1b679. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->