### PR TITLE
feat(databricks): add system.ai.* model service entries

### DIFF
--- a/providers/databricks/system.ai.claude-haiku-4-5.yaml
+++ b/providers/databricks/system.ai.claude-haiku-4-5.yaml
@@ -1,0 +1,37 @@
+costs:
+    - cache_creation_input_token_cost: 0.00000125
+      cache_creation_input_token_cost_per_hour: 0.000002
+      cache_read_input_token_cost: 1e-7
+      input_cost_per_token: 0.000001
+      input_cost_per_token_batches: 5e-7
+      output_cost_per_token: 0.000005
+      output_cost_per_token_batches: 0.0000025
+      region: "*"
+features:
+    - function_calling
+    - tool_choice
+    - assistant_prefill
+    - system_messages
+    - prompt_caching
+    - cache_control
+limits:
+    context_window: 200000
+    max_input_tokens: 200000
+    max_output_tokens: 64000
+    max_tokens: 64000
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
+mode: chat
+model: system.ai.claude-haiku-4-5
+provisioning: serverless
+sources:
+    - https://platform.claude.com/docs/en/about-claude/models
+    - https://platform.claude.com/docs/en/about-claude/pricing
+status: active
+supportedModes:
+    - chat
+thinking: true

--- a/providers/databricks/system.ai.claude-opus-4-1.yaml
+++ b/providers/databricks/system.ai.claude-opus-4-1.yaml
@@ -1,0 +1,28 @@
+costs:
+    - input_cost_per_token: 0.000015
+      output_cost_per_token: 0.000075
+      region: "*"
+features:
+    - function_calling
+    - tool_choice
+    - assistant_prefill
+limits:
+    context_window: 200000
+    max_input_tokens: 200000
+    max_output_tokens: 32000
+    max_tokens: 32000
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
+mode: chat
+model: system.ai.claude-opus-4-1
+provisioning: serverless
+removeParams:
+    - reasoning_effort
+status: active
+supportedModes:
+    - chat
+thinking: true

--- a/providers/databricks/system.ai.claude-opus-4-5.yaml
+++ b/providers/databricks/system.ai.claude-opus-4-5.yaml
@@ -1,0 +1,33 @@
+costs:
+    - cache_creation_input_token_cost: 6.25e-6
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 0.000005
+      output_cost_per_token: 0.000025
+      region: "*"
+features:
+    - function_calling
+    - tool_choice
+    - assistant_prefill
+    - prompt_caching
+    - system_messages
+limits:
+    context_window: 200000
+    max_input_tokens: 200000
+    max_output_tokens: 32000
+    max_tokens: 32000
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
+mode: chat
+model: system.ai.claude-opus-4-5
+provisioning: serverless
+sources:
+    - https://www.databricks.com/product/pricing/proprietary-foundation-model-serving
+    - https://learn.microsoft.com/en-us/azure/databricks/machine-learning/foundation-model-apis/limits
+status: active
+supportedModes:
+    - chat
+thinking: true

--- a/providers/databricks/system.ai.claude-opus-4-6.yaml
+++ b/providers/databricks/system.ai.claude-opus-4-6.yaml
@@ -1,0 +1,53 @@
+costs:
+    - cache_creation_input_token_cost: 0.00000625
+      cache_creation_input_token_cost_per_hour: 0.00001
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 0.000005
+      input_cost_per_token_batches: 0.0000025
+      output_cost_per_token: 0.000025
+      output_cost_per_token_batches: 0.0000125
+      region: "*"
+features:
+    - function_calling
+    - tool_choice
+    - prompt_caching
+    - structured_output
+    - cache_control
+    - assistant_prefill
+limits:
+    context_window: 1000000
+    max_input_tokens: 1000000
+    max_output_tokens: 128000
+    max_tokens: 128000
+    tool_use_system_prompt_tokens: 497
+modalities:
+    input:
+        - text
+        - image
+        - pdf
+    output:
+        - text
+mode: chat
+model: system.ai.claude-opus-4-6
+params:
+    - key: max_tokens
+      maxValue: 128000
+    - defaultValue: high
+      key: reasoning_effort
+      supportedValues:
+          - low
+          - medium
+          - high
+          - max
+      type: string
+provisioning: serverless
+retirementDate: "2027-02-05"
+sources:
+    - https://platform.claude.com/docs/en/about-claude/pricing
+    - https://platform.claude.com/docs/en/about-claude/models/overview
+    - https://platform.claude.com/docs/en/about-claude/model-deprecations
+    - https://www.databricks.com/product/pricing/proprietary-foundation-model-serving
+status: active
+supportedModes:
+    - chat
+thinking: true

--- a/providers/databricks/system.ai.claude-opus-4-7.yaml
+++ b/providers/databricks/system.ai.claude-opus-4-7.yaml
@@ -1,0 +1,49 @@
+costs:
+    - cache_creation_input_token_cost: 0.00000625
+      cache_creation_input_token_cost_per_hour: 0.00001
+      cache_read_input_token_cost: 5e-7
+      input_cost_per_token: 0.000005
+      input_cost_per_token_batches: 0.0000025
+      output_cost_per_token: 0.000025
+      output_cost_per_token_batches: 0.0000125
+      region: "*"
+features:
+    - function_calling
+    - parallel_function_calling
+    - cache_control
+    - system_messages
+    - tool_choice
+    - prompt_caching
+    - assistant_prefill
+    - structured_output
+    - code_execution
+limits:
+    context_window: 1000000
+    max_input_tokens: 1000000
+    max_output_tokens: 128000
+    max_tokens: 128000
+    tool_use_system_prompt_tokens: 346
+modalities:
+    input:
+        - text
+        - image
+        - pdf
+    output:
+        - text
+mode: chat
+model: system.ai.claude-opus-4-7
+params:
+    - defaultValue: 256
+      key: max_tokens
+      maxValue: 128000
+      minValue: 1
+provisioning: serverless
+removeParams:
+    - temperature
+    - top_p
+    - top_k
+    - reasoning_effort
+status: active
+supportedModes:
+    - chat
+thinking: true

--- a/providers/databricks/system.ai.claude-sonnet-4-5.yaml
+++ b/providers/databricks/system.ai.claude-sonnet-4-5.yaml
@@ -1,0 +1,34 @@
+costs:
+    - input_cost_per_token: 0.000003
+      output_cost_per_token: 0.000015
+      region: "*"
+features:
+    - function_calling
+    - tool_choice
+    - assistant_prefill
+    - prompt_caching
+    - cache_control
+    - system_messages
+limits:
+    context_window: 200000
+    max_input_tokens: 200000
+    max_output_tokens: 64000
+    max_tokens: 64000
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
+mode: chat
+model: system.ai.claude-sonnet-4-5
+provisioning: serverless
+removeParams:
+    - reasoning_effort
+sources:
+    - https://docs.databricks.com/aws/en/machine-learning/model-serving/function-calling
+    - https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/limits
+status: active
+supportedModes:
+    - chat
+thinking: true

--- a/providers/databricks/system.ai.claude-sonnet-4-6.yaml
+++ b/providers/databricks/system.ai.claude-sonnet-4-6.yaml
@@ -1,0 +1,42 @@
+costs:
+    - cache_creation_input_token_cost: 0.00000375
+      cache_creation_input_token_cost_per_hour: 0.000006
+      cache_read_input_token_cost: 3e-7
+      input_cost_per_token: 0.000003
+      input_cost_per_token_batches: 0.0000015
+      output_cost_per_token: 0.000015
+      output_cost_per_token_batches: 0.0000075
+      region: "*"
+features:
+    - function_calling
+    - parallel_function_calling
+    - tool_choice
+    - prompt_caching
+    - cache_control
+    - structured_output
+    - assistant_prefill
+    - system_messages
+limits:
+    context_window: 1000000
+    max_output_tokens: 64000
+    max_tokens: 64000
+    tool_use_system_prompt_tokens: 346
+modalities:
+    input:
+        - text
+        - image
+        - pdf
+    output:
+        - text
+mode: chat
+model: system.ai.claude-sonnet-4-6
+params:
+    - defaultValue: 256
+      key: max_tokens
+      maxValue: 64000
+      minValue: 1
+provisioning: serverless
+status: active
+supportedModes:
+    - chat
+thinking: true

--- a/providers/databricks/system.ai.claude-sonnet-4.yaml
+++ b/providers/databricks/system.ai.claude-sonnet-4.yaml
@@ -1,0 +1,32 @@
+costs:
+    - input_cost_per_token: 3e-6
+      output_cost_per_token: 1.5e-5
+      region: "*"
+deprecationDate: "2026-04-14"
+features:
+    - function_calling
+    - tool_choice
+    - assistant_prefill
+isDeprecated: true
+limits:
+    context_window: 200000
+    max_input_tokens: 200000
+    max_output_tokens: 64000
+    max_tokens: 64000
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
+mode: chat
+model: system.ai.claude-sonnet-4
+provisioning: serverless
+retirementDate: "2026-06-15"
+sources:
+    - https://platform.claude.com/docs/en/docs/about-claude/models
+    - https://platform.claude.com/docs/en/about-claude/pricing
+status: retired
+supportedModes:
+    - chat
+thinking: true

--- a/providers/databricks/system.ai.gemini-2-5-flash.yaml
+++ b/providers/databricks/system.ai.gemini-2-5-flash.yaml
@@ -1,0 +1,36 @@
+costs:
+    - input_cost_per_token: 3e-7
+      output_cost_per_token: 0.0000025
+      region: "*"
+features:
+    - function_calling
+    - tool_choice
+    - structured_output
+    - system_messages
+    - prompt_caching
+limits:
+    context_window: 1048576
+    max_input_tokens: 1048576
+    max_output_tokens: 65536
+    max_tokens: 65536
+modalities:
+    input:
+        - text
+        - image
+        - video
+        - audio
+    output:
+        - text
+mode: chat
+model: system.ai.gemini-2-5-flash
+provisioning: serverless
+removeParams:
+    - reasoning_effort
+sources:
+    - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-flash
+    - https://ai.google.dev/gemini-api/docs/models/gemini-2.5-flash
+    - https://docs.databricks.com/aws/en/machine-learning/model-serving/query-gemini-api
+status: active
+supportedModes:
+    - chat
+thinking: true

--- a/providers/databricks/system.ai.gemini-2-5-pro.yaml
+++ b/providers/databricks/system.ai.gemini-2-5-pro.yaml
@@ -1,0 +1,32 @@
+costs:
+    - input_cost_per_token: 0.00000125
+      output_cost_per_token: 0.00001
+      region: "*"
+features:
+    - function_calling
+    - tool_choice
+    - structured_output
+    - system_messages
+    - json_output
+limits:
+    context_window: 1048576
+    max_input_tokens: 1048576
+    max_output_tokens: 65536
+    max_tokens: 65536
+modalities:
+    input:
+        - text
+        - image
+        - audio
+        - video
+    output:
+        - text
+mode: chat
+model: system.ai.gemini-2-5-pro
+provisioning: serverless
+sources:
+    - https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/limits
+status: active
+supportedModes:
+    - chat
+thinking: true

--- a/providers/databricks/system.ai.gemma-3-12b.yaml
+++ b/providers/databricks/system.ai.gemma-3-12b.yaml
@@ -1,0 +1,30 @@
+costs:
+    - input_cost_per_token: 1.5e-7
+      output_cost_per_token: 5e-7
+      region: "*"
+features:
+    - function_calling
+    - json_output
+limits:
+    context_window: 128000
+    max_input_tokens: 128000
+    max_output_tokens: 8192
+    max_tokens: 8192
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
+mode: chat
+model: system.ai.gemma-3-12b
+provisioning: serverless
+removeParams:
+    - reasoning_effort
+sources:
+    - https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/limits
+    - https://docs.databricks.com/aws/en/machine-learning/model-serving/function-calling
+    - https://www.databricks.com/product/pricing/foundation-model-serving
+status: active
+supportedModes:
+    - chat

--- a/providers/databricks/system.ai.gpt-5-1.yaml
+++ b/providers/databricks/system.ai.gpt-5-1.yaml
@@ -1,0 +1,53 @@
+costs:
+    - cache_creation_input_token_cost: 0.00000125
+      cache_read_input_token_cost: 1.25e-7
+      input_cost_per_token: 0.00000125
+      output_cost_per_token: 0.00001
+      region: "*"
+features:
+    - system_messages
+    - function_calling
+    - structured_output
+    - json_output
+    - tool_choice
+    - prompt_caching
+limits:
+    context_window: 400000
+    max_input_tokens: 272000
+    max_output_tokens: 128000
+    max_tokens: 128000
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
+mode: chat
+model: system.ai.gpt-5-1
+params:
+    - defaultValue: 1
+      key: temperature
+      maxValue: 2
+      minValue: 0
+    - defaultValue: 1
+      key: top_p
+      maxValue: 1
+      minValue: 0
+    - defaultValue: none
+      key: reasoning_effort
+      supportedValues:
+          - none
+          - medium
+          - high
+      type: string
+provisioning: serverless
+sources:
+    - https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/api-reference
+    - https://docs.databricks.com/aws/en/machine-learning/retired-models-policy
+    - https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/limits
+    - https://www.databricks.com/product/pricing/proprietary-foundation-model-serving-1
+status: active
+supportedModes:
+    - chat
+    - responses
+thinking: true

--- a/providers/databricks/system.ai.gpt-5-2.yaml
+++ b/providers/databricks/system.ai.gpt-5-2.yaml
@@ -1,0 +1,47 @@
+costs:
+    - cache_creation_input_token_cost: 1.75e-6
+      cache_read_input_token_cost: 1.75e-7
+      input_cost_per_token: 0.00000175
+      output_cost_per_token: 0.000014
+      region: "*"
+features:
+    - function_calling
+    - system_messages
+    - tool_choice
+    - prompt_caching
+    - structured_output
+limits:
+    context_window: 400000
+    max_output_tokens: 128000
+    max_tokens: 128000
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
+mode: chat
+model: system.ai.gpt-5-2
+params:
+    - defaultValue: none
+      key: reasoning_effort
+      supportedValues:
+          - none
+          - low
+          - medium
+          - high
+          - xhigh
+      type: string
+provisioning: serverless
+sources:
+    - https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/supported-models
+    - https://docs.databricks.com/aws/en/machine-learning/model-serving/query-openai-responses
+    - https://docs.databricks.com/aws/en/machine-learning/model-serving/query-reason-models
+    - https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/limits
+    - https://www.databricks.com/product/pricing/proprietary-foundation-model-serving
+    - https://developers.openai.com/api/docs/models/gpt-5.2
+status: active
+supportedModes:
+    - chat
+    - responses
+thinking: true

--- a/providers/databricks/system.ai.gpt-5-3-codex.yaml
+++ b/providers/databricks/system.ai.gpt-5-3-codex.yaml
@@ -1,0 +1,40 @@
+costs:
+    - cache_creation_input_token_cost: 1.75e-6
+      cache_read_input_token_cost: 1.75e-7
+      input_cost_per_token: 1.75e-6
+      output_cost_per_token: 0.000014
+      region: "*"
+features:
+    - function_calling
+    - system_messages
+    - tool_choice
+    - prompt_caching
+    - structured_output
+limits:
+    context_window: 400000
+    max_output_tokens: 128000
+    max_tokens: 128000
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
+mode: responses
+model: system.ai.gpt-5-3-codex
+params:
+    - defaultValue: medium
+      key: reasoning_effort
+      type: string
+provisioning: serverless
+sources:
+    - https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/supported-models
+    - https://docs.databricks.com/aws/en/machine-learning/model-serving/query-openai-responses
+    - https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/limits
+    - https://www.databricks.com/product/pricing/proprietary-foundation-model-serving
+    - https://developers.openai.com/api/docs/models/gpt-5.3-codex
+status: active
+supportedModes:
+    - responses
+    - chat
+thinking: true

--- a/providers/databricks/system.ai.gpt-5-4-mini.yaml
+++ b/providers/databricks/system.ai.gpt-5-4-mini.yaml
@@ -1,0 +1,48 @@
+costs:
+    - cache_creation_input_token_cost: 7.5e-7
+      cache_read_input_token_cost: 7.5e-8
+      input_cost_per_token: 7.5e-7
+      output_cost_per_token: 0.0000045
+      region: "*"
+features:
+    - function_calling
+    - structured_output
+    - prompt_caching
+    - tool_choice
+    - system_messages
+    - json_output
+limits:
+    context_window: 400000
+    max_input_tokens: 272000
+    max_output_tokens: 128000
+    max_tokens: 128000
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
+mode: chat
+model: system.ai.gpt-5-4-mini
+params:
+    - defaultValue: none
+      key: reasoning_effort
+      supportedValues:
+          - none
+          - low
+          - medium
+          - high
+          - xhigh
+      type: string
+provisioning: serverless
+sources:
+    - https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/supported-models
+    - https://docs.databricks.com/aws/en/machine-learning/model-serving/query-openai-responses
+    - https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/limits
+    - https://www.databricks.com/product/pricing/proprietary-foundation-model-serving
+    - https://developers.openai.com/api/docs/models/gpt-5.4-mini
+status: active
+supportedModes:
+    - chat
+    - responses
+thinking: true

--- a/providers/databricks/system.ai.gpt-5-4-nano.yaml
+++ b/providers/databricks/system.ai.gpt-5-4-nano.yaml
@@ -1,0 +1,47 @@
+costs:
+    - cache_creation_input_token_cost: 2e-7
+      cache_read_input_token_cost: 2e-8
+      input_cost_per_token: 2e-7
+      output_cost_per_token: 0.00000125
+      region: "*"
+features:
+    - function_calling
+    - structured_output
+    - tool_choice
+    - system_messages
+    - prompt_caching
+limits:
+    context_window: 400000
+    max_input_tokens: 272000
+    max_output_tokens: 128000
+    max_tokens: 128000
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
+mode: chat
+model: system.ai.gpt-5-4-nano
+params:
+    - defaultValue: none
+      key: reasoning_effort
+      supportedValues:
+          - none
+          - low
+          - medium
+          - high
+          - xhigh
+      type: string
+provisioning: serverless
+sources:
+    - https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/supported-models
+    - https://docs.databricks.com/aws/en/machine-learning/model-serving/query-openai-responses
+    - https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/limits
+    - https://www.databricks.com/product/pricing/proprietary-foundation-model-serving
+    - https://developers.openai.com/api/docs/models/gpt-5.4-nano
+status: active
+supportedModes:
+    - chat
+    - responses
+thinking: true

--- a/providers/databricks/system.ai.gpt-5-4.yaml
+++ b/providers/databricks/system.ai.gpt-5-4.yaml
@@ -1,0 +1,61 @@
+costs:
+    - cache_creation_input_token_cost: 0.0000025
+      cache_read_input_token_cost: 2.5e-7
+      input_cost_per_token: 0.0000025
+      output_cost_per_token: 0.000015
+      region: "*"
+      tiered_pricing:
+          cache_read:
+              - cost_per_token: 5e-7
+                from: 272000
+          cache_write:
+              - cost_per_token: 0.000005
+                from: 272000
+          input:
+              - cost_per_token: 0.000005
+                from: 272000
+          output:
+              - cost_per_token: 0.0000225
+                from: 272000
+          pricing_mode: cumulative
+features:
+    - function_calling
+    - tool_choice
+    - system_messages
+    - structured_output
+    - prompt_caching
+    - json_output
+limits:
+    context_window: 1050000
+    max_output_tokens: 128000
+    max_tokens: 128000
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
+mode: chat
+model: system.ai.gpt-5-4
+params:
+    - defaultValue: none
+      key: reasoning_effort
+      supportedValues:
+          - none
+          - low
+          - medium
+          - high
+          - xhigh
+      type: string
+provisioning: serverless
+sources:
+    - https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/supported-models
+    - https://docs.databricks.com/aws/en/machine-learning/model-serving/query-openai-responses
+    - https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/limits
+    - https://www.databricks.com/product/pricing/proprietary-foundation-model-serving
+    - https://developers.openai.com/api/docs/models/gpt-5.4
+status: active
+supportedModes:
+    - chat
+    - responses
+thinking: true

--- a/providers/databricks/system.ai.gpt-5-5-pro.yaml
+++ b/providers/databricks/system.ai.gpt-5-5-pro.yaml
@@ -1,0 +1,50 @@
+costs:
+    - input_cost_per_token: 0.00003
+      output_cost_per_token: 0.00018
+      region: "*"
+      tiered_pricing:
+          input:
+              - cost_per_token: 0.00006
+                from: 272000
+          output:
+              - cost_per_token: 0.00027
+                from: 272000
+          pricing_mode: cumulative
+features:
+    - function_calling
+    - structured_output
+    - system_messages
+    - tool_choice
+    - json_output
+limits:
+    context_window: 1050000
+    max_output_tokens: 128000
+    max_tokens: 128000
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
+mode: responses
+model: system.ai.gpt-5-5-pro
+params:
+    - defaultValue: medium
+      key: reasoning_effort
+      supportedValues:
+          - medium
+          - high
+          - xhigh
+      type: string
+provisioning: serverless
+sources:
+    - https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/supported-models
+    - https://docs.databricks.com/aws/en/machine-learning/model-serving/query-openai-responses
+    - https://docs.databricks.com/aws/en/machine-learning/model-serving/query-reason-models
+    - https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/limits
+    - https://www.databricks.com/product/pricing/proprietary-foundation-model-serving
+    - https://developers.openai.com/api/docs/models/gpt-5.5-pro
+status: active
+supportedModes:
+    - responses
+thinking: true

--- a/providers/databricks/system.ai.gpt-5-mini.yaml
+++ b/providers/databricks/system.ai.gpt-5-mini.yaml
@@ -1,0 +1,48 @@
+costs:
+    - cache_creation_input_token_cost: 2.5e-7
+      cache_read_input_token_cost: 2.5e-8
+      input_cost_per_token: 2.5e-7
+      output_cost_per_token: 0.000002
+      region: "*"
+features:
+    - function_calling
+    - tool_choice
+    - structured_output
+    - json_output
+    - prompt_caching
+    - system_messages
+    - cache_control
+limits:
+    context_window: 400000
+    max_input_tokens: 272000
+    max_output_tokens: 128000
+    max_tokens: 128000
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
+mode: chat
+model: system.ai.gpt-5-mini
+params:
+    - defaultValue: minimal
+      key: reasoning_effort
+      supportedValues:
+          - none
+          - minimal
+          - low
+          - medium
+          - high
+      type: string
+provisioning: serverless
+sources:
+    - https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/limits
+    - https://docs.databricks.com/aws/en/machine-learning/model-serving/function-calling
+    - https://docs.databricks.com/aws/en/machine-learning/model-serving/structured-outputs
+    - https://www.databricks.com/product/pricing/proprietary-foundation-model-serving
+status: active
+supportedModes:
+    - chat
+    - responses
+thinking: true

--- a/providers/databricks/system.ai.gpt-5-nano.yaml
+++ b/providers/databricks/system.ai.gpt-5-nano.yaml
@@ -1,0 +1,44 @@
+costs:
+    - cache_creation_input_token_cost: 5e-8
+      cache_read_input_token_cost: 5e-9
+      input_cost_per_token: 5e-8
+      output_cost_per_token: 4e-7
+      region: "*"
+features:
+    - system_messages
+    - function_calling
+    - tool_choice
+    - structured_output
+    - prompt_caching
+limits:
+    context_window: 400000
+    max_input_tokens: 272000
+    max_output_tokens: 128000
+    max_tokens: 128000
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
+mode: chat
+model: system.ai.gpt-5-nano
+params:
+    - defaultValue: minimal
+      key: reasoning_effort
+      supportedValues:
+          - minimal
+          - low
+          - medium
+          - high
+      type: string
+provisioning: serverless
+sources:
+    - https://docs.databricks.com/aws/en/machine-learning/model-serving/query-reason-models
+    - https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/supported-models
+    - https://developers.openai.com/api/docs/models/gpt-5-nano
+status: active
+supportedModes:
+    - chat
+    - responses
+thinking: true

--- a/providers/databricks/system.ai.gpt-5.yaml
+++ b/providers/databricks/system.ai.gpt-5.yaml
@@ -1,0 +1,49 @@
+costs:
+    - cache_creation_input_token_cost: 0.00000125
+      cache_read_input_token_cost: 1.25e-7
+      input_cost_per_token: 0.00000125
+      output_cost_per_token: 0.00001
+      region: "*"
+features:
+    - function_calling
+    - parallel_function_calling
+    - system_messages
+    - tool_choice
+    - structured_output
+    - prompt_caching
+    - json_output
+limits:
+    context_window: 400000
+    max_output_tokens: 128000
+    max_tokens: 128000
+messages:
+    options:
+        - system
+        - user
+        - assistant
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
+mode: chat
+model: system.ai.gpt-5
+params:
+    - defaultValue: minimal
+      key: reasoning_effort
+      supportedValues:
+          - minimal
+          - low
+          - medium
+          - high
+      type: string
+provisioning: serverless
+sources:
+    - https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/api-reference
+    - https://www.databricks.com/product/pricing/proprietary-foundation-model-serving
+status: active
+supportedModes:
+    - chat
+    - responses
+thinking: true

--- a/providers/databricks/system.ai.gpt-oss-120b.yaml
+++ b/providers/databricks/system.ai.gpt-oss-120b.yaml
@@ -1,0 +1,38 @@
+costs:
+    - input_cost_per_token: 1.5e-7
+      output_cost_per_token: 6e-7
+      region: "*"
+features:
+    - function_calling
+    - system_messages
+    - tool_choice
+    - structured_output
+    - json_output
+limits:
+    context_window: 128000
+    max_output_tokens: 25000
+    max_tokens: 25000
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: chat
+model: system.ai.gpt-oss-120b
+params:
+    - defaultValue: medium
+      key: reasoning_effort
+      supportedValues:
+          - low
+          - medium
+          - high
+      type: string
+provisioning: serverless
+sources:
+    - https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/api-reference
+    - https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/limits
+    - https://www.databricks.com/product/pricing/foundation-model-serving
+status: active
+supportedModes:
+    - chat
+thinking: true

--- a/providers/databricks/system.ai.gpt-oss-20b.yaml
+++ b/providers/databricks/system.ai.gpt-oss-20b.yaml
@@ -1,0 +1,39 @@
+costs:
+    - input_cost_per_token: 7e-8
+      output_cost_per_token: 3e-7
+      region: "*"
+features:
+    - function_calling
+    - structured_output
+    - json_output
+    - system_messages
+    - tool_choice
+limits:
+    context_window: 128000
+    max_output_tokens: 25000
+    max_tokens: 25000
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: chat
+model: system.ai.gpt-oss-20b
+params:
+    - defaultValue: medium
+      key: reasoning_effort
+      supportedValues:
+          - low
+          - medium
+          - high
+      type: string
+provisioning: serverless
+sources:
+    - https://www.databricks.com/product/pricing/foundation-model-serving
+    - https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/limits
+    - https://docs.databricks.com/aws/en/machine-learning/model-serving/function-calling
+    - https://docs.databricks.com/aws/en/machine-learning/model-serving/structured-outputs
+status: active
+supportedModes:
+    - chat
+thinking: true

--- a/providers/databricks/system.ai.gte-large-en.yaml
+++ b/providers/databricks/system.ai.gte-large-en.yaml
@@ -1,0 +1,22 @@
+costs:
+    - input_cost_per_token: 1.3e-7
+      output_cost_per_token: 0
+      region: "*"
+limits:
+    context_window: 8192
+    max_input_tokens: 8192
+    output_vector_size: 1024
+modalities:
+    input:
+        - text
+    output:
+        - embedding
+mode: embedding
+model: system.ai.gte-large-en
+provisioning: serverless
+removeParams:
+    - max_tokens
+    - reasoning_effort
+status: active
+supportedModes:
+    - embedding

--- a/providers/databricks/system.ai.llama-4-maverick.yaml
+++ b/providers/databricks/system.ai.llama-4-maverick.yaml
@@ -1,0 +1,30 @@
+costs:
+    - input_cost_per_token: 5e-7
+      output_cost_per_token: 0.0000015
+      region: "*"
+features:
+    - function_calling
+    - tool_choice
+    - structured_output
+limits:
+    max_output_tokens: 8192
+    max_tokens: 8192
+modalities:
+    input:
+        - text
+        - image
+    output:
+        - text
+mode: chat
+model: system.ai.llama-4-maverick
+provisioning: serverless
+removeParams:
+    - reasoning_effort
+sources:
+    - https://docs.databricks.com/aws/en/machine-learning/model-serving/score-foundation-models
+    - https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/limits
+    - https://docs.databricks.com/aws/en/machine-learning/model-serving/function-calling
+    - https://www.databricks.com/product/pricing/foundation-model-serving
+status: active
+supportedModes:
+    - chat

--- a/providers/databricks/system.ai.meta-llama-3-3-70b-instruct.yaml
+++ b/providers/databricks/system.ai.meta-llama-3-3-70b-instruct.yaml
@@ -1,0 +1,30 @@
+costs:
+    - input_cost_per_token: 5e-7
+      output_cost_per_token: 0.0000015
+      region: "*"
+features:
+    - tool_choice
+    - function_calling
+    - structured_output
+    - json_output
+    - system_messages
+limits:
+    context_window: 128000
+    max_output_tokens: 8192
+    max_tokens: 8192
+modalities:
+    input:
+        - text
+    output:
+        - text
+mode: chat
+model: system.ai.meta-llama-3-3-70b-instruct
+provisioning: serverless
+removeParams:
+    - reasoning_effort
+sources:
+    - https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/limits
+    - https://docs.databricks.com/aws/en/machine-learning/model-serving/function-calling
+status: active
+supportedModes:
+    - chat


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Additive metadata-only YAML with no runtime or auth changes; main risk is incorrect pricing or limits affecting cost estimates and routing for new model IDs.
> 
> **Overview**
> Adds **24 new** Databricks provider YAML definitions for **`system.ai.*`** foundation-model serving IDs, alongside existing `databricks-*` entries.
> 
> Coverage spans **Claude** (Haiku/Sonnet/Opus 4.x, including retired `claude-sonnet-4`), **Gemini 2.5** and **Gemma 3**, **GPT-5** family (including `gpt-5-4` / `gpt-5-5-pro` tiered pricing and responses-only codex/pro variants), **gpt-oss** open models, **Llama/Meta** instruct models, and **`gte-large-en`** embeddings.
> 
> Each file records **serverless** provisioning, **token costs** (often with prompt-cache fields), **limits/modalities**, **features**, and per-model **`params`**, **`removeParams`**, **`supportedModes`** (chat vs responses), and lifecycle fields where relevant (`retirementDate`, deprecated `claude-sonnet-4`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04f28977f0be294dc0995c42b73e55ae3fe8d5f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->