### PR TITLE
feat: add priority_pricing

### DIFF
--- a/.github/scripts/autogen/types.ts
+++ b/.github/scripts/autogen/types.ts
@@ -39,6 +39,7 @@ export interface components {
             output_cost_per_token?: number;
             output_cost_per_token_batches?: number;
             output_cost_per_video_token?: number;
+            priority_pricing?: components["schemas"]["Cost"];
             tiered_pricing?: components["schemas"]["TieredPricing"];
         };
         /** @description Pricing entry; "*" applies to all regions */

--- a/.github/scripts/autogen/types.ts
+++ b/.github/scripts/autogen/types.ts
@@ -39,11 +39,11 @@ export interface components {
             output_cost_per_token?: number;
             output_cost_per_token_batches?: number;
             output_cost_per_video_token?: number;
-            priority_pricing?: components["schemas"]["Cost"];
             tiered_pricing?: components["schemas"]["TieredPricing"];
         };
         /** @description Pricing entry; "*" applies to all regions */
         CostWithRegion: {
+            priority_pricing?: components["schemas"]["Cost"];
             /** @enum {string} */
             region?: "*" | "af-south-1" | "ap-east-1" | "ap-east-2" | "ap-northeast-1" | "ap-northeast-2" | "ap-northeast-3" | "ap-south-1" | "ap-south-2" | "ap-southeast-1" | "ap-southeast-2" | "ap-southeast-3" | "ap-southeast-4" | "ap-southeast-5" | "ap-southeast-6" | "ap-southeast-7" | "ca-central-1" | "ca-west-1" | "cn-north-1" | "cn-northwest-1" | "eu-central-1" | "eu-central-2" | "eu-north-1" | "eu-south-1" | "eu-south-2" | "eu-west-1" | "eu-west-2" | "eu-west-3" | "il-central-1" | "me-central-1" | "me-south-1" | "mx-central-1" | "sa-east-1" | "us-east-1" | "us-east-2" | "us-gov-east-1" | "us-gov-west-1" | "us-west-1" | "us-west-2" | "asia-east1" | "asia-east2" | "asia-northeast1" | "asia-northeast2" | "asia-northeast3" | "asia-south1" | "asia-south2" | "asia-southeast1" | "asia-southeast2" | "australia-southeast1" | "australia-southeast2" | "europe-central2" | "europe-north1" | "europe-southwest1" | "europe-west1" | "europe-west2" | "europe-west3" | "europe-west4" | "europe-west6" | "europe-west8" | "europe-west9" | "global" | "me-central1" | "me-central2" | "me-west1" | "northamerica-northeast1" | "northamerica-northeast2" | "southamerica-east1" | "us-central1" | "us-east1" | "us-east4" | "us-east5" | "us-south1" | "us-west1" | "us-west2" | "us-west3" | "us-west4" | "datazone_eu" | "datazone_us" | "us" | "eu";
         } & (components["schemas"]["Cost"] & unknown);

--- a/.github/test/model.cue
+++ b/.github/test/model.cue
@@ -128,7 +128,6 @@ package model
 	output_cost_per_token?:                	number & >= 0
 	output_cost_per_token_batches?:      	number & >= 0
 	output_cost_per_video_token?:          	number & >= 0
-	priority_pricing?:                     	#Cost
 	tiered_pricing?:                       	#TieredPricing
 
 	// Resolution-based image pricing: matches fields like output_cost_per_image_1k, output_cost_per_image_4k, etc.
@@ -141,6 +140,7 @@ package model
 #CostWithRegion: {
 	region: "*" | #AWSRegion | #GCPRegion | #AzureRegion | #VertexRegion
 	#Cost
+	priority_pricing?: #Cost
 }
 
 // Supported feature flags a model can declare

--- a/.github/test/model.cue
+++ b/.github/test/model.cue
@@ -128,6 +128,7 @@ package model
 	output_cost_per_token?:                	number & >= 0
 	output_cost_per_token_batches?:      	number & >= 0
 	output_cost_per_video_token?:          	number & >= 0
+	priority_pricing?:                     	#Cost
 	tiered_pricing?:                       	#TieredPricing
 
 	// Resolution-based image pricing: matches fields like output_cost_per_image_1k, output_cost_per_image_4k, etc.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Schema-only, optional field with no behavior changes in this diff; downstream cost calculation must explicitly use it to affect billing.
> 
> **Overview**
> Adds an optional **`priority_pricing`** block on each **`CostWithRegion`** entry so model YAML can declare a separate **`#Cost`** profile (same fields as standard pricing) alongside the existing regional **`#Cost`** fields.
> 
> The Cue schema in **`model.cue`** is the source of truth; **`types.ts`** picks up the same optional **`priority_pricing?: Cost`** on **`CostWithRegion`** via the existing OpenAPI/typegen pipeline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe8d146ba61da3f45fb4edaede6ff0241458e892. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->