### PR TITLE
GATEWAY-2686: Add ElevenLabs TTS/STT pricing

### DIFF
--- a/providers/elevenlabs/default.yaml
+++ b/providers/elevenlabs/default.yaml
@@ -1,0 +1,4 @@
+documentation:
+    - https://elevenlabs.io/pricing/api
+    - https://elevenlabs.io/docs/overview/models
+    - https://elevenlabs.io/docs/api-reference/speech-to-text/convert

--- a/providers/elevenlabs/eleven_flash_v2.yaml
+++ b/providers/elevenlabs/eleven_flash_v2.yaml
@@ -1,4 +1,16 @@
+costs:
+    - input_cost_per_character: 0.00005
+      region: "*"
+modalities:
+    input:
+        - text
+    output:
+        - audio
 mode: text_to_speech
 model: eleven_flash_v2
+sources:
+    - https://elevenlabs.io/pricing/api
+    - https://elevenlabs.io/docs/overview/models
+status: active
 supportedModes:
     - text_to_speech

--- a/providers/elevenlabs/eleven_flash_v2_5.yaml
+++ b/providers/elevenlabs/eleven_flash_v2_5.yaml
@@ -1,4 +1,16 @@
+costs:
+    - input_cost_per_character: 0.00005
+      region: "*"
+modalities:
+    input:
+        - text
+    output:
+        - audio
 mode: text_to_speech
 model: eleven_flash_v2_5
+sources:
+    - https://elevenlabs.io/pricing/api
+    - https://elevenlabs.io/docs/overview/models
+status: active
 supportedModes:
     - text_to_speech

--- a/providers/elevenlabs/eleven_multilingual_v2.yaml
+++ b/providers/elevenlabs/eleven_multilingual_v2.yaml
@@ -1,4 +1,16 @@
+costs:
+    - input_cost_per_character: 0.0001
+      region: "*"
+modalities:
+    input:
+        - text
+    output:
+        - audio
 mode: text_to_speech
 model: eleven_multilingual_v2
+sources:
+    - https://elevenlabs.io/pricing/api
+    - https://elevenlabs.io/docs/overview/models
+status: active
 supportedModes:
     - text_to_speech

--- a/providers/elevenlabs/eleven_v3.yaml
+++ b/providers/elevenlabs/eleven_v3.yaml
@@ -1,4 +1,16 @@
+costs:
+    - input_cost_per_character: 0.0001
+      region: "*"
+modalities:
+    input:
+        - text
+    output:
+        - audio
 mode: text_to_speech
 model: eleven_v3
+sources:
+    - https://elevenlabs.io/pricing/api
+    - https://elevenlabs.io/docs/overview/models
+status: active
 supportedModes:
     - text_to_speech

--- a/providers/elevenlabs/scribe_v2.yaml
+++ b/providers/elevenlabs/scribe_v2.yaml
@@ -1,0 +1,17 @@
+costs:
+    # Scribe v2 batch — $0.22 per audio hour → per second for gateway costing.
+    - input_cost_per_second: 0.00006111
+      region: "*"
+modalities:
+    input:
+        - audio
+    output:
+        - text
+mode: audio_transcription
+model: scribe_v2
+sources:
+    - https://elevenlabs.io/pricing/api
+    - https://elevenlabs.io/docs/api-reference/speech-to-text/convert
+status: active
+supportedModes:
+    - audio_transcription


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> YAML-only provider pricing and model metadata; no runtime or auth changes, though incorrect rates would affect billing accuracy.
> 
> **Overview**
> Adds **gateway costing and metadata** for ElevenLabs text-to-speech and speech-to-text so usage can be billed and routed correctly.
> 
> Four existing TTS models (`eleven_flash_v2`, `eleven_flash_v2_5`, `eleven_multilingual_v2`, `eleven_v3`) now declare **per-character** rates (Flash at `0.00005`, multilingual/v3 at `0.0001`), **text→audio** modalities, `status: active`, and pricing doc **sources**. A new **`scribe_v2`** entry covers **audio transcription** with **per-second** cost derived from $0.22/audio hour (`0.00006111`), plus **audio→text** modalities. Provider **`default.yaml`** adds shared documentation links including the Scribe STT API reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8703c318593a33f3872026e9b37a3e460cb976de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->