### PR TITLE
feat: add provider-scoped config with anthropic_betas

### DIFF
--- a/.github/scripts/autogen/types.ts
+++ b/.github/scripts/autogen/types.ts
@@ -14,6 +14,10 @@ export interface components {
         AWSRegion: "af-south-1" | "ap-east-1" | "ap-east-2" | "ap-northeast-1" | "ap-northeast-2" | "ap-northeast-3" | "ap-south-1" | "ap-south-2" | "ap-southeast-1" | "ap-southeast-2" | "ap-southeast-3" | "ap-southeast-4" | "ap-southeast-5" | "ap-southeast-6" | "ap-southeast-7" | "ca-central-1" | "ca-west-1" | "cn-north-1" | "cn-northwest-1" | "eu-central-1" | "eu-central-2" | "eu-north-1" | "eu-south-1" | "eu-south-2" | "eu-west-1" | "eu-west-2" | "eu-west-3" | "il-central-1" | "me-central-1" | "me-south-1" | "mx-central-1" | "sa-east-1" | "us-east-1" | "us-east-2" | "us-gov-east-1" | "us-gov-west-1" | "us-west-1" | "us-west-2";
         /** @enum {string} */
         AzureRegion: "datazone_eu" | "datazone_us" | "global";
+        /** @description One anthropic-beta column: clientToken -> providerToken, or null to drop */
+        BetaColumn: {
+            [key: string]: string | null;
+        };
         Cost: {
             cache_creation_input_audio_token_cost?: number;
             cache_creation_input_token_cost?: number;
@@ -170,6 +174,16 @@ export interface components {
             from: number;
         };
         /**
+         * @description Schema for provider-config.yaml files (provider-scoped, not per-model).
+         *     Every field is optional so future provider-scoped settings can slot in.
+         */
+        ProviderConfig: {
+            /** @description anthropic-beta translation keyed by provider flavor (e.g. invoke/converse, or default) */
+            anthropic_betas?: {
+                [key: string]: components["schemas"]["BetaColumn"];
+            };
+        };
+        /**
          * @description How the model is made available to callers
          * @enum {string}
          */
@@ -213,6 +227,7 @@ export type operations = Record<string, never>;
 
 export type AWSRegion = components['schemas']['AWSRegion'];
 export type AzureRegion = components['schemas']['AzureRegion'];
+export type BetaColumn = components['schemas']['BetaColumn'];
 export type Cost = components['schemas']['Cost'];
 export type CostWithRegion = components['schemas']['CostWithRegion'];
 export type DefaultConfig = components['schemas']['DefaultConfig'];
@@ -231,6 +246,7 @@ export type ModelParamKey = components['schemas']['ModelParamKey'];
 export type ModelParamType = components['schemas']['ModelParamType'];
 export type PricingMode = components['schemas']['PricingMode'];
 export type PricingTier = components['schemas']['PricingTier'];
+export type ProviderConfig = components['schemas']['ProviderConfig'];
 export type Provisioning = components['schemas']['Provisioning'];
 export type Status = components['schemas']['Status'];
 export type TieredPricing = components['schemas']['TieredPricing'];

--- a/.github/scripts/build-provider-configs.ts
+++ b/.github/scripts/build-provider-configs.ts
@@ -1,0 +1,61 @@
+import fs from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+import { PROVIDER_CONFIG_YAML } from './constants';
+import { UnifiedProviderConfig } from './types';
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const PROVIDERS_DIR = path.join(REPO_ROOT, 'providers');
+const OUTPUT_DIR = path.join(REPO_ROOT, 'dist');
+const OUTPUT_FILE = path.join(OUTPUT_DIR, 'provider-configs.json');
+
+function main(): void {
+  // Keyed by provider directory name. Providers without a provider-config.yaml
+  // are absent rather than `{}` — an empty config is a meaningful value
+  // downstream (e.g. "drop every anthropic-beta token").
+  const configs: Record<string, UnifiedProviderConfig> = {};
+
+  const providerDirs = fs
+    .readdirSync(PROVIDERS_DIR, { withFileTypes: true })
+    .filter((e: fs.Dirent) => e.isDirectory())
+    .map((e: fs.Dirent) => e.name)
+    .sort((a: string, b: string) => a.localeCompare(b));
+
+  console.log(`Found ${providerDirs.length} providers`);
+
+  for (const providerName of providerDirs) {
+    const configPath = path.join(
+      PROVIDERS_DIR,
+      providerName,
+      PROVIDER_CONFIG_YAML,
+    );
+    if (!fs.existsSync(configPath)) continue;
+
+    try {
+      const providerConfig = yaml.load(
+        fs.readFileSync(configPath, 'utf-8'),
+      ) as UnifiedProviderConfig | null | undefined;
+      if (!providerConfig) {
+        console.warn(`Warning: ${configPath} is empty; skipping`);
+        continue;
+      }
+      configs[providerName] = providerConfig;
+      console.log(`  ${providerName}: ${PROVIDER_CONFIG_YAML}`);
+    } catch (err) {
+      console.warn(`Warning: failed to parse ${configPath}: ${err}`);
+    }
+  }
+
+  if (!fs.existsSync(OUTPUT_DIR)) {
+    fs.mkdirSync(OUTPUT_DIR, { recursive: true });
+  }
+
+  const json = JSON.stringify(configs, null, 2);
+  fs.writeFileSync(OUTPUT_FILE, json, 'utf-8');
+
+  console.log(
+    `\nWrote ${Object.keys(configs).length} provider configs to ${OUTPUT_FILE}`,
+  );
+}
+
+main();

--- a/.github/scripts/build-unified-json.ts
+++ b/.github/scripts/build-unified-json.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import yaml from 'js-yaml';
 import { DefaultConfig, ModelConfig } from './autogen/types';
+import { NON_MODEL_YAML } from './constants';
 import { UnifiedModelConfig } from './types';
 
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
@@ -19,7 +20,7 @@ function collectModelFiles(dir: string): string[] {
     } else if (
       entry.isFile() &&
       entry.name.endsWith('.yaml') &&
-      entry.name !== 'default.yaml'
+      !NON_MODEL_YAML.has(entry.name)
     ) {
       results.push(fullPath);
     }

--- a/.github/scripts/constants.ts
+++ b/.github/scripts/constants.ts
@@ -1,0 +1,5 @@
+/** Yamls under providers/ that describe the provider itself, not a model. */
+export const NON_MODEL_YAML = new Set(['default.yaml', 'provider-config.yaml']);
+
+/** Provider-scoped config file name, sibling of default.yaml. */
+export const PROVIDER_CONFIG_YAML = 'provider-config.yaml';

--- a/.github/scripts/trigger_changed_model_tests.py
+++ b/.github/scripts/trigger_changed_model_tests.py
@@ -35,6 +35,10 @@ from typing import Dict, List
 _SAFE_PROVIDER = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 _SAFE_MODEL = re.compile(r"^[A-Za-z0-9~][A-Za-z0-9._@:/~-]*$")
 
+# Yamls under providers/ that describe the provider itself, not a model. There is
+# nothing per-model to test for these, so they never trigger a test run.
+NON_MODEL_YAML = frozenset({"default.yaml", "provider-config.yaml"})
+
 
 def _require_env(name: str) -> str:
     value = os.environ.get(name)
@@ -72,10 +76,11 @@ def _fetch_pr_files(repo: str, pr_number: str) -> List[dict]:
 
 
 def _changed_provider_yaml_paths(files: List[dict]) -> List[str]:
-    """Filter the PR file list to provider yamls that still exist post-PR.
+    """Filter the PR file list to model yamls that still exist post-PR.
 
     Removed files are skipped — there's nothing to test for a model the PR
-    deletes. Non-yaml and non-providers paths are dropped entirely.
+    deletes. Non-yaml and non-providers paths are dropped entirely, as are
+    provider-scoped yamls (see NON_MODEL_YAML), which name no model to test.
     """
     paths: List[str] = []
     for entry in files:
@@ -83,6 +88,9 @@ def _changed_provider_yaml_paths(files: List[dict]) -> List[str]:
             continue
         path = entry.get("filename", "")
         if not path.startswith("providers/") or not path.endswith(".yaml"):
+            continue
+        if os.path.basename(path) in NON_MODEL_YAML:
+            print(f"Skipping provider-scoped yaml: {path}")
             continue
         paths.append(path)
     return paths

--- a/.github/scripts/types.ts
+++ b/.github/scripts/types.ts
@@ -4,3 +4,5 @@ export interface UnifiedModelConfig extends Generated.ModelConfig {
   defaultProviderParams?: Generated.DefaultConfig;
   provider: string;
 }
+
+export type UnifiedProviderConfig = Generated.ProviderConfig;

--- a/.github/scripts/update-readme-counts.ts
+++ b/.github/scripts/update-readme-counts.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import { NON_MODEL_YAML } from './constants';
 
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
 const PROVIDERS_DIR = path.join(REPO_ROOT, 'providers');
@@ -43,7 +44,7 @@ function countModelFiles(dir: string): number {
     } else if (
       entry.isFile() &&
       entry.name.endsWith('.yaml') &&
-      entry.name !== 'default.yaml'
+      !NON_MODEL_YAML.has(entry.name)
     ) {
       count++;
     }

--- a/.github/test/model.cue
+++ b/.github/test/model.cue
@@ -68,6 +68,16 @@ package model
 	tool_pricing?: #ToolPricing
 }
 
+// One anthropic-beta column: clientToken -> providerToken, or null to drop
+#BetaColumn: {[string]: string | null}
+
+// Schema for provider-config.yaml files (provider-scoped, not per-model).
+// Every field is optional so future provider-scoped settings can slot in.
+#ProviderConfig: {
+	// anthropic-beta translation keyed by provider flavor (e.g. invoke/converse, or default)
+	anthropic_betas?: {[string]: #BetaColumn}
+}
+
 // ============================================================
 // Section 3: Model config definitions
 // ============================================================

--- a/.github/test/validate.sh
+++ b/.github/test/validate.sh
@@ -22,12 +22,12 @@ validate_file() {
     local filename=$(basename "$file")
     local definition
 
-    # Use different definition for default.yaml vs model files
-    if [ "$filename" = "default.yaml" ]; then
-        definition="#DefaultConfig"
-    else
-        definition="#ModelConfig"
-    fi
+    # Provider-scoped yamls each have their own definition; everything else is a model
+    case "$filename" in
+        default.yaml)         definition="#DefaultConfig" ;;
+        provider-config.yaml) definition="#ProviderConfig" ;;
+        *)                    definition="#ModelConfig" ;;
+    esac
 
     cat "$file" | cue vet "$MODEL_SCHEMA" "$MODEL_RULES" yaml: - -d "$definition" 2>&1
 }

--- a/.github/workflows/trigger-sync.yml
+++ b/.github/workflows/trigger-sync.yml
@@ -51,11 +51,16 @@ jobs:
       - name: Build unified JSON
         run: npm run build:json
 
+      - name: Build provider configs JSON
+        run: npm run build:provider-configs
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: ai-models
-          path: dist/ai-models.json
+          path: |
+            dist/ai-models.json
+            dist/provider-configs.json
 
   upload:
     name: Upload to S3
@@ -79,3 +84,9 @@ jobs:
 
       - name: Upload to S3 Production
         run: aws s3 cp ai-models.json s3://${{ secrets.BUCKET_NAME }}/llm-gateway/v2/prod/ai-models.json
+
+      - name: Upload provider configs to S3 DevTest
+        run: aws s3 cp provider-configs.json s3://${{ secrets.BUCKET_NAME }}/llm-gateway/v2/devtest/provider-configs.json
+
+      - name: Upload provider configs to S3 Production
+        run: aws s3 cp provider-configs.json s3://${{ secrets.BUCKET_NAME }}/llm-gateway/v2/prod/provider-configs.json

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "validate": "./.github/test/validate.sh",
     "generate:types": "ts-node --project .github/scripts/tsconfig.json .github/scripts/generate-types.ts",
     "build:json": "ts-node --project .github/scripts/tsconfig.json .github/scripts/build-unified-json.ts",
+    "build:provider-configs": "ts-node --project .github/scripts/tsconfig.json .github/scripts/build-provider-configs.ts",
     "lint:yaml": "yamllint -c .yamllint.yml providers/",
     "sort:yaml": "ts-node --project .github/scripts/tsconfig.json .github/scripts/sort-yaml-keys.ts",
     "lint:yaml:fix": "npm run sort:yaml && prettier --write --log-level silent --tab-width 4 --print-width 256 'providers/**/*.yaml'",

--- a/providers/aws-bedrock-mantle/provider-config.yaml
+++ b/providers/aws-bedrock-mantle/provider-config.yaml
@@ -1,0 +1,22 @@
+# anthropic-beta translation: clientToken -> providerToken, null drops. Strict allowlist; unknown betas are rejected.
+# Assumed to match AWS Bedrock InvokeModel; not independently verified.
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-anthropic-claude-messages-tool-use.html
+anthropic_betas:
+    default:
+        advanced-tool-use-2025-11-20: tool-search-tool-2025-10-19
+        compact-2026-01-12: compact-2026-01-12
+        # AWS documents computer-use-2024-10-22 and tool-examples-2025-10-29.
+        computer-use-2024-10-22: computer-use-2024-10-22
+        computer-use-2025-01-24: computer-use-2025-01-24
+        computer-use-2025-11-24: computer-use-2025-11-24
+        context-1m-2025-08-07: context-1m-2025-08-07
+        context-management-2025-06-27: context-management-2025-06-27
+        # dev-full-thinking, interleaved-thinking, output-128k and token-efficient-tools all work here today.
+        dev-full-thinking-2025-05-14: dev-full-thinking-2025-05-14
+        effort-2025-11-24: effort-2025-11-24
+        fine-grained-tool-streaming-2025-05-14: fine-grained-tool-streaming-2025-05-14
+        interleaved-thinking-2025-05-14: interleaved-thinking-2025-05-14
+        output-128k-2025-02-19: output-128k-2025-02-19
+        token-efficient-tools-2025-02-19: token-efficient-tools-2025-02-19
+        tool-examples-2025-10-29: tool-examples-2025-10-29
+        tool-search-tool-2025-10-19: tool-search-tool-2025-10-19

--- a/providers/aws-bedrock/provider-config.yaml
+++ b/providers/aws-bedrock/provider-config.yaml
@@ -1,0 +1,43 @@
+# anthropic-beta translation: clientToken -> providerToken, null drops. Strict allowlist; Bedrock 400s betas it does not know.
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-anthropic-claude-messages-tool-use.html
+# Only entries needing justification beyond the AWS docs above are commented.
+anthropic_betas:
+    # AWS: tool search is InvokeModel-only, so Converse rejects it and any rename onto it.
+    converse:
+        advanced-tool-use-2025-11-20: null
+        compact-2026-01-12: compact-2026-01-12
+        # AWS documents computer-use-2024-10-22 and tool-examples-2025-10-29.
+        computer-use-2024-10-22: computer-use-2024-10-22
+        computer-use-2025-01-24: computer-use-2025-01-24
+        computer-use-2025-11-24: computer-use-2025-11-24
+        context-1m-2025-08-07: context-1m-2025-08-07
+        # AWS documents this with no API restriction, so Converse accepts it too.
+        context-management-2025-06-27: context-management-2025-06-27
+        # dev-full-thinking, interleaved-thinking, output-128k and token-efficient-tools all work here today.
+        dev-full-thinking-2025-05-14: dev-full-thinking-2025-05-14
+        effort-2025-11-24: effort-2025-11-24
+        fine-grained-tool-streaming-2025-05-14: fine-grained-tool-streaming-2025-05-14
+        interleaved-thinking-2025-05-14: interleaved-thinking-2025-05-14
+        output-128k-2025-02-19: output-128k-2025-02-19
+        structured-outputs-2025-11-13: structured-outputs-2025-11-13
+        token-efficient-tools-2025-02-19: token-efficient-tools-2025-02-19
+        tool-examples-2025-10-29: tool-examples-2025-10-29
+        tool-search-tool-2025-10-19: null
+    invoke:
+        advanced-tool-use-2025-11-20: tool-search-tool-2025-10-19
+        compact-2026-01-12: compact-2026-01-12
+        # AWS documents computer-use-2024-10-22 and tool-examples-2025-10-29.
+        computer-use-2024-10-22: computer-use-2024-10-22
+        computer-use-2025-01-24: computer-use-2025-01-24
+        computer-use-2025-11-24: computer-use-2025-11-24
+        context-1m-2025-08-07: context-1m-2025-08-07
+        context-management-2025-06-27: context-management-2025-06-27
+        # dev-full-thinking, interleaved-thinking, output-128k and token-efficient-tools all work here today.
+        dev-full-thinking-2025-05-14: dev-full-thinking-2025-05-14
+        effort-2025-11-24: effort-2025-11-24
+        fine-grained-tool-streaming-2025-05-14: fine-grained-tool-streaming-2025-05-14
+        interleaved-thinking-2025-05-14: interleaved-thinking-2025-05-14
+        output-128k-2025-02-19: output-128k-2025-02-19
+        token-efficient-tools-2025-02-19: token-efficient-tools-2025-02-19
+        tool-examples-2025-10-29: tool-examples-2025-10-29
+        tool-search-tool-2025-10-19: tool-search-tool-2025-10-19

--- a/providers/google-vertex/provider-config.yaml
+++ b/providers/google-vertex/provider-config.yaml
@@ -1,0 +1,18 @@
+# anthropic-beta translation: clientToken -> providerToken, null drops. Strict allowlist; unknown betas are rejected.
+# https://platform.claude.com/docs/en/build-with-claude/claude-on-vertex-ai
+# Files API, Agent Skills, MCP connector and code execution are absent per Vertex's "Features not supported" list.
+anthropic_betas:
+    default:
+        advanced-tool-use-2025-11-20: tool-search-tool-2025-10-19
+        compact-2026-01-12: compact-2026-01-12
+        computer-use-2025-01-24: computer-use-2025-01-24
+        computer-use-2025-11-24: computer-use-2025-11-24
+        context-1m-2025-08-07: context-1m-2025-08-07
+        context-management-2025-06-27: context-management-2025-06-27
+        # GA on Google Cloud per Anthropic's feature matrix.
+        fine-grained-tool-streaming-2025-05-14: fine-grained-tool-streaming-2025-05-14
+        interleaved-thinking-2025-05-14: interleaved-thinking-2025-05-14
+        structured-outputs-2025-11-13: structured-outputs-2025-11-13
+        tool-search-tool-2025-10-19: tool-search-tool-2025-10-19
+        # Web search 400s as a beta header (anthropics/claude-code#12429).
+        web-search-2025-03-05: null


### PR DESCRIPTION
## Context

Provider-level quirks that aren't per-model were hardcoded in the LLM gateway — the `anthropic-beta` translation table. Changing an allowlist meant a gateway code change, review, build and deploy.

This moves that table here, published as a new artifact `provider-configs.json` next to `ai-models.json`, so a beta mapping change is a YAML PR.

The map is keyed by **provider + API flavor** (`invoke` vs `converse` differ — tool search is InvokeModel-only), not per-model, so it can't ride inside `ai-models.json` rows.

## Changes

**New** `providers/{aws-bedrock,aws-bedrock-mantle,google-vertex}/provider-config.yaml` — `anthropic_betas` columns, ported verbatim from the gateway. `aws-bedrock` has `invoke`/`converse`; the others use a single `default`. Providers that forward betas untouched today (anthropic, azure-open-ai) deliberately get no file.

**Schema** `#BetaColumn` + `#ProviderConfig` in `model.cue`, all fields optional so future provider-scoped fields (allowed tools, etc.) slot in. Types regenerated via `npm run generate:types`.

**Builder** `build-provider-configs.ts` → `dist/provider-configs.json`, an object keyed by provider directory name. Providers without a config are absent, never `{}` — an empty object means "drop every beta" downstream.

**Four exclusion carve-outs** — `provider-config.yaml` lives under `providers/`, so everything walking that tree needed the same treatment `default.yaml` already gets: the JSON builder, the readme counter, `validate.sh` (validates it as `#ProviderConfig`), and `trigger_changed_model_tests.py`. A shared `NON_MODEL_YAML` set replaces scattered string comparisons.

**Publish** `trigger-sync.yml` builds and uploads it to the existing `llm-gateway/v2/{devtest,prod}/` prefixes.

## Verification

- `lint:yaml` clean, `validate.sh`: 3252 passed / 0 failed, `tsc --noEmit` clean
- **Model count unchanged: 2594 → 2594** (the new file is correctly excluded)
- **Equivalence check: PASS** — all 4 generated columns are byte-identical to the table they replace, keys and values including every `null` (invoke 15 tokens/0 null, converse 16/2, mantle 15/0, vertex 11/1). Verified independently, and mutation-tested (flipping one `null` makes the checker report FAIL, so the pass isn't vacuous).
- CUE schema negative-tested: rejects unknown fields and non-string/non-null beta values

## Rollout

Consumed by servicefoundry-server → tfy-k8s-controller → tfy-llm-gateway. This PR publishes data nobody reads yet, so it is safe to land first. **The gateway change must land last**, and only after the NATS KV keys are confirmed populated — it makes this file the sole source of the columns.

Note: `npm run update:readme` produces a large diff that predates this change (README counts are stale across ~15 providers). Left untouched; worth regenerating separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes gateway-facing beta header behavior once consumed; incorrect mappings or `null` drops could break Bedrock/Vertex requests, though this PR only publishes data and the gateway rollout is separate.
> 
> **Overview**
> Moves **anthropic-beta** allowlist/translation tables out of the LLM gateway into provider-scoped `provider-config.yaml` files, built and published as **`provider-configs.json`** alongside `ai-models.json`.
> 
> Adds CUE/TS types (`#ProviderConfig`, `#BetaColumn`) and initial YAML for **aws-bedrock** (separate `invoke` / `converse` columns), **aws-bedrock-mantle**, and **google-vertex** (`default`), mapping client beta tokens to provider tokens or `null` to drop. Providers without a file are omitted from the JSON (not `{}`).
> 
> Introduces `build-provider-configs.ts`, `npm run build:provider-configs`, and S3 upload in `trigger-sync.yml`. Shared **`NON_MODEL_YAML`** excludes `provider-config.yaml` from the model JSON builder, README counts, CUE validation (`#ProviderConfig`), and changed-model test triggers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82bb83a717e4bdf073fb6704fc758424a879cb29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->