### PR TITLE
GATEWAY-2521: add provider aws-bedrock-mantle

### DIFF
--- a/providers/aws-bedrock-mantle/default.yaml
+++ b/providers/aws-bedrock-mantle/default.yaml
@@ -1,0 +1,4 @@
+documentation:
+    - https://docs.aws.amazon.com/bedrock/
+    - https://aws.amazon.com/bedrock/pricing/
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/model-cards.html

--- a/providers/aws-bedrock/default.yaml
+++ b/providers/aws-bedrock/default.yaml
@@ -2,7 +2,6 @@ documentation:
     - https://docs.aws.amazon.com/bedrock/
     - https://aws.amazon.com/bedrock/pricing/
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-cards.html
-    - https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-lifecycle.html
     - https://docs.aws.amazon.com/bedrock/latest/userguide/structured-output.html
     - https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Configuration-only changes: a new provider YAML and a documentation link removal, with no runtime or auth logic in this diff.
> 
> **Overview**
> Introduces a new **`aws-bedrock-mantle`** provider with a minimal `default.yaml` that only lists core Bedrock documentation links (general docs, pricing, and model cards)—unlike **`aws-bedrock`**, which carries full message roles, sampling params, and extended doc references.
> 
> The existing **`aws-bedrock`** provider drops the **models-supported** documentation URL from its doc list; other Bedrock settings in that file are unchanged in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c462977e24574aebb70369491473635fc41a7e04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->