### PR TITLE
feat(databricks): add responses mode and 10 OpenAI foundation model entries

### DIFF
--- a/providers/databricks/databricks-gpt-5-1.yaml
+++ b/providers/databricks/databricks-gpt-5-1.yaml
@@ -49,4 +49,5 @@ sources:
 status: active
 supportedModes:
     - chat
+    - responses
 thinking: true

--- a/providers/databricks/databricks-gpt-5-2.yaml
+++ b/providers/databricks/databricks-gpt-5-2.yaml
@@ -1,20 +1,17 @@
 costs:
-    - cache_creation_input_token_cost: 2.5e-7
-      cache_read_input_token_cost: 2.5e-8
-      input_cost_per_token: 2.5e-7
-      output_cost_per_token: 0.000002
+    - cache_creation_input_token_cost: 1.75e-6
+      cache_read_input_token_cost: 1.75e-7
+      input_cost_per_token: 0.00000175
+      output_cost_per_token: 0.000014
       region: "*"
 features:
     - function_calling
-    - tool_choice
-    - structured_output
-    - json_output
-    - prompt_caching
     - system_messages
-    - cache_control
+    - tool_choice
+    - prompt_caching
+    - structured_output
 limits:
     context_window: 400000
-    max_input_tokens: 272000
     max_output_tokens: 128000
     max_tokens: 128000
 modalities:
@@ -24,23 +21,25 @@ modalities:
     output:
         - text
 mode: chat
-model: databricks-gpt-5-mini
+model: databricks-gpt-5-2
 params:
-    - defaultValue: minimal
+    - defaultValue: none
       key: reasoning_effort
       supportedValues:
           - none
-          - minimal
           - low
           - medium
           - high
+          - xhigh
       type: string
 provisioning: serverless
 sources:
+    - https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/supported-models
+    - https://docs.databricks.com/aws/en/machine-learning/model-serving/query-openai-responses
+    - https://docs.databricks.com/aws/en/machine-learning/model-serving/query-reason-models
     - https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/limits
-    - https://docs.databricks.com/aws/en/machine-learning/model-serving/function-calling
-    - https://docs.databricks.com/aws/en/machine-learning/model-serving/structured-outputs
     - https://www.databricks.com/product/pricing/proprietary-foundation-model-serving
+    - https://developers.openai.com/api/docs/models/gpt-5.2
 status: active
 supportedModes:
     - chat

--- a/providers/databricks/databricks-gpt-5-3-codex.yaml
+++ b/providers/databricks/databricks-gpt-5-3-codex.yaml
@@ -1,0 +1,40 @@
+costs:
+    - cache_creation_input_token_cost: 1.75e-6
+      cache_read_input_token_cost: 1.75e-7
+      input_cost_per_token: 1.75e-6
+      output_cost_per_token: 0.000014
+      region: "*"
+features:
+    - function_calling
+    - system_messages
+    - tool_choice
+    - prompt_caching
+    - structured_output
+limits:
+    context_window: 400000
+    max_output_tokens: 128000
+    max_tokens: 128000
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
+mode: responses
+model: databricks-gpt-5-3-codex
+params:
+    - defaultValue: medium
+      key: reasoning_effort
+      type: string
+provisioning: serverless
+sources:
+    - https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/supported-models
+    - https://docs.databricks.com/aws/en/machine-learning/model-serving/query-openai-responses
+    - https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/limits
+    - https://www.databricks.com/product/pricing/proprietary-foundation-model-serving
+    - https://developers.openai.com/api/docs/models/gpt-5.3-codex
+status: active
+supportedModes:
+    - responses
+    - chat
+thinking: true

--- a/providers/databricks/databricks-gpt-5-4-mini.yaml
+++ b/providers/databricks/databricks-gpt-5-4-mini.yaml
@@ -1,17 +1,16 @@
 costs:
-    - cache_creation_input_token_cost: 2.5e-7
-      cache_read_input_token_cost: 2.5e-8
-      input_cost_per_token: 2.5e-7
-      output_cost_per_token: 0.000002
+    - cache_creation_input_token_cost: 7.5e-7
+      cache_read_input_token_cost: 7.5e-8
+      input_cost_per_token: 7.5e-7
+      output_cost_per_token: 0.0000045
       region: "*"
 features:
     - function_calling
-    - tool_choice
     - structured_output
-    - json_output
     - prompt_caching
+    - tool_choice
     - system_messages
-    - cache_control
+    - json_output
 limits:
     context_window: 400000
     max_input_tokens: 272000
@@ -24,23 +23,24 @@ modalities:
     output:
         - text
 mode: chat
-model: databricks-gpt-5-mini
+model: databricks-gpt-5-4-mini
 params:
-    - defaultValue: minimal
+    - defaultValue: none
       key: reasoning_effort
       supportedValues:
           - none
-          - minimal
           - low
           - medium
           - high
+          - xhigh
       type: string
 provisioning: serverless
 sources:
+    - https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/supported-models
+    - https://docs.databricks.com/aws/en/machine-learning/model-serving/query-openai-responses
     - https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/limits
-    - https://docs.databricks.com/aws/en/machine-learning/model-serving/function-calling
-    - https://docs.databricks.com/aws/en/machine-learning/model-serving/structured-outputs
     - https://www.databricks.com/product/pricing/proprietary-foundation-model-serving
+    - https://developers.openai.com/api/docs/models/gpt-5.4-mini
 status: active
 supportedModes:
     - chat

--- a/providers/databricks/databricks-gpt-5-4-nano.yaml
+++ b/providers/databricks/databricks-gpt-5-4-nano.yaml
@@ -1,17 +1,15 @@
 costs:
-    - cache_creation_input_token_cost: 2.5e-7
-      cache_read_input_token_cost: 2.5e-8
-      input_cost_per_token: 2.5e-7
-      output_cost_per_token: 0.000002
+    - cache_creation_input_token_cost: 2e-7
+      cache_read_input_token_cost: 2e-8
+      input_cost_per_token: 2e-7
+      output_cost_per_token: 0.00000125
       region: "*"
 features:
     - function_calling
-    - tool_choice
     - structured_output
-    - json_output
-    - prompt_caching
+    - tool_choice
     - system_messages
-    - cache_control
+    - prompt_caching
 limits:
     context_window: 400000
     max_input_tokens: 272000
@@ -24,23 +22,24 @@ modalities:
     output:
         - text
 mode: chat
-model: databricks-gpt-5-mini
+model: databricks-gpt-5-4-nano
 params:
-    - defaultValue: minimal
+    - defaultValue: none
       key: reasoning_effort
       supportedValues:
           - none
-          - minimal
           - low
           - medium
           - high
+          - xhigh
       type: string
 provisioning: serverless
 sources:
+    - https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/supported-models
+    - https://docs.databricks.com/aws/en/machine-learning/model-serving/query-openai-responses
     - https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/limits
-    - https://docs.databricks.com/aws/en/machine-learning/model-serving/function-calling
-    - https://docs.databricks.com/aws/en/machine-learning/model-serving/structured-outputs
     - https://www.databricks.com/product/pricing/proprietary-foundation-model-serving
+    - https://developers.openai.com/api/docs/models/gpt-5.4-nano
 status: active
 supportedModes:
     - chat

--- a/providers/databricks/databricks-gpt-5-4.yaml
+++ b/providers/databricks/databricks-gpt-5-4.yaml
@@ -1,0 +1,61 @@
+costs:
+    - cache_creation_input_token_cost: 0.0000025
+      cache_read_input_token_cost: 2.5e-7
+      input_cost_per_token: 0.0000025
+      output_cost_per_token: 0.000015
+      region: "*"
+      tiered_pricing:
+          cache_read:
+              - cost_per_token: 5e-7
+                from: 272000
+          cache_write:
+              - cost_per_token: 0.000005
+                from: 272000
+          input:
+              - cost_per_token: 0.000005
+                from: 272000
+          output:
+              - cost_per_token: 0.0000225
+                from: 272000
+          pricing_mode: cumulative
+features:
+    - function_calling
+    - tool_choice
+    - system_messages
+    - structured_output
+    - prompt_caching
+    - json_output
+limits:
+    context_window: 1050000
+    max_output_tokens: 128000
+    max_tokens: 128000
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
+mode: chat
+model: databricks-gpt-5-4
+params:
+    - defaultValue: none
+      key: reasoning_effort
+      supportedValues:
+          - none
+          - low
+          - medium
+          - high
+          - xhigh
+      type: string
+provisioning: serverless
+sources:
+    - https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/supported-models
+    - https://docs.databricks.com/aws/en/machine-learning/model-serving/query-openai-responses
+    - https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/limits
+    - https://www.databricks.com/product/pricing/proprietary-foundation-model-serving
+    - https://developers.openai.com/api/docs/models/gpt-5.4
+status: active
+supportedModes:
+    - chat
+    - responses
+thinking: true

--- a/providers/databricks/databricks-gpt-5-5-pro.yaml
+++ b/providers/databricks/databricks-gpt-5-5-pro.yaml
@@ -1,0 +1,50 @@
+costs:
+    - input_cost_per_token: 0.00003
+      output_cost_per_token: 0.00018
+      region: "*"
+      tiered_pricing:
+          input:
+              - cost_per_token: 0.00006
+                from: 272000
+          output:
+              - cost_per_token: 0.00027
+                from: 272000
+          pricing_mode: cumulative
+features:
+    - function_calling
+    - structured_output
+    - system_messages
+    - tool_choice
+    - json_output
+limits:
+    context_window: 1050000
+    max_output_tokens: 128000
+    max_tokens: 128000
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
+mode: responses
+model: databricks-gpt-5-5-pro
+params:
+    - defaultValue: medium
+      key: reasoning_effort
+      supportedValues:
+          - medium
+          - high
+          - xhigh
+      type: string
+provisioning: serverless
+sources:
+    - https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/supported-models
+    - https://docs.databricks.com/aws/en/machine-learning/model-serving/query-openai-responses
+    - https://docs.databricks.com/aws/en/machine-learning/model-serving/query-reason-models
+    - https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/limits
+    - https://www.databricks.com/product/pricing/proprietary-foundation-model-serving
+    - https://developers.openai.com/api/docs/models/gpt-5.5-pro
+status: active
+supportedModes:
+    - responses
+thinking: true

--- a/providers/databricks/databricks-gpt-5-5.yaml
+++ b/providers/databricks/databricks-gpt-5-5.yaml
@@ -1,0 +1,62 @@
+costs:
+    - cache_creation_input_token_cost: 0.000005
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.00003
+      region: "*"
+      tiered_pricing:
+          cache_read:
+              - cost_per_token: 0.000001
+                from: 272000
+          cache_write:
+              - cost_per_token: 0.00001
+                from: 272000
+          input:
+              - cost_per_token: 0.00001
+                from: 272000
+          output:
+              - cost_per_token: 0.000045
+                from: 272000
+          pricing_mode: cumulative
+features:
+    - function_calling
+    - tool_choice
+    - system_messages
+    - prompt_caching
+    - structured_output
+    - json_output
+limits:
+    context_window: 1050000
+    max_output_tokens: 128000
+    max_tokens: 128000
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
+mode: chat
+model: databricks-gpt-5-5
+params:
+    - defaultValue: medium
+      key: reasoning_effort
+      supportedValues:
+          - none
+          - low
+          - medium
+          - high
+          - xhigh
+      type: string
+provisioning: serverless
+sources:
+    - https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/supported-models
+    - https://docs.databricks.com/aws/en/machine-learning/model-serving/query-openai-responses
+    - https://docs.databricks.com/aws/en/machine-learning/model-serving/query-reason-models
+    - https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/limits
+    - https://www.databricks.com/product/pricing/proprietary-foundation-model-serving
+    - https://developers.openai.com/api/docs/models/gpt-5.5
+status: active
+supportedModes:
+    - chat
+    - responses
+thinking: true

--- a/providers/databricks/databricks-gpt-5-6-luna.yaml
+++ b/providers/databricks/databricks-gpt-5-6-luna.yaml
@@ -1,0 +1,62 @@
+costs:
+    - cache_creation_input_token_cost: 2.5e-7
+      cache_read_input_token_cost: 2e-8
+      input_cost_per_token: 2e-7
+      output_cost_per_token: 0.0000012
+      region: "*"
+      tiered_pricing:
+          cache_read:
+              - cost_per_token: 4e-8
+                from: 272000
+          cache_write:
+              - cost_per_token: 5e-7
+                from: 272000
+          input:
+              - cost_per_token: 4e-7
+                from: 272000
+          output:
+              - cost_per_token: 0.0000018
+                from: 272000
+          pricing_mode: cumulative
+features:
+    - function_calling
+    - structured_output
+    - prompt_caching
+    - system_messages
+    - tool_choice
+    - json_output
+limits:
+    context_window: 1050000
+    max_output_tokens: 128000
+    max_tokens: 128000
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
+mode: chat
+model: databricks-gpt-5-6-luna
+params:
+    - defaultValue: medium
+      key: reasoning_effort
+      supportedValues:
+          - none
+          - low
+          - medium
+          - high
+          - xhigh
+          - max
+      type: string
+provisioning: serverless
+sources:
+    - https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/supported-models
+    - https://docs.databricks.com/aws/en/machine-learning/model-serving/query-openai-responses
+    - https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/limits
+    - https://www.databricks.com/product/pricing/proprietary-foundation-model-serving
+    - https://developers.openai.com/api/docs/models/gpt-5.6-luna
+status: active
+supportedModes:
+    - chat
+    - responses
+thinking: true

--- a/providers/databricks/databricks-gpt-5-6-sol.yaml
+++ b/providers/databricks/databricks-gpt-5-6-sol.yaml
@@ -1,0 +1,60 @@
+costs:
+    - cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.00003
+      region: "*"
+      tiered_pricing:
+          cache_read:
+              - cost_per_token: 0.000001
+                from: 272000
+          cache_write:
+              - cost_per_token: 0.0000125
+                from: 272000
+          input:
+              - cost_per_token: 0.00001
+                from: 272000
+          output:
+              - cost_per_token: 0.000045
+                from: 272000
+          pricing_mode: cumulative
+features:
+    - function_calling
+    - structured_output
+    - prompt_caching
+    - system_messages
+limits:
+    context_window: 1050000
+    max_output_tokens: 128000
+    max_tokens: 128000
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
+mode: chat
+model: databricks-gpt-5-6-sol
+params:
+    - defaultValue: medium
+      key: reasoning_effort
+      supportedValues:
+          - none
+          - low
+          - medium
+          - high
+          - xhigh
+          - max
+      type: string
+provisioning: serverless
+sources:
+    - https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/supported-models
+    - https://docs.databricks.com/aws/en/machine-learning/model-serving/query-openai-responses
+    - https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/limits
+    - https://www.databricks.com/product/pricing/proprietary-foundation-model-serving
+    - https://developers.openai.com/api/docs/models/gpt-5.6-sol
+status: active
+supportedModes:
+    - chat
+    - responses
+thinking: true

--- a/providers/databricks/databricks-gpt-5-6-terra.yaml
+++ b/providers/databricks/databricks-gpt-5-6-terra.yaml
@@ -1,0 +1,61 @@
+costs:
+    - cache_creation_input_token_cost: 0.0000025
+      cache_read_input_token_cost: 2e-7
+      input_cost_per_token: 0.000002
+      output_cost_per_token: 0.000012
+      region: "*"
+      tiered_pricing:
+          cache_read:
+              - cost_per_token: 4e-7
+                from: 272000
+          cache_write:
+              - cost_per_token: 0.000005
+                from: 272000
+          input:
+              - cost_per_token: 0.000004
+                from: 272000
+          output:
+              - cost_per_token: 0.000018
+                from: 272000
+          pricing_mode: cumulative
+features:
+    - function_calling
+    - system_messages
+    - tool_choice
+    - prompt_caching
+    - structured_output
+limits:
+    context_window: 1050000
+    max_output_tokens: 128000
+    max_tokens: 128000
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
+mode: chat
+model: databricks-gpt-5-6-terra
+params:
+    - defaultValue: medium
+      key: reasoning_effort
+      supportedValues:
+          - none
+          - low
+          - medium
+          - high
+          - xhigh
+          - max
+      type: string
+provisioning: serverless
+sources:
+    - https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/supported-models
+    - https://docs.databricks.com/aws/en/machine-learning/model-serving/query-openai-responses
+    - https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/limits
+    - https://www.databricks.com/product/pricing/proprietary-foundation-model-serving
+    - https://developers.openai.com/api/docs/models/gpt-5.6-terra
+status: active
+supportedModes:
+    - chat
+    - responses
+thinking: true

--- a/providers/databricks/databricks-gpt-5-nano.yaml
+++ b/providers/databricks/databricks-gpt-5-nano.yaml
@@ -1,5 +1,6 @@
 costs:
-    - cache_read_input_token_cost: 5e-9
+    - cache_creation_input_token_cost: 5e-8
+      cache_read_input_token_cost: 5e-9
       input_cost_per_token: 5e-8
       output_cost_per_token: 4e-7
       region: "*"
@@ -39,4 +40,5 @@ sources:
 status: active
 supportedModes:
     - chat
+    - responses
 thinking: true

--- a/providers/databricks/databricks-gpt-5.yaml
+++ b/providers/databricks/databricks-gpt-5.yaml
@@ -45,4 +45,5 @@ sources:
 status: active
 supportedModes:
     - chat
+    - responses
 thinking: true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> YAML-only model metadata and pricing updates with no runtime or routing logic changes; incorrect numbers would affect cost estimates but not security or data handling.
> 
> **Overview**
> Expands the Databricks provider catalog with **ten new GPT-5.x foundation models** (5.2, 5.3-codex, 5.4/mini/nano, 5.5/5.5-pro, 5.6 luna/sol/terra), each with costs, limits, modalities, `reasoning_effort` options, and doc sources. Several entries use **cumulative tiered pricing** above 272k tokens; `databricks-gpt-5-5-pro` is **responses-only**, while most others list both **chat** and **responses**.
> 
> Existing GPT-5 family entries (`databricks-gpt-5`, `gpt-5-1`, `mini`, `nano`) now advertise **responses** in `supportedModes`. **`databricks-gpt-5-nano`** also adds **`cache_creation_input_token_cost`** alongside the existing cache-read pricing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff7259a93f4d1307138ca796efdf3c1a8ce7eeba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->