### PR TITLE
add: supportedValues for reasoning effort

### DIFF
--- a/.github/scripts/autogen/types.ts
+++ b/.github/scripts/autogen/types.ts
@@ -131,6 +131,7 @@ export interface components {
             key: components["schemas"]["ModelParamKey"];
             maxValue?: number;
             minValue?: number;
+            supportedValues?: string[];
             type?: components["schemas"]["ModelParamType"];
         };
         /** @enum {string} */

--- a/.github/test/model.cue
+++ b/.github/test/model.cue
@@ -9,7 +9,8 @@ package model
 	key:           #ModelParamKey
 	maxValue?:     number
 	minValue?:     number
-	type?:         #ModelParamType
+	supportedValues?: [...string]
+	type?: #ModelParamType
 }
 
 #ModelParamKey:

--- a/.github/test/model.rules.cue
+++ b/.github/test/model.rules.cue
@@ -1,0 +1,22 @@
+package model
+
+#ReasoningEffortValue:
+	"high" |
+	"low" |
+	"max" |
+	"medium" |
+	"minimal" |
+	"none" |
+	"xhigh"
+
+#ModelParam: {
+	key: string
+	if key == "reasoning_effort" {
+		supportedValues?: [...#ReasoningEffortValue]
+	}
+
+	// If the key is not reasoning_effort, supportedValues must be absent
+	if key != "reasoning_effort" {
+		supportedValues?: _|_
+	}
+}

--- a/.github/test/validate.sh
+++ b/.github/test/validate.sh
@@ -7,6 +7,8 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MODEL_SCHEMA="$SCRIPT_DIR/model.cue"
+# Validation-only constraints; not used by type generation (see model.rules.cue)
+MODEL_RULES="$SCRIPT_DIR/model.rules.cue"
 
 # Check if cue is installed
 if ! command -v cue &> /dev/null; then
@@ -27,7 +29,7 @@ validate_file() {
         definition="#ModelConfig"
     fi
 
-    cat "$file" | cue vet "$MODEL_SCHEMA" yaml: - -d "$definition" 2>&1
+    cat "$file" | cue vet "$MODEL_SCHEMA" "$MODEL_RULES" yaml: - -d "$definition" 2>&1
 }
 
 if [ "$#" -gt 0 ]; then

--- a/providers/anthropic/default.yaml
+++ b/providers/anthropic/default.yaml
@@ -33,3 +33,12 @@ params:
       type: boolean
     - defaultValue: null
       key: tool_choice
+    - defaultValue: high
+      key: reasoning_effort
+      supportedValues:
+          - low
+          - medium
+          - high
+          - xhigh
+          - max
+      type: string

--- a/providers/azure-ai-foundry/default.yaml
+++ b/providers/azure-ai-foundry/default.yaml
@@ -3,6 +3,7 @@ documentation:
     - https://azure.microsoft.com/en-us/pricing/details/microsoft-foundry/
     - https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/foundry-models-overview
     - https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement
+    - https://learn.microsoft.com/en-us/azure/foundry/openai/concepts/model-retirement-schedule
 messages:
     options:
         - system

--- a/providers/azure-open-ai/default.yaml
+++ b/providers/azure-open-ai/default.yaml
@@ -3,6 +3,7 @@ documentation:
     - https://azure.microsoft.com/en-us/pricing/details/azure-openai/
     - https://learn.microsoft.com/en-us/azure/ai-foundry/foundry-models/concepts/models-sold-directly-by-azure
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/model-retirements
+    - https://learn.microsoft.com/en-us/azure/foundry/openai/concepts/model-retirement-schedule
 messages:
     options:
         - system

--- a/providers/google-gemini/default.yaml
+++ b/providers/google-gemini/default.yaml
@@ -34,3 +34,11 @@ params:
       type: boolean
     - defaultValue: null
       key: tool_choice
+    - defaultValue: medium
+      key: reasoning_effort
+      supportedValues:
+          - minimal
+          - low
+          - medium
+          - high
+      type: string

--- a/providers/openai/default.yaml
+++ b/providers/openai/default.yaml
@@ -40,3 +40,13 @@ params:
     - defaultValue: true
       key: parallel_tool_calls
       type: boolean
+    - defaultValue: medium
+      key: reasoning_effort
+      supportedValues:
+          - none
+          - minimal
+          - low
+          - medium
+          - high
+          - xhigh
+      type: string


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Metadata and validation for provider YAML configs only; no runtime gateway or auth logic changes.
> 
> **Overview**
> Adds optional **`supportedValues`** on **`ModelParam`** so provider defaults can declare which **`reasoning_effort`** levels each vendor allows, with matching updates in the CUE schema and generated **`types.ts`**.
> 
> Validation now loads **`model.rules.cue`**: **`supportedValues`** is only permitted when **`key`** is **`reasoning_effort`**, and entries must be from a fixed effort enum. **`validate.sh`** applies both schema and rules when vetting YAML.
> 
> **Anthropic**, **OpenAI**, and **Google Gemini** **`default.yaml`** files gain a **`reasoning_effort`** param (defaults and per-provider allowed values differ). Azure provider docs pick up an extra model-retirement schedule link only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b4e498b34ae412489c7b9d617c8dd9cb3aba797. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->