### PR TITLE
fix(google-gemini): correct bot regressions for flash image and flash

### DIFF
--- a/providers/google-gemini/gemini-2.5-flash-image.yaml
+++ b/providers/google-gemini/gemini-2.5-flash-image.yaml
@@ -1,5 +1,7 @@
 costs:
-    - input_cost_per_token: 3e-7
+    - cache_creation_input_token_cost_per_hour: 0.000001
+      cache_read_input_token_cost: 3e-8
+      input_cost_per_token: 3e-7
       input_cost_per_token_batches: 1.5e-7
       output_cost_per_image_1k: 0.039
       output_cost_per_image_token: 0.00003

--- a/providers/google-gemini/gemini-3.1-flash-image-preview.yaml
+++ b/providers/google-gemini/gemini-3.1-flash-image-preview.yaml
@@ -11,7 +11,6 @@ features:
     - structured_output
     - function_calling
     - code_execution
-    - prompt_caching
 isDeprecated: true
 limits:
     context_window: 131072

--- a/providers/google-gemini/gemini-3.1-flash-image.yaml
+++ b/providers/google-gemini/gemini-3.1-flash-image.yaml
@@ -1,7 +1,5 @@
 costs:
-    - cache_creation_input_token_cost_per_hour: 1e-6
-      cache_read_input_token_cost: 5e-8
-      input_cost_per_token: 5e-7
+    - input_cost_per_token: 5e-7
       input_cost_per_token_batches: 2.5e-7
       output_cost_per_image_token: 6e-5
       output_cost_per_token: 3e-6
@@ -17,7 +15,6 @@ modalities:
     input:
         - text
         - image
-        - audio
         - video
     output:
         - text

--- a/providers/google-gemini/gemini-3.5-flash.yaml
+++ b/providers/google-gemini/gemini-3.5-flash.yaml
@@ -40,6 +40,14 @@ params:
       key: top_p
     - defaultValue: 64
       key: top_k
+    - defaultValue: medium
+      key: reasoning_effort
+      supportedValues:
+          - minimal
+          - low
+          - medium
+          - high
+      type: string
 provisioning: serverless
 sources:
     - https://ai.google.dev/gemini-api/docs/models/gemini-3.5-flash

--- a/providers/google-gemini/gemini-3.6-flash.yaml
+++ b/providers/google-gemini/gemini-3.6-flash.yaml
@@ -1,10 +1,10 @@
 costs:
-    - cache_creation_input_token_cost_per_hour: 5e-7
-      cache_read_input_token_cost: 7.5e-8
-      input_cost_per_token: 7.5e-7
-      input_cost_per_token_batches: 3.75e-7
-      output_cost_per_token: 3.75e-6
-      output_cost_per_token_batches: 1.875e-6
+    - cache_creation_input_token_cost_per_hour: 1e-6
+      cache_read_input_token_cost: 1.5e-7
+      input_cost_per_token: 1.5e-6
+      input_cost_per_token_batches: 7.5e-7
+      output_cost_per_token: 7.5e-6
+      output_cost_per_token_batches: 3.75e-6
       region: "*"
 features:
     - function_calling
@@ -38,6 +38,14 @@ params:
       key: top_p
     - defaultValue: 64
       key: top_k
+    - defaultValue: medium
+      key: reasoning_effort
+      supportedValues:
+          - minimal
+          - low
+          - medium
+          - high
+      type: string
 provisioning: serverless
 sources:
     - https://ai.google.dev/gemini-api/docs/models/gemini-3.6-flash


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes incorrect / inconsistent Google Gemini model YAML updates from `bot/update-google-gemini-20260820-110806` (PR #2261), verified against Gemini API model and pricing docs.

## Fixes

### Cache / feature consistency
- **`gemini-2.5-flash-image`**: restore `cache_creation_input_token_cost_per_hour` (`0.000001`) and `cache_read_input_token_cost` (`3e-8`). Caching is supported; rates match Gemini 2.5 Flash text pricing.
- **`gemini-3.1-flash-image`**: remove incorrectly added cache costs (Caching **not** supported for Nano Banana 2) and remove unsupported `audio` input modality.
- **`gemini-3.1-flash-image-preview`**: remove `prompt_caching` from features (retired preview; caching not supported for this family).

### Pricing / params regressions in the same bot PR
- **`gemini-3.6-flash`**: restore standard paid-tier rates (bot had applied half/batch values as standard). Also add documented `reasoning_effort` levels (`minimal`/`low`/`medium`/`high`, default `medium`).
- **`gemini-3.5-flash`**: restore removed `reasoning_effort` and include `minimal` per current thinking-level docs.

## Left unchanged (reviewed, look intentional)
- `gemini-2.5-flash-lite`: retirementDate removal (model page still lists as supported/active)
- `gemini-3-pro-image` / `gemini-omni-flash-preview`: `removeParams` additions
- `gemini-embedding-2-preview`: retire/deprecate (preview superseded)

## Pre-existing gaps (not introduced by this bot PR)
Some older models still advertise `prompt_caching` without cache cost fields (e.g. `gemini-2.0-flash-lite`, `gemini-1.5-flash-latest`). Out of scope here.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a576c950-addd-41bf-810e-b8420fafdb0d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a576c950-addd-41bf-810e-b8420fafdb0d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

