### PR TITLE
feat[reasoning_effort]: add supported values

### DIFF
--- a/.github/test/model.rules.cue
+++ b/.github/test/model.rules.cue
@@ -1,6 +1,7 @@
 package model
 
 #ReasoningEffortValue:
+	"default" |
 	"high" |
 	"low" |
 	"max" |

--- a/providers/anthropic/default.yaml
+++ b/providers/anthropic/default.yaml
@@ -3,6 +3,7 @@ documentation:
     - https://platform.claude.com/docs/en/about-claude/pricing
     - https://platform.claude.com/docs/en/about-claude/models/overview
     - https://platform.claude.com/docs/en/about-claude/model-deprecations
+    - https://platform.claude.com/docs/en/build-with-claude/effort
 messages:
     options:
         - system

--- a/providers/aws-bedrock/default.yaml
+++ b/providers/aws-bedrock/default.yaml
@@ -6,6 +6,7 @@ documentation:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/structured-output.html
     - https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html
     - https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference-supported-models-features.html
+    - https://docs.aws.amazon.com/nova/latest/nova2-userguide/extended-thinking.html
 messages:
     options:
         - system
@@ -34,3 +35,13 @@ params:
     - defaultValue: true
       key: stream
       type: boolean
+    - defaultValue: medium
+      key: reasoning_effort
+      supportedValues:
+          - none
+          - low
+          - medium
+          - high
+          - xhigh
+          - max
+      type: string

--- a/providers/azure-open-ai/default.yaml
+++ b/providers/azure-open-ai/default.yaml
@@ -4,6 +4,7 @@ documentation:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/foundry-models/concepts/models-sold-directly-by-azure
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/model-retirements
     - https://learn.microsoft.com/en-us/azure/foundry/openai/concepts/model-retirement-schedule
+    - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/reasoning
 messages:
     options:
         - system
@@ -41,3 +42,13 @@ params:
     - defaultValue: true
       key: parallel_tool_calls
       type: boolean
+    - defaultValue: medium
+      key: reasoning_effort
+      supportedValues:
+          - none
+          - minimal
+          - low
+          - medium
+          - high
+          - xhigh
+      type: string

--- a/providers/cerebras/default.yaml
+++ b/providers/cerebras/default.yaml
@@ -4,6 +4,7 @@ documentation:
     - https://cerebras.ai/pricing
     - https://inference-docs.cerebras.ai/models/overview
     - https://inference-docs.cerebras.ai/api-reference/versions
+    - https://inference-docs.cerebras.ai/capabilities/reasoning
 messages:
     options:
         - system
@@ -28,3 +29,11 @@ params:
     - defaultValue: true
       key: stream
       type: boolean
+    - defaultValue: medium
+      key: reasoning_effort
+      supportedValues:
+          - none
+          - low
+          - medium
+          - high
+      type: string

--- a/providers/databricks/default.yaml
+++ b/providers/databricks/default.yaml
@@ -1,2 +1,13 @@
 documentation:
     - https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/supported-models
+    - https://docs.databricks.com/aws/en/machine-learning/model-serving/query-reason-models
+params:
+    - defaultValue: medium
+      key: reasoning_effort
+      supportedValues:
+          - none
+          - minimal
+          - low
+          - medium
+          - high
+      type: string

--- a/providers/deepinfra/default.yaml
+++ b/providers/deepinfra/default.yaml
@@ -1,2 +1,12 @@
 documentation:
     - https://deepinfra.com/pricing
+    - https://docs.deepinfra.com/chat/reasoning
+params:
+    - defaultValue: medium
+      key: reasoning_effort
+      supportedValues:
+          - none
+          - low
+          - medium
+          - high
+      type: string

--- a/providers/google-gemini/default.yaml
+++ b/providers/google-gemini/default.yaml
@@ -5,6 +5,7 @@ documentation:
     - https://ai.google.dev/gemini-api/docs/pricing#batch
     - https://ai.google.dev/gemini-api/docs/models
     - https://ai.google.dev/gemini-api/docs/changelog
+    - https://ai.google.dev/gemini-api/docs/thinking#thinking-levels
 messages:
     options:
         - user

--- a/providers/groq/default.yaml
+++ b/providers/groq/default.yaml
@@ -3,6 +3,7 @@ documentation:
     - https://groq.com/pricing/
     - https://console.groq.com/docs/models
     - https://console.groq.com/docs/deprecations
+    - https://console.groq.com/docs/reasoning
 messages:
     options:
         - system
@@ -27,3 +28,12 @@ params:
     - defaultValue: true
       key: stream
       type: boolean
+    - defaultValue: default
+      key: reasoning_effort
+      supportedValues:
+          - none
+          - default
+          - low
+          - medium
+          - high
+      type: string

--- a/providers/openai/default.yaml
+++ b/providers/openai/default.yaml
@@ -6,6 +6,7 @@ documentation:
     - https://developers.openai.com/api/docs/models
     - https://developers.openai.com/docs/pricing
     - https://developers.openai.com/docs/deprecations
+    - https://developers.openai.com/api/docs/guides/reasoning#reasoning-effort
 messages:
     options:
         - system

--- a/providers/openrouter/default.yaml
+++ b/providers/openrouter/default.yaml
@@ -1,6 +1,7 @@
 documentation:
     - https://openrouter.ai/docs
     - https://openrouter.ai/models
+    - https://openrouter.ai/docs/guides/best-practices/reasoning-tokens
 params:
     - defaultValue: 128
       key: max_tokens
@@ -26,4 +27,14 @@ params:
       type: boolean
     - defaultValue: null
       key: response_format
+      type: string
+    - defaultValue: medium
+      key: reasoning_effort
+      supportedValues:
+          - none
+          - minimal
+          - low
+          - medium
+          - high
+          - xhigh
       type: string

--- a/providers/perplexity-ai/default.yaml
+++ b/providers/perplexity-ai/default.yaml
@@ -2,6 +2,7 @@ documentation:
     - https://docs.perplexity.ai/docs/sonar/models
     - https://docs.perplexity.ai/docs/agent-api/models
     - https://docs.perplexity.ai/docs/getting-started/pricing
+    - https://docs.perplexity.ai/api-reference/sonar-post
 messages:
     options:
         - system
@@ -34,3 +35,10 @@ params:
     - defaultValue: true
       key: stream
       type: boolean
+    - defaultValue: medium
+      key: reasoning_effort
+      supportedValues:
+          - low
+          - medium
+          - high
+      type: string

--- a/providers/sambanova/default.yaml
+++ b/providers/sambanova/default.yaml
@@ -2,3 +2,11 @@ documentation:
     - https://docs.sambanova.ai/docs/en/models/sambacloud-models
     - https://cloud.sambanova.ai/plans/pricing
     - https://docs.sambanova.ai/docs/en/models/deprecations
+params:
+    - defaultValue: medium
+      key: reasoning_effort
+      supportedValues:
+          - low
+          - medium
+          - high
+      type: string

--- a/providers/together-ai/default.yaml
+++ b/providers/together-ai/default.yaml
@@ -3,3 +3,13 @@ documentation:
     - https://docs.together.ai/docs/deprecations
     - https://docs.together.ai/docs/changelog
     - https://docs.together.ai/docs/serverless-models
+    - https://docs.together.ai/docs/inference/chat/reasoning
+params:
+    - defaultValue: medium
+      key: reasoning_effort
+      supportedValues:
+          - low
+          - medium
+          - high
+          - max
+      type: string

--- a/providers/xai/default.yaml
+++ b/providers/xai/default.yaml
@@ -2,6 +2,7 @@ documentation:
     - https://docs.x.ai
     - https://docs.x.ai/developers/models#models-and-pricing
     - https://docs.x.ai/developers/models
+    - https://docs.x.ai/developers/model-capabilities/text/reasoning
 messages:
     options:
         - system
@@ -30,3 +31,11 @@ params:
     - defaultValue: true
       key: stream
       type: boolean
+    - defaultValue: low
+      key: reasoning_effort
+      supportedValues:
+          - none
+          - low
+          - medium
+          - high
+      type: string


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Declarative provider metadata and schema validation only; no runtime inference or auth logic changes.
> 
> **Overview**
> Extends **`reasoning_effort`** provider defaults so callers can see which effort levels each integration accepts, and tightens validation so those lists use a shared enum.
> 
> **Validation:** `#ReasoningEffortValue` in `model.rules.cue` now includes **`default`** (for Groq-style APIs). Params with `key: reasoning_effort` must declare `supportedValues` drawn from that set; other params still cannot use `supportedValues`.
> 
> **Provider defaults:** Many `providers/*/default.yaml` files gain or expand a `reasoning_effort` param (`defaultValue`, `type: string`, provider-specific `supportedValues`). Sets differ by vendor—for example Bedrock/OpenRouter include `none` through `max`/`xhigh`, Perplexity/Sambanova only `low`/`medium`/`high`, Groq adds **`default`**, and xAI defaults to **`low`**. Databricks, DeepInfra, Sambanova, and Together AI add a params block where they previously had documentation only.
> 
> **Docs links:** Reasoning/thinking documentation URLs are added for Anthropic, Bedrock, Azure OpenAI, Cerebras, Databricks, DeepInfra, Gemini, Groq, OpenAI, OpenRouter, Perplexity, Together, and xAI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc06a991644a87273673cdbb808a6f8754379a02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->