### PR TITLE
chore[bedrock]: structured_output support for claude opus 4.7, 4.8

### DIFF
--- a/providers/aws-bedrock/au.anthropic.claude-opus-4-8.yaml
+++ b/providers/aws-bedrock/au.anthropic.claude-opus-4-8.yaml
@@ -18,7 +18,7 @@ features:
     - system_messages
     - tool_choice
     - prompt_caching
-    - structured_output
+    # - structured_output is not supported in bedrock-converse
     - assistant_prefill
 limits:
     context_window: 1000000

--- a/providers/aws-bedrock/eu.anthropic.claude-opus-4-7.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-opus-4-7.yaml
@@ -52,7 +52,7 @@ features:
     - cache_control
     - function_calling
     - prompt_caching
-    - structured_output
+    # - structured_output is not supported in bedrock-converse
     - system_messages
     - tool_choice
 limits:

--- a/providers/aws-bedrock/eu.anthropic.claude-opus-4-8.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-opus-4-8.yaml
@@ -70,7 +70,7 @@ features:
     - system_messages
     - tool_choice
     - prompt_caching
-    - structured_output
+    # - structured_output is not supported in bedrock-converse
     - assistant_prefill
 limits:
     context_window: 1000000

--- a/providers/aws-bedrock/global.anthropic.claude-opus-4-7.yaml
+++ b/providers/aws-bedrock/global.anthropic.claude-opus-4-7.yaml
@@ -186,7 +186,7 @@ features:
     - system_messages
     - prompt_caching
     - cache_control
-    - structured_output
+    # - structured_output is not supported in bedrock-converse
     - tool_choice
 limits:
     context_window: 1000000

--- a/providers/aws-bedrock/jp.anthropic.claude-opus-4-7.yaml
+++ b/providers/aws-bedrock/jp.anthropic.claude-opus-4-7.yaml
@@ -18,7 +18,7 @@ features:
     - tool_choice
     - prompt_caching
     - cache_control
-    - structured_output
+    # - structured_output is not supported in bedrock-converse
     - assistant_prefill
 limits:
     context_window: 1000000

--- a/providers/aws-bedrock/jp.anthropic.claude-opus-4-8.yaml
+++ b/providers/aws-bedrock/jp.anthropic.claude-opus-4-8.yaml
@@ -22,7 +22,7 @@ features:
     - system_messages
     - tool_choice
     - prompt_caching
-    - structured_output
+    # - structured_output is not supported in bedrock-converse
     - assistant_prefill
 limits:
     context_window: 1000000

--- a/providers/aws-bedrock/us.anthropic.claude-opus-4-8.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-opus-4-8.yaml
@@ -46,7 +46,7 @@ features:
     - system_messages
     - prompt_caching
     - cache_control
-    - structured_output
+    # - structured_output is not supported in bedrock-converse
     - assistant_prefill
     - json_output
 limits:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Metadata-only changes to model feature flags; no runtime code paths, but may affect routing or UI that gates structured-output requests on these models.
> 
> **Overview**
> **Removes `structured_output` from the advertised feature lists** for Claude Opus **4.7** and **4.8** across seven AWS Bedrock provider YAMLs (au, eu, global, jp, and us regional variants).
> 
> Each former `- structured_output` entry is replaced with a comment noting that **structured output is not supported in bedrock-converse**, so callers relying on these catalogs should no longer treat those models as supporting structured output on the Converse path. Other features (e.g. `json_output` on the US 4.8 config) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6656fed37b2c7a434eac47a85ce399017452b63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->