### PR TITLE
fix params

### DIFF
--- a/providers/azure-open-ai/gpt-5-chat-2025-08-07.yaml
+++ b/providers/azure-open-ai/gpt-5-chat-2025-08-07.yaml
@@ -28,9 +28,11 @@ mode: chat
 model: gpt-5-chat-2025-08-07
 params:
     - defaultValue: 128
-      key: max_tokens
+      key: max_completion_tokens
       maxValue: 16384
       minValue: 1
+removeParams:
+    - max_tokens
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
 status: deprecated

--- a/providers/azure-open-ai/gpt-5-chat-2025-08-15.yaml
+++ b/providers/azure-open-ai/gpt-5-chat-2025-08-15.yaml
@@ -27,9 +27,11 @@ mode: chat
 model: gpt-5-chat-2025-08-15
 params:
     - defaultValue: 128
-      key: max_tokens
+      key: max_completion_tokens
       maxValue: 16384
       minValue: 1
+removeParams:
+    - max_tokens
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
 status: retired

--- a/providers/azure-open-ai/gpt-5-chat-2025-10-03.yaml
+++ b/providers/azure-open-ai/gpt-5-chat-2025-10-03.yaml
@@ -26,10 +26,11 @@ modalities:
 mode: chat
 model: gpt-5-chat-2025-10-03
 params:
-    - key: max_tokens
+    - key: max_completion_tokens
       maxValue: 16384
 provisioning: serverless
 removeParams:
+    - max_tokens
     - reasoning_effort
 retirementDate: "2026-05-13"
 sources:

--- a/providers/azure-open-ai/gpt-5-chat.yaml
+++ b/providers/azure-open-ai/gpt-5-chat.yaml
@@ -26,10 +26,12 @@ mode: chat
 model: gpt-5-chat
 params:
     - defaultValue: 128
-      key: max_tokens
+      key: max_completion_tokens
       maxValue: 16384
       minValue: 1
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2026-06-29"
 status: preview
 supportedModes:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Provider metadata-only changes with no runtime code; misconfiguration could affect how max output tokens are passed to Azure for these four models.
> 
> **Overview**
> Updates **four** Azure Open AI **gpt-5-chat** model definitions so output length is configured via **`max_completion_tokens`** instead of **`max_tokens`**, matching newer Azure/OpenAI chat APIs and the pattern already used on models like **gpt-4.1-mini**.
> 
> Each touched YAML swaps the **`params`** key from **`max_tokens`** to **`max_completion_tokens`** (defaults and max/min bounds unchanged where they existed). **`removeParams`** now lists **`max_tokens`** so upstream clients strip the legacy parameter—new for **gpt-5-chat**, **gpt-5-chat-2025-08-07**, and **gpt-5-chat-2025-08-15**; **gpt-5-chat-2025-10-03** adds **`max_tokens`** to its existing **`removeParams`** block (alongside **`reasoning_effort`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e71dbc2b05c4184dd51516103607f7fa1ac3ef6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->