### PR TITLE
GATEWAY-2538: add AWS Claude Platform in the json

### DIFF
--- a/.github/scripts/build-unified-json.ts
+++ b/.github/scripts/build-unified-json.ts
@@ -75,6 +75,18 @@ function main(): void {
         configs.push(
           buildUnifiedConfig(modelData, providerName, defaultProviderParams),
         );
+
+        // Anthropic models are also available through the AWS Claude platform,
+        // so emit an exact copy under the aws-claude-platform provider.
+        if (providerName === 'anthropic') {
+          configs.push(
+            buildUnifiedConfig(
+              modelData,
+              'aws-claude-platform',
+              defaultProviderParams,
+            ),
+          );
+        }
       } catch (err) {
         console.warn(`Warning: failed to parse ${modelFilePath}: ${err}`);
       }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the published model catalog consumed by the gateway; incorrect parity between Anthropic and AWS Claude Platform could affect routing or pricing if those backends diverge.
> 
> **Overview**
> The unified JSON build now **adds a second catalog entry** for every Anthropic model that already passes the existing cost/mode filters, with **`provider` set to `aws-claude-platform`** and otherwise the same model config and Anthropic `defaultProviderParams`.
> 
> There is **no new YAML provider folder**—entries are emitted at build time in `build-unified-json.ts`, so `dist/ai-models.json` (and downstream S3 sync) will roughly **double Anthropic-shaped rows** under an additional provider key for gateway routing/discovery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 548403784b5952e10040cc04146ffb76621f9994. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->