### PR TITLE
fix[deepinfra]: response-schema

### DIFF
--- a/providers/deepinfra/MiniMaxAI/MiniMax-M2.7.yaml
+++ b/providers/deepinfra/MiniMaxAI/MiniMax-M2.7.yaml
@@ -6,7 +6,7 @@ costs:
 features:
     - prompt_caching
     - function_calling
-    - json_output
+    - structured_output
 limits:
     context_window: 196608
     max_tokens: 196608

--- a/providers/deepinfra/NousResearch/Hermes-3-Llama-3.1-405B.yaml
+++ b/providers/deepinfra/NousResearch/Hermes-3-Llama-3.1-405B.yaml
@@ -4,7 +4,7 @@ costs:
       region: "*"
 features:
     # - function_calling is not supported for this model
-    - json_output
+    - structured_output
 limits:
     context_window: 131072
 modalities:

--- a/providers/deepinfra/NousResearch/Hermes-3-Llama-3.1-70B.yaml
+++ b/providers/deepinfra/NousResearch/Hermes-3-Llama-3.1-70B.yaml
@@ -4,7 +4,7 @@ costs:
       region: "*"
 features:
     # - function_calling is not supported for this model
-    - json_output
+    - structured_output
     - prompt_caching
 limits:
     context_window: 131072

--- a/providers/deepinfra/Qwen/Qwen2.5-72B-Instruct.yaml
+++ b/providers/deepinfra/Qwen/Qwen2.5-72B-Instruct.yaml
@@ -4,7 +4,7 @@ costs:
       region: "*"
 features:
     - function_calling
-    - json_output
+    - structured_output
     - prompt_caching
 limits:
     context_window: 32768

--- a/providers/deepinfra/Qwen/Qwen3-14B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-14B.yaml
@@ -4,7 +4,7 @@ costs:
       region: "*"
 features:
     - function_calling
-    - json_output
+    - structured_output
     - prompt_caching
 limits:
     context_window: 40960

--- a/providers/deepinfra/Qwen/Qwen3-30B-A3B.yaml
+++ b/providers/deepinfra/Qwen/Qwen3-30B-A3B.yaml
@@ -4,7 +4,7 @@ costs:
       region: "*"
 features:
     - function_calling
-    - json_output
+    - structured_output
     - prompt_caching
 limits:
     context_window: 40960

--- a/providers/deepinfra/Sao10K/L3-8B-Lunaris-v1-Turbo.yaml
+++ b/providers/deepinfra/Sao10K/L3-8B-Lunaris-v1-Turbo.yaml
@@ -3,7 +3,7 @@ costs:
       output_cost_per_token: 5e-8
       region: "*"
 features:
-    - json_output
+    - structured_output
 limits:
     context_window: 8192
     max_input_tokens: 8192

--- a/providers/deepinfra/Sao10K/L3.1-70B-Euryale-v2.2.yaml
+++ b/providers/deepinfra/Sao10K/L3.1-70B-Euryale-v2.2.yaml
@@ -4,7 +4,7 @@ costs:
       region: "*"
 features:
     - prompt_caching
-    - json_output
+    - structured_output
 limits:
     context_window: 131072
 modalities:

--- a/providers/deepinfra/deepseek-ai/DeepSeek-R1-Distill-Llama-70B.yaml
+++ b/providers/deepinfra/deepseek-ai/DeepSeek-R1-Distill-Llama-70B.yaml
@@ -3,7 +3,7 @@ costs:
       output_cost_per_token: 8e-7
       region: "*"
 features:
-    - json_output
+    - structured_output
 limits:
     context_window: 131072
     max_input_tokens: 131072

--- a/providers/deepinfra/deepseek-ai/DeepSeek-V3-0324.yaml
+++ b/providers/deepinfra/deepseek-ai/DeepSeek-V3-0324.yaml
@@ -6,7 +6,7 @@ costs:
 features:
     - prompt_caching
     - function_calling
-    - json_output
+    - structured_output
 limits:
     context_window: 163840
     max_input_tokens: 163840

--- a/providers/deepinfra/deepseek-ai/DeepSeek-V3.yaml
+++ b/providers/deepinfra/deepseek-ai/DeepSeek-V3.yaml
@@ -4,7 +4,7 @@ costs:
       region: "*"
 features:
     - function_calling
-    - json_output
+    - structured_output
     - prompt_caching
 limits:
     context_window: 163840

--- a/providers/deepinfra/google/gemini-3.5-flash.yaml
+++ b/providers/deepinfra/google/gemini-3.5-flash.yaml
@@ -4,7 +4,7 @@ costs:
       region: "*"
 features:
     - function_calling
-    - json_output
+    - structured_output
 limits:
     context_window: 1000000
     max_tokens: 1000000

--- a/providers/deepinfra/meta-llama/Llama-4-Scout-17B-16E-Instruct.yaml
+++ b/providers/deepinfra/meta-llama/Llama-4-Scout-17B-16E-Instruct.yaml
@@ -4,7 +4,7 @@ costs:
       region: "*"
 features:
     - function_calling
-    - json_output
+    - structured_output
 limits:
     context_window: 327680
     max_input_tokens: 327680

--- a/providers/deepinfra/meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo.yaml
+++ b/providers/deepinfra/meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo.yaml
@@ -4,7 +4,7 @@ costs:
       region: "*"
 features:
     - function_calling
-    - json_output
+    - structured_output
 limits:
     context_window: 131072
     max_input_tokens: 131072

--- a/providers/deepinfra/meta-llama/Meta-Llama-3.1-70B-Instruct.yaml
+++ b/providers/deepinfra/meta-llama/Meta-Llama-3.1-70B-Instruct.yaml
@@ -4,7 +4,7 @@ costs:
       region: "*"
 features:
     - function_calling
-    - json_output
+    - structured_output
 limits:
     context_window: 131072
     max_input_tokens: 131072

--- a/providers/deepinfra/meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo.yaml
+++ b/providers/deepinfra/meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo.yaml
@@ -4,7 +4,7 @@ costs:
       region: "*"
 features:
     - function_calling
-    - json_output
+    - structured_output
 limits:
     context_window: 131072
     max_input_tokens: 131072

--- a/providers/deepinfra/meta-llama/Meta-Llama-3.1-8B-Instruct.yaml
+++ b/providers/deepinfra/meta-llama/Meta-Llama-3.1-8B-Instruct.yaml
@@ -4,7 +4,7 @@ costs:
       region: "*"
 features:
     - function_calling
-    - json_output
+    - structured_output
     - prompt_caching
 limits:
     context_window: 131072

--- a/providers/deepinfra/microsoft/phi-4.yaml
+++ b/providers/deepinfra/microsoft/phi-4.yaml
@@ -3,7 +3,7 @@ costs:
       output_cost_per_token: 1.4e-7
       region: "*"
 features:
-    - json_output
+    - structured_output
 limits:
     context_window: 16384
     max_input_tokens: 16384

--- a/providers/deepinfra/mistralai/Mistral-Small-24B-Instruct-2501.yaml
+++ b/providers/deepinfra/mistralai/Mistral-Small-24B-Instruct-2501.yaml
@@ -4,7 +4,7 @@ costs:
       region: "*"
 features:
     # - function_calling is not supported for this model
-    - json_output
+    - structured_output
 limits:
     context_window: 32768
     max_input_tokens: 32768

--- a/providers/deepinfra/mistralai/Mistral-Small-3.2-24B-Instruct-2506.yaml
+++ b/providers/deepinfra/mistralai/Mistral-Small-3.2-24B-Instruct-2506.yaml
@@ -4,7 +4,7 @@ costs:
       region: "*"
 features:
     - function_calling
-    - json_output
+    - structured_output
 limits:
     context_window: 128000
     max_input_tokens: 128000


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Metadata-only feature flag changes in provider YAML; no runtime code paths modified.
> 
> **Overview**
> Updates **DeepInfra** model metadata across many chat models so the `features` list advertises **`structured_output`** instead of **`json_output`**.
> 
> This is a metadata-only rename aligned with how the catalog distinguishes generic JSON output from **JSON-schema / response-schema** constrained generation (matching the response-schema fix in the PR title). Pricing, limits, modalities, and other flags are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ad570c372ecac710447a6430418018a8c0e6ed0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->