### PR TITLE
fix: retire models, feature fixes

### DIFF
--- a/providers/deepinfra/ByteDance/Seed-2.0-code.yaml
+++ b/providers/deepinfra/ByteDance/Seed-2.0-code.yaml
@@ -6,7 +6,6 @@ costs:
 features:
     - prompt_caching
     - function_calling
-    - json_output
 limits:
     context_window: 256000
     max_tokens: 256000

--- a/providers/deepinfra/ByteDance/Seed-2.0-code.yaml
+++ b/providers/deepinfra/ByteDance/Seed-2.0-code.yaml
@@ -6,8 +6,8 @@ costs:
 features:
     - prompt_caching
     - function_calling
-    - json-output
-    - structured-output
+    - json_output
+    - structured_output
 limits:
     context_window: 256000
     max_tokens: 256000

--- a/providers/deepinfra/ByteDance/Seed-2.0-code.yaml
+++ b/providers/deepinfra/ByteDance/Seed-2.0-code.yaml
@@ -6,7 +6,6 @@ costs:
 features:
     - prompt_caching
     - function_calling
-    - json_output
     - structured_output
 limits:
     context_window: 256000

--- a/providers/deepinfra/ByteDance/Seed-2.0-code.yaml
+++ b/providers/deepinfra/ByteDance/Seed-2.0-code.yaml
@@ -6,6 +6,8 @@ costs:
 features:
     - prompt_caching
     - function_calling
+    - json-output
+    - structured-output
 limits:
     context_window: 256000
     max_tokens: 256000

--- a/providers/deepinfra/google/gemini-2.0-flash-001.yaml
+++ b/providers/deepinfra/google/gemini-2.0-flash-001.yaml
@@ -11,3 +11,4 @@ limits:
     max_tokens: 1000000
 mode: chat
 model: google/gemini-2.0-flash-001
+status: retired

--- a/providers/google-gemini/gemini-2.0-flash-001.yaml
+++ b/providers/google-gemini/gemini-2.0-flash-001.yaml
@@ -26,3 +26,4 @@ modalities:
         - pdf
 mode: chat
 model: gemini-2.0-flash-001
+status: retired

--- a/providers/google-gemini/gemini-2.0-flash-lite-001.yaml
+++ b/providers/google-gemini/gemini-2.0-flash-lite-001.yaml
@@ -23,3 +23,4 @@ modalities:
         - audio
 mode: chat
 model: gemini-2.0-flash-lite-001
+status: retired

--- a/providers/google-gemini/gemini-2.0-flash-lite.yaml
+++ b/providers/google-gemini/gemini-2.0-flash-lite.yaml
@@ -23,3 +23,4 @@ modalities:
         - audio
 mode: chat
 model: gemini-2.0-flash-lite
+status: retired

--- a/providers/google-gemini/gemini-2.0-flash.yaml
+++ b/providers/google-gemini/gemini-2.0-flash.yaml
@@ -33,3 +33,4 @@ params:
     - defaultValue: null
       key: response_format
       type: string
+status: retired

--- a/providers/google-vertex/anthropic/claude-opus-4-8.yaml
+++ b/providers/google-vertex/anthropic/claude-opus-4-8.yaml
@@ -45,6 +45,8 @@ params:
       maxValue: 128000
       minValue: 1
 provisioning: serverless
+removeParams:
+    - temperature
 sources:
     - https://platform.claude.com/docs/en/about-claude/models/overview
     - https://platform.claude.com/docs/en/about-claude/pricing

--- a/providers/google-vertex/gemini-2.0-flash-001.yaml
+++ b/providers/google-vertex/gemini-2.0-flash-001.yaml
@@ -143,6 +143,7 @@ features:
     - prompt_caching
     - structured_output
     - code_execution
+isDeprecated: true
 limits:
     context_window: 1048576
     max_input_tokens: 1048576
@@ -169,6 +170,6 @@ provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-0-flash
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/context-cache/context-cache-overview
-status: active
+status: retired
 supportedModes:
     - chat

--- a/providers/google-vertex/gemini-2.0-flash-lite-001.yaml
+++ b/providers/google-vertex/gemini-2.0-flash-lite-001.yaml
@@ -187,6 +187,7 @@ features:
     - tool_choice
     - prompt_caching
     - structured_output
+isDeprecated: true
 limits:
     context_window: 1048576
     max_input_tokens: 1048576
@@ -221,6 +222,6 @@ provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-0-flash-lite
     - https://ai.google.dev/gemini-api/docs/changelog
-status: active
+status: retired
 supportedModes:
     - chat

--- a/providers/google-vertex/gemini-2.0-flash-lite.yaml
+++ b/providers/google-vertex/gemini-2.0-flash-lite.yaml
@@ -97,6 +97,7 @@ features:
     - tool_choice
     - prompt_caching
     - structured_output
+isDeprecated: true
 limits:
     context_window: 1048576
     max_input_tokens: 1048576
@@ -118,6 +119,6 @@ provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-0-flash-lite
     - https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/gemini/2-0-flash-lite
-status: active
+status: retired
 supportedModes:
     - chat

--- a/providers/google-vertex/gemini-2.0-flash.yaml
+++ b/providers/google-vertex/gemini-2.0-flash.yaml
@@ -144,6 +144,7 @@ features:
     - structured_output
     - code_execution
     - json_output
+isDeprecated: true
 limits:
     context_window: 1048576
     max_input_tokens: 1048576
@@ -167,6 +168,6 @@ provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-0-flash
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/context-cache/context-cache-overview
-status: active
+status: retired
 supportedModes:
     - chat

--- a/providers/google-vertex/google/gemini-2.0-flash-001.yaml
+++ b/providers/google-vertex/google/gemini-2.0-flash-001.yaml
@@ -16,6 +16,7 @@ features:
     - json_output
     - code_execution
     - prompt_caching
+isDeprecated: true
 limits:
     context_window: 1048576
     max_input_tokens: 1048576
@@ -42,6 +43,6 @@ provisioning: serverless
 sources:
     - https://firebase.google.com/docs/ai-logic/models
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-0-flash
-status: active
+status: retired
 supportedModes:
     - chat

--- a/providers/google-vertex/google/gemini-2.0-flash-lite-001.yaml
+++ b/providers/google-vertex/google/gemini-2.0-flash-lite-001.yaml
@@ -96,6 +96,7 @@ features:
     - structured_output
     - prompt_caching
     - json_output
+isDeprecated: true
 limits:
     context_window: 1048576
     max_input_tokens: 1048576
@@ -121,6 +122,6 @@ provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-0-flash-lite
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/model-versions
-status: active
+status: retired
 supportedModes:
     - chat

--- a/providers/openrouter/alibaba/tongyi-deepresearch-30b-a3b.yaml
+++ b/providers/openrouter/alibaba/tongyi-deepresearch-30b-a3b.yaml
@@ -9,6 +9,7 @@ features:
     - prompt_caching
     - structured_output
     - tool_choice
+isDeprecated: true
 limits:
     context_window: 131072
 modalities:
@@ -22,7 +23,7 @@ provisioning: serverless
 sources:
     - https://openrouter.ai/alibaba/tongyi-deepresearch-30b-a3b
     - https://openrouter.ai/alibaba/tongyi-deepresearch-30b-a3b/api
-status: active
+status: retired
 supportedModes:
     - chat
 thinking: true

--- a/providers/openrouter/arcee-ai/trinity-large-preview.yaml
+++ b/providers/openrouter/arcee-ai/trinity-large-preview.yaml
@@ -6,6 +6,7 @@ features:
     - function_calling
     - json_output
     - structured_output
+isDeprecated: true
 limits:
     context_window: 131000
 modalities:
@@ -23,6 +24,6 @@ params:
 provisioning: serverless
 sources:
     - https://openrouter.ai/arcee-ai/trinity-large-preview
-status: active
+status: retired
 supportedModes:
     - chat

--- a/providers/openrouter/baidu/ernie-4.5-21b-a3b-thinking.yaml
+++ b/providers/openrouter/baidu/ernie-4.5-21b-a3b-thinking.yaml
@@ -2,6 +2,7 @@ costs:
     - input_cost_per_token: 7e-8
       output_cost_per_token: 2.8e-7
       region: "*"
+isDeprecated: true
 limits:
     context_window: 131072
     max_output_tokens: 65536
@@ -21,7 +22,7 @@ params:
 provisioning: serverless
 sources:
     - https://openrouter.ai/baidu/ernie-4.5-21b-a3b-thinking/api
-status: active
+status: retired
 supportedModes:
     - chat
 thinking: true

--- a/providers/openrouter/baidu/ernie-4.5-21b-a3b.yaml
+++ b/providers/openrouter/baidu/ernie-4.5-21b-a3b.yaml
@@ -5,6 +5,7 @@ costs:
 features:
     - function_calling
     - tool_choice
+isDeprecated: true
 limits:
     context_window: 120000
     max_output_tokens: 8000
@@ -20,6 +21,6 @@ provisioning: serverless
 sources:
     - https://openrouter.ai/baidu/ernie-4.5-21b-a3b
     - https://openrouter.ai/baidu/ernie-4.5-21b-a3b/api
-status: active
+status: retired
 supportedModes:
     - chat

--- a/providers/openrouter/baidu/ernie-4.5-300b-a47b.yaml
+++ b/providers/openrouter/baidu/ernie-4.5-300b-a47b.yaml
@@ -5,6 +5,7 @@ costs:
 features:
     - json_output
     - structured_output
+isDeprecated: true
 limits:
     context_window: 123000
     max_output_tokens: 12000
@@ -27,6 +28,6 @@ removeParams:
 sources:
     - https://openrouter.ai/baidu/ernie-4.5-300b-a47b
     - https://openrouter.ai/baidu/ernie-4.5-300b-a47b/api
-status: active
+status: retired
 supportedModes:
     - chat

--- a/providers/openrouter/gemini-2.0-flash-001.yaml
+++ b/providers/openrouter/gemini-2.0-flash-001.yaml
@@ -9,4 +9,4 @@ model: gemini-2.0-flash-001
 params:
     - key: max_tokens
       maxValue: 8192
-status: deprecated
+status: retired

--- a/providers/openrouter/gemini-2.0-flash-lite-001.yaml
+++ b/providers/openrouter/gemini-2.0-flash-lite-001.yaml
@@ -9,4 +9,4 @@ model: gemini-2.0-flash-lite-001
 params:
     - key: max_tokens
       maxValue: 8192
-status: deprecated
+status: retired

--- a/providers/openrouter/google/gemini-2.0-flash-001.yaml
+++ b/providers/openrouter/google/gemini-2.0-flash-001.yaml
@@ -14,6 +14,7 @@ features:
     - structured_output
     - prompt_caching
     - json_output
+isDeprecated: true
 limits:
     context_window: 1048576
     max_input_tokens: 1048576
@@ -33,6 +34,6 @@ model: google/gemini-2.0-flash-001
 provisioning: serverless
 sources:
     - https://openrouter.ai/google/gemini-2.0-flash-001
-status: active
+status: retired
 supportedModes:
     - chat

--- a/providers/openrouter/mistralai/devstral-medium.yaml
+++ b/providers/openrouter/mistralai/devstral-medium.yaml
@@ -9,6 +9,7 @@ features:
     - prompt_caching
     - structured_output
     - tool_choice
+isDeprecated: true
 limits:
     context_window: 131072
 modalities:
@@ -23,6 +24,6 @@ sources:
     - https://openrouter.ai/mistralai/devstral-medium
     - https://openrouter.ai/mistralai/devstral-medium/api
     - https://docs.mistral.ai/models/devstral-medium-1-0-25-07
-status: active
+status: retired
 supportedModes:
     - chat

--- a/providers/openrouter/mistralai/devstral-small.yaml
+++ b/providers/openrouter/mistralai/devstral-small.yaml
@@ -9,6 +9,7 @@ features:
     - prompt_caching
     - structured_output
     - tool_choice
+isDeprecated: true
 limits:
     context_window: 131072
 modalities:
@@ -22,6 +23,6 @@ provisioning: serverless
 sources:
     - https://openrouter.ai/mistralai/devstral-small
     - https://openrouter.ai/mistralai/devstral-small/api
-status: active
+status: retired
 supportedModes:
     - chat

--- a/providers/openrouter/mistralai/mistral-7b-instruct-v0.1.yaml
+++ b/providers/openrouter/mistralai/mistral-7b-instruct-v0.1.yaml
@@ -2,6 +2,7 @@ costs:
     - input_cost_per_token: 1.1e-7
       output_cost_per_token: 1.9e-7
       region: "*"
+isDeprecated: true
 limits:
     context_window: 2824
 modalities:
@@ -14,6 +15,6 @@ model: mistralai/mistral-7b-instruct-v0.1
 provisioning: serverless
 sources:
     - https://openrouter.ai/mistralai/mistral-7b-instruct-v0.1
-status: active
+status: retired
 supportedModes:
     - chat

--- a/providers/openrouter/mistralai/mistral-large-2411.yaml
+++ b/providers/openrouter/mistralai/mistral-large-2411.yaml
@@ -9,6 +9,7 @@ features:
     - prompt_caching
     - structured_output
     - tool_choice
+isDeprecated: true
 limits:
     context_window: 131072
 modalities:
@@ -22,6 +23,6 @@ provisioning: serverless
 sources:
     - https://openrouter.ai/mistralai/mistral-large-2411/api
     - https://openrouter.ai/mistralai/mistral-large-2411
-status: active
+status: retired
 supportedModes:
     - chat

--- a/providers/openrouter/mistralai/pixtral-large-2411.yaml
+++ b/providers/openrouter/mistralai/pixtral-large-2411.yaml
@@ -9,6 +9,7 @@ features:
     - prompt_caching
     - structured_output
     - tool_choice
+isDeprecated: true
 limits:
     context_window: 131072
     max_output_tokens: 4096
@@ -25,6 +26,6 @@ provisioning: serverless
 sources:
     - https://openrouter.ai/mistralai/pixtral-large-2411/api
     - https://openrouter.ai/mistralai/pixtral-large-2411
-status: active
+status: retired
 supportedModes:
     - chat


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Catalog-only changes, but marking models retired affects routing and discoverability for anyone still referencing those IDs; incorrect entries could hide usable models or leave bad ones selectable.
> 
> **Overview**
> This PR **updates provider model catalog YAML** to reflect models that are no longer available or should not be selected, plus a couple of capability/param fixes.
> 
> **Lifecycle:** Many entries across **google-gemini**, **google-vertex**, **deepinfra**, and **openrouter** move to **`status: retired`** (from `active` or `deprecated`). Several **Gemini 2.0 Flash / Flash Lite** variants on Vertex also gain **`isDeprecated: true`** alongside retirement. **OpenRouter** listings for Mistral, Baidu ERNIE, Alibaba Tongyi, Arcee Trinity, and related Gemini 2.0 routes follow the same pattern.
> 
> **Metadata tweaks:** **ByteDance/Seed-2.0-code** on DeepInfra replaces the **`json_output`** feature with **`structured_output`**. **anthropic/claude-opus-4-8** on Google Vertex adds **`removeParams: [temperature]`** so callers do not send an unsupported parameter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 123f1a531883356d27c5488a3cbc46d7c0d0b260. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->