### PR TITLE
chore add 2 mistral ocr models in azure ai foundry

### DIFF
--- a/providers/azure-ai-foundry/azure_ai/global/mistral-document-ai-2512.yaml
+++ b/providers/azure-ai-foundry/azure_ai/global/mistral-document-ai-2512.yaml
@@ -1,0 +1,25 @@
+costs:
+    - input_cost_per_annotated_page: 0.003
+      region: "*"
+features:
+    - function_calling
+    - structured_output
+    - json_output
+limits:
+    context_window: 16384
+modalities:
+    input:
+        - image
+        - pdf
+        - doc
+    output:
+        - text
+mode: unknown
+model: azure_ai/global/mistral-document-ai-2512
+params:
+    - defaultValue: 0
+      key: temperature
+provisioning: serverless
+sources:
+    - https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/mistral-ai/
+status: active

--- a/providers/azure-ai-foundry/azure_ai/global/mistral-document-ai-2512.yaml
+++ b/providers/azure-ai-foundry/azure_ai/global/mistral-document-ai-2512.yaml
@@ -14,7 +14,7 @@ modalities:
         - doc
     output:
         - text
-mode: unknown
+mode: ocr
 model: azure_ai/global/mistral-document-ai-2512
 params:
     - defaultValue: 0

--- a/providers/azure-ai-foundry/azure_ai/global/mistral-document-ai-2512.yaml
+++ b/providers/azure-ai-foundry/azure_ai/global/mistral-document-ai-2512.yaml
@@ -22,4 +22,5 @@ params:
 provisioning: serverless
 sources:
     - https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/mistral-ai/
+    - https://ai.azure.com/catalog/models/mistral-document-ai-2512
 status: active

--- a/providers/azure-ai-foundry/mistral-document-ai-2505.yaml
+++ b/providers/azure-ai-foundry/mistral-document-ai-2505.yaml
@@ -1,7 +1,6 @@
 costs:
     - input_cost_per_annotated_page: 0.003
-      region: "*"
-    - input_cost_per_page: 0.003
+      input_cost_per_page: 0.003
       region: "*"
 limits:
     context_window: 16384

--- a/providers/azure-ai-foundry/mistral-document-ai-2505.yaml
+++ b/providers/azure-ai-foundry/mistral-document-ai-2505.yaml
@@ -1,5 +1,6 @@
 costs:
     - input_cost_per_annotated_page: 0.003
+    - input_cost_per_page: 0.0003
       region: "*"
 features:
     - structured_output

--- a/providers/azure-ai-foundry/mistral-document-ai-2505.yaml
+++ b/providers/azure-ai-foundry/mistral-document-ai-2505.yaml
@@ -19,6 +19,7 @@ model: mistral-document-ai-2505
 params:
     - defaultValue: 0
       key: temperature
+provisioning: serverless
 sources:
     - https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/mistral-ai/
     - https://ai.azure.com/catalog/models/mistral-document-ai-2505

--- a/providers/azure-ai-foundry/mistral-document-ai-2505.yaml
+++ b/providers/azure-ai-foundry/mistral-document-ai-2505.yaml
@@ -1,0 +1,19 @@
+costs:
+    - input_cost_per_annotated_page: 0.003
+      region: "*"
+features:
+    - function_calling
+limits:
+    context_window: 16384
+modalities:
+    input:
+        - image
+        - pdf
+mode: unknown
+model: mistral-document-ai-2505
+params:
+    - defaultValue: 0
+      key: temperature
+sources:
+    - https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/mistral-ai/
+status: active

--- a/providers/azure-ai-foundry/mistral-document-ai-2505.yaml
+++ b/providers/azure-ai-foundry/mistral-document-ai-2505.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_annotated_page: 0.003
-    - input_cost_per_page: 0.0003
+    - input_cost_per_page: 0.003
       region: "*"
 features:
     - structured_output

--- a/providers/azure-ai-foundry/mistral-document-ai-2505.yaml
+++ b/providers/azure-ai-foundry/mistral-document-ai-2505.yaml
@@ -1,5 +1,6 @@
 costs:
     - input_cost_per_annotated_page: 0.003
+      region: "*"
     - input_cost_per_page: 0.003
       region: "*"
 features:

--- a/providers/azure-ai-foundry/mistral-document-ai-2505.yaml
+++ b/providers/azure-ai-foundry/mistral-document-ai-2505.yaml
@@ -3,9 +3,6 @@ costs:
       region: "*"
     - input_cost_per_page: 0.003
       region: "*"
-features:
-    - structured_output
-    - json_output
 limits:
     context_window: 16384
 modalities:

--- a/providers/azure-ai-foundry/mistral-document-ai-2505.yaml
+++ b/providers/azure-ai-foundry/mistral-document-ai-2505.yaml
@@ -9,7 +9,7 @@ modalities:
     input:
         - image
         - pdf
-mode: unknown
+mode: ocr
 model: mistral-document-ai-2505
 params:
     - defaultValue: 0

--- a/providers/azure-ai-foundry/mistral-document-ai-2505.yaml
+++ b/providers/azure-ai-foundry/mistral-document-ai-2505.yaml
@@ -12,6 +12,8 @@ modalities:
     input:
         - image
         - pdf
+    output:
+        - text
 mode: ocr
 model: mistral-document-ai-2505
 params:

--- a/providers/azure-ai-foundry/mistral-document-ai-2505.yaml
+++ b/providers/azure-ai-foundry/mistral-document-ai-2505.yaml
@@ -2,7 +2,8 @@ costs:
     - input_cost_per_annotated_page: 0.003
       region: "*"
 features:
-    - function_calling
+    - structured_output
+    - json_output
 limits:
     context_window: 16384
 modalities:

--- a/providers/azure-ai-foundry/mistral-document-ai-2505.yaml
+++ b/providers/azure-ai-foundry/mistral-document-ai-2505.yaml
@@ -16,4 +16,5 @@ params:
       key: temperature
 sources:
     - https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/mistral-ai/
+    - https://ai.azure.com/catalog/models/mistral-document-ai-2505
 status: active

--- a/providers/azure-ai-foundry/mistral-document-ai-2512.yaml
+++ b/providers/azure-ai-foundry/mistral-document-ai-2512.yaml
@@ -1,7 +1,6 @@
 costs:
     - input_cost_per_annotated_page: 0.003
-      region: "*"
-    - input_cost_per_page: 0.003
+      input_cost_per_page: 0.003
       region: "*"
 limits:
     context_window: 16384

--- a/providers/azure-ai-foundry/mistral-document-ai-2512.yaml
+++ b/providers/azure-ai-foundry/mistral-document-ai-2512.yaml
@@ -1,5 +1,6 @@
 costs:
     - input_cost_per_annotated_page: 0.003
+    - input_cost_per_page: 0.0003
       region: "*"
 features:
     - structured_output

--- a/providers/azure-ai-foundry/mistral-document-ai-2512.yaml
+++ b/providers/azure-ai-foundry/mistral-document-ai-2512.yaml
@@ -1,6 +1,6 @@
 costs:
     - input_cost_per_annotated_page: 0.003
-    - input_cost_per_page: 0.0003
+    - input_cost_per_page: 0.003
       region: "*"
 features:
     - structured_output

--- a/providers/azure-ai-foundry/mistral-document-ai-2512.yaml
+++ b/providers/azure-ai-foundry/mistral-document-ai-2512.yaml
@@ -1,5 +1,6 @@
 costs:
     - input_cost_per_annotated_page: 0.003
+      region: "*"
     - input_cost_per_page: 0.003
       region: "*"
 features:

--- a/providers/azure-ai-foundry/mistral-document-ai-2512.yaml
+++ b/providers/azure-ai-foundry/mistral-document-ai-2512.yaml
@@ -3,9 +3,6 @@ costs:
       region: "*"
     - input_cost_per_page: 0.003
       region: "*"
-features:
-    - structured_output
-    - json_output
 limits:
     context_window: 16384
 modalities:

--- a/providers/azure-ai-foundry/mistral-document-ai-2512.yaml
+++ b/providers/azure-ai-foundry/mistral-document-ai-2512.yaml
@@ -2,7 +2,6 @@ costs:
     - input_cost_per_annotated_page: 0.003
       region: "*"
 features:
-    - function_calling
     - structured_output
     - json_output
 limits:
@@ -11,11 +10,10 @@ modalities:
     input:
         - image
         - pdf
-        - doc
     output:
         - text
 mode: ocr
-model: azure_ai/global/mistral-document-ai-2512
+model: mistral-document-ai-2512
 params:
     - defaultValue: 0
       key: temperature


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Metadata-only YAML additions to the model catalog; no application or routing logic changes.
> 
> **Overview**
> Adds **two new Azure AI Foundry model catalog entries** for Mistral Document AI OCR: `mistral-document-ai-2505` and `mistral-document-ai-2512`.
> 
> Each entry registers **`mode: ocr`** with **image and PDF** inputs, **text** output, **16k** context, **serverless** provisioning, and **active** status. Pricing is set at **$0.003 per page** (including annotated pages) for all regions, with **temperature** defaulting to **0**. Official Azure pricing and catalog URLs are included as sources.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6da6430ac3b30f28edbba4d9e5ffb4f188edab53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->