### PR TITLE
fix: retire models, remove params, provision models

### DIFF
--- a/providers/aws-bedrock/au.anthropic.claude-opus-4-8.yaml
+++ b/providers/aws-bedrock/au.anthropic.claude-opus-4-8.yaml
@@ -38,6 +38,8 @@ params:
       maxValue: 128000
       minValue: 1
 provisioning: serverless
+removeParams:
+    - temperature
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-4-8.html
     - https://platform.claude.com/docs/en/about-claude/pricing

--- a/providers/aws-bedrock/eu.amazon.nova-lite-v1:0.yaml
+++ b/providers/aws-bedrock/eu.amazon.nova-lite-v1:0.yaml
@@ -33,7 +33,7 @@ features:
     - tool_choice
     - prompt_caching
     - assistant_prefill
-    - structured_output
+    # - structured_output is not supported
 limits:
     context_window: 300000
     max_input_tokens: 300000

--- a/providers/aws-bedrock/jp.amazon.nova-2-lite-v1:0.yaml
+++ b/providers/aws-bedrock/jp.amazon.nova-2-lite-v1:0.yaml
@@ -8,7 +8,7 @@ features:
     - prompt_caching
     - system_messages
     - tool_choice
-    - structured_output
+    # - structured_output is not supported
 limits:
     context_window: 1000000
     max_input_tokens: 1000000

--- a/providers/aws-bedrock/us.amazon.nova-pro-v1:0.yaml
+++ b/providers/aws-bedrock/us.amazon.nova-pro-v1:0.yaml
@@ -19,7 +19,7 @@ features:
     - prompt_caching
     - system_messages
     - tool_choice
-    - structured_output
+    # - structured_output is not supported
     - assistant_prefill
 limits:
     context_window: 300000

--- a/providers/aws-bedrock/us.anthropic.claude-opus-4-8.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-opus-4-8.yaml
@@ -71,6 +71,8 @@ params:
     - key: thinking
       type: json
 provisioning: serverless
+removeParams:
+    - temperature
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-4-8.html
     - https://platform.claude.com/docs/en/about-claude/models/overview

--- a/providers/aws-bedrock/us.writer.palmyra-x5-v1:0.yaml
+++ b/providers/aws-bedrock/us.writer.palmyra-x5-v1:0.yaml
@@ -13,7 +13,7 @@ costs:
       region: us-east-1
 features:
     - function_calling
-    - structured_output
+    # - structured_output is not supported
 limits:
     context_window: 1048192
     max_input_tokens: 1040000

--- a/providers/google-vertex/meta/llama4.yaml
+++ b/providers/google-vertex/meta/llama4.yaml
@@ -25,7 +25,7 @@ params:
       key: max_tokens
       maxValue: 8192
       minValue: 1
-provisioning: serverless
+provisioning: provisioned
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/llama
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/llama/llama4-maverick

--- a/providers/mistral-ai/mistral-embed-dim256-2510.yaml
+++ b/providers/mistral-ai/mistral-embed-dim256-2510.yaml
@@ -10,4 +10,6 @@ modalities:
         - embedding
 mode: embedding
 model: mistral-embed-dim256-2510
+removeParams:
+    - max_tokens
 status: active

--- a/providers/openai/gpt-3.5-turbo-instruct.yaml
+++ b/providers/openai/gpt-3.5-turbo-instruct.yaml
@@ -14,7 +14,7 @@ modalities:
         - text
     output:
         - text
-mode: responses
+mode: chat
 model: gpt-3.5-turbo-instruct
 provisioning: serverless
 removeParams:

--- a/providers/openrouter/baidu/ernie-4.5-vl-28b-a3b.yaml
+++ b/providers/openrouter/baidu/ernie-4.5-vl-28b-a3b.yaml
@@ -5,6 +5,7 @@ costs:
 features:
     - function_calling
     - tool_choice
+isDeprecated: true
 limits:
     context_window: 30000
     max_output_tokens: 8000
@@ -19,8 +20,8 @@ mode: chat
 model: baidu/ernie-4.5-vl-28b-a3b
 provisioning: serverless
 sources:
-    - https://openrouter.ai/baidu/ernie-4.5-vl-28b-a3b/api
-status: active
+    - https://openrouter.ai/baidu/ernie-4.5-vl-28b-a3b
+status: retired
 supportedModes:
     - chat
 thinking: true

--- a/providers/openrouter/nex-agi/deepseek-v3.1-nex-n1.yaml
+++ b/providers/openrouter/nex-agi/deepseek-v3.1-nex-n1.yaml
@@ -8,6 +8,7 @@ features:
     - json_output
     - structured_output
     - tool_choice
+isDeprecated: true
 limits:
     context_window: 131072
     max_output_tokens: 163840
@@ -22,7 +23,6 @@ model: nex-agi/deepseek-v3.1-nex-n1
 provisioning: serverless
 sources:
     - https://openrouter.ai/nex-agi/deepseek-v3.1-nex-n1
-    - https://openrouter.ai/nex-agi/deepseek-v3.1-nex-n1/api
-status: active
+status: retired
 supportedModes:
     - chat

--- a/providers/openrouter/qwen/qwen-2.5-7b-instruct.yaml
+++ b/providers/openrouter/qwen/qwen-2.5-7b-instruct.yaml
@@ -3,7 +3,7 @@ costs:
       output_cost_per_token: 1e-7
       region: "*"
 features:
-    - function_calling
+    # - function_calling is not supported
     - json_output
     - tool_choice
 limits:

--- a/providers/openrouter/sao10k/l3-euryale-70b.yaml
+++ b/providers/openrouter/sao10k/l3-euryale-70b.yaml
@@ -6,6 +6,7 @@ deprecationDate: "2026-06-05"
 features:
     - function_calling
     - tool_choice
+isDeprecated: true
 limits:
     context_window: 8192
     max_output_tokens: 8192
@@ -21,6 +22,6 @@ provisioning: serverless
 sources:
     - https://openrouter.ai/sao10k/l3-euryale-70b
     - https://openrouter.ai/sao10k/l3-euryale-70b/api
-status: active
+status: retired
 supportedModes:
     - chat

--- a/providers/together-ai/Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8.yaml
+++ b/providers/together-ai/Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8.yaml
@@ -17,7 +17,7 @@ modalities:
         - text
 mode: chat
 model: Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8
-provisioning: serverless
+provisioning: provisioned
 sources:
     - https://www.together.ai/models/qwen3-coder-480b-a35b-instruct
     - https://docs.together.ai/docs/function-calling

--- a/providers/together-ai/meta-llama/Llama-3.3-70B-Instruct-Turbo-test.yaml
+++ b/providers/together-ai/meta-llama/Llama-3.3-70B-Instruct-Turbo-test.yaml
@@ -9,6 +9,7 @@ features:
     - structured_output
     - json_output
     - system_messages
+isDeprecated: true
 limits:
     context_window: 131072
 modalities:
@@ -22,6 +23,6 @@ provisioning: serverless
 sources:
     - https://docs.together.ai/docs/function-calling
     - https://docs.together.ai/docs/json-mode
-status: active
+status: retired
 supportedModes:
     - chat


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> YAML-only provider metadata changes; no application logic, but retired models and param stripping can affect which models appear and which request fields are sent.
> 
> **Overview**
> Updates provider model catalog YAML to align capabilities, routing, and lifecycle with current provider behavior.
> 
> **Claude Opus 4-8** on AWS Bedrock (`au`/`us`) now **strips `temperature`** via `removeParams` (consistent with thinking-enabled configs). **Mistral** `mistral-embed-dim256-2510` drops **`max_tokens`** the same way; **OpenAI** `gpt-3.5-turbo-instruct` primary **`mode` is `chat`** instead of `responses`.
> 
> Several **Bedrock Nova / Palmyra** entries no longer advertise **`structured_output`** (left as comments that it is unsupported). **Vertex** `meta/llama4` and **Together** `Qwen3-Coder-480B` switch **`provisioning` from `serverless` to `provisioned`**.
> 
> **OpenRouter** models **ERNIE 4.5 VL**, **DeepSeek v3.1 Nex N1**, and **L3 Euryale 70B** are marked **`isDeprecated: true`** with **`status: retired`**; **Qwen 2.5 7B Instruct** drops **`function_calling`**. **Together** `Llama-3.3-70B-Instruct-Turbo-test` is also **retired**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 554396504b74c0b020131e5f1c518de14ff70176. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->