### PR TITLE
Reasoning effort fix

### DIFF
--- a/providers/aws-bedrock-mantle/openai.gpt-oss-20b.yaml
+++ b/providers/aws-bedrock-mantle/openai.gpt-oss-20b.yaml
@@ -53,6 +53,13 @@ modalities:
         - text
 mode: chat
 model: openai.gpt-oss-20b
+params:
+    - key: reasoning_effort
+      supportedValues:
+          - low
+          - medium
+          - high
+      type: string
 provisioning: serverless
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-oss-20b.html

--- a/providers/aws-bedrock-mantle/openai.gpt-oss-safeguard-120b.yaml
+++ b/providers/aws-bedrock-mantle/openai.gpt-oss-safeguard-120b.yaml
@@ -50,6 +50,13 @@ modalities:
         - text
 mode: chat
 model: openai.gpt-oss-safeguard-120b
+params:
+    - key: reasoning_effort
+      supportedValues:
+          - low
+          - medium
+          - high
+      type: string
 provisioning: serverless
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-oss-safeguard-120b.html

--- a/providers/cohere/cohere-transcribe-03-2026.yaml
+++ b/providers/cohere/cohere-transcribe-03-2026.yaml
@@ -10,6 +10,7 @@ removeParams:
     - max_tokens
     - temperature
     - stream
+    - reasoning_effort
 sources:
     - https://docs.cohere.com/docs/transcribe
 status: active

--- a/providers/cohere/default.yaml
+++ b/providers/cohere/default.yaml
@@ -20,3 +20,9 @@ params:
     - defaultValue: true
       key: stream
       type: boolean
+    - defaultValue: high
+      key: reasoning_effort
+      supportedValues:
+          - none
+          - high
+      type: string

--- a/providers/cohere/embed-english-light-v3.0.yaml
+++ b/providers/cohere/embed-english-light-v3.0.yaml
@@ -19,6 +19,7 @@ removeParams:
     - temperature
     - stream
     - max_tokens
+    - reasoning_effort
 sources:
     - https://docs.cohere.com/docs/cohere-embed
     - https://docs.cohere.com/reference/embed

--- a/providers/cohere/embed-english-v3.0-image.yaml
+++ b/providers/cohere/embed-english-v3.0-image.yaml
@@ -13,6 +13,7 @@ removeParams:
     - max_tokens
     - temperature
     - stream
+    - reasoning_effort
 sources:
     - https://docs.cohere.com/docs/cohere-embed
     - https://docs.cohere.com/reference/embed

--- a/providers/cohere/embed-english-v3.0.yaml
+++ b/providers/cohere/embed-english-v3.0.yaml
@@ -20,6 +20,7 @@ removeParams:
     - max_tokens
     - temperature
     - stream
+    - reasoning_effort
 sources:
     - https://docs.cohere.com/reference/embed
     - https://docs.cohere.com/docs/cohere-embed

--- a/providers/cohere/embed-multilingual-light-v3.0-image.yaml
+++ b/providers/cohere/embed-multilingual-light-v3.0-image.yaml
@@ -14,6 +14,7 @@ removeParams:
     - max_tokens
     - temperature
     - stream
+    - reasoning_effort
 sources:
     - https://docs.cohere.com/docs/cohere-embed
     - https://docs.cohere.com/reference/embed

--- a/providers/cohere/embed-multilingual-light-v3.0.yaml
+++ b/providers/cohere/embed-multilingual-light-v3.0.yaml
@@ -19,6 +19,7 @@ removeParams:
     - max_tokens
     - temperature
     - stream
+    - reasoning_effort
 sources:
     - https://docs.cohere.com/docs/cohere-embed
     - https://docs.cohere.com/v2/reference/embed

--- a/providers/cohere/embed-multilingual-v3.0-image.yaml
+++ b/providers/cohere/embed-multilingual-v3.0-image.yaml
@@ -15,6 +15,7 @@ removeParams:
     - max_tokens
     - temperature
     - stream
+    - reasoning_effort
 sources:
     - https://docs.cohere.com/reference/embed
     - https://docs.cohere.com/docs/cohere-embed

--- a/providers/cohere/embed-multilingual-v3.0.yaml
+++ b/providers/cohere/embed-multilingual-v3.0.yaml
@@ -19,6 +19,7 @@ removeParams:
     - max_tokens
     - temperature
     - stream
+    - reasoning_effort
 sources:
     - https://docs.cohere.com/docs/cohere-embed
     - https://docs.cohere.com/reference/embed

--- a/providers/cohere/embed-v4.0.yaml
+++ b/providers/cohere/embed-v4.0.yaml
@@ -20,6 +20,7 @@ removeParams:
     - temperature
     - stream
     - max_tokens
+    - reasoning_effort
 sources:
     - https://docs.cohere.com/docs/cohere-embed
     - https://docs.cohere.com/reference/embed

--- a/providers/cohere/rerank-english-v3.0.yaml
+++ b/providers/cohere/rerank-english-v3.0.yaml
@@ -15,6 +15,7 @@ removeParams:
     - max_tokens
     - temperature
     - stream
+    - reasoning_effort
 sources:
     - https://docs.cohere.com/docs/rerank
     - https://docs.cohere.com/reference/rerank

--- a/providers/cohere/rerank-multilingual-v3.0.yaml
+++ b/providers/cohere/rerank-multilingual-v3.0.yaml
@@ -15,6 +15,7 @@ removeParams:
     - max_tokens
     - temperature
     - stream
+    - reasoning_effort
 sources:
     - https://docs.cohere.com/docs/rerank
     - https://docs.cohere.com/reference/rerank

--- a/providers/cohere/rerank-v3.5.yaml
+++ b/providers/cohere/rerank-v3.5.yaml
@@ -16,6 +16,7 @@ removeParams:
     - max_tokens
     - temperature
     - stream
+    - reasoning_effort
 sources:
     - https://docs.cohere.com/docs/rerank
     - https://docs.cohere.com/v2/reference/rerank

--- a/providers/cohere/rerank-v4.0-fast.yaml
+++ b/providers/cohere/rerank-v4.0-fast.yaml
@@ -10,6 +10,7 @@ removeParams:
     - max_tokens
     - temperature
     - stream
+    - reasoning_effort
 sources:
     - https://docs.cohere.com/docs/rerank
     - https://docs.cohere.com/reference/rerank

--- a/providers/cohere/rerank-v4.0-pro.yaml
+++ b/providers/cohere/rerank-v4.0-pro.yaml
@@ -15,6 +15,7 @@ removeParams:
     - max_tokens
     - temperature
     - stream
+    - reasoning_effort
 sources:
     - https://docs.cohere.com/reference/rerank
     - https://docs.cohere.com/docs/rerank

--- a/providers/google-vertex/anthropic/claude-fable-5.yaml
+++ b/providers/google-vertex/anthropic/claude-fable-5.yaml
@@ -44,6 +44,15 @@ params:
       key: max_tokens
       maxValue: 128000
       minValue: 1
+    - defaultValue: high
+      key: reasoning_effort
+      supportedValues:
+          - low
+          - medium
+          - high
+          - xhigh
+          - max
+      type: string
 provisioning: serverless
 removeParams:
     - temperature

--- a/providers/google-vertex/anthropic/claude-haiku-4-5.yaml
+++ b/providers/google-vertex/anthropic/claude-haiku-4-5.yaml
@@ -66,6 +66,7 @@ params:
 provisioning: serverless
 removeParams:
     - "n"
+    - reasoning_effort
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude/haiku-4-5
     - https://platform.claude.com/docs/en/about-claude/models

--- a/providers/google-vertex/anthropic/claude-haiku-4-5@20251001.yaml
+++ b/providers/google-vertex/anthropic/claude-haiku-4-5@20251001.yaml
@@ -55,6 +55,8 @@ params:
     - key: max_tokens
       maxValue: 64000
 provisioning: serverless
+removeParams:
+    - reasoning_effort
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude/haiku-4-5
     - https://platform.claude.com/docs/en/about-claude/pricing

--- a/providers/google-vertex/anthropic/claude-opus-4-1.yaml
+++ b/providers/google-vertex/anthropic/claude-opus-4-1.yaml
@@ -42,6 +42,15 @@ model: anthropic/claude-opus-4-1
 params:
     - key: max_tokens
       maxValue: 32000
+    - defaultValue: high
+      key: reasoning_effort
+      supportedValues:
+          - low
+          - medium
+          - high
+          - xhigh
+          - max
+      type: string
 provisioning: serverless
 retirementDate: "2026-08-05"
 sources:

--- a/providers/google-vertex/anthropic/claude-opus-4-1@20250805.yaml
+++ b/providers/google-vertex/anthropic/claude-opus-4-1@20250805.yaml
@@ -40,6 +40,15 @@ model: anthropic/claude-opus-4-1@20250805
 params:
     - key: max_tokens
       maxValue: 32000
+    - defaultValue: high
+      key: reasoning_effort
+      supportedValues:
+          - low
+          - medium
+          - high
+          - xhigh
+          - max
+      type: string
 provisioning: serverless
 retirementDate: "2026-08-05"
 sources:

--- a/providers/google-vertex/anthropic/claude-opus-4-5.yaml
+++ b/providers/google-vertex/anthropic/claude-opus-4-5.yaml
@@ -57,6 +57,13 @@ model: anthropic/claude-opus-4-5
 params:
     - key: max_tokens
       maxValue: 64000
+    - defaultValue: high
+      key: reasoning_effort
+      supportedValues:
+          - low
+          - medium
+          - high
+      type: string
 provisioning: serverless
 retirementDate: "2026-11-24"
 sources:

--- a/providers/google-vertex/anthropic/claude-opus-4-5@20251101.yaml
+++ b/providers/google-vertex/anthropic/claude-opus-4-5@20251101.yaml
@@ -62,6 +62,13 @@ model: anthropic/claude-opus-4-5@20251101
 params:
     - key: max_tokens
       maxValue: 64000
+    - defaultValue: high
+      key: reasoning_effort
+      supportedValues:
+          - low
+          - medium
+          - high
+      type: string
 provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude/opus-4-5

--- a/providers/google-vertex/anthropic/claude-opus-4-6.yaml
+++ b/providers/google-vertex/anthropic/claude-opus-4-6.yaml
@@ -65,6 +65,14 @@ params:
       key: max_tokens
       maxValue: 128000
       minValue: 1
+    - defaultValue: high
+      key: reasoning_effort
+      supportedValues:
+          - low
+          - medium
+          - high
+          - max
+      type: string
 provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude/opus-4-6

--- a/providers/google-vertex/anthropic/claude-opus-4-6@default.yaml
+++ b/providers/google-vertex/anthropic/claude-opus-4-6@default.yaml
@@ -77,6 +77,14 @@ params:
       maxValue: 128000
     - key: temperature
       maxValue: 1
+    - defaultValue: high
+      key: reasoning_effort
+      supportedValues:
+          - low
+          - medium
+          - high
+          - max
+      type: string
 provisioning: serverless
 removeParams:
     - "n"

--- a/providers/google-vertex/anthropic/claude-opus-4-7.yaml
+++ b/providers/google-vertex/anthropic/claude-opus-4-7.yaml
@@ -49,6 +49,15 @@ model: anthropic/claude-opus-4-7
 params:
     - key: max_tokens
       maxValue: 128000
+    - defaultValue: high
+      key: reasoning_effort
+      supportedValues:
+          - low
+          - medium
+          - high
+          - xhigh
+          - max
+      type: string
 provisioning: serverless
 removeParams:
     - "n"

--- a/providers/google-vertex/anthropic/claude-opus-4-8.yaml
+++ b/providers/google-vertex/anthropic/claude-opus-4-8.yaml
@@ -44,6 +44,15 @@ params:
       key: max_tokens
       maxValue: 128000
       minValue: 1
+    - defaultValue: high
+      key: reasoning_effort
+      supportedValues:
+          - low
+          - medium
+          - high
+          - xhigh
+          - max
+      type: string
 provisioning: serverless
 removeParams:
     - temperature

--- a/providers/google-vertex/anthropic/claude-opus-4.yaml
+++ b/providers/google-vertex/anthropic/claude-opus-4.yaml
@@ -43,6 +43,15 @@ params:
       key: max_tokens
       maxValue: 32000
       minValue: 1
+    - defaultValue: high
+      key: reasoning_effort
+      supportedValues:
+          - low
+          - medium
+          - high
+          - xhigh
+          - max
+      type: string
 provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude/opus-4

--- a/providers/google-vertex/anthropic/claude-opus-4@20250514.yaml
+++ b/providers/google-vertex/anthropic/claude-opus-4@20250514.yaml
@@ -39,6 +39,15 @@ model: anthropic/claude-opus-4@20250514
 params:
     - key: max_tokens
       maxValue: 32000
+    - defaultValue: high
+      key: reasoning_effort
+      supportedValues:
+          - low
+          - medium
+          - high
+          - xhigh
+          - max
+      type: string
 provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude

--- a/providers/google-vertex/anthropic/claude-sonnet-4-5.yaml
+++ b/providers/google-vertex/anthropic/claude-sonnet-4-5.yaml
@@ -149,6 +149,8 @@ params:
       maxValue: 64000
       minValue: 1
 provisioning: serverless
+removeParams:
+    - reasoning_effort
 sources:
     - https://platform.claude.com/docs/en/about-claude/models/overview
     - https://platform.claude.com/docs/en/about-claude/pricing

--- a/providers/google-vertex/anthropic/claude-sonnet-4-5@20250929.yaml
+++ b/providers/google-vertex/anthropic/claude-sonnet-4-5@20250929.yaml
@@ -147,6 +147,15 @@ model: anthropic/claude-sonnet-4-5@20250929
 params:
     - key: max_tokens
       maxValue: 64000
+    - defaultValue: high
+      key: reasoning_effort
+      supportedValues:
+          - low
+          - medium
+          - high
+          - xhigh
+          - max
+      type: string
 provisioning: serverless
 sources:
     - https://platform.claude.com/docs/en/about-claude/models

--- a/providers/google-vertex/anthropic/claude-sonnet-4-5@20250929.yaml
+++ b/providers/google-vertex/anthropic/claude-sonnet-4-5@20250929.yaml
@@ -147,16 +147,9 @@ model: anthropic/claude-sonnet-4-5@20250929
 params:
     - key: max_tokens
       maxValue: 64000
-    - defaultValue: high
-      key: reasoning_effort
-      supportedValues:
-          - low
-          - medium
-          - high
-          - xhigh
-          - max
-      type: string
 provisioning: serverless
+removeParams:
+    - reasoning_effort
 sources:
     - https://platform.claude.com/docs/en/about-claude/models
     - https://platform.claude.com/docs/en/about-claude/pricing

--- a/providers/google-vertex/anthropic/claude-sonnet-4-6.yaml
+++ b/providers/google-vertex/anthropic/claude-sonnet-4-6.yaml
@@ -60,6 +60,15 @@ params:
       maxValue: 64000
     - key: temperature
       maxValue: 1
+    - defaultValue: high
+      key: reasoning_effort
+      supportedValues:
+          - low
+          - medium
+          - high
+          - xhigh
+          - max
+      type: string
 provisioning: serverless
 removeParams:
     - "n"

--- a/providers/google-vertex/anthropic/claude-sonnet-4-6@default.yaml
+++ b/providers/google-vertex/anthropic/claude-sonnet-4-6@default.yaml
@@ -76,6 +76,15 @@ params:
       maxValue: 64000
     - key: temperature
       maxValue: 1
+    - defaultValue: high
+      key: reasoning_effort
+      supportedValues:
+          - low
+          - medium
+          - high
+          - xhigh
+          - max
+      type: string
 provisioning: serverless
 removeParams:
     - "n"

--- a/providers/google-vertex/anthropic/claude-sonnet-4.yaml
+++ b/providers/google-vertex/anthropic/claude-sonnet-4.yaml
@@ -85,6 +85,15 @@ model: anthropic/claude-sonnet-4
 params:
     - key: max_tokens
       maxValue: 64000
+    - defaultValue: high
+      key: reasoning_effort
+      supportedValues:
+          - low
+          - medium
+          - high
+          - xhigh
+          - max
+      type: string
 provisioning: serverless
 sources:
     - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude/sonnet-4

--- a/providers/google-vertex/anthropic/claude-sonnet-4@20250514.yaml
+++ b/providers/google-vertex/anthropic/claude-sonnet-4@20250514.yaml
@@ -47,6 +47,15 @@ params:
       key: max_tokens
       maxValue: 64000
       minValue: 1
+    - defaultValue: high
+      key: reasoning_effort
+      supportedValues:
+          - low
+          - medium
+          - high
+          - xhigh
+          - max
+      type: string
 provisioning: serverless
 sources:
     - https://platform.claude.com/docs/en/about-claude/models


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are catalog/metadata only (params and removeParams); no runtime code paths. Wrong values could mislead API clients but are easy to spot in config review.
> 
> **Overview**
> This PR **corrects how `reasoning_effort` is declared** on provider model YAML so clients only see the knob where it applies, with per-model allowed values.
> 
> **Cohere** adds `reasoning_effort` to `default.yaml` (default `high`, `none`/`high`) for chat-capable configs, and **strips** it from embed, rerank, and transcribe models via `removeParams`.
> 
> **AWS Bedrock Mantle** GPT-OSS chat models now **expose** `reasoning_effort` with `low`/`medium`/`high`.
> 
> **Google Vertex Anthropic** chat entries are split: many Opus/Fable/Sonnet variants **gain** explicit `reasoning_effort` (defaults and tiers like `xhigh`/`max` where relevant), while **Haiku 4.5** and **Sonnet 4.5** entries **remove** `reasoning_effort` so it is not offered on those Vertex routes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 888a72f8c31b1cb0ee767d2d77751d6b327f8ebe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->