### PR TITLE
fix(azure-open-ai/gpt-5.4-2026-03-05): use max_completion_tokens

### DIFF
--- a/providers/azure-open-ai/gpt-5.4-2026-03-05.yaml
+++ b/providers/azure-open-ai/gpt-5.4-2026-03-05.yaml
@@ -45,13 +45,15 @@ mode: chat
 model: gpt-5.4-2026-03-05
 params:
     - defaultValue: 128
-      key: max_tokens
+      key: max_completion_tokens
       maxValue: 128000
       minValue: 1
     - defaultValue: medium
       key: reasoning_effort
       type: string
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2027-03-05"
 status: active
 supportedModes:


### PR DESCRIPTION
## Summary
- Change `params` key from `max_tokens` to `max_completion_tokens` for `gpt-5.4-2026-03-05`.
- Add `removeParams: [max_tokens]` so the unsupported param is stripped.

## Test plan
- [ ] Confirm YAML params match sibling Azure GPT-5 models (`max_completion_tokens` + `removeParams: max_tokens`)
- [ ] `npm run validate` passes


Made with [Cursor](https://cursor.com)