### PR TITLE
Add ap-southeast-2 to au.anthropic.claude-sonnet-5

### DIFF
--- a/providers/aws-bedrock/au.anthropic.claude-sonnet-5.yaml
+++ b/providers/aws-bedrock/au.anthropic.claude-sonnet-5.yaml
@@ -5,6 +5,12 @@ costs:
       input_cost_per_token: 2.2e-6
       output_cost_per_token: 1.1e-5
       region: ap-southeast-4
+    - cache_creation_input_token_cost: 2.75e-6
+      cache_creation_input_token_cost_per_hour: 4.4e-6
+      cache_read_input_token_cost: 2.2e-7
+      input_cost_per_token: 2.2e-6
+      output_cost_per_token: 1.1e-5
+      region: ap-southeast-2
 features:
     - function_calling
     - parallel_function_calling


### PR DESCRIPTION
## Summary

Follow-up to #1889: adds `ap-southeast-2` to `au.anthropic.claude-sonnet-5` with the same pricing as `ap-southeast-4`.

The [model card's](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-sonnet-5.html) Regional Availability table currently shows Geo=No for ap-southeast-2 (Sydney), but the live Bedrock API disagrees — `bedrock get-inference-profile` called **from ap-southeast-2** returns the AU profile as `ACTIVE`, with Sydney listed as both a source and destination region, and invocations from Sydney succeed:

```json
{
    "inferenceProfileName": "AU Anthropic Claude Sonnet 5",
    "description": "Routes requests to Claude Sonnet 5 in ap-southeast-2, ap-southeast-4.",
    "inferenceProfileArn": "arn:aws:bedrock:ap-southeast-2:...:inference-profile/au.anthropic.claude-sonnet-5",
    "models": [
        {"modelArn": "arn:aws:bedrock:ap-southeast-2::foundation-model/anthropic.claude-sonnet-5"},
        {"modelArn": "arn:aws:bedrock:ap-southeast-4::foundation-model/anthropic.claude-sonnet-5"}
    ],
    "status": "ACTIVE",
    "type": "SYSTEM_DEFINED"
}
```

The docs table appears stale; the profile behaves like the other AU Claude profiles (e.g. `au.anthropic.claude-sonnet-4-6`, `au.anthropic.claude-opus-5`), which all list ap-southeast-2.

## Changes

- Add an `ap-southeast-2` cost entry mirroring `ap-southeast-4` (AU geo pricing is uniform): input `2.2e-6`, output `1.1e-5`, cache write `2.75e-6`, 1-hour cache write `4.4e-6`, cache read `2.2e-7`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static pricing YAML only; no runtime or billing logic changes.
> 
> **Overview**
> Adds **`ap-southeast-2` (Sydney)** to the `costs` list for **`au.anthropic.claude-sonnet-5`**, using the same token and cache rates as the existing **`ap-southeast-4`** entry so Bedrock cost lookup works when the AU inference profile routes to Sydney.
> 
> No feature flags, limits, or model metadata change—only an additional regional cost block in `providers/aws-bedrock/au.anthropic.claude-sonnet-5.yaml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8f364a44f506c07a5be4bea063eef48b18181eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->