### PR TITLE
feat(xai/grok-4.6): add new model

### DIFF
--- a/providers/xai/grok-4.6.yaml
+++ b/providers/xai/grok-4.6.yaml
@@ -1,0 +1,50 @@
+costs:
+    - cache_read_input_token_cost: 5e-7
+      input_cost_per_image_token: 2e-6
+      input_cost_per_token: 2e-6
+      output_cost_per_token: 6e-6
+      region: "*"
+      tiered_pricing:
+          cache_read:
+              - cost_per_token: 1e-6
+                from: 200000
+          input:
+              - cost_per_token: 4e-6
+                from: 200000
+          output:
+              - cost_per_token: 1.2e-5
+                from: 200000
+          pricing_mode: cumulative
+features:
+    - function_calling
+    - structured_output
+    - prompt_caching
+    - system_messages
+    - tool_choice
+limits:
+    context_window: 500000
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
+mode: chat
+model: grok-4.6
+params:
+    - defaultValue: high
+      key: reasoning_effort
+      supportedValues:
+          - low
+          - medium
+          - high
+          - xhigh
+      type: string
+provisioning: serverless
+sources:
+    - https://docs.x.ai/developers/grok-4-6
+    - https://docs.x.ai/developers/pricing
+status: active
+supportedModes:
+    - chat
+thinking: true


### PR DESCRIPTION
## What

Adds `providers/xai/grok-4.6.yaml` — xAI's Grok 4.6, released 2026-08-12.

| Field | Value |
|---|---|
| Model ID | `grok-4.6` |
| Context window | 500,000 |
| Modalities | text, image → text |
| Thinking | yes — `reasoning_effort`: `low` / `medium` / `high` (default) / `xhigh` |
| Features | function_calling, structured_output, prompt_caching, system_messages, tool_choice |
| Status | active, serverless |

## Pricing

Below a 200k-token prompt: **$2.00** input / **$0.50** cached input / **$6.00** output per 1M tokens.

Once the prompt reaches 200k tokens, xAI re-rates the **entire** request to **$4.00 / $1.00 / $12.00**, so this is modelled with `tiered_pricing` at `from: 200000` plus `pricing_mode: cumulative` (same shape as `grok-4.5.yaml`, whose rates differ only in cached input).

Image input is not priced separately by xAI, so `input_cost_per_image_token` mirrors the text input rate.

## Notes

- Only the canonical `grok-4.6` ID is documented — no `grok-4.6-latest` alias or dated snapshot is listed on the xAI docs, so none was added. Happy to add it if the API listing shows one.
- `./.github/test/validate.sh providers/xai/grok-4.6.yaml` passes; prettier/yaml-sort clean.

## Sources

- https://docs.x.ai/developers/grok-4-6
- https://docs.x.ai/developers/pricing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new model metadata file only; no runtime, auth, or application logic changes.
> 
> **Overview**
> Adds **`grok-4.6`** to the xAI provider as a new serverless chat model with a **500k** context window, text/image input, and **thinking** via `reasoning_effort` (`low`–`xhigh`, default `high`).
> 
> Pricing mirrors **`grok-4.5`**’s shape: base input/output rates plus **cumulative** `tiered_pricing` at **200k** prompt tokens (higher input, cache-read, and output above that threshold). Cached-read base and tier rates are slightly higher than 4.5; image tokens use the same per-token input rate as text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ea4bc97f6c9ba7f18e309af10bdc3f94f9557c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->