### PR TITLE
reasoning effort fixes

### DIFF
--- a/providers/anthropic/claude-sonnet-4-5-20250929.yaml
+++ b/providers/anthropic/claude-sonnet-4-5-20250929.yaml
@@ -37,6 +37,7 @@ params:
 provisioning: serverless
 removeParams:
     - top_p
+    - reasoning_effort
 retirementDate: "2026-09-29"
 sources:
     - https://platform.claude.com/docs/en/build-with-claude/context-windows

--- a/providers/anthropic/claude-sonnet-4-6.yaml
+++ b/providers/anthropic/claude-sonnet-4-6.yaml
@@ -35,6 +35,14 @@ params:
       key: max_tokens
       maxValue: 128000
       minValue: 1
+    - defaultValue: high
+      key: reasoning_effort
+      supportedValues:
+          - low
+          - medium
+          - high
+          - max
+      type: string
 provisioning: serverless
 status: active
 supportedModes:

--- a/providers/aws-bedrock/apac.amazon.nova-lite-v1:0.yaml
+++ b/providers/aws-bedrock/apac.amazon.nova-lite-v1:0.yaml
@@ -70,15 +70,9 @@ params:
       key: max_tokens
       maxValue: 5000
       minValue: 1
-    - defaultValue: medium
-      key: reasoning_effort
-      supportedValues:
-          - none
-          - low
-          - medium
-          - high
-      type: string
 provisioning: serverless
+removeParams:
+    - reasoning_effort
 sources:
     - https://docs.aws.amazon.com/nova/latest/userguide/what-is-nova.html
     - https://docs.aws.amazon.com/nova/latest/userguide/complete-request-schema.html
@@ -90,4 +84,3 @@ sources:
 status: active
 supportedModes:
     - chat
-thinking: true

--- a/providers/aws-bedrock/apac.amazon.nova-pro-v1:0.yaml
+++ b/providers/aws-bedrock/apac.amazon.nova-pro-v1:0.yaml
@@ -58,14 +58,9 @@ params:
       key: max_tokens
       maxValue: 5000
       minValue: 1
-    - defaultValue: medium
-      key: reasoning_effort
-      supportedValues:
-          - low
-          - medium
-          - high
-      type: string
 provisioning: serverless
+removeParams:
+    - reasoning_effort
 sources:
     - https://docs.aws.amazon.com/nova/latest/userguide/what-is-nova.html
     - https://docs.aws.amazon.com/nova/latest/userguide/complete-request-schema.html
@@ -78,4 +73,3 @@ sources:
 status: active
 supportedModes:
     - chat
-thinking: true

--- a/providers/aws-bedrock/au.anthropic.claude-haiku-4-5-20251001-v1:0.yaml
+++ b/providers/aws-bedrock/au.anthropic.claude-haiku-4-5-20251001-v1:0.yaml
@@ -42,6 +42,8 @@ params:
       maxValue: 64000
       minValue: 1
 provisioning: serverless
+removeParams:
+    - reasoning_effort
 sources:
     - https://platform.claude.com/docs/en/docs/about-claude/models
     - https://platform.claude.com/docs/en/about-claude/pricing

--- a/providers/aws-bedrock/au.anthropic.claude-opus-4-6-v1.yaml
+++ b/providers/aws-bedrock/au.anthropic.claude-opus-4-6-v1.yaml
@@ -49,6 +49,15 @@ params:
       key: max_tokens
       maxValue: 128000
       minValue: 1
+    - defaultValue: high
+      key: reasoning_effort
+      supportedValues:
+          - none
+          - low
+          - medium
+          - high
+          - max
+      type: string
 provisioning: serverless
 removeParams:
     - "n"

--- a/providers/aws-bedrock/au.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
+++ b/providers/aws-bedrock/au.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
@@ -93,6 +93,7 @@ params:
 provisioning: serverless
 removeParams:
     - "n"
+    - reasoning_effort
 sources:
     - https://platform.claude.com/docs/en/about-claude/models
     - https://platform.claude.com/docs/en/about-claude/pricing

--- a/providers/aws-bedrock/au.anthropic.claude-sonnet-4-6.yaml
+++ b/providers/aws-bedrock/au.anthropic.claude-sonnet-4-6.yaml
@@ -50,6 +50,15 @@ params:
       key: max_tokens
       maxValue: 64000
       minValue: 1
+    - defaultValue: high
+      key: reasoning_effort
+      supportedValues:
+          - none
+          - low
+          - medium
+          - high
+          - max
+      type: string
 provisioning: serverless
 sources:
     - https://platform.claude.com/docs/en/about-claude/pricing

--- a/providers/aws-bedrock/ca.amazon.nova-lite-v1:0.yaml
+++ b/providers/aws-bedrock/ca.amazon.nova-lite-v1:0.yaml
@@ -41,6 +41,7 @@ params:
 provisioning: serverless
 removeParams:
     - "n"
+    - reasoning_effort
 sources:
     - https://docs.aws.amazon.com/nova/latest/userguide/what-is-nova.html
     - https://docs.aws.amazon.com/nova/latest/userguide/complete-request-schema.html

--- a/providers/aws-bedrock/eu.amazon.nova-lite-v1:0.yaml
+++ b/providers/aws-bedrock/eu.amazon.nova-lite-v1:0.yaml
@@ -58,15 +58,9 @@ params:
     - key: top_k
       maxValue: 128
       minValue: 0
-    - defaultValue: medium
-      key: reasoning_effort
-      supportedValues:
-          - none
-          - low
-          - medium
-          - high
-      type: string
 provisioning: serverless
+removeParams:
+    - reasoning_effort
 sources:
     - https://docs.aws.amazon.com/nova/latest/userguide/what-is-nova.html
     - https://docs.aws.amazon.com/nova/latest/userguide/complete-request-schema.html
@@ -80,4 +74,3 @@ sources:
 status: active
 supportedModes:
     - chat
-thinking: true

--- a/providers/aws-bedrock/eu.amazon.nova-pro-v1:0.yaml
+++ b/providers/aws-bedrock/eu.amazon.nova-pro-v1:0.yaml
@@ -70,16 +70,10 @@ params:
     - key: top_k
       maxValue: 128
       minValue: 0
-    - defaultValue: medium
-      key: reasoning_effort
-      supportedValues:
-          - low
-          - medium
-          - high
-      type: string
 provisioning: serverless
 removeParams:
     - "n"
+    - reasoning_effort
 sources:
     - https://docs.aws.amazon.com/nova/latest/userguide/what-is-nova.html
     - https://docs.aws.amazon.com/nova/latest/userguide/complete-request-schema.html
@@ -90,4 +84,3 @@ sources:
 status: active
 supportedModes:
     - chat
-thinking: true

--- a/providers/aws-bedrock/eu.anthropic.claude-haiku-4-5-20251001-v1:0.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-haiku-4-5-20251001-v1:0.yaml
@@ -96,6 +96,7 @@ params:
 provisioning: serverless
 removeParams:
     - top_p
+    - reasoning_effort
 sources:
     - https://platform.claude.com/docs/en/docs/about-claude/models
     - https://platform.claude.com/docs/en/about-claude/pricing

--- a/providers/aws-bedrock/eu.anthropic.claude-opus-4-5-20251101-v1:0.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-opus-4-5-20251101-v1:0.yaml
@@ -91,6 +91,13 @@ params:
       maxValue: 128000
       minValue: 1024
       type: number
+    - defaultValue: high
+      key: reasoning_effort
+      supportedValues:
+          - low
+          - medium
+          - high
+      type: string
 provisioning: serverless
 removeParams:
     - temperature

--- a/providers/aws-bedrock/eu.anthropic.claude-opus-4-6-v1.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-opus-4-6-v1.yaml
@@ -91,6 +91,15 @@ params:
       key: max_tokens
       maxValue: 128000
       minValue: 1
+    - defaultValue: high
+      key: reasoning_effort
+      supportedValues:
+          - none
+          - low
+          - medium
+          - high
+          - max
+      type: string
 provisioning: serverless
 sources:
     - https://platform.claude.com/docs/en/docs/about-claude/models

--- a/providers/aws-bedrock/eu.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
@@ -97,6 +97,7 @@ params:
 provisioning: serverless
 removeParams:
     - top_p
+    - reasoning_effort
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-sonnet-4-5.html
     - https://platform.claude.com/docs/en/docs/about-claude/models

--- a/providers/aws-bedrock/eu.anthropic.claude-sonnet-4-6.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-sonnet-4-6.yaml
@@ -88,6 +88,15 @@ params:
       key: max_tokens
       maxValue: 64000
       minValue: 1
+    - defaultValue: high
+      key: reasoning_effort
+      supportedValues:
+          - none
+          - low
+          - medium
+          - high
+          - max
+      type: string
 provisioning: serverless
 sources:
     - https://platform.claude.com/docs/en/about-claude/models

--- a/providers/aws-bedrock/global.amazon.nova-2-lite-v1:0.yaml
+++ b/providers/aws-bedrock/global.amazon.nova-2-lite-v1:0.yaml
@@ -128,6 +128,7 @@ params:
     - defaultValue: medium
       key: reasoning_effort
       supportedValues:
+          - none
           - low
           - medium
           - high

--- a/providers/aws-bedrock/global.anthropic.claude-haiku-4-5-20251001-v1:0.yaml
+++ b/providers/aws-bedrock/global.anthropic.claude-haiku-4-5-20251001-v1:0.yaml
@@ -294,6 +294,7 @@ params:
 provisioning: serverless
 removeParams:
     - top_p
+    - reasoning_effort
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-haiku-4-5.html
     - https://platform.claude.com/docs/en/about-claude/pricing

--- a/providers/aws-bedrock/global.anthropic.claude-opus-4-5-20251101-v1:0.yaml
+++ b/providers/aws-bedrock/global.anthropic.claude-opus-4-5-20251101-v1:0.yaml
@@ -293,6 +293,13 @@ params:
       maxValue: 128000
       minValue: 1024
       type: number
+    - defaultValue: high
+      key: reasoning_effort
+      supportedValues:
+          - low
+          - medium
+          - high
+      type: string
 provisioning: serverless
 removeParams:
     - temperature

--- a/providers/aws-bedrock/global.anthropic.claude-opus-4-6-v1.yaml
+++ b/providers/aws-bedrock/global.anthropic.claude-opus-4-6-v1.yaml
@@ -291,6 +291,15 @@ params:
       key: max_tokens
       maxValue: 128000
       minValue: 1
+    - defaultValue: high
+      key: reasoning_effort
+      supportedValues:
+          - none
+          - low
+          - medium
+          - high
+          - max
+      type: string
 provisioning: serverless
 sources:
     - https://platform.claude.com/docs/en/docs/about-claude/models

--- a/providers/aws-bedrock/global.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
+++ b/providers/aws-bedrock/global.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
@@ -758,6 +758,7 @@ params:
 provisioning: serverless
 removeParams:
     - "n"
+    - reasoning_effort
 sources:
     - https://platform.claude.com/docs/en/docs/about-claude/models
     - https://platform.claude.com/docs/en/about-claude/pricing

--- a/providers/aws-bedrock/global.anthropic.claude-sonnet-4-6.yaml
+++ b/providers/aws-bedrock/global.anthropic.claude-sonnet-4-6.yaml
@@ -290,6 +290,15 @@ params:
       key: max_tokens
       maxValue: 64000
       minValue: 1
+    - defaultValue: high
+      key: reasoning_effort
+      supportedValues:
+          - none
+          - low
+          - medium
+          - high
+          - max
+      type: string
 provisioning: serverless
 sources:
     - https://platform.claude.com/docs/en/docs/about-claude/models

--- a/providers/aws-bedrock/jp.amazon.nova-2-lite-v1:0.yaml
+++ b/providers/aws-bedrock/jp.amazon.nova-2-lite-v1:0.yaml
@@ -32,6 +32,7 @@ params:
     - defaultValue: medium
       key: reasoning_effort
       supportedValues:
+          - none
           - low
           - medium
           - high

--- a/providers/aws-bedrock/jp.anthropic.claude-haiku-4-5-20251001-v1:0.yaml
+++ b/providers/aws-bedrock/jp.anthropic.claude-haiku-4-5-20251001-v1:0.yaml
@@ -42,6 +42,8 @@ params:
       maxValue: 64000
       minValue: 1
 provisioning: serverless
+removeParams:
+    - reasoning_effort
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference-support.html
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-haiku-4-5.html

--- a/providers/aws-bedrock/jp.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
+++ b/providers/aws-bedrock/jp.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
@@ -71,6 +71,8 @@ params:
       maxValue: 64000
       minValue: 1
 provisioning: serverless
+removeParams:
+    - reasoning_effort
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-sonnet-4-5.html

--- a/providers/aws-bedrock/jp.anthropic.claude-sonnet-4-6.yaml
+++ b/providers/aws-bedrock/jp.anthropic.claude-sonnet-4-6.yaml
@@ -43,6 +43,15 @@ params:
       key: max_tokens
       maxValue: 64000
       minValue: 1
+    - defaultValue: high
+      key: reasoning_effort
+      supportedValues:
+          - none
+          - low
+          - medium
+          - high
+          - max
+      type: string
 provisioning: serverless
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-sonnet-4-6.html

--- a/providers/aws-bedrock/openai.gpt-oss-120b-1:0.yaml
+++ b/providers/aws-bedrock/openai.gpt-oss-120b-1:0.yaml
@@ -66,6 +66,13 @@ params:
       maxValue: 16000
     - key: temperature
       maxValue: 2
+    - defaultValue: medium
+      key: reasoning_effort
+      supportedValues:
+          - low
+          - medium
+          - high
+      type: string
 provisioning: serverless
 removeParams:
     - stream

--- a/providers/aws-bedrock/openai.gpt-oss-safeguard-120b.yaml
+++ b/providers/aws-bedrock/openai.gpt-oss-safeguard-120b.yaml
@@ -58,6 +58,13 @@ params:
       key: max_tokens
       maxValue: 16000
       minValue: 1
+    - defaultValue: medium
+      key: reasoning_effort
+      supportedValues:
+          - low
+          - medium
+          - high
+      type: string
 provisioning: serverless
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-oss-safeguard-120b.html

--- a/providers/aws-bedrock/openai.gpt-oss-safeguard-20b.yaml
+++ b/providers/aws-bedrock/openai.gpt-oss-safeguard-20b.yaml
@@ -49,6 +49,13 @@ params:
       key: max_tokens
       maxValue: 16000
       minValue: 1
+    - defaultValue: medium
+      key: reasoning_effort
+      supportedValues:
+          - low
+          - medium
+          - high
+      type: string
 provisioning: serverless
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-openai.html

--- a/providers/aws-bedrock/qwen.qwen3-235b-a22b-2507-v1:0.yaml
+++ b/providers/aws-bedrock/qwen.qwen3-235b-a22b-2507-v1:0.yaml
@@ -47,6 +47,14 @@ params:
       key: max_tokens
       maxValue: 8000
       minValue: 1
+    - defaultValue: medium
+      key: reasoning_effort
+      supportedValues:
+          - none
+          - low
+          - medium
+          - high
+      type: string
 provisioning: serverless
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-qwen-qwen3-235b-a22b-2507.html

--- a/providers/aws-bedrock/qwen.qwen3-32b-v1:0.yaml
+++ b/providers/aws-bedrock/qwen.qwen3-32b-v1:0.yaml
@@ -56,6 +56,14 @@ params:
       key: max_tokens
       maxValue: 8000
       minValue: 1
+    - defaultValue: medium
+      key: reasoning_effort
+      supportedValues:
+          - none
+          - low
+          - medium
+          - high
+      type: string
 provisioning: serverless
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-qwen-qwen3-32b.html

--- a/providers/aws-bedrock/qwen.qwen3-coder-30b-a3b-v1:0.yaml
+++ b/providers/aws-bedrock/qwen.qwen3-coder-30b-a3b-v1:0.yaml
@@ -56,9 +56,15 @@ params:
       key: max_tokens
       maxValue: 16000
       minValue: 1
+    - defaultValue: medium
+      key: reasoning_effort
+      supportedValues:
+          - none
+          - low
+          - medium
+          - high
+      type: string
 provisioning: serverless
-removeParams:
-    - reasoning_effort
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-qwen-qwen3-coder-30b-a3b-instruct.html
 status: active

--- a/providers/aws-bedrock/qwen.qwen3-coder-480b-a35b-v1:0.yaml
+++ b/providers/aws-bedrock/qwen.qwen3-coder-480b-a35b-v1:0.yaml
@@ -43,9 +43,15 @@ params:
       key: max_tokens
       maxValue: 16000
       minValue: 1
+    - defaultValue: medium
+      key: reasoning_effort
+      supportedValues:
+          - none
+          - low
+          - medium
+          - high
+      type: string
 provisioning: serverless
-removeParams:
-    - reasoning_effort
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-qwen-qwen3-coder-480b-a35b-instruct.html
 status: active

--- a/providers/aws-bedrock/qwen.qwen3-vl-235b-a22b.yaml
+++ b/providers/aws-bedrock/qwen.qwen3-vl-235b-a22b.yaml
@@ -48,6 +48,14 @@ params:
       key: max_tokens
       maxValue: 8000
       minValue: 1
+    - defaultValue: medium
+      key: reasoning_effort
+      supportedValues:
+          - none
+          - low
+          - medium
+          - high
+      type: string
 provisioning: serverless
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-qwen-qwen3-vl-235b-a22b.html

--- a/providers/aws-bedrock/us.amazon.nova-2-lite-v1:0.yaml
+++ b/providers/aws-bedrock/us.amazon.nova-2-lite-v1:0.yaml
@@ -53,6 +53,7 @@ params:
     - defaultValue: medium
       key: reasoning_effort
       supportedValues:
+          - none
           - low
           - medium
           - high

--- a/providers/aws-bedrock/us.amazon.nova-pro-v1:0.yaml
+++ b/providers/aws-bedrock/us.amazon.nova-pro-v1:0.yaml
@@ -46,17 +46,10 @@ params:
       key: temperature
       maxValue: 1
       minValue: 0.00001
-    - defaultValue: medium
-      key: reasoning_effort
-      supportedValues:
-          - none
-          - low
-          - medium
-          - high
-      type: string
 provisioning: serverless
 removeParams:
     - "n"
+    - reasoning_effort
 sources:
     - https://docs.aws.amazon.com/nova/latest/userguide/what-is-nova.html
     - https://docs.aws.amazon.com/nova/latest/userguide/tool-use.html
@@ -65,4 +58,3 @@ sources:
 status: active
 supportedModes:
     - chat
-thinking: true

--- a/providers/aws-bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0.yaml
@@ -69,6 +69,7 @@ params:
 provisioning: serverless
 removeParams:
     - top_p
+    - reasoning_effort
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-haiku-4-5.html
     - https://platform.claude.com/docs/en/about-claude/pricing

--- a/providers/aws-bedrock/us.anthropic.claude-opus-4-5-20251101-v1:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-opus-4-5-20251101-v1:0.yaml
@@ -68,6 +68,13 @@ params:
       maxValue: 128000
       minValue: 1024
       type: number
+    - defaultValue: high
+      key: reasoning_effort
+      supportedValues:
+          - low
+          - medium
+          - high
+      type: string
 provisioning: serverless
 removeParams:
     - temperature

--- a/providers/aws-bedrock/us.anthropic.claude-opus-4-6-v1.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-opus-4-6-v1.yaml
@@ -75,6 +75,15 @@ params:
       key: max_tokens
       maxValue: 128000
       minValue: 1
+    - defaultValue: high
+      key: reasoning_effort
+      supportedValues:
+          - none
+          - low
+          - medium
+          - high
+          - max
+      type: string
 provisioning: serverless
 sources:
     - https://platform.claude.com/docs/en/docs/about-claude/models

--- a/providers/aws-bedrock/us.anthropic.claude-opus-4-8.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-opus-4-8.yaml
@@ -80,6 +80,7 @@ params:
     - defaultValue: high
       key: reasoning_effort
       supportedValues:
+          - none
           - low
           - medium
           - high

--- a/providers/aws-bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0.yaml
@@ -74,6 +74,7 @@ params:
 provisioning: serverless
 removeParams:
     - top_p
+    - reasoning_effort
 sources:
     - https://platform.claude.com/docs/en/docs/about-claude/models
     - https://platform.claude.com/docs/en/about-claude/pricing

--- a/providers/aws-bedrock/us.anthropic.claude-sonnet-4-6.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-sonnet-4-6.yaml
@@ -75,6 +75,15 @@ params:
       key: max_tokens
       maxValue: 64000
       minValue: 1
+    - defaultValue: high
+      key: reasoning_effort
+      supportedValues:
+          - none
+          - low
+          - medium
+          - high
+          - max
+      type: string
 provisioning: serverless
 sources:
     - https://platform.claude.com/docs/en/about-claude/models

--- a/providers/deepinfra/default.yaml
+++ b/providers/deepinfra/default.yaml
@@ -9,4 +9,5 @@ params:
           - low
           - medium
           - high
+          - xhigh
       type: string

--- a/providers/deepinfra/openai/gpt-oss-20b.yaml
+++ b/providers/deepinfra/openai/gpt-oss-20b.yaml
@@ -17,14 +17,6 @@ modalities:
         - text
 mode: chat
 model: openai/gpt-oss-20b
-params:
-    - defaultValue: medium
-      key: reasoning_effort
-      supportedValues:
-          - low
-          - medium
-          - high
-      type: string
 provisioning: serverless
 sources:
     - https://deepinfra.com/openai/gpt-oss-20b

--- a/providers/mistral-ai/codestral-2508.yaml
+++ b/providers/mistral-ai/codestral-2508.yaml
@@ -24,6 +24,8 @@ params:
     - defaultValue: 0.3
       key: temperature
 provisioning: serverless
+removeParams:
+    - reasoning_effort
 sources:
     - https://docs.mistral.ai/models/codestral-25-08
 status: active

--- a/providers/mistral-ai/codestral-latest.yaml
+++ b/providers/mistral-ai/codestral-latest.yaml
@@ -23,6 +23,8 @@ params:
     - defaultValue: 0.3
       key: temperature
 provisioning: serverless
+removeParams:
+    - reasoning_effort
 sources:
     - https://docs.mistral.ai/models/codestral-25-08
 status: active

--- a/providers/mistral-ai/default.yaml
+++ b/providers/mistral-ai/default.yaml
@@ -30,3 +30,11 @@ params:
     - defaultValue: true
       key: stream
       type: boolean
+    - key: reasoning_effort
+      supportedValues:
+          - none
+          - minimal
+          - low
+          - medium
+          - high
+          - xhigh

--- a/providers/mistral-ai/ministral-14b-2512.yaml
+++ b/providers/mistral-ai/ministral-14b-2512.yaml
@@ -20,6 +20,8 @@ params:
     - defaultValue: 0.3
       key: temperature
 provisioning: serverless
+removeParams:
+    - reasoning_effort
 sources:
     - https://docs.mistral.ai/models/ministral-3-14b-25-12
 status: active

--- a/providers/mistral-ai/ministral-14b-latest.yaml
+++ b/providers/mistral-ai/ministral-14b-latest.yaml
@@ -27,6 +27,8 @@ params:
     - defaultValue: 0.3
       key: temperature
 provisioning: serverless
+removeParams:
+    - reasoning_effort
 sources:
     - https://docs.mistral.ai/models/ministral-3-14b-25-12
     - https://docs.mistral.ai/capabilities/function_calling

--- a/providers/mistral-ai/ministral-3b-2512.yaml
+++ b/providers/mistral-ai/ministral-3b-2512.yaml
@@ -20,6 +20,8 @@ params:
     - defaultValue: 0.3
       key: temperature
 provisioning: serverless
+removeParams:
+    - reasoning_effort
 sources:
     - https://docs.mistral.ai/models/ministral-3-3b-25-12
     - https://docs.mistral.ai/capabilities/vision/

--- a/providers/mistral-ai/ministral-3b-latest.yaml
+++ b/providers/mistral-ai/ministral-3b-latest.yaml
@@ -26,6 +26,8 @@ params:
     - defaultValue: 0.3
       key: temperature
 provisioning: serverless
+removeParams:
+    - reasoning_effort
 sources:
     - https://docs.mistral.ai/models/ministral-3-3b-25-12
 status: active

--- a/providers/mistral-ai/ministral-8b-2512.yaml
+++ b/providers/mistral-ai/ministral-8b-2512.yaml
@@ -24,6 +24,8 @@ params:
     - defaultValue: 0.3
       key: temperature
 provisioning: serverless
+removeParams:
+    - reasoning_effort
 sources:
     - https://docs.mistral.ai/models/ministral-3-8b-25-12
 status: active

--- a/providers/mistral-ai/ministral-8b-latest.yaml
+++ b/providers/mistral-ai/ministral-8b-latest.yaml
@@ -25,6 +25,8 @@ params:
     - defaultValue: 0.3
       key: temperature
 provisioning: serverless
+removeParams:
+    - reasoning_effort
 sources:
     - https://docs.mistral.ai/models/ministral-3-8b-25-12
     - https://docs.mistral.ai/capabilities/vision

--- a/providers/mistral-ai/mistral-code-agent-latest.yaml
+++ b/providers/mistral-ai/mistral-code-agent-latest.yaml
@@ -7,6 +7,8 @@ model: mistral-code-agent-latest
 params:
     - defaultValue: 0.2
       key: temperature
+removeParams:
+    - reasoning_effort
 status: active
 supportedModes:
     - chat

--- a/providers/mistral-ai/mistral-code-fim-latest.yaml
+++ b/providers/mistral-ai/mistral-code-fim-latest.yaml
@@ -18,6 +18,8 @@ model: mistral-code-fim-latest
 params:
     - defaultValue: 0.3
       key: temperature
+removeParams:
+    - reasoning_effort
 status: active
 supportedModes:
     - completion

--- a/providers/mistral-ai/mistral-code-latest.yaml
+++ b/providers/mistral-ai/mistral-code-latest.yaml
@@ -22,6 +22,8 @@ model: mistral-code-latest
 params:
     - defaultValue: 0.3
       key: temperature
+removeParams:
+    - reasoning_effort
 sources:
     - https://mistral.ai/news/mistral-code/
     - https://mistral.ai/news/codestral-25-08/

--- a/providers/mistral-ai/mistral-large-2512.yaml
+++ b/providers/mistral-ai/mistral-large-2512.yaml
@@ -24,6 +24,8 @@ params:
     - defaultValue: 0.3
       key: temperature
 provisioning: serverless
+removeParams:
+    - reasoning_effort
 sources:
     - https://docs.mistral.ai/models/mistral-large-3-25-12
     - https://docs.mistral.ai/capabilities/vision

--- a/providers/mistral-ai/mistral-medium-2604.yaml
+++ b/providers/mistral-ai/mistral-medium-2604.yaml
@@ -24,6 +24,10 @@ model: mistral-medium-2604
 params:
     - defaultValue: 0.7
       key: temperature
+    - key: reasoning_effort
+      supportedValues:
+          - none
+          - high
 sources:
     - https://docs.mistral.ai/models/model-cards/mistral-medium-3-5-26-04
 status: active

--- a/providers/mistral-ai/mistral-medium-3.5.yaml
+++ b/providers/mistral-ai/mistral-medium-3.5.yaml
@@ -26,6 +26,10 @@ model: mistral-medium-3.5
 params:
     - defaultValue: 0.7
       key: temperature
+    - key: reasoning_effort
+      supportedValues:
+          - none
+          - high
 sources:
     - https://docs.mistral.ai/models/model-cards/mistral-medium-3-5-26-04
 status: active

--- a/providers/mistral-ai/mistral-medium-latest.yaml
+++ b/providers/mistral-ai/mistral-medium-latest.yaml
@@ -23,6 +23,10 @@ model: mistral-medium-latest
 params:
     - defaultValue: 0.3
       key: temperature
+    - key: reasoning_effort
+      supportedValues:
+          - none
+          - high
 provisioning: serverless
 sources:
     - https://docs.mistral.ai/models/model-cards/mistral-medium-3-5-26-04

--- a/providers/mistral-ai/mistral-vibe-cli-fast.yaml
+++ b/providers/mistral-ai/mistral-vibe-cli-fast.yaml
@@ -17,6 +17,10 @@ model: mistral-vibe-cli-fast
 params:
     - defaultValue: 0.3
       key: temperature
+    - key: reasoning_effort
+      supportedValues:
+          - none
+          - high
 provisioning: serverless
 sources:
     - https://docs.mistral.ai/mistral-vibe/introduction

--- a/providers/mistral-ai/mistral-vibe-cli-latest.yaml
+++ b/providers/mistral-ai/mistral-vibe-cli-latest.yaml
@@ -20,6 +20,10 @@ model: mistral-vibe-cli-latest
 params:
     - defaultValue: 0.2
       key: temperature
+    - key: reasoning_effort
+      supportedValues:
+          - none
+          - high
 provisioning: serverless
 sources:
     - https://docs.mistral.ai/mistral-vibe/introduction

--- a/providers/mistral-ai/mistral-vibe-cli-with-tools.yaml
+++ b/providers/mistral-ai/mistral-vibe-cli-with-tools.yaml
@@ -19,6 +19,10 @@ model: mistral-vibe-cli-with-tools
 params:
     - defaultValue: 0.3
       key: temperature
+    - key: reasoning_effort
+      supportedValues:
+          - none
+          - high
 provisioning: serverless
 sources:
     - https://docs.mistral.ai/models/devstral-2-25-12

--- a/providers/mistral-ai/voxtral-small-latest.yaml
+++ b/providers/mistral-ai/voxtral-small-latest.yaml
@@ -20,6 +20,8 @@ params:
     - defaultValue: 0.2
       key: temperature
 provisioning: serverless
+removeParams:
+    - reasoning_effort
 sources:
     - https://docs.mistral.ai/models/voxtral-small-25-07
     - https://mistral.ai/pricing

--- a/providers/openai/chat-latest.yaml
+++ b/providers/openai/chat-latest.yaml
@@ -23,6 +23,12 @@ modalities:
         - text
 mode: chat
 model: chat-latest
+params:
+    - defaultValue: medium
+      key: reasoning_effort
+      supportedValues:
+          - medium
+      type: string
 provisioning: serverless
 removeParams:
     - max_tokens

--- a/providers/openai/gpt-4.1-mini-2025-04-14.yaml
+++ b/providers/openai/gpt-4.1-mini-2025-04-14.yaml
@@ -37,6 +37,7 @@ params:
 provisioning: serverless
 removeParams:
     - max_tokens
+    - reasoning_effort
 sources:
     - https://developers.openai.com/api/docs/models/gpt-4.1-mini
 status: active

--- a/providers/openai/gpt-4.1-mini.yaml
+++ b/providers/openai/gpt-4.1-mini.yaml
@@ -36,6 +36,7 @@ params:
 provisioning: serverless
 removeParams:
     - max_tokens
+    - reasoning_effort
 sources:
     - https://developers.openai.com/api/docs/models/gpt-4.1-mini
     - https://developers.openai.com/docs/guides/pdf-files

--- a/providers/openai/gpt-4.1.yaml
+++ b/providers/openai/gpt-4.1.yaml
@@ -38,6 +38,7 @@ params:
 provisioning: serverless
 removeParams:
     - max_tokens
+    - reasoning_effort
 sources:
     - https://developers.openai.com/api/docs/models/gpt-4.1
 status: active

--- a/providers/openai/gpt-4o-2024-05-13.yaml
+++ b/providers/openai/gpt-4o-2024-05-13.yaml
@@ -31,6 +31,8 @@ params:
       key: response_format
       type: string
 provisioning: serverless
+removeParams:
+    - reasoning_effort
 retirementDate: "2026-10-23"
 sources:
     - https://developers.openai.com/api/docs/models/gpt-4o

--- a/providers/openai/gpt-4o-2024-11-20.yaml
+++ b/providers/openai/gpt-4o-2024-11-20.yaml
@@ -33,6 +33,8 @@ params:
       key: response_format
       type: string
 provisioning: serverless
+removeParams:
+    - reasoning_effort
 sources:
     - https://developers.openai.com/api/docs/models/gpt-4o
 status: active

--- a/providers/openai/gpt-4o-mini-2024-07-18.yaml
+++ b/providers/openai/gpt-4o-mini-2024-07-18.yaml
@@ -33,6 +33,8 @@ params:
       key: response_format
       type: string
 provisioning: serverless
+removeParams:
+    - reasoning_effort
 sources:
     - https://developers.openai.com/api/docs/models/gpt-4o-mini
 status: active

--- a/providers/openai/gpt-4o-mini.yaml
+++ b/providers/openai/gpt-4o-mini.yaml
@@ -33,6 +33,8 @@ params:
       key: response_format
       type: string
 provisioning: serverless
+removeParams:
+    - reasoning_effort
 sources:
     - https://developers.openai.com/api/docs/models/gpt-4o-mini
 status: active

--- a/providers/openai/gpt-4o.yaml
+++ b/providers/openai/gpt-4o.yaml
@@ -34,6 +34,8 @@ params:
       key: response_format
       type: string
 provisioning: serverless
+removeParams:
+    - reasoning_effort
 sources:
     - https://developers.openai.com/api/docs/models/gpt-4o
     - https://developers.openai.com/docs/guides/pdf-files

--- a/providers/openai/gpt-5-mini.yaml
+++ b/providers/openai/gpt-5-mini.yaml
@@ -38,6 +38,11 @@ params:
       key: reasoning
     - defaultValue: null
       key: reasoning_effort
+      supportedValues:
+          - minimal
+          - low
+          - medium
+          - high
       type: string
     - defaultValue: null
       key: verbosity

--- a/providers/openai/gpt-5.4-mini-2026-03-17.yaml
+++ b/providers/openai/gpt-5.4-mini-2026-03-17.yaml
@@ -33,8 +33,15 @@ params:
       key: max_completion_tokens
       maxValue: 128000
       minValue: 1
-    - defaultValue: medium
+    - defaultValue: none
       key: reasoning_effort
+      supportedValues:
+          - none
+          - low
+          - medium
+          - high
+          - xhigh
+      type: string
 provisioning: serverless
 removeParams:
     - max_tokens

--- a/providers/openai/gpt-5.4-mini.yaml
+++ b/providers/openai/gpt-5.4-mini.yaml
@@ -33,8 +33,15 @@ params:
       key: max_completion_tokens
       maxValue: 128000
       minValue: 1
-    - defaultValue: medium
+    - defaultValue: none
       key: reasoning_effort
+      supportedValues:
+          - none
+          - low
+          - medium
+          - high
+          - xhigh
+      type: string
 provisioning: serverless
 removeParams:
     - max_tokens

--- a/providers/openai/gpt-5.4-nano-2026-03-17.yaml
+++ b/providers/openai/gpt-5.4-nano-2026-03-17.yaml
@@ -29,8 +29,14 @@ params:
       key: max_completion_tokens
       maxValue: 128000
       minValue: 1
-    - defaultValue: medium
+    - defaultValue: none
       key: reasoning_effort
+      supportedValues:
+          - none
+          - low
+          - medium
+          - high
+          - xhigh
       type: string
 provisioning: serverless
 removeParams:

--- a/providers/openai/gpt-5.4-nano.yaml
+++ b/providers/openai/gpt-5.4-nano.yaml
@@ -28,6 +28,15 @@ params:
       key: max_completion_tokens
       maxValue: 128000
       minValue: 1
+    - defaultValue: none
+      key: reasoning_effort
+      supportedValues:
+          - none
+          - low
+          - medium
+          - high
+          - xhigh
+      type: string
 provisioning: serverless
 removeParams:
     - max_tokens

--- a/providers/openai/gpt-image-2.yaml
+++ b/providers/openai/gpt-image-2.yaml
@@ -22,6 +22,7 @@ removeParams:
     - stream
     - tool_choice
     - parallel_tool_calls
+    - reasoning_effort
 sources:
     - https://developers.openai.com/api/docs/models/gpt-image-2
 status: active

--- a/providers/xai/grok-3-mini-fast-high-beta.yaml
+++ b/providers/xai/grok-3-mini-fast-high-beta.yaml
@@ -19,6 +19,9 @@ params:
     - defaultValue: high
       key: reasoning_effort
       supportedValues:
+          - none
+          - low
+          - medium
           - high
       type: string
 provisioning: serverless

--- a/providers/xai/grok-3-mini-fast-high.yaml
+++ b/providers/xai/grok-3-mini-fast-high.yaml
@@ -21,6 +21,9 @@ params:
     - defaultValue: high
       key: reasoning_effort
       supportedValues:
+          - none
+          - low
+          - medium
           - high
       type: string
 provisioning: serverless

--- a/providers/xai/grok-3.yaml
+++ b/providers/xai/grok-3.yaml
@@ -21,8 +21,6 @@ modalities:
 mode: chat
 model: grok-3
 provisioning: serverless
-removeParams:
-    - reasoning_effort
 status: active
 supportedModes:
     - chat


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Wide catalog changes can alter which request params clients may send per model; wrong add/remove could cause API errors or silent behavior changes for reasoning-capable routes.
> 
> **Overview**
> This PR **reconciles `reasoning_effort` (and related thinking flags)** across many provider model YAML files so advertised params match what each endpoint actually supports.
> 
> **Models that should not expose `reasoning_effort`** now drop it via **`removeParams`** (or by removing mistaken inline `params`), including Claude 4.5 / Haiku (extended **`thinking`** only), Amazon Nova **v1** Lite/Pro (also drops erroneous **`thinking: true`**), legacy OpenAI GPT‑4o / 4.1, non‑reasoning Mistral Codestral/Ministral/code models, and **`gpt-image-2`**.
> 
> **Models that do support reasoning** gain or tighten explicit **`reasoning_effort`** entries: Claude **4.6** / Opus **4.5+** on Anthropic and Bedrock (defaults like **`high`**, enums including **`none`/`max`** where applicable), Bedrock **Qwen3**, **GPT‑OSS**, and **Nova 2** Lite (adds **`none`**). OpenAI **5.4 mini/nano** switch default to **`none`** and document **`none`–`xhigh`**; **`gpt-5-mini`** lists **`minimal`–`high`**; **`chat-latest`** is constrained to **`medium`** only.
> 
> **Provider defaults:** Mistral **`default.yaml`** adds a shared **`reasoning_effort`** enum (with per‑model overrides or **`removeParams`**); DeepInfra default adds **`xhigh`**; DeepInfra **`gpt-oss-20b`** drops a duplicate param block. xAI Grok‑3 mini variants expand supported effort levels; **`grok-3`** no longer strips **`reasoning_effort`** from defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32897a09c69759070fdcf629c85563264276c3b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->