### PR TITLE
add provider: wafer

### DIFF
--- a/providers/wafer/default.yaml
+++ b/providers/wafer/default.yaml
@@ -1,0 +1,2 @@
+documentation:
+    - https://docs.wafer.ai


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only provider config with no auth, API, or runtime code changes in the diff.
> 
> **Overview**
> Introduces **Wafer** as a provider by adding `providers/wafer/default.yaml` with a single **documentation** link to `https://docs.wafer.ai`, matching the pattern other providers use for doc references in this repo.
> 
> This change is metadata-only in the diff shown; it does not add messages, params, or model definitions in this file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8477b29b1b7ff46bc1efcb26990dcc71edbe0320. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->