### PR TITLE
Fix gpt-5.2-chat

### DIFF
--- a/providers/azure-open-ai/gpt-5.2-chat.yaml
+++ b/providers/azure-open-ai/gpt-5.2-chat.yaml
@@ -26,7 +26,7 @@ modalities:
 mode: chat
 model: gpt-5.2-chat
 params:
-    - key: max_tokens
+    - key: max_completion_tokens
       maxValue: 16384
 provisioning: serverless
 sources:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single metadata key rename in one provider YAML; no runtime code or security-sensitive paths changed.
> 
> **Overview**
> Updates the **gpt-5.2-chat** Azure provider config so the exposed completion limit param uses **`max_completion_tokens`** instead of **`max_tokens`**, keeping **`maxValue: 16384`** unchanged.
> 
> This aligns the model definition with Azure’s newer chat API parameter naming (same pattern as other recent Azure OpenAI model YAMLs) so clients routing through this catalog send the correct field for gpt-5.2-chat.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c566d4e4f9ae79c43c152964b1aff2d85bb313fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->