### PR TITLE
fix(openai): stop removing temperature/top_p for gpt-5.1 and gpt-5.2

### DIFF
--- a/providers/openai/gpt-5.1.yaml
+++ b/providers/openai/gpt-5.1.yaml
@@ -42,8 +42,6 @@ params:
       type: string
 provisioning: serverless
 removeParams:
-    - temperature
-    - top_p
     - "n"
     - max_tokens
 sources:

--- a/providers/openai/gpt-5.2.yaml
+++ b/providers/openai/gpt-5.2.yaml
@@ -43,8 +43,6 @@ params:
       type: string
 provisioning: serverless
 removeParams:
-    - temperature
-    - top_p
     - "n"
     - max_tokens
 sources:


### PR DESCRIPTION
## What

Removes `temperature` and `top_p` from `removeParams` for **gpt-5.1** and **gpt-5.2**. Keeps `n` and `max_tokens` removed (see "What this PR deliberately does not change").

## Why

The `removeParams` list on these two files appears to have been carried forward from `gpt-5.yaml`, where it was correct: the original gpt-5 rejects any non-default `temperature`/`top_p` unconditionally. That contract changed with gpt-5.1.

OpenAI's current [GPT-5.2 guide, "GPT-5.2 parameter compatibility"](https://developers.openai.com/api/docs/guides/latest-model/gpt-5.2) states verbatim:

> The following parameters are only supported when using GPT-5.2 with reasoning effort set to `none`: `temperature`, `top_p`, `logprobs`. Requests to GPT-5.2 **or GPT-5.1** with any other reasoning effort setting, or to older GPT-5 models — for example, `gpt-5`, `gpt-5-mini`, or `gpt-5-nano` — that include these fields will raise an error.

And `none` is the **default** reasoning effort for both models, per their model pages ([gpt-5.1](https://developers.openai.com/api/docs/models/gpt-5.1): "Reasoning.effort supports: none (default), low, medium, and high"; [gpt-5.2](https://developers.openai.com/api/docs/models/gpt-5.2): "none (default), low, medium, high and xhigh") — consistent with these files' own `params` entry (`reasoning_effort`, `defaultValue: none`).

So for the default-configuration request — the common case — OpenAI **accepts** `temperature` and `top_p`, and the gateway strips them anyway.

## Impact of the current behavior

The strip is silent: a caller sending `temperature: 0` to gpt-5.2 gets HTTP 200 and is actually served the model defaults (`temperature: 1`, and gpt-5.2's internal `top_p` default of `0.98` — see [this OpenAI forum thread](https://community.openai.com/t/top-p-problem-when-running-gpt-5-2-api/1369144)). Nothing in the response indicates the parameter was discarded except the echoed values.

We hit this in production: a pipeline that pinned `temperature: 0` for deterministic output was migrated from a Claude target (where the gateway forwards temperature untouched) to `openai/gpt-5.2`, and began sampling at temperature 1 with no error anywhere — the regression surfaced as nondeterministic output quality and took an incident investigation to trace back to the registry entry.

Note that OpenAI itself never silently ignores these params — unsupported combinations get an explicit 400 (`"Unsupported value: 'temperature' does not support 0.5 with this model."`). After this change, a caller that combines `temperature`/`top_p` with `reasoning_effort` ≥ `low` will receive that 400 instead of a silent drop. We'd argue that's the better contract: it matches the raw OpenAI API, and it's an actionable client error rather than an invisible behavior change. (This is the same fix direction LiteLLM took for the equivalent issue — see [BerriAI/litellm#21911](https://github.com/BerriAI/litellm/issues/21911) / [#27351](https://github.com/BerriAI/litellm/issues/27351), where sampling params are now gated on per-model `supports_none_reasoning_effort` flags rather than dropped across the board.)

## What this PR deliberately does not change

- **`max_tokens` stays removed** — gpt-5.x still rejects it; callers must use `max_completion_tokens` / `max_output_tokens`.
- **`n` stays removed** — we found no official OpenAI statement that gpt-5.x accepts `n`, so we left it alone.
- **gpt-5.4** likely has the same contract (LiteLLM's registry and Azure behavior agree), but OpenAI's guide only names 5.1 and 5.2 explicitly, so we scoped this PR to what's officially documented. Happy to extend to gpt-5.4 if you have confirmation.
- **gpt-5.5 / gpt-5.6 family untouched** — their default reasoning effort is `medium`, so removing the strip there would 400 default-effort callers who send temperature. The removal is still protective for those models.
- **`gpt-5.2-chat-latest`** (if/where present) should keep rejecting/removing temperature — OpenAI returns 400 for non-1 temperature on that variant regardless of effort.

## Sources

- https://developers.openai.com/api/docs/guides/latest-model/gpt-5.2 (parameter-compatibility section)
- https://developers.openai.com/api/docs/models/gpt-5.1
- https://developers.openai.com/api/docs/models/gpt-5.2
- https://community.openai.com/t/top-p-problem-when-running-gpt-5-2-api/1369144 (gpt-5.2 internal top_p default 0.98)
- https://github.com/BerriAI/litellm/issues/21911, https://github.com/BerriAI/litellm/issues/27351 (same bug class + fix in LiteLLM)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request parameter forwarding for production gpt-5.1/5.2 traffic. Callers combining temperature/top_p with non-default reasoning effort may start receiving OpenAI 400s instead of silent param drops.
> 
> **Overview**
> Stops silently stripping `temperature` and `top_p` from requests to **gpt-5.1** and **gpt-5.2**. Those params are now forwarded to OpenAI, matching the models' documented support when `reasoning_effort` is `none` (the default).
> 
> `n` and `max_tokens` remain in `removeParams`. Callers that send `temperature`/`top_p` with non-`none` reasoning effort will now get OpenAI's explicit 400 instead of a silent drop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad2cdd1a7e19b78be4e2ec13a18ffcde20cfec38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->