### PR TITLE
fix(aws-bedrock-mantle): fill missing per-region costs from aws pricing

### DIFF
--- a/providers/aws-bedrock-mantle/deepseek.v3.1.yaml
+++ b/providers/aws-bedrock-mantle/deepseek.v3.1.yaml
@@ -1,27 +1,36 @@
 costs:
-    - region: us-west-2
-      # not found in official docs — V3.1 pricing not published for this region
-    - region: us-east-2
-      # not found in official docs — V3.1 pricing not published for this region
-    - region: us-east-1
-      # not found in official docs — V3.1 pricing not published for this region
-    - region: sa-east-1
-      # not found in official docs — V3.1 pricing not published for this region
-    - region: eu-west-2
-      # not found in official docs — V3.1 pricing not published for this region
-    - region: eu-north-1
-      # not found in official docs — V3.1 pricing not published for this region
+    - input_cost_per_token: 5.8e-7
+      output_cost_per_token: 0.00000168
+      region: us-west-2
+    - input_cost_per_token: 5.8e-7
+      output_cost_per_token: 0.00000168
+      region: us-east-2
+    - input_cost_per_token: 5.8e-7
+      output_cost_per_token: 0.00000168
+      region: us-east-1
+    - input_cost_per_token: 6.96e-7
+      output_cost_per_token: 0.000002016
+      region: sa-east-1
+    - input_cost_per_token: 8.99985e-7
+      output_cost_per_token: 0.000002606853
+      region: eu-west-2
+    - input_cost_per_token: 5.8e-7
+      output_cost_per_token: 0.00000168
+      region: eu-north-1
     - region: ap-southeast-4
       # not found in official docs — V3.1 pricing not published for this region
-    - region: ap-southeast-3
-      # not found in official docs — V3.1 pricing not published for this region
+    - input_cost_per_token: 6e-7
+      output_cost_per_token: 0.00000174
+      region: ap-southeast-3
     - input_cost_per_token: 5.974e-7
       output_cost_per_token: 0.0000017304
       region: ap-southeast-2
-    - region: ap-south-1
-      # not found in official docs — V3.1 pricing not published for this region
-    - region: ap-northeast-1
-      # not found in official docs — V3.1 pricing not published for this region
+    - input_cost_per_token: 6.82424e-7
+      output_cost_per_token: 0.000001976678
+      region: ap-south-1
+    - input_cost_per_token: 7.01666e-7
+      output_cost_per_token: 0.000002032411
+      region: ap-northeast-1
 features:
     - function_calling
     - system_messages

--- a/providers/aws-bedrock-mantle/deepseek.v3.2.yaml
+++ b/providers/aws-bedrock-mantle/deepseek.v3.2.yaml
@@ -11,8 +11,9 @@ costs:
     - input_cost_per_token: 7.4e-7
       output_cost_per_token: 2.22e-6
       region: sa-east-1
-    - region: eu-west-2
-      # not found in official docs
+    - input_cost_per_token: 9.61e-7
+      output_cost_per_token: 2.8675e-6
+      region: eu-west-2
     - input_cost_per_token: 7.4e-7
       output_cost_per_token: 2.22e-6
       region: eu-north-1

--- a/providers/aws-bedrock-mantle/deepseek.v3.2.yaml
+++ b/providers/aws-bedrock-mantle/deepseek.v3.2.yaml
@@ -22,8 +22,8 @@ costs:
     - input_cost_per_token: 7.4e-7
       output_cost_per_token: 2.22e-6
       region: ap-southeast-3
-    - input_cost_per_token: 6.386e-7
-      output_cost_per_token: 1.9055e-6
+    - input_cost_per_token: 6.4e-7
+      output_cost_per_token: 1.91e-6
       region: ap-southeast-2
     - input_cost_per_token: 7.4e-7
       output_cost_per_token: 2.22e-6

--- a/providers/aws-bedrock-mantle/google.gemma-3-12b-it.yaml
+++ b/providers/aws-bedrock-mantle/google.gemma-3-12b-it.yaml
@@ -20,14 +20,17 @@ costs:
     - input_cost_per_token: 1.1e-7
       output_cost_per_token: 3.4e-7
       region: eu-south-1
-    - region: eu-north-1
-      # pricing not published on AWS Bedrock pricing page
-    - region: eu-central-1
-      # pricing not published on AWS Bedrock pricing page
+    - input_cost_per_token: 1.08e-7
+      output_cost_per_token: 3.48e-7
+      region: eu-north-1
+    - input_cost_per_token: 1.08e-7
+      output_cost_per_token: 3.48e-7
+      region: eu-central-1
     - region: ap-southeast-4
       # pricing not published on AWS Bedrock pricing page
-    - region: ap-southeast-3
-      # pricing not published on AWS Bedrock pricing page
+    - input_cost_per_token: 1.08e-7
+      output_cost_per_token: 3.48e-7
+      region: ap-southeast-3
     - input_cost_per_token: 9.27e-8
       output_cost_per_token: 2.987e-7
       region: ap-southeast-2

--- a/providers/aws-bedrock-mantle/google.gemma-3-27b-it.yaml
+++ b/providers/aws-bedrock-mantle/google.gemma-3-27b-it.yaml
@@ -20,12 +20,16 @@ costs:
     - input_cost_per_token: 2.7e-7
       output_cost_per_token: 4.5e-7
       region: eu-south-1
-    - region: eu-north-1 # pricing not found in official docs
+    - input_cost_per_token: 2.76e-7
+      output_cost_per_token: 4.56e-7
+      region: eu-north-1
     - input_cost_per_token: 2.7e-7
       output_cost_per_token: 4.5e-7
       region: eu-central-1
     - region: ap-southeast-4 # pricing not found in official docs
-    - region: ap-southeast-3 # pricing not found in official docs
+    - input_cost_per_token: 2.76e-7
+      output_cost_per_token: 4.56e-7
+      region: ap-southeast-3
     - input_cost_per_token: 2.369e-7
       output_cost_per_token: 3.914e-7
       region: ap-southeast-2

--- a/providers/aws-bedrock-mantle/google.gemma-3-27b-it.yaml
+++ b/providers/aws-bedrock-mantle/google.gemma-3-27b-it.yaml
@@ -23,8 +23,8 @@ costs:
     - input_cost_per_token: 2.76e-7
       output_cost_per_token: 4.56e-7
       region: eu-north-1
-    - input_cost_per_token: 2.7e-7
-      output_cost_per_token: 4.5e-7
+    - input_cost_per_token: 2.76e-7
+      output_cost_per_token: 4.56e-7
       region: eu-central-1
     - region: ap-southeast-4 # pricing not found in official docs
     - input_cost_per_token: 2.76e-7

--- a/providers/aws-bedrock-mantle/google.gemma-3-4b-it.yaml
+++ b/providers/aws-bedrock-mantle/google.gemma-3-4b-it.yaml
@@ -20,10 +20,16 @@ costs:
     - input_cost_per_token: 5e-8
       output_cost_per_token: 9e-8
       region: eu-south-1
-    - region: eu-north-1 # price not published on AWS Bedrock pricing page
-    - region: eu-central-1 # price not published on AWS Bedrock pricing page
+    - input_cost_per_token: 4.8e-8
+      output_cost_per_token: 9.6e-8
+      region: eu-north-1
+    - input_cost_per_token: 4.8e-8
+      output_cost_per_token: 9.6e-8
+      region: eu-central-1
     - region: ap-southeast-4 # price not published on AWS Bedrock pricing page
-    - region: ap-southeast-3 # price not published on AWS Bedrock pricing page
+    - input_cost_per_token: 4.8e-8
+      output_cost_per_token: 9.6e-8
+      region: ap-southeast-3
     - input_cost_per_token: 4.12e-8
       output_cost_per_token: 8.24e-8
       region: ap-southeast-2

--- a/providers/aws-bedrock-mantle/google.gemma-4-26b-a4b.yaml
+++ b/providers/aws-bedrock-mantle/google.gemma-4-26b-a4b.yaml
@@ -8,7 +8,7 @@ costs:
     - input_cost_per_token: 1.3e-7
       output_cost_per_token: 4e-7
       region: us-east-1
-    - input_cost_per_token: 1.6e-7
+    - input_cost_per_token: 1.56e-7
       output_cost_per_token: 4.8e-7
       region: eu-central-1
 features:

--- a/providers/aws-bedrock-mantle/google.gemma-4-31b.yaml
+++ b/providers/aws-bedrock-mantle/google.gemma-4-31b.yaml
@@ -8,7 +8,7 @@ costs:
     - input_cost_per_token: 1.4e-7
       output_cost_per_token: 4e-7
       region: us-east-1
-    - input_cost_per_token: 1.7e-7
+    - input_cost_per_token: 1.68e-7
       output_cost_per_token: 4.8e-7
       region: eu-central-1
 features:

--- a/providers/aws-bedrock-mantle/google.gemma-4-e2b.yaml
+++ b/providers/aws-bedrock-mantle/google.gemma-4-e2b.yaml
@@ -8,8 +8,8 @@ costs:
     - input_cost_per_token: 4e-8
       output_cost_per_token: 8e-8
       region: us-east-1
-    - input_cost_per_token: 5e-8
-      output_cost_per_token: 1e-7
+    - input_cost_per_token: 4.8e-8
+      output_cost_per_token: 9.6e-8
       region: eu-central-1
 features:
     - function_calling

--- a/providers/aws-bedrock-mantle/minimax.minimax-m2.1.yaml
+++ b/providers/aws-bedrock-mantle/minimax.minimax-m2.1.yaml
@@ -29,8 +29,8 @@ costs:
     - input_cost_per_token: 3.6e-7
       output_cost_per_token: 0.00000144
       region: ap-southeast-3
-    - input_cost_per_token: 3.09e-7
-      output_cost_per_token: 0.000001236
+    - input_cost_per_token: 3.1e-7
+      output_cost_per_token: 0.00000124
       region: ap-southeast-2
     - input_cost_per_token: 3.6e-7
       output_cost_per_token: 0.00000144

--- a/providers/aws-bedrock-mantle/minimax.minimax-m2.5.yaml
+++ b/providers/aws-bedrock-mantle/minimax.minimax-m2.5.yaml
@@ -26,7 +26,7 @@ costs:
     - input_cost_per_token: 3.6e-7
       output_cost_per_token: 1.44e-6
       region: eu-central-1
-    - region: ap-southeast-4
+    - region: ap-southeast-4 # not found in official docs
     - input_cost_per_token: 3.6e-7
       output_cost_per_token: 1.44e-6
       region: ap-southeast-3

--- a/providers/aws-bedrock-mantle/mistral.magistral-small-2509.yaml
+++ b/providers/aws-bedrock-mantle/mistral.magistral-small-2509.yaml
@@ -20,14 +20,17 @@ costs:
     - input_cost_per_token: 5.9e-7
       output_cost_per_token: 1.76e-6
       region: eu-south-1
-    - region: eu-north-1
-      # pricing not published on AWS Bedrock pricing page
-    - region: eu-central-1
-      # pricing not published on AWS Bedrock pricing page
+    - input_cost_per_token: 6e-7
+      output_cost_per_token: 1.8e-6
+      region: eu-north-1
+    - input_cost_per_token: 6e-7
+      output_cost_per_token: 1.8e-6
+      region: eu-central-1
     - region: ap-southeast-4
       # pricing not published on AWS Bedrock pricing page
-    - region: ap-southeast-3
-      # pricing not published on AWS Bedrock pricing page
+    - input_cost_per_token: 6e-7
+      output_cost_per_token: 1.8e-6
+      region: ap-southeast-3
     - input_cost_per_token: 5.15e-7
       output_cost_per_token: 1.545e-6
       region: ap-southeast-2

--- a/providers/aws-bedrock-mantle/mistral.ministral-3-14b-instruct.yaml
+++ b/providers/aws-bedrock-mantle/mistral.ministral-3-14b-instruct.yaml
@@ -14,11 +14,11 @@ costs:
     - input_cost_per_token: 3.1e-7
       output_cost_per_token: 3.1e-7
       region: eu-west-2
-    - input_cost_per_token: 2.4e-7
-      output_cost_per_token: 2.4e-7
+    - input_cost_per_token: 2.3e-7
+      output_cost_per_token: 2.3e-7
       region: eu-west-1
-    - input_cost_per_token: 2.4e-7
-      output_cost_per_token: 2.4e-7
+    - input_cost_per_token: 2.3e-7
+      output_cost_per_token: 2.3e-7
       region: eu-south-1
     - input_cost_per_token: 2.4e-7
       output_cost_per_token: 2.4e-7

--- a/providers/aws-bedrock-mantle/mistral.ministral-3-3b-instruct.yaml
+++ b/providers/aws-bedrock-mantle/mistral.ministral-3-3b-instruct.yaml
@@ -20,10 +20,16 @@ costs:
     - input_cost_per_token: 1.2e-7
       output_cost_per_token: 1.2e-7
       region: eu-south-1
-    - region: eu-north-1 # price not published on AWS Bedrock pricing page
-    - region: eu-central-1 # price not published on AWS Bedrock pricing page
+    - input_cost_per_token: 1.2e-7
+      output_cost_per_token: 1.2e-7
+      region: eu-north-1
+    - input_cost_per_token: 1.2e-7
+      output_cost_per_token: 1.2e-7
+      region: eu-central-1
     - region: ap-southeast-4 # price not published on AWS Bedrock pricing page
-    - region: ap-southeast-3 # price not published on AWS Bedrock pricing page
+    - input_cost_per_token: 1.2e-7
+      output_cost_per_token: 1.2e-7
+      region: ap-southeast-3
     - input_cost_per_token: 1.03e-7
       output_cost_per_token: 1.03e-7
       region: ap-southeast-2

--- a/providers/aws-bedrock-mantle/mistral.ministral-3-8b-instruct.yaml
+++ b/providers/aws-bedrock-mantle/mistral.ministral-3-8b-instruct.yaml
@@ -20,9 +20,15 @@ costs:
     - input_cost_per_token: 1.8e-7
       output_cost_per_token: 1.8e-7
       region: eu-south-1
-    - region: eu-north-1 # price not published on AWS Bedrock pricing page
-    - region: eu-central-1 # price not published on AWS Bedrock pricing page
-    - region: ap-southeast-3 # price not published on AWS Bedrock pricing page
+    - input_cost_per_token: 1.8e-7
+      output_cost_per_token: 1.8e-7
+      region: eu-north-1
+    - input_cost_per_token: 1.8e-7
+      output_cost_per_token: 1.8e-7
+      region: eu-central-1
+    - input_cost_per_token: 1.8e-7
+      output_cost_per_token: 1.8e-7
+      region: ap-southeast-3
     - input_cost_per_token: 1.545e-7
       output_cost_per_token: 1.545e-7
       region: ap-southeast-2

--- a/providers/aws-bedrock-mantle/mistral.mistral-large-3-675b-instruct.yaml
+++ b/providers/aws-bedrock-mantle/mistral.mistral-large-3-675b-instruct.yaml
@@ -14,9 +14,13 @@ costs:
     - input_cost_per_token: 7.8e-7
       output_cost_per_token: 2.33e-6
       region: eu-west-2 # pricing not found in official docs
-    - region: eu-north-1 # pricing not found in official docs
-    - region: ap-southeast-4
-    - region: ap-southeast-3 # pricing not found in official docs
+    - input_cost_per_token: 6e-7
+      output_cost_per_token: 1.8e-6
+      region: eu-north-1
+    - region: ap-southeast-4 # not found in official docs
+    - input_cost_per_token: 6e-7
+      output_cost_per_token: 1.8e-6
+      region: ap-southeast-3
     - input_cost_per_token: 5.15e-7
       output_cost_per_token: 1.545e-6
       region: ap-southeast-2

--- a/providers/aws-bedrock-mantle/mistral.mistral-large-3-675b-instruct.yaml
+++ b/providers/aws-bedrock-mantle/mistral.mistral-large-3-675b-instruct.yaml
@@ -11,8 +11,8 @@ costs:
     - input_cost_per_token: 6.1e-7
       output_cost_per_token: 1.82e-6
       region: sa-east-1
-    - input_cost_per_token: 7.8e-7
-      output_cost_per_token: 2.33e-6
+    - input_cost_per_token: 7.75e-7
+      output_cost_per_token: 2.325e-6
       region: eu-west-2 # pricing not found in official docs
     - input_cost_per_token: 6e-7
       output_cost_per_token: 1.8e-6

--- a/providers/aws-bedrock-mantle/mistral.voxtral-mini-3b-2507.yaml
+++ b/providers/aws-bedrock-mantle/mistral.voxtral-mini-3b-2507.yaml
@@ -20,10 +20,16 @@ costs:
     - input_cost_per_token: 5e-8
       output_cost_per_token: 5e-8
       region: eu-south-1
-    - region: eu-north-1 # pricing not found in official docs
-    - region: eu-central-1 # pricing not found in official docs
+    - input_cost_per_token: 4.8e-8
+      output_cost_per_token: 4.8e-8
+      region: eu-north-1
+    - input_cost_per_token: 4.8e-8
+      output_cost_per_token: 4.8e-8
+      region: eu-central-1
     - region: ap-southeast-4 # pricing not found in official docs
-    - region: ap-southeast-3 # pricing not found in official docs
+    - input_cost_per_token: 4.8e-8
+      output_cost_per_token: 4.8e-8
+      region: ap-southeast-3
     - input_cost_per_token: 4.12e-8
       output_cost_per_token: 4.12e-8
       region: ap-southeast-2

--- a/providers/aws-bedrock-mantle/mistral.voxtral-small-24b-2507.yaml
+++ b/providers/aws-bedrock-mantle/mistral.voxtral-small-24b-2507.yaml
@@ -21,14 +21,14 @@ costs:
       output_cost_per_token: 3.5e-7
       region: eu-south-1
     - input_cost_per_token: 1.2e-7
-      output_cost_per_token: 3.5e-7
+      output_cost_per_token: 3.6e-7
       region: eu-north-1 # not found in official docs
     - input_cost_per_token: 1.2e-7
-      output_cost_per_token: 3.5e-7
+      output_cost_per_token: 3.6e-7
       region: eu-central-1 # not found in official docs
     - region: ap-southeast-4 # price not published in official docs
     - input_cost_per_token: 1.2e-7
-      output_cost_per_token: 3.5e-7
+      output_cost_per_token: 3.6e-7
       region: ap-southeast-3 # not found in official docs
     - input_cost_per_token: 1.03e-7
       output_cost_per_token: 3.09e-7

--- a/providers/aws-bedrock-mantle/moonshotai.kimi-k2-thinking.yaml
+++ b/providers/aws-bedrock-mantle/moonshotai.kimi-k2-thinking.yaml
@@ -11,10 +11,16 @@ costs:
     - input_cost_per_token: 7.3e-7
       output_cost_per_token: 0.00000303
       region: sa-east-1
-    - region: eu-west-2 # pricing not yet published on AWS Bedrock pricing page
-    - region: eu-north-1 # pricing not yet published on AWS Bedrock pricing page
+    - input_cost_per_token: 9.3e-7
+      output_cost_per_token: 0.000003875
+      region: eu-west-2
+    - input_cost_per_token: 7.2e-7
+      output_cost_per_token: 0.000003
+      region: eu-north-1
     - region: ap-southeast-4 # pricing not yet published on AWS Bedrock pricing page
-    - region: ap-southeast-3 # pricing not yet published on AWS Bedrock pricing page
+    - input_cost_per_token: 7.2e-7
+      output_cost_per_token: 0.000003
+      region: ap-southeast-3
     - input_cost_per_token: 6.18e-7
       output_cost_per_token: 0.000002575
       region: ap-southeast-2

--- a/providers/aws-bedrock-mantle/moonshotai.kimi-k2.5.yaml
+++ b/providers/aws-bedrock-mantle/moonshotai.kimi-k2.5.yaml
@@ -22,7 +22,7 @@ costs:
     - input_cost_per_token: 7.2e-7
       output_cost_per_token: 3.6e-6
       region: ap-southeast-3
-    - input_cost_per_token: 6.18e-7
+    - input_cost_per_token: 6.2e-7
       output_cost_per_token: 3.09e-6
       region: ap-southeast-2
     - input_cost_per_token: 7.2e-7

--- a/providers/aws-bedrock-mantle/moonshotai.kimi-k2.5.yaml
+++ b/providers/aws-bedrock-mantle/moonshotai.kimi-k2.5.yaml
@@ -11,8 +11,9 @@ costs:
     - input_cost_per_token: 7.2e-7
       output_cost_per_token: 3.6e-6
       region: sa-east-1
-    - region: eu-west-2
-      # pricing not yet published on https://aws.amazon.com/bedrock/pricing/
+    - input_cost_per_token: 9.3e-7
+      output_cost_per_token: 4.65e-6
+      region: eu-west-2
     - input_cost_per_token: 7.2e-7
       output_cost_per_token: 3.6e-6
       region: eu-north-1

--- a/providers/aws-bedrock-mantle/nvidia.nemotron-nano-12b-v2.yaml
+++ b/providers/aws-bedrock-mantle/nvidia.nemotron-nano-12b-v2.yaml
@@ -23,10 +23,16 @@ costs:
     - input_cost_per_token: 2.4e-7
       output_cost_per_token: 7.1e-7
       region: eu-south-1
-    - region: eu-north-1 # price not found in official docs
-    - region: eu-central-1 # price not found in official docs
+    - input_cost_per_token: 2.4e-7
+      output_cost_per_token: 7.2e-7
+      region: eu-north-1
+    - input_cost_per_token: 2.4e-7
+      output_cost_per_token: 7.2e-7
+      region: eu-central-1
     - region: ap-southeast-4 # price not found in official docs
-    - region: ap-southeast-3 # price not found in official docs
+    - input_cost_per_token: 2.4e-7
+      output_cost_per_token: 7.2e-7
+      region: ap-southeast-3
     - input_cost_per_token: 2.06e-7
       output_cost_per_token: 6.18e-7
       region: ap-southeast-2

--- a/providers/aws-bedrock-mantle/nvidia.nemotron-nano-12b-v2.yaml
+++ b/providers/aws-bedrock-mantle/nvidia.nemotron-nano-12b-v2.yaml
@@ -17,11 +17,11 @@ costs:
     - input_cost_per_token: 3.1e-7
       output_cost_per_token: 9.3e-7
       region: eu-west-2
-    - input_cost_per_token: 2.4e-7
-      output_cost_per_token: 7.1e-7
+    - input_cost_per_token: 2.3e-7
+      output_cost_per_token: 7e-7
       region: eu-west-1
-    - input_cost_per_token: 2.4e-7
-      output_cost_per_token: 7.1e-7
+    - input_cost_per_token: 2.3e-7
+      output_cost_per_token: 7e-7
       region: eu-south-1
     - input_cost_per_token: 2.4e-7
       output_cost_per_token: 7.2e-7

--- a/providers/aws-bedrock-mantle/nvidia.nemotron-nano-3-30b.yaml
+++ b/providers/aws-bedrock-mantle/nvidia.nemotron-nano-3-30b.yaml
@@ -23,10 +23,16 @@ costs:
     - input_cost_per_token: 7e-8
       output_cost_per_token: 2.8e-7
       region: eu-south-1
-    - region: eu-north-1 # pricing not found in official docs
-    - region: eu-central-1 # pricing not found in official docs
+    - input_cost_per_token: 7.2e-8
+      output_cost_per_token: 2.88e-7
+      region: eu-north-1
+    - input_cost_per_token: 7.2e-8
+      output_cost_per_token: 2.88e-7
+      region: eu-central-1
     - region: ap-southeast-4 # pricing not found in official docs
-    - region: ap-southeast-3 # pricing not found in official docs
+    - input_cost_per_token: 7.2e-8
+      output_cost_per_token: 2.88e-7
+      region: ap-southeast-3
     - input_cost_per_token: 6.18e-8
       output_cost_per_token: 2.472e-7
       region: ap-southeast-2

--- a/providers/aws-bedrock-mantle/nvidia.nemotron-nano-9b-v2.yaml
+++ b/providers/aws-bedrock-mantle/nvidia.nemotron-nano-9b-v2.yaml
@@ -20,9 +20,15 @@ costs:
     - input_cost_per_token: 7e-8
       output_cost_per_token: 2.7e-7
       region: eu-south-1
-    - region: eu-north-1 # pricing not yet published on AWS Bedrock pricing page
-    - region: eu-central-1 # pricing not yet published on AWS Bedrock pricing page
-    - region: ap-southeast-3 # pricing not yet published on AWS Bedrock pricing page
+    - input_cost_per_token: 7.2e-8
+      output_cost_per_token: 2.76e-7
+      region: eu-north-1
+    - input_cost_per_token: 7.2e-8
+      output_cost_per_token: 2.76e-7
+      region: eu-central-1
+    - input_cost_per_token: 7.2e-8
+      output_cost_per_token: 2.76e-7
+      region: ap-southeast-3
     - input_cost_per_token: 6.18e-8
       output_cost_per_token: 2.369e-7
       region: ap-southeast-2

--- a/providers/aws-bedrock-mantle/nvidia.nemotron-super-3-120b.yaml
+++ b/providers/aws-bedrock-mantle/nvidia.nemotron-super-3-120b.yaml
@@ -29,7 +29,7 @@ costs:
     - input_cost_per_token: 1.8e-7
       output_cost_per_token: 7.8e-7
       region: eu-central-1
-    - region: ap-southeast-4
+    - region: ap-southeast-4 # not found in official docs
     - input_cost_per_token: 1.8e-7
       output_cost_per_token: 7.8e-7
       region: ap-southeast-3

--- a/providers/aws-bedrock-mantle/openai.gpt-oss-120b.yaml
+++ b/providers/aws-bedrock-mantle/openai.gpt-oss-120b.yaml
@@ -1,23 +1,49 @@
 costs:
-    - region: us-west-2
-    - region: us-gov-west-1
-    - region: us-east-2
-    - region: us-east-1
-    - region: sa-east-1
-    - region: eu-west-2
-    - region: eu-west-1
-    - region: eu-south-1
-    - region: eu-north-1
-    - region: eu-central-1
-    - region: ap-southeast-4
-    - region: ap-southeast-3
+    - input_cost_per_token: 1.5e-7
+      output_cost_per_token: 6e-7
+      region: us-west-2
+    - input_cost_per_token: 1.8e-7
+      output_cost_per_token: 7.2e-7
+      region: us-gov-west-1
+    - input_cost_per_token: 1.5e-7
+      output_cost_per_token: 6e-7
+      region: us-east-2
+    - input_cost_per_token: 1.5e-7
+      output_cost_per_token: 6e-7
+      region: us-east-1
+    - input_cost_per_token: 1.8e-7
+      output_cost_per_token: 7.3e-7
+      region: sa-east-1
+    - input_cost_per_token: 2.3e-7
+      output_cost_per_token: 9.3e-7
+      region: eu-west-2
+    - input_cost_per_token: 1.8e-7
+      output_cost_per_token: 7e-7
+      region: eu-west-1
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 7.9e-7
+      region: eu-south-1
+    - input_cost_per_token: 1.5e-7
+      output_cost_per_token: 6e-7
+      region: eu-north-1
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 7.9e-7
+      region: eu-central-1
+    - region: ap-southeast-4 # not found in official docs
+    - input_cost_per_token: 1.6e-7
+      output_cost_per_token: 6.2e-7
+      region: ap-southeast-3
     - input_cost_per_token: 1.545e-7
       input_cost_per_token_batches: 7.73e-8
       output_cost_per_token: 6.18e-7
       output_cost_per_token_batches: 3.09e-7
       region: ap-southeast-2
-    - region: ap-south-1
-    - region: ap-northeast-1
+    - input_cost_per_token: 1.8e-7
+      output_cost_per_token: 7.1e-7
+      region: ap-south-1
+    - input_cost_per_token: 1.8e-7
+      output_cost_per_token: 7.3e-7
+      region: ap-northeast-1
 features:
     - function_calling
     - parallel_function_calling

--- a/providers/aws-bedrock-mantle/openai.gpt-oss-20b.yaml
+++ b/providers/aws-bedrock-mantle/openai.gpt-oss-20b.yaml
@@ -21,7 +21,7 @@ costs:
       output_cost_per_token: 4e-7
       region: eu-south-1
     - input_cost_per_token: 7e-8
-      output_cost_per_token: 3e-8
+      output_cost_per_token: 3e-7
       region: eu-north-1
     - input_cost_per_token: 9e-8
       output_cost_per_token: 4e-7

--- a/providers/aws-bedrock-mantle/openai.gpt-oss-safeguard-120b.yaml
+++ b/providers/aws-bedrock-mantle/openai.gpt-oss-safeguard-120b.yaml
@@ -9,7 +9,7 @@ costs:
       output_cost_per_token: 6e-7
       region: us-east-1
     - input_cost_per_token: 1.8e-7
-      output_cost_per_token: 7.1e-7
+      output_cost_per_token: 7.3e-7
       region: sa-east-1
     - input_cost_per_token: 2.3e-7
       output_cost_per_token: 9.3e-7
@@ -37,7 +37,7 @@ costs:
       output_cost_per_token: 7.1e-7
       region: ap-south-1
     - input_cost_per_token: 1.8e-7
-      output_cost_per_token: 7.1e-7
+      output_cost_per_token: 7.3e-7
       region: ap-northeast-1
 features:
     - function_calling

--- a/providers/aws-bedrock-mantle/openai.gpt-oss-safeguard-120b.yaml
+++ b/providers/aws-bedrock-mantle/openai.gpt-oss-safeguard-120b.yaml
@@ -20,10 +20,16 @@ costs:
     - input_cost_per_token: 1.8e-7
       output_cost_per_token: 7e-7
       region: eu-south-1
-    - region: eu-north-1 # pricing not published on AWS Bedrock pricing page
-    - region: eu-central-1 # pricing not published on AWS Bedrock pricing page
+    - input_cost_per_token: 1.8e-7
+      output_cost_per_token: 7.2e-7
+      region: eu-north-1
+    - input_cost_per_token: 1.8e-7
+      output_cost_per_token: 7.2e-7
+      region: eu-central-1
     - region: ap-southeast-4 # pricing not published on AWS Bedrock pricing page
-    - region: ap-southeast-3 # pricing not published on AWS Bedrock pricing page
+    - input_cost_per_token: 1.8e-7
+      output_cost_per_token: 7.2e-7
+      region: ap-southeast-3
     - input_cost_per_token: 1.545e-7
       output_cost_per_token: 6.18e-7
       region: ap-southeast-2

--- a/providers/aws-bedrock-mantle/openai.gpt-oss-safeguard-20b.yaml
+++ b/providers/aws-bedrock-mantle/openai.gpt-oss-safeguard-20b.yaml
@@ -20,10 +20,16 @@ costs:
     - input_cost_per_token: 8e-8
       output_cost_per_token: 2.3e-7
       region: eu-south-1
-    - region: eu-north-1 # not found in official docs
-    - region: eu-central-1 # not found in official docs
+    - input_cost_per_token: 8.4e-8
+      output_cost_per_token: 2.4e-7
+      region: eu-north-1
+    - input_cost_per_token: 8.4e-8
+      output_cost_per_token: 2.4e-7
+      region: eu-central-1
     - region: ap-southeast-4 # not found in official docs
-    - region: ap-southeast-3 # not found in official docs
+    - input_cost_per_token: 8.4e-8
+      output_cost_per_token: 2.4e-7
+      region: ap-southeast-3
     - input_cost_per_token: 7.21e-8
       output_cost_per_token: 2.06e-7
       region: ap-southeast-2

--- a/providers/aws-bedrock-mantle/qwen.qwen3-235b-a22b-2507.yaml
+++ b/providers/aws-bedrock-mantle/qwen.qwen3-235b-a22b-2507.yaml
@@ -1,20 +1,44 @@
 costs:
-    - region: us-west-2
-    - region: us-east-2
-    - region: us-east-1
-    - region: sa-east-1
-    - region: eu-west-2
-    - region: eu-west-1
-    - region: eu-south-1
-    - region: eu-north-1
-    - region: eu-central-1
-    - region: ap-southeast-4
-    - region: ap-southeast-3
+    - input_cost_per_token: 2.2e-7
+      output_cost_per_token: 8.8e-7
+      region: us-west-2
+    - input_cost_per_token: 2.2e-7
+      output_cost_per_token: 8.8e-7
+      region: us-east-2
+    - input_cost_per_token: 2.2e-7
+      output_cost_per_token: 8.8e-7
+      region: us-east-1
+    - input_cost_per_token: 2.64e-7
+      output_cost_per_token: 1.056e-6
+      region: sa-east-1
+    - input_cost_per_token: 3.4e-7
+      output_cost_per_token: 1.37e-6
+      region: eu-west-2
+    - input_cost_per_token: 2.64e-7
+      output_cost_per_token: 1.056e-6
+      region: eu-west-1
+    - input_cost_per_token: 2.9e-7
+      output_cost_per_token: 1.16e-6
+      region: eu-south-1
+    - input_cost_per_token: 2.2e-7
+      output_cost_per_token: 8.8e-7
+      region: eu-north-1
+    - input_cost_per_token: 2.9e-7
+      output_cost_per_token: 1.16e-6
+      region: eu-central-1
+    - region: ap-southeast-4 # not found in official docs
+    - input_cost_per_token: 2.3e-7
+      output_cost_per_token: 9.1e-7
+      region: ap-southeast-3
     - input_cost_per_token: 2.266e-7
       output_cost_per_token: 9.064e-7
       region: ap-southeast-2
-    - region: ap-south-1
-    - region: ap-northeast-1
+    - input_cost_per_token: 2.6e-7
+      output_cost_per_token: 1.04e-6
+      region: ap-south-1
+    - input_cost_per_token: 2.7e-7
+      output_cost_per_token: 1.06e-6
+      region: ap-northeast-1
 features:
     - function_calling
     - tool_choice

--- a/providers/aws-bedrock-mantle/qwen.qwen3-32b.yaml
+++ b/providers/aws-bedrock-mantle/qwen.qwen3-32b.yaml
@@ -1,22 +1,46 @@
 costs:
-    - region: us-west-2
-    - region: us-east-2
-    - region: us-east-1
-    - region: sa-east-1
-    - region: eu-west-2
-    - region: eu-west-1
-    - region: eu-south-1
-    - region: eu-north-1
-    - region: eu-central-1
-    - region: ap-southeast-4
-    - region: ap-southeast-3
+    - input_cost_per_token: 1.5e-7
+      output_cost_per_token: 6e-7
+      region: us-west-2
+    - input_cost_per_token: 1.5e-7
+      output_cost_per_token: 6e-7
+      region: us-east-2
+    - input_cost_per_token: 1.5e-7
+      output_cost_per_token: 6e-7
+      region: us-east-1
+    - input_cost_per_token: 1.8e-7
+      output_cost_per_token: 7.3e-7
+      region: sa-east-1
+    - input_cost_per_token: 2.3e-7
+      output_cost_per_token: 9.3e-7
+      region: eu-west-2
+    - input_cost_per_token: 1.8e-7
+      output_cost_per_token: 7e-7
+      region: eu-west-1
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 7.9e-7
+      region: eu-south-1
+    - input_cost_per_token: 1.5e-7
+      output_cost_per_token: 6e-7
+      region: eu-north-1
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 7.9e-7
+      region: eu-central-1
+    - region: ap-southeast-4 # not found in official docs
+    - input_cost_per_token: 1.6e-7
+      output_cost_per_token: 6.2e-7
+      region: ap-southeast-3
     - input_cost_per_token: 1.545e-7
       input_cost_per_token_batches: 7.73e-8
       output_cost_per_token: 6.18e-7
       output_cost_per_token_batches: 3.09e-7
       region: ap-southeast-2
-    - region: ap-south-1
-    - region: ap-northeast-1
+    - input_cost_per_token: 1.8e-7
+      output_cost_per_token: 7.1e-7
+      region: ap-south-1
+    - input_cost_per_token: 1.8e-7
+      output_cost_per_token: 7.3e-7
+      region: ap-northeast-1
 features:
     - function_calling
     - structured_output

--- a/providers/aws-bedrock-mantle/qwen.qwen3-coder-30b-a3b-instruct.yaml
+++ b/providers/aws-bedrock-mantle/qwen.qwen3-coder-30b-a3b-instruct.yaml
@@ -1,20 +1,44 @@
 costs:
-    - region: us-west-2
-    - region: us-east-2
-    - region: us-east-1
-    - region: sa-east-1
-    - region: eu-west-2
-    - region: eu-west-1
-    - region: eu-south-1
-    - region: eu-north-1
-    - region: eu-central-1
-    - region: ap-southeast-4
-    - region: ap-southeast-3
+    - input_cost_per_token: 1.5e-7
+      output_cost_per_token: 6e-7
+      region: us-west-2
+    - input_cost_per_token: 1.5e-7
+      output_cost_per_token: 6e-7
+      region: us-east-2
+    - input_cost_per_token: 1.5e-7
+      output_cost_per_token: 6e-7
+      region: us-east-1
+    - input_cost_per_token: 1.8e-7
+      output_cost_per_token: 7.3e-7
+      region: sa-east-1
+    - input_cost_per_token: 2.3e-7
+      output_cost_per_token: 9.3e-7
+      region: eu-west-2
+    - input_cost_per_token: 1.8e-7
+      output_cost_per_token: 7e-7
+      region: eu-west-1
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 7.9e-7
+      region: eu-south-1
+    - input_cost_per_token: 1.5e-7
+      output_cost_per_token: 6e-7
+      region: eu-north-1
+    - input_cost_per_token: 2e-7
+      output_cost_per_token: 7.9e-7
+      region: eu-central-1
+    - region: ap-southeast-4 # not found in official docs
+    - input_cost_per_token: 1.6e-7
+      output_cost_per_token: 6.2e-7
+      region: ap-southeast-3
     - input_cost_per_token: 1.545e-7
       output_cost_per_token: 6.18e-7
       region: ap-southeast-2
-    - region: ap-south-1
-    - region: ap-northeast-1
+    - input_cost_per_token: 1.8e-7
+      output_cost_per_token: 7.1e-7
+      region: ap-south-1
+    - input_cost_per_token: 1.8e-7
+      output_cost_per_token: 7.3e-7
+      region: ap-northeast-1
 features:
     - function_calling
 limits:

--- a/providers/aws-bedrock-mantle/qwen.qwen3-coder-480b-a35b-instruct.yaml
+++ b/providers/aws-bedrock-mantle/qwen.qwen3-coder-480b-a35b-instruct.yaml
@@ -5,19 +5,25 @@ costs:
     - input_cost_per_token: 4.5e-7
       output_cost_per_token: 1.8e-6
       region: us-east-2
-    - region: us-east-1
-    - region: sa-east-1
+    - input_cost_per_token: 4.5e-7
+      output_cost_per_token: 1.8e-6
+      region: us-east-1
+    - input_cost_per_token: 5.4e-7
+      output_cost_per_token: 2.16e-6
+      region: sa-east-1
     - input_cost_per_token: 7e-7
       output_cost_per_token: 2.79e-6
       region: eu-west-2
     - input_cost_per_token: 4.5e-7
       output_cost_per_token: 1.8e-6
       region: eu-north-1
-    - region: ap-southeast-4
+    - region: ap-southeast-4 # not found in official docs
     - input_cost_per_token: 4.7e-7
       output_cost_per_token: 1.87e-6
       region: ap-southeast-3
-    - region: ap-southeast-2
+    - input_cost_per_token: 4.635e-7
+      output_cost_per_token: 1.854e-6
+      region: ap-southeast-2
     - input_cost_per_token: 5.3e-7
       output_cost_per_token: 2.12e-6
       region: ap-south-1

--- a/providers/aws-bedrock-mantle/qwen.qwen3-coder-next.yaml
+++ b/providers/aws-bedrock-mantle/qwen.qwen3-coder-next.yaml
@@ -20,7 +20,9 @@ costs:
     - input_cost_per_token: 6e-7
       output_cost_per_token: 1.44e-6
       region: eu-south-1
-    - region: eu-north-1 # not found in official docs
+    - input_cost_per_token: 6e-7
+      output_cost_per_token: 1.44e-6
+      region: eu-north-1
     - input_cost_per_token: 6e-7
       output_cost_per_token: 1.44e-6
       region: eu-central-1

--- a/providers/aws-bedrock-mantle/qwen.qwen3-coder-next.yaml
+++ b/providers/aws-bedrock-mantle/qwen.qwen3-coder-next.yaml
@@ -30,8 +30,8 @@ costs:
     - input_cost_per_token: 6e-7
       output_cost_per_token: 1.44e-6
       region: ap-southeast-3
-    - input_cost_per_token: 5.15e-7
-      output_cost_per_token: 1.236e-6
+    - input_cost_per_token: 5.2e-7
+      output_cost_per_token: 1.24e-6
       region: ap-southeast-2
     - input_cost_per_token: 6e-7
       output_cost_per_token: 1.44e-6

--- a/providers/aws-bedrock-mantle/qwen.qwen3-next-80b-a3b-instruct.yaml
+++ b/providers/aws-bedrock-mantle/qwen.qwen3-next-80b-a3b-instruct.yaml
@@ -20,9 +20,15 @@ costs:
     - input_cost_per_token: 1.8e-7
       output_cost_per_token: 0.00000141
       region: eu-south-1
-    - region: eu-north-1 # not found in official docs
-    - region: eu-central-1 # not found in official docs
-    - region: ap-southeast-3 # not found in official docs
+    - input_cost_per_token: 1.68e-7
+      output_cost_per_token: 0.00000144
+      region: eu-north-1
+    - input_cost_per_token: 1.68e-7
+      output_cost_per_token: 0.00000144
+      region: eu-central-1
+    - input_cost_per_token: 1.68e-7
+      output_cost_per_token: 0.00000144
+      region: ap-southeast-3
     - input_cost_per_token: 1.545e-7
       output_cost_per_token: 0.000001236
       region: ap-southeast-2

--- a/providers/aws-bedrock-mantle/qwen.qwen3-next-80b-a3b-instruct.yaml
+++ b/providers/aws-bedrock-mantle/qwen.qwen3-next-80b-a3b-instruct.yaml
@@ -1,24 +1,24 @@
 costs:
-    - input_cost_per_token: 1.5e-7
+    - input_cost_per_token: 1.4e-7
       output_cost_per_token: 0.0000012
       region: us-west-2
-    - input_cost_per_token: 1.5e-7
+    - input_cost_per_token: 1.4e-7
       output_cost_per_token: 0.0000012
       region: us-east-2
-    - input_cost_per_token: 1.5e-7
+    - input_cost_per_token: 1.4e-7
       output_cost_per_token: 0.0000012
       region: us-east-1
-    - input_cost_per_token: 1.8e-7
-      output_cost_per_token: 0.00000145
+    - input_cost_per_token: 1.68e-7
+      output_cost_per_token: 0.00000144
       region: sa-east-1
-    - input_cost_per_token: 2.3e-7
+    - input_cost_per_token: 2.17e-7
       output_cost_per_token: 0.00000186
       region: eu-west-2
-    - input_cost_per_token: 1.8e-7
-      output_cost_per_token: 0.00000141
+    - input_cost_per_token: 1.68e-7
+      output_cost_per_token: 0.00000144
       region: eu-west-1
-    - input_cost_per_token: 1.8e-7
-      output_cost_per_token: 0.00000141
+    - input_cost_per_token: 1.68e-7
+      output_cost_per_token: 0.00000144
       region: eu-south-1
     - input_cost_per_token: 1.68e-7
       output_cost_per_token: 0.00000144
@@ -29,14 +29,14 @@ costs:
     - input_cost_per_token: 1.68e-7
       output_cost_per_token: 0.00000144
       region: ap-southeast-3
-    - input_cost_per_token: 1.545e-7
+    - input_cost_per_token: 1.442e-7
       output_cost_per_token: 0.000001236
       region: ap-southeast-2
-    - input_cost_per_token: 1.8e-7
-      output_cost_per_token: 0.00000141
+    - input_cost_per_token: 1.68e-7
+      output_cost_per_token: 0.00000144
       region: ap-south-1
-    - input_cost_per_token: 1.8e-7
-      output_cost_per_token: 0.00000145
+    - input_cost_per_token: 1.68e-7
+      output_cost_per_token: 0.00000144
       region: ap-northeast-1
 features:
     - function_calling

--- a/providers/aws-bedrock-mantle/qwen.qwen3-vl-235b-a22b-instruct.yaml
+++ b/providers/aws-bedrock-mantle/qwen.qwen3-vl-235b-a22b-instruct.yaml
@@ -15,10 +15,10 @@ costs:
       output_cost_per_token: 0.00000412
       region: eu-west-2
     - input_cost_per_token: 6.2e-7
-      output_cost_per_token: 0.00000313
+      output_cost_per_token: 0.00000312
       region: eu-west-1
     - input_cost_per_token: 6.2e-7
-      output_cost_per_token: 0.00000313
+      output_cost_per_token: 0.00000312
       region: eu-south-1
     - input_cost_per_token: 6.36e-7
       output_cost_per_token: 0.000003192

--- a/providers/aws-bedrock-mantle/qwen.qwen3-vl-235b-a22b-instruct.yaml
+++ b/providers/aws-bedrock-mantle/qwen.qwen3-vl-235b-a22b-instruct.yaml
@@ -20,9 +20,15 @@ costs:
     - input_cost_per_token: 6.2e-7
       output_cost_per_token: 0.00000313
       region: eu-south-1
-    - region: eu-north-1 # pricing not published on AWS Bedrock pricing page
-    - region: eu-central-1 # pricing not published on AWS Bedrock pricing page
-    - region: ap-southeast-3 # pricing not published on AWS Bedrock pricing page
+    - input_cost_per_token: 6.36e-7
+      output_cost_per_token: 0.000003192
+      region: eu-north-1
+    - input_cost_per_token: 6.36e-7
+      output_cost_per_token: 0.000003192
+      region: eu-central-1
+    - input_cost_per_token: 6.36e-7
+      output_cost_per_token: 0.000003192
+      region: ap-southeast-3
     - input_cost_per_token: 5.459e-7
       output_cost_per_token: 0.0000027398
       region: ap-southeast-2

--- a/providers/aws-bedrock-mantle/writer.palmyra-vision-7b.yaml
+++ b/providers/aws-bedrock-mantle/writer.palmyra-vision-7b.yaml
@@ -8,38 +8,38 @@ costs:
     - input_cost_per_token: 1.5e-7
       output_cost_per_token: 6e-7
       region: us-east-1
-    - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6e-7
+    - input_cost_per_token: 1.8e-7
+      output_cost_per_token: 7.2e-7
       region: sa-east-1
-    - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6e-7
+    - input_cost_per_token: 2.3e-7
+      output_cost_per_token: 9.3e-7
       region: eu-west-2
-    - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6e-7
+    - input_cost_per_token: 1.8e-7
+      output_cost_per_token: 7.2e-7
       region: eu-west-1
-    - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6e-7
+    - input_cost_per_token: 1.8e-7
+      output_cost_per_token: 7.2e-7
       region: eu-south-1
-    - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6e-7
+    - input_cost_per_token: 1.8e-7
+      output_cost_per_token: 7.2e-7
       region: eu-north-1
-    - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6e-7
+    - input_cost_per_token: 1.8e-7
+      output_cost_per_token: 7.2e-7
       region: eu-central-1
     - input_cost_per_token: 1.5e-7
       output_cost_per_token: 6e-7
       region: ap-southeast-4
-    - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6e-7
+    - input_cost_per_token: 1.8e-7
+      output_cost_per_token: 7.2e-7
       region: ap-southeast-3
     - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6e-7
+      output_cost_per_token: 6.2e-7
       region: ap-southeast-2
-    - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6e-7
+    - input_cost_per_token: 1.8e-7
+      output_cost_per_token: 7.2e-7
       region: ap-south-1 # listed in input YAML but not on the AWS Bedrock model card; preserved per never-drop-existing-region rule
-    - input_cost_per_token: 1.5e-7
-      output_cost_per_token: 6e-7
+    - input_cost_per_token: 1.8e-7
+      output_cost_per_token: 7.2e-7
       region: ap-northeast-1
 features:
     - system_messages

--- a/providers/aws-bedrock-mantle/zai.glm-4.7-flash.yaml
+++ b/providers/aws-bedrock-mantle/zai.glm-4.7-flash.yaml
@@ -30,8 +30,8 @@ costs:
     - input_cost_per_token: 8e-8
       output_cost_per_token: 4.8e-7
       region: ap-southeast-3
-    - input_cost_per_token: 7.21e-8
-      output_cost_per_token: 4.12e-7
+    - input_cost_per_token: 7e-8
+      output_cost_per_token: 4.1e-7
       region: ap-southeast-2
     - input_cost_per_token: 8e-8
       output_cost_per_token: 4.8e-7

--- a/providers/aws-bedrock-mantle/zai.glm-4.7.yaml
+++ b/providers/aws-bedrock-mantle/zai.glm-4.7.yaml
@@ -21,8 +21,8 @@ costs:
     - input_cost_per_token: 7.2e-7
       output_cost_per_token: 2.64e-6
       region: ap-southeast-3
-    - input_cost_per_token: 6.18e-7
-      output_cost_per_token: 2.266e-6
+    - input_cost_per_token: 6.2e-7
+      output_cost_per_token: 2.27e-6
       region: ap-southeast-2
     - input_cost_per_token: 7.2e-7
       output_cost_per_token: 2.64e-6

--- a/providers/aws-bedrock-mantle/zai.glm-4.7.yaml
+++ b/providers/aws-bedrock-mantle/zai.glm-4.7.yaml
@@ -11,7 +11,9 @@ costs:
     - input_cost_per_token: 7.2e-7
       output_cost_per_token: 2.64e-6
       region: sa-east-1
-    - region: eu-west-2 # pricing not found in official docs
+    - input_cost_per_token: 9.3e-7
+      output_cost_per_token: 3.41e-6
+      region: eu-west-2
     - input_cost_per_token: 7.2e-7
       output_cost_per_token: 2.64e-6
       region: eu-north-1


### PR DESCRIPTION
## Summary

Two commits that bring all `providers/aws-bedrock-mantle/` costs in line with official AWS pricing:

1. **Backfill missing region costs** — adds `input_cost_per_token` / `output_cost_per_token` for **111 region entries across 28 models** that previously listed a region with no price.
2. **Correct drifted pre-existing costs** — fixes **69 values across 19 models** that no longer matched official pricing, including:
   - a 10x typo: `openai.gpt-oss-20b` / `eu-north-1` output `3e-8` → `3e-7`
   - stale flat pricing on `writer.palmyra-vision-7b` (19 values; non-US regions have premiums)
   - re-priced `qwen.qwen3-next-80b-a3b-instruct` regions (15 values)
   - rounding-level drift on `ap-southeast-2` and several EU regions across 15 other models

Source of truth: the **AWS Price List API** (`https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonBedrock/current/index.json`) using the Mantle-specific SKUs (`*-mantle-*-tokens-standard`), cross-validated against the pricing page's own data file (`meteredUnitMaps/bedrock.json`) — the JSON that https://aws.amazon.com/bedrock/pricing/ renders. Per-1K-token rates converted to per-token.

Follows the models-agent updation rules: no region entry dropped, only standard-tier input/output costs touched (no batch/flex/priority).

## Validation

- Price List API vs pricing page data: **1,037 Mantle standard-tier SKUs, 0 mismatches** — the two official sources agree.
- After both commits: **927/927 comparable YAML values match official pricing exactly** (the remaining fields — Anthropic/GPT-5.x models, batch/cache-write rates — are not in the Mantle price list and were left untouched).
- All 54 `aws-bedrock-mantle` YAMLs pass CUE schema validation (`validate.sh`).

## Still unpriced (intentionally left cost-less)

- `ap-southeast-4` (Melbourne) across 26 models — not present in the official price list.
- `zai.glm-4.6` — no published Mantle pricing at all.

These keep their cost-less region entries with `# not found in official docs` style comments.

## Test plan

- [x] All 54 `aws-bedrock-mantle` YAMLs pass CUE schema validation
- [x] 111/111 newly added values match the AWS Price List API exactly
- [x] 69/69 drifted values corrected; full sweep now shows 0 mismatches (927 comparable fields)
- [x] Price List API cross-validated against the official pricing page data (0 mismatches on 1,037 SKUs)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect cost estimation for many models/regions; incorrect rates would mislead billing dashboards, though scope is config-only with no runtime logic.
> 
> **Overview**
> Updates **standard-tier** `input_cost_per_token` / `output_cost_per_token` across many `providers/aws-bedrock-mantle/` model YAMLs so regional Bedrock Mantle pricing matches the official AWS price list.
> 
> **Backfills** regions that only had a `region` stub (and “not found” comments) with real per-token rates—e.g. DeepSeek V3.1 US/EU/AP entries, and full regional matrices for several Qwen and `openai.gpt-oss-120b` configs that were region-only before.
> 
> **Corrects** values that had drifted: notable fix is `openai.gpt-oss-20b` **eu-north-1** output `3e-8` → `3e-7` (10× typo). Other touch-ups include region-specific premiums on `writer.palmyra-vision-7b`, refreshed pricing on `qwen.qwen3-next-80b-a3b-instruct`, and small rounding/API-alignment tweaks on EU and `ap-southeast-2` for Mistral, Gemma, Nemotron, Kimi, GLM, etc.
> 
> Regions still missing from AWS (e.g. **ap-southeast-4** on many models) stay as cost-less entries with doc comments; batch-only fields on existing rows are left unchanged where the diff doesn’t touch them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52da491246a119667b78d538045b13dc1f51f039. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->