### PR TITLE
feat(aws-bedrock-mantle): add web_search tool pricing

### DIFF
--- a/providers/aws-bedrock-mantle/default.yaml
+++ b/providers/aws-bedrock-mantle/default.yaml
@@ -3,3 +3,6 @@ documentation:
     - https://aws.amazon.com/bedrock/pricing/
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-cards.html
     - https://docs.aws.amazon.com/bedrock/latest/userguide/structured-output.html#structured-output-supported-apis
+tool_pricing:
+    web_search:
+        per_thousand_requests: 12


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single YAML config addition with no runtime or security impact; only affects cost attribution for web search on this provider.
> 
> **Overview**
> Adds **`tool_pricing`** for the **aws-bedrock-mantle** provider so **`web_search`** usage can be costed at **$12 per thousand requests**, matching the same `tool_pricing.web_search.per_thousand_requests` pattern used on other providers (e.g. Anthropic/OpenAI at $10).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20609ad59b43be33b9ac755ca8ae95ea77d5e991. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->