### PR TITLE
Add retirement dates

### DIFF
--- a/.github/scripts/autogen/types.ts
+++ b/.github/scripts/autogen/types.ts
@@ -118,6 +118,8 @@ export interface components {
             removeParams?: components["schemas"]["ModelParamKey"][];
             /** @description Param keys that must always be provided by callers */
             requiredParams?: components["schemas"]["ModelParamKey"][];
+            /** @description Retirement date of the model (YYYY-MM-DD) */
+            retirementDate?: string;
             /** @description Documentation or pricing source URLs */
             sources?: string[];
             status?: components["schemas"]["Status"];

--- a/.github/test/model.cue
+++ b/.github/test/model.cue
@@ -311,7 +311,7 @@ package model
 // Lifecycle status of a model
 #Status:
 	"active" |      // Model is fully supported and recommended for use (aka stable, ga)
-	"deprecated" |  // Model is deprecated and may be removed in the future
+	"deprecated" |  // Model is deprecated and may be removed in the future (aka legacy)
 	"preview" |     // Model is in early access and may change or have limited support (aka beta, experimental)
 	"retired"       // Model has been fully removed and is no longer accessible (aka removed, deleted, end-of-life)
 

--- a/.github/test/model.cue
+++ b/.github/test/model.cue
@@ -279,6 +279,8 @@ package model
 	removeParams?: [...#ModelParamKey]
 	// Param keys that must always be provided by callers
 	requiredParams?: [...#ModelParamKey]
+	// Retirement date of the model (YYYY-MM-DD)
+	retirementDate?: string & =~"^\\d{4}-\\d{2}-\\d{2}$"
 	// Documentation or pricing source URLs
 	sources?: [...string]
 	// Lifecycle status of the model
@@ -309,9 +311,9 @@ package model
 // Lifecycle status of a model
 #Status:
 	"active" |      // Model is fully supported and recommended for use (aka stable, ga)
-	"deprecated" |  // Model is deprecated and may be removed in the future (aka sunset, end-of-life)
+	"deprecated" |  // Model is deprecated and may be removed in the future
 	"preview" |     // Model is in early access and may change or have limited support (aka beta, experimental)
-	"retired"       // Model has been fully removed and is no longer accessible (aka removed, deleted)
+	"retired"       // Model has been fully removed and is no longer accessible (aka removed, deleted, end-of-life)
 
 #TieredPricing: {
 	cache_read?:  [...#PricingTier]

--- a/providers/aws-bedrock/default.yaml
+++ b/providers/aws-bedrock/default.yaml
@@ -1,6 +1,7 @@
 documentation:
     - https://docs.aws.amazon.com/bedrock/
     - https://aws.amazon.com/bedrock/pricing/
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/model-cards.html
     - https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-lifecycle.html
     - https://docs.aws.amazon.com/bedrock/latest/userguide/structured-output.html

--- a/providers/aws-bedrock/meta.llama3-1-405b-instruct-v1:0.yaml
+++ b/providers/aws-bedrock/meta.llama3-1-405b-instruct-v1:0.yaml
@@ -1,10 +1,13 @@
 costs:
     - region: us-west-2
-isDeprecated: true
 modalities:
     input:
         - text
     output:
         - text
-mode: unknown
+mode: chat
 model: meta.llama3-1-405b-instruct-v1:0
+retirementDate: "2026-07-07"
+sources:
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-meta-llama-3-1-405b-instruct.html
+status: deprecated

--- a/providers/aws-bedrock/us.anthropic.claude-sonnet-4-20250514-v1:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-sonnet-4-20250514-v1:0.yaml
@@ -35,7 +35,6 @@ features:
     - system_messages
     - tool_choice
     - assistant_prefill
-isDeprecated: true
 limits:
     context_window: 200000
     max_input_tokens: 200000
@@ -57,10 +56,11 @@ params:
       type: number
     - key: tool_choice
       type: json
+retirementDate: "2026-06-10"
 sources:
     - https://platform.claude.com/docs/en/docs/about-claude/models
     - https://platform.claude.com/docs/en/about-claude/pricing
-    - https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference-support.html
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-sonnet-4.html
 status: deprecated
 supportedModes:
     - chat


### PR DESCRIPTION
FE uses isDeprecated flag for 'FIX NOW', keeping status deprecated is fine


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema and metadata-only changes to model catalog YAML and generated types; no runtime auth or API behavior in this diff.
> 
> **Overview**
> Introduces optional **`retirementDate`** (YYYY-MM-DD) on model configs in the Cue schema and generated TypeScript types, alongside small clarifications to **`#Status`** comments for deprecated vs retired.
> 
> Two AWS Bedrock models are updated to use **`status: deprecated`**, concrete retirement dates, and model-card **sources** instead of **`isDeprecated`** on the YAML entries. The Llama 3.1 405B entry also sets **`mode: chat`** (was `unknown`) and drops the deprecated flag from regional costs.
> 
> Bedrock provider **documentation** gains a link to AWS model cards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3af667fd69bfbd3f90f3ed8ef374ffc5a00acb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->