### PR TITLE
fix(openai): align GPT-5 deprecation metadata with official notice

### DIFF
--- a/providers/openai/gpt-5-2025-08-07.yaml
+++ b/providers/openai/gpt-5-2025-08-07.yaml
@@ -44,6 +44,7 @@ removeParams:
     - max_tokens
 retirementDate: "2026-12-11"
 sources:
+    - https://developers.openai.com/api/docs/deprecations
     - https://developers.openai.com/docs/models/gpt-5
 status: deprecated
 supportedModes:

--- a/providers/openai/gpt-5-mini-2025-08-07.yaml
+++ b/providers/openai/gpt-5-mini-2025-08-07.yaml
@@ -46,6 +46,7 @@ removeParams:
     - max_tokens
 retirementDate: "2026-12-11"
 sources:
+    - https://developers.openai.com/api/docs/deprecations
     - https://developers.openai.com/docs/models/gpt-5-mini
 status: deprecated
 supportedModes:

--- a/providers/openai/gpt-5-nano-2025-08-07.yaml
+++ b/providers/openai/gpt-5-nano-2025-08-07.yaml
@@ -46,6 +46,7 @@ removeParams:
     - max_tokens
 retirementDate: "2026-12-11"
 sources:
+    - https://developers.openai.com/api/docs/deprecations
     - https://developers.openai.com/api/docs/models/gpt-5-nano
 status: deprecated
 supportedModes:

--- a/providers/openai/gpt-5-nano.yaml
+++ b/providers/openai/gpt-5-nano.yaml
@@ -3,7 +3,6 @@ costs:
       input_cost_per_token: 5e-8
       output_cost_per_token: 4e-7
       region: "*"
-deprecationDate: "2026-06-11"
 features:
     - function_calling
     - parallel_function_calling
@@ -11,7 +10,6 @@ features:
     - tool_choice
     - prompt_caching
     - structured_output
-isDeprecated: true
 limits:
     context_window: 400000
     max_output_tokens: 128000
@@ -42,10 +40,9 @@ removeParams:
     - top_p
     - n
     - max_tokens
-retirementDate: "2026-12-11"
 sources:
     - https://developers.openai.com/api/docs/models/gpt-5-nano
-status: deprecated
+status: active
 supportedModes:
     - chat
     - responses

--- a/providers/openai/gpt-5-pro-2025-10-06.yaml
+++ b/providers/openai/gpt-5-pro-2025-10-06.yaml
@@ -36,6 +36,7 @@ removeParams:
     - reasoning_effort
 retirementDate: "2026-12-11"
 sources:
+    - https://developers.openai.com/api/docs/deprecations
     - https://developers.openai.com/api/docs/models/gpt-5-pro
 status: deprecated
 supportedModes:

--- a/providers/openai/gpt-5-pro.yaml
+++ b/providers/openai/gpt-5-pro.yaml
@@ -4,11 +4,9 @@ costs:
       output_cost_per_token: 0.00012
       output_cost_per_token_batches: 0.00012
       region: "*"
-deprecationDate: "2026-06-11"
 features:
     - function_calling
     - structured_output
-isDeprecated: true
 limits:
     context_window: 400000
     max_output_tokens: 272000
@@ -35,10 +33,9 @@ removeParams:
     - max_tokens
     - max_completion_tokens
     - reasoning_effort
-retirementDate: "2026-12-11"
 sources:
     - https://developers.openai.com/api/docs/models/gpt-5-pro
-status: deprecated
+status: active
 supportedModes:
     - responses
 thinking: true

--- a/providers/openai/gpt-5.2-chat-latest.yaml
+++ b/providers/openai/gpt-5.2-chat-latest.yaml
@@ -5,7 +5,7 @@ costs:
       output_cost_per_token: 1.4e-5
       output_cost_per_token_batches: 7e-6
       region: "*"
-deprecationDate: "2026-08-10"
+deprecationDate: "2026-05-08"
 features:
     - function_calling
     - parallel_function_calling
@@ -45,8 +45,10 @@ removeParams:
     - top_p
     - n
     - max_tokens
+retirementDate: "2026-08-10"
 sources:
     - https://developers.openai.com/api/docs/models/gpt-5.2-chat-latest
+    - https://developers.openai.com/api/docs/deprecations
 status: deprecated
 supportedModes:
     - chat

--- a/providers/openai/gpt-5.3-chat-latest.yaml
+++ b/providers/openai/gpt-5.3-chat-latest.yaml
@@ -5,7 +5,7 @@ costs:
       output_cost_per_token: 1.4e-5
       output_cost_per_token_batches: 7e-6
       region: "*"
-deprecationDate: "2026-08-10"
+deprecationDate: "2026-05-08"
 features:
     - function_calling
     - tool_choice
@@ -33,8 +33,10 @@ params:
 provisioning: serverless
 removeParams:
     - max_tokens
+retirementDate: "2026-08-10"
 sources:
     - https://developers.openai.com/api/docs/models/gpt-5.3-chat-latest
+    - https://developers.openai.com/api/docs/deprecations
 status: deprecated
 supportedModes:
     - chat

--- a/providers/openai/gpt-5.yaml
+++ b/providers/openai/gpt-5.yaml
@@ -51,7 +51,6 @@ removeParams:
     - top_p
     - "n"
     - max_tokens
-retirementDate: "2026-12-11"
 sources:
     - https://developers.openai.com/api/docs/models/gpt-5
 status: active


### PR DESCRIPTION
## Summary
- Align OpenAI GPT-5 metadata with the [official deprecations notice](https://developers.openai.com/api/docs/deprecations): only dated snapshots (`gpt-5-2025-08-07`, `gpt-5-mini-2025-08-07`, `gpt-5-nano-2025-08-07`, `gpt-5-pro-2025-10-06`) retire on **Dec 11, 2026**; floating aliases (`gpt-5`, `gpt-5-nano`, `gpt-5-pro`) stay active.
- Fix `gpt-5.2-chat-latest` and `gpt-5.3-chat-latest`: set `deprecationDate` to the May 8, 2026 announcement and add missing `retirementDate` of **Aug 10, 2026**.
- Add deprecations doc links on the dated snapshot YAMLs.

## Test plan
- [ ] Confirm dated snapshots still have `isDeprecated: true`, `status: deprecated`, `deprecationDate: 2026-06-11`, `retirementDate: 2026-12-11`
- [ ] Confirm `gpt-5`, `gpt-5-nano`, and `gpt-5-pro` are `status: active` with no deprecation/retirement fields
- [ ] Confirm chat-latest models have `deprecationDate: 2026-05-08` and `retirementDate: 2026-08-10`
- [ ] Spot-check against https://developers.openai.com/api/docs/deprecations


Made with [Cursor](https://cursor.com)