### PR TITLE
pin version for cue-lang

### DIFF
--- a/.github/workflows/trigger-sync.yml
+++ b/.github/workflows/trigger-sync.yml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Set up CUE
         uses: cue-lang/setup-cue@v1.0.1
+        with:
+          version: 'v0.16.1'
       - name: Validate (CUE)
         run: ./.github/test/validate.sh
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -30,6 +30,8 @@ jobs:
 
       - name: Install CUE
         uses: cue-lang/setup-cue@v1.0.1
+        with:
+          version: 'v0.16.1'
 
       - name: Run validation
         run: ./.github/test/validate.sh

--- a/providers/mistral-ai/mistral-small.yaml
+++ b/providers/mistral-ai/mistral-small.yaml
@@ -25,6 +25,9 @@ mode: chat
 model: mistral-small
 params:
     - key: reasoning_effort
+      supportedValues:
+          - none
+          - high
 provisioning: serverless
 sources:
     - https://docs.mistral.ai/models/mistral-small-3-2-25-06


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI tooling pin and a small, schema-aligned model config update with no runtime or security impact.
> 
> **Overview**
> **Pins CUE to `v0.16.1`** in the PR validation workflow and the main-branch build/sync workflow so local and CI validation use the same `cue-lang/setup-cue` version instead of whatever the action default is.
> 
> **Documents allowed `reasoning_effort` values** for `mistral-small` as `none` and `high`, matching the pattern used on other thinking models and satisfying CUE rules for that param key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a2d67166242308bcfa9570adae3f60a29e81062. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->