### PR TITLE
fix: remove param n for image model

### DIFF
--- a/providers/aws-bedrock/stability.stable-image-ultra-v1:1.yaml
+++ b/providers/aws-bedrock/stability.stable-image-ultra-v1:1.yaml
@@ -16,7 +16,7 @@ removeParams:
     - max_tokens
     - temperature
     - top_p
-    - "n"
+    - n
     - stop
     - stream
     - reasoning_effort


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-line YAML style change in one model metadata file with no runtime logic changes.
> 
> **Overview**
> Updates **`stability.stable-image-ultra-v1:1`** so `removeParams` lists **`n`** as an unquoted YAML scalar (`- n` instead of `- "n"`), matching other Bedrock **image** model configs such as **`amazon.nova-canvas-v1:0`**.
> 
> Behavior is unchanged: **`n`** stays in **`removeParams`** alongside chat-oriented fields (`max_tokens`, `temperature`, etc.) so those parameters are not forwarded to this image model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ce286324041adb9e19a4b7f5c8d47d6b708a7d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->