### PR TITLE
fix(aws-bedrock): drop compact-2026-01-12 on Converse

### DIFF
--- a/providers/aws-bedrock/provider-config.yaml
+++ b/providers/aws-bedrock/provider-config.yaml
@@ -1,11 +1,13 @@
 # anthropic-beta translation: clientToken -> providerToken, null drops. Strict allowlist; Bedrock 400s betas it does not know.
 # https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-anthropic-claude-messages-tool-use.html
+# https://docs.aws.amazon.com/bedrock/latest/userguide/claude-messages-compaction.html
 # Only entries needing justification beyond the AWS docs above are commented.
 anthropic_betas:
     # AWS: tool search is InvokeModel-only, so Converse rejects it and any rename onto it.
     converse:
         advanced-tool-use-2025-11-20: null
-        compact-2026-01-12: compact-2026-01-12
+        # AWS: "Compaction is currently not supported by the Converse API, however it is supported with InvokeModel."
+        compact-2026-01-12: null
         # AWS documents computer-use-2024-10-22 and tool-examples-2025-10-29.
         computer-use-2024-10-22: computer-use-2024-10-22
         computer-use-2025-01-24: computer-use-2025-01-24


### PR DESCRIPTION
## Context

AWS documents compaction as InvokeModel-only:

> Compaction is currently in beta. Include the beta header `compact-2026-01-12` in your API requests to use this feature. **Compaction is currently not supported by the Converse API, however it is supported with InvokeModel.**

https://docs.aws.amazon.com/bedrock/latest/userguide/claude-messages-compaction.html

The `converse` column forwarded it anyway, so a caller sending `compact-2026-01-12` to a Converse-routed Claude model had the beta passed through to an API that does not accept it.

## Changes

`providers/aws-bedrock/provider-config.yaml` — `converse.compact-2026-01-12` → `null`, so it is dropped on that path. This matches how the column already handles `tool-search-tool-2025-10-19`, which AWS scopes to InvokeModel in the same way.

The `invoke` column is unchanged — compaction is supported there.

## Verification

- `npm run validate`: 3305 passed / 0 failed. `npm run lint:yaml` clean.
- `dist/provider-configs.json`: `converse.compact-2026-01-12` = `null` (column now 13 forwards, was 14); `invoke.compact-2026-01-12` unchanged.