### PR TITLE
feat(google-vertex): add root-level gemini-3.5-flash and 3.6-flash entries

### DIFF
--- a/providers/google-vertex/gemini-3.5-flash.yaml
+++ b/providers/google-vertex/gemini-3.5-flash.yaml
@@ -1,0 +1,84 @@
+costs:
+    - cache_read_input_token_cost: 1.65e-7
+      input_cost_per_token: 0.00000165
+      input_cost_per_token_batches: 8.25e-7
+      output_cost_per_token: 0.0000099
+      output_cost_per_token_batches: 0.00000495
+      region: us
+    - cache_read_input_token_cost: 1.5e-7
+      input_cost_per_token: 0.0000015
+      input_cost_per_token_batches: 7.5e-7
+      output_cost_per_token: 0.000009
+      output_cost_per_token_batches: 0.0000045
+      region: global
+    - cache_read_input_token_cost: 1.65e-7
+      input_cost_per_token: 0.00000165
+      input_cost_per_token_batches: 8.25e-7
+      output_cost_per_token: 0.0000099
+      output_cost_per_token_batches: 0.00000495
+      region: europe-west2
+    - cache_read_input_token_cost: 1.65e-7
+      input_cost_per_token: 0.00000165
+      input_cost_per_token_batches: 8.25e-7
+      output_cost_per_token: 0.0000099
+      output_cost_per_token_batches: 0.00000495
+      region: eu
+    - cache_read_input_token_cost: 1.65e-7
+      input_cost_per_token: 0.00000165
+      input_cost_per_token_batches: 8.25e-7
+      output_cost_per_token: 0.0000099
+      output_cost_per_token_batches: 0.00000495
+      region: asia-southeast1
+    - cache_read_input_token_cost: 1.65e-7
+      input_cost_per_token: 0.00000165
+      input_cost_per_token_batches: 8.25e-7
+      output_cost_per_token: 0.0000099
+      output_cost_per_token_batches: 0.00000495
+      region: asia-south1
+    - cache_read_input_token_cost: 1.65e-7
+      input_cost_per_token: 0.00000165
+      input_cost_per_token_batches: 8.25e-7
+      output_cost_per_token: 0.0000099
+      output_cost_per_token_batches: 0.00000495
+      region: asia-northeast1
+features:
+    - function_calling
+    - parallel_function_calling
+    - system_messages
+    - tool_choice
+    - prompt_caching
+    - structured_output
+    - code_execution
+    - json_output
+limits:
+    context_window: 1048576
+    max_input_tokens: 1048576
+    max_output_tokens: 65536
+    max_tokens: 65536
+modalities:
+    input:
+        - text
+        - image
+        - video
+        - audio
+        - pdf
+    output:
+        - text
+mode: chat
+model: gemini-3.5-flash
+params:
+    - defaultValue: 65536
+      key: max_tokens
+      maxValue: 65536
+      minValue: 1
+provisioning: serverless
+sources:
+    - https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/gemini/3-5-flash
+    - https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing
+    - https://ai.google.dev/gemini-api/docs/models/gemini-3.5-flash
+    - https://deepmind.google/models/gemini/flash/
+    - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/3-5-flash
+status: active
+supportedModes:
+    - chat
+thinking: true

--- a/providers/google-vertex/gemini-3.6-flash.yaml
+++ b/providers/google-vertex/gemini-3.6-flash.yaml
@@ -1,0 +1,45 @@
+costs:
+    - cache_read_input_token_cost: 7.5e-8
+      input_cost_per_token: 7.5e-7
+      input_cost_per_token_batches: 3.75e-7
+      output_cost_per_token: 3.75e-6
+      output_cost_per_token_batches: 1.875e-6
+      region: global
+features:
+    - function_calling
+    - parallel_function_calling
+    - prompt_caching
+    - structured_output
+    - system_messages
+    - tool_choice
+    - code_execution
+    - json_output
+limits:
+    context_window: 1048576
+    max_input_tokens: 1048576
+    max_output_tokens: 65536
+    max_tokens: 65536
+modalities:
+    input:
+        - text
+        - image
+        - video
+        - audio
+        - pdf
+    output:
+        - text
+mode: chat
+model: gemini-3.6-flash
+provisioning: serverless
+removeParams:
+    - temperature
+    - top_p
+sources:
+    - https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/gemini/3-6-flash
+    - https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing
+    - https://ai.google.dev/gemini-api/docs/models/gemini-3.6-flash
+    - https://ai.google.dev/gemini-api/docs/pricing
+status: active
+supportedModes:
+    - chat
+thinking: true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Metadata-only additions to the model catalog; no runtime or application logic changes.
> 
> **Overview**
> Adds two new **google-vertex** model registry files at the provider root: `gemini-3.5-flash` and `gemini-3.6-flash`, so callers can use those model IDs without the `google/` prefix (alongside existing `google/gemini-3.5-flash` style entries).
> 
> **`gemini-3.5-flash`** is marked active with thinking enabled, 1M context / 65k output limits, multimodal inputs (text, image, video, audio, pdf), and **region-specific** token pricing (us, global, eu, and several Asia regions). It includes a `max_tokens` param default of 65536.
> 
> **`gemini-3.6-flash`** is also active with thinking, the same limits and modalities, **global-only** pricing (lower than 3.5), and **`removeParams`** for `temperature` and `top_p` so those sampling knobs are not exposed for this model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c40cef4b98a331522e1659ac55159d11a1ef72c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->