### PR TITLE
GATEWAY-2580: add tool pricing

### DIFF
--- a/.github/scripts/autogen/types.ts
+++ b/.github/scripts/autogen/types.ts
@@ -54,8 +54,7 @@ export interface components {
             messages?: components["schemas"]["MessageConfig"];
             /** @description Configurable parameters with defaults */
             params?: components["schemas"]["ModelParam"][];
-            /** @description Pricing for built-in tools, keyed by tool name */
-            tool_pricing?: Record<string, never>;
+            tool_pricing?: components["schemas"]["ToolPricing"];
         };
         /**
          * @description Supported feature flags a model can declare
@@ -171,19 +170,16 @@ export interface components {
             output?: components["schemas"]["PricingTier"][];
             pricing_mode?: components["schemas"]["PricingMode"];
         };
-        /** @description A single billable rate; a tool maps to a list of these */
+        /** @description Pricing per billing unit; value is the cost */
         ToolCost: {
             /** @description pricing in USD */
-            cost: number;
-            unit: components["schemas"]["ToolPricingUnit"];
+            per_request?: number;
+            per_thousand_requests?: number;
         };
-        /**
-         * @description Built-in tools that can incur usage-based pricing beyond token costs
-         * @enum {string}
-         */
-        ToolName: "web_search";
-        /** @enum {string} */
-        ToolPricingUnit: "per_request" | "per_thousand_requests";
+        /** @description Pricing for built-in tools that can incur usage-based pricing beyond token costs */
+        ToolPricing: {
+            web_search?: components["schemas"]["ToolCost"];
+        };
         /**
          * @description Vertex region identifiers
          * @enum {string}
@@ -222,6 +218,5 @@ export type Provisioning = components['schemas']['Provisioning'];
 export type Status = components['schemas']['Status'];
 export type TieredPricing = components['schemas']['TieredPricing'];
 export type ToolCost = components['schemas']['ToolCost'];
-export type ToolName = components['schemas']['ToolName'];
-export type ToolPricingUnit = components['schemas']['ToolPricingUnit'];
+export type ToolPricing = components['schemas']['ToolPricing'];
 export type VertexRegion = components['schemas']['VertexRegion'];

--- a/.github/scripts/autogen/types.ts
+++ b/.github/scripts/autogen/types.ts
@@ -54,6 +54,8 @@ export interface components {
             messages?: components["schemas"]["MessageConfig"];
             /** @description Configurable parameters with defaults */
             params?: components["schemas"]["ModelParam"][];
+            /** @description Pricing for built-in tools, keyed by tool name */
+            tool_pricing?: Record<string, never>;
         };
         /**
          * @description Supported feature flags a model can declare
@@ -169,6 +171,19 @@ export interface components {
             output?: components["schemas"]["PricingTier"][];
             pricing_mode?: components["schemas"]["PricingMode"];
         };
+        /** @description A single billable rate; a tool maps to a list of these */
+        ToolCost: {
+            /** @description pricing in USD */
+            cost: number;
+            unit: components["schemas"]["ToolPricingUnit"];
+        };
+        /**
+         * @description Built-in tools that can incur usage-based pricing beyond token costs
+         * @enum {string}
+         */
+        ToolName: "web_search";
+        /** @enum {string} */
+        ToolPricingUnit: "per_request" | "per_thousand_requests";
         /**
          * @description Vertex region identifiers
          * @enum {string}
@@ -206,4 +221,7 @@ export type PricingTier = components['schemas']['PricingTier'];
 export type Provisioning = components['schemas']['Provisioning'];
 export type Status = components['schemas']['Status'];
 export type TieredPricing = components['schemas']['TieredPricing'];
+export type ToolCost = components['schemas']['ToolCost'];
+export type ToolName = components['schemas']['ToolName'];
+export type ToolPricingUnit = components['schemas']['ToolPricingUnit'];
 export type VertexRegion = components['schemas']['VertexRegion'];

--- a/.github/scripts/autogen/types.ts
+++ b/.github/scripts/autogen/types.ts
@@ -96,7 +96,7 @@ export interface components {
          * @description Canonical mode values for a model
          * @enum {string}
          */
-        Mode: "audio_transcription" | "audio_translation" | "chat" | "completion" | "embedding" | "image" | "moderation" | "realtime" | "rerank" | "responses" | "text_to_speech" | "unknown" | "unsupported" | "video";
+        Mode: "audio_transcription" | "audio_translation" | "chat" | "completion" | "embedding" | "image" | "moderation" | "ocr" | "realtime" | "rerank" | "responses" | "text_to_speech" | "unknown" | "unsupported" | "video";
         ModelConfig: {
             /** @description Pricing entries per region; use "*" for global/uniform pricing */
             costs?: components["schemas"]["CostWithRegion"][];

--- a/.github/test/model.cue
+++ b/.github/test/model.cue
@@ -258,6 +258,7 @@ package model
 	"embedding" |
 	"image" |
 	"moderation" |
+	"ocr" |
 	"realtime" |
 	"rerank" |
 	"responses" |

--- a/.github/test/model.cue
+++ b/.github/test/model.cue
@@ -44,19 +44,16 @@ package model
 // Section 2: Default provider config
 // ============================================================
 
-#ToolPricingUnit:
-	"per_request" |
-	"per_thousand_requests"
-
-// Built-in tools that can incur usage-based pricing beyond token costs
-#ToolName:
-	"web_search"
-
-// A single billable rate; a tool maps to a list of these
+// Pricing per billing unit; value is the cost
 #ToolCost: {
-	unit: #ToolPricingUnit
 	// pricing in USD
-	cost: number & >= 0
+	per_request?:           number & >= 0
+	per_thousand_requests?: number & >= 0
+}
+
+// Pricing for built-in tools that can incur usage-based pricing beyond token costs
+#ToolPricing: {
+	web_search?: #ToolCost
 }
 
 // Schema for default.yaml files (provider-level defaults)
@@ -67,8 +64,8 @@ package model
 	messages?: #MessageConfig
 	// Configurable parameters with defaults
 	params?: [...#ModelParam]
-	// Pricing for built-in tools, keyed by tool name
-	tool_pricing?: {[#ToolName]: [...#ToolCost]}
+	// Pricing for built-in tools
+	tool_pricing?: #ToolPricing
 }
 
 // ============================================================

--- a/.github/test/model.cue
+++ b/.github/test/model.cue
@@ -44,6 +44,21 @@ package model
 // Section 2: Default provider config
 // ============================================================
 
+#ToolPricingUnit:
+	"per_request" |
+	"per_thousand_requests"
+
+// Built-in tools that can incur usage-based pricing beyond token costs
+#ToolName:
+	"web_search"
+
+// A single billable rate; a tool maps to a list of these
+#ToolCost: {
+	unit: #ToolPricingUnit
+	// pricing in USD
+	cost: number & >= 0
+}
+
 // Schema for default.yaml files (provider-level defaults)
 #DefaultConfig: {
 	// Official documentation links for models, pricing, and deprecations
@@ -52,6 +67,8 @@ package model
 	messages?: #MessageConfig
 	// Configurable parameters with defaults
 	params?: [...#ModelParam]
+	// Pricing for built-in tools, keyed by tool name
+	tool_pricing?: {[#ToolName]: [...#ToolCost]}
 }
 
 // ============================================================

--- a/providers/anthropic/default.yaml
+++ b/providers/anthropic/default.yaml
@@ -45,5 +45,4 @@ params:
       type: string
 tool_pricing:
     web_search:
-        - cost: 10
-          unit: per_thousand_requests
+        per_thousand_requests: 10

--- a/providers/anthropic/default.yaml
+++ b/providers/anthropic/default.yaml
@@ -43,3 +43,7 @@ params:
           - xhigh
           - max
       type: string
+tool_pricing:
+    web_search:
+        - cost: 10
+          unit: per_thousand_requests

--- a/providers/openai/default.yaml
+++ b/providers/openai/default.yaml
@@ -53,5 +53,4 @@ params:
       type: string
 tool_pricing:
     web_search:
-        - cost: 10
-          unit: per_thousand_requests
+        per_thousand_requests: 10

--- a/providers/openai/default.yaml
+++ b/providers/openai/default.yaml
@@ -51,3 +51,7 @@ params:
           - high
           - xhigh
       type: string
+tool_pricing:
+    web_search:
+        - cost: 10
+          unit: per_thousand_requests


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Schema and YAML metadata only; no request-path or billing runtime changes in this diff.
> 
> **Overview**
> Adds **provider-level tool pricing** to the model config schema so built-in tools (starting with **web search**) can declare usage costs separate from token pricing.
> 
> **`tool_pricing`** on provider `default.yaml` is validated via new **`#ToolPricing` / `#ToolCost`** in Cue and mirrored in autogen **`ToolPricing`** / **`ToolCost`** TypeScript types (`per_request`, `per_thousand_requests`). Anthropic and OpenAI defaults now set **web search** at **$10 per thousand requests**.
> 
> Also extends the canonical **`Mode`** enum with **`ocr`** alongside the schema/type updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3598d150d4002bd92aa68281bb0113a89faafdc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->