### PR TITLE
refactor(azure-open-ai): rename max_tokens to max_completion_tokens and remove deprecated parameters across multiple models

### DIFF
--- a/providers/azure-open-ai/gpt-5-2025-08-07.yaml
+++ b/providers/azure-open-ai/gpt-5-2025-08-07.yaml
@@ -33,7 +33,7 @@ modalities:
 mode: chat
 model: gpt-5-2025-08-07
 params:
-    - key: max_tokens
+    - key: max_completion_tokens
       maxValue: 128000
     - defaultValue: medium
       key: reasoning_effort
@@ -44,6 +44,8 @@ params:
           - high
       type: string
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2027-02-09"
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models

--- a/providers/azure-open-ai/gpt-5-codex-2025-09-15.yaml
+++ b/providers/azure-open-ai/gpt-5-codex-2025-09-15.yaml
@@ -26,7 +26,7 @@ mode: responses
 model: gpt-5-codex-2025-09-15
 params:
     - defaultValue: 128
-      key: max_tokens
+      key: max_completion_tokens
       maxValue: 128000
       minValue: 1
     - defaultValue: medium
@@ -37,6 +37,8 @@ params:
           - high
       type: string
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2027-03-17"
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models

--- a/providers/azure-open-ai/gpt-5-mini-2025-08-07-lite.yaml
+++ b/providers/azure-open-ai/gpt-5-mini-2025-08-07-lite.yaml
@@ -32,7 +32,14 @@ modalities:
         - text
 mode: chat
 model: gpt-5-mini-2025-08-07-lite
+params:
+    - defaultValue: 128
+      key: max_completion_tokens
+      maxValue: 128000
+      minValue: 1
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2027-02-09"
 status: active
 supportedModes:

--- a/providers/azure-open-ai/gpt-5-mini-2025-08-07.yaml
+++ b/providers/azure-open-ai/gpt-5-mini-2025-08-07.yaml
@@ -38,7 +38,7 @@ mode: chat
 model: gpt-5-mini-2025-08-07
 params:
     - defaultValue: 128
-      key: max_tokens
+      key: max_completion_tokens
       maxValue: 128000
       minValue: 1
     - defaultValue: medium
@@ -50,6 +50,8 @@ params:
           - high
       type: string
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2027-02-09"
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models

--- a/providers/azure-open-ai/gpt-5-mini-lite-2025-08-07.yaml
+++ b/providers/azure-open-ai/gpt-5-mini-lite-2025-08-07.yaml
@@ -4,7 +4,11 @@
 # are omitted because they cannot be confirmed from official documentation.
 mode: chat
 model: gpt-5-mini-lite-2025-08-07
+params:
+    - key: max_completion_tokens
 provisioning: serverless
+removeParams:
+    - max_tokens
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/model-retirements
     - https://learn.microsoft.com/en-us/azure/ai-foundry/foundry-models/concepts/models-sold-directly-by-azure

--- a/providers/azure-open-ai/gpt-5-nano-2025-08-07.yaml
+++ b/providers/azure-open-ai/gpt-5-nano-2025-08-07.yaml
@@ -34,7 +34,7 @@ mode: chat
 model: gpt-5-nano-2025-08-07
 params:
     - defaultValue: 128
-      key: max_tokens
+      key: max_completion_tokens
       maxValue: 128000
       minValue: 1
     - defaultValue: medium
@@ -46,6 +46,8 @@ params:
           - high
       type: string
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2027-02-09"
 status: active
 supportedModes:

--- a/providers/azure-open-ai/gpt-5-pro-2025-10-06.yaml
+++ b/providers/azure-open-ai/gpt-5-pro-2025-10-06.yaml
@@ -25,7 +25,7 @@ mode: responses
 model: gpt-5-pro-2025-10-06
 params:
     - defaultValue: 128000
-      key: max_tokens
+      key: max_completion_tokens
       maxValue: 128000
       minValue: 1
     - defaultValue: high
@@ -34,6 +34,8 @@ params:
           - high
       type: string
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2027-04-07"
 status: active
 supportedModes:

--- a/providers/azure-open-ai/gpt-5.1-chat-2025-11-13.yaml
+++ b/providers/azure-open-ai/gpt-5.1-chat-2025-11-13.yaml
@@ -44,6 +44,7 @@ removeParams:
     - top_p
     - tool_choice
     - parallel_tool_calls
+    - max_tokens
 retirementDate: "2026-06-29"
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models

--- a/providers/azure-open-ai/gpt-5.1-codex-2025-11-13.yaml
+++ b/providers/azure-open-ai/gpt-5.1-codex-2025-11-13.yaml
@@ -41,9 +41,11 @@ modalities:
 mode: responses
 model: gpt-5.1-codex-2025-11-13
 params:
-    - key: max_tokens
+    - key: max_completion_tokens
       maxValue: 128000
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2027-05-15"
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models

--- a/providers/azure-open-ai/gpt-5.1-codex-max-2025-12-04.yaml
+++ b/providers/azure-open-ai/gpt-5.1-codex-max-2025-12-04.yaml
@@ -30,7 +30,7 @@ mode: responses
 model: gpt-5.1-codex-max-2025-12-04
 params:
     - defaultValue: 128000
-      key: max_tokens
+      key: max_completion_tokens
       maxValue: 128000
       minValue: 1
     - defaultValue: medium
@@ -43,6 +43,8 @@ params:
           - xhigh
       type: string
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2027-05-18"
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models

--- a/providers/azure-open-ai/gpt-5.1-codex-max.yaml
+++ b/providers/azure-open-ai/gpt-5.1-codex-max.yaml
@@ -24,6 +24,10 @@ modalities:
 mode: responses
 model: gpt-5.1-codex-max
 params:
+    - defaultValue: 128
+      key: max_completion_tokens
+      maxValue: 128000
+      minValue: 1
     - defaultValue: medium
       key: reasoning_effort
       supportedValues:
@@ -34,6 +38,8 @@ params:
           - xhigh
       type: string
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2027-05-18"
 status: active
 supportedModes:

--- a/providers/azure-open-ai/gpt-5.1-codex-mini-2025-11-13.yaml
+++ b/providers/azure-open-ai/gpt-5.1-codex-mini-2025-11-13.yaml
@@ -42,7 +42,7 @@ mode: responses
 model: gpt-5.1-codex-mini-2025-11-13
 params:
     - defaultValue: 128
-      key: max_tokens
+      key: max_completion_tokens
       maxValue: 128000
       minValue: 1
     - defaultValue: medium
@@ -56,6 +56,7 @@ params:
 provisioning: serverless
 removeParams:
     - "n"
+    - max_tokens
 retirementDate: "2027-05-15"
 status: active
 supportedModes:

--- a/providers/azure-open-ai/gpt-5.2-chat-2025-12-11.yaml
+++ b/providers/azure-open-ai/gpt-5.2-chat-2025-12-11.yaml
@@ -26,7 +26,7 @@ modalities:
 mode: chat
 model: gpt-5.2-chat-2025-12-11
 params:
-    - key: max_tokens
+    - key: max_completion_tokens
       maxValue: 16384
     - defaultValue: medium
       key: reasoning_effort
@@ -37,6 +37,8 @@ params:
           - high
       type: string
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2026-05-13"
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models

--- a/providers/azure-open-ai/gpt-5.2-chat-2026-02-10.yaml
+++ b/providers/azure-open-ai/gpt-5.2-chat-2026-02-10.yaml
@@ -26,9 +26,11 @@ modalities:
 mode: chat
 model: gpt-5.2-chat-2026-02-10
 params:
-    - key: max_tokens
+    - key: max_completion_tokens
       maxValue: 16384
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2026-06-29"
 status: retired
 supportedModes:

--- a/providers/azure-open-ai/gpt-5.2-chat.yaml
+++ b/providers/azure-open-ai/gpt-5.2-chat.yaml
@@ -29,6 +29,8 @@ params:
     - key: max_completion_tokens
       maxValue: 16384
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2026-06-29"
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models

--- a/providers/azure-open-ai/gpt-5.2-codex-2026-01-14.yaml
+++ b/providers/azure-open-ai/gpt-5.2-codex-2026-01-14.yaml
@@ -26,10 +26,12 @@ mode: responses
 model: gpt-5.2-codex-2026-01-14
 params:
     - defaultValue: 128
-      key: max_tokens
+      key: max_completion_tokens
       maxValue: 128000
       minValue: 1
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2027-07-13"
 status: active
 supportedModes:

--- a/providers/azure-open-ai/gpt-5.2-codex.yaml
+++ b/providers/azure-open-ai/gpt-5.2-codex.yaml
@@ -24,7 +24,14 @@ modalities:
         - text
 mode: responses
 model: gpt-5.2-codex
+params:
+    - defaultValue: 128
+      key: max_completion_tokens
+      maxValue: 128000
+      minValue: 1
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2027-07-13"
 status: active
 supportedModes:

--- a/providers/azure-open-ai/gpt-5.3-chat-2026-03-03.yaml
+++ b/providers/azure-open-ai/gpt-5.3-chat-2026-03-03.yaml
@@ -27,10 +27,12 @@ mode: chat
 model: gpt-5.3-chat-2026-03-03
 params:
     - defaultValue: 128
-      key: max_tokens
+      key: max_completion_tokens
       maxValue: 16384
       minValue: 1
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2026-06-29"
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models

--- a/providers/azure-open-ai/gpt-5.3-codex-2026-02-20.yaml
+++ b/providers/azure-open-ai/gpt-5.3-codex-2026-02-20.yaml
@@ -26,7 +26,7 @@ mode: responses
 model: gpt-5.3-codex-2026-02-20
 params:
     - defaultValue: 128
-      key: max_tokens
+      key: max_completion_tokens
       maxValue: 128000
       minValue: 1
     - defaultValue: medium
@@ -37,6 +37,8 @@ params:
           - high
       type: string
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2027-08-24"
 status: active
 supportedModes:

--- a/providers/azure-open-ai/gpt-5.3-codex-2026-02-24.yaml
+++ b/providers/azure-open-ai/gpt-5.3-codex-2026-02-24.yaml
@@ -26,13 +26,15 @@ mode: responses
 model: gpt-5.3-codex-2026-02-24
 params:
     - defaultValue: 128
-      key: max_tokens
+      key: max_completion_tokens
       maxValue: 128000
       minValue: 1
     - defaultValue: medium
       key: reasoning_effort
       type: string
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2027-08-24"
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models

--- a/providers/azure-open-ai/gpt-5.3-codex.yaml
+++ b/providers/azure-open-ai/gpt-5.3-codex.yaml
@@ -24,7 +24,14 @@ modalities:
         - text
 mode: responses
 model: gpt-5.3-codex
+params:
+    - defaultValue: 128
+      key: max_completion_tokens
+      maxValue: 128000
+      minValue: 1
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2027-08-24"
 status: active
 supportedModes:

--- a/providers/azure-open-ai/gpt-5.4-mini-2026-03-17.yaml
+++ b/providers/azure-open-ai/gpt-5.4-mini-2026-03-17.yaml
@@ -27,7 +27,7 @@ mode: chat
 model: gpt-5.4-mini-2026-03-17
 params:
     - defaultValue: 128
-      key: max_tokens
+      key: max_completion_tokens
       maxValue: 128000
       minValue: 1
     - defaultValue: none
@@ -40,6 +40,8 @@ params:
           - xhigh
       type: string
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2027-09-21"
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models

--- a/providers/azure-open-ai/gpt-5.4-mini.yaml
+++ b/providers/azure-open-ai/gpt-5.4-mini.yaml
@@ -25,6 +25,10 @@ modalities:
 mode: chat
 model: gpt-5.4-mini
 params:
+    - defaultValue: 128
+      key: max_completion_tokens
+      maxValue: 128000
+      minValue: 1
     - defaultValue: none
       key: reasoning_effort
       supportedValues:
@@ -35,6 +39,8 @@ params:
           - xhigh
       type: string
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2027-09-21"
 status: active
 supportedModes:

--- a/providers/azure-open-ai/gpt-5.4-nano-2026-03-17.yaml
+++ b/providers/azure-open-ai/gpt-5.4-nano-2026-03-17.yaml
@@ -26,7 +26,7 @@ modalities:
 mode: chat
 model: gpt-5.4-nano-2026-03-17
 params:
-    - key: max_tokens
+    - key: max_completion_tokens
       maxValue: 128000
     - defaultValue: none
       key: reasoning_effort
@@ -38,6 +38,8 @@ params:
           - xhigh
       type: string
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2027-09-21"
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models

--- a/providers/azure-open-ai/gpt-5.4-nano.yaml
+++ b/providers/azure-open-ai/gpt-5.4-nano.yaml
@@ -24,6 +24,10 @@ modalities:
 mode: chat
 model: gpt-5.4-nano
 params:
+    - defaultValue: 128
+      key: max_completion_tokens
+      maxValue: 128000
+      minValue: 1
     - defaultValue: none
       key: reasoning_effort
       supportedValues:
@@ -34,6 +38,8 @@ params:
           - xhigh
       type: string
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2027-09-21"
 status: active
 supportedModes:

--- a/providers/azure-open-ai/gpt-5.4-pro-2026-03-05.yaml
+++ b/providers/azure-open-ai/gpt-5.4-pro-2026-03-05.yaml
@@ -36,7 +36,7 @@ mode: responses
 model: gpt-5.4-pro-2026-03-05
 params:
     - defaultValue: 128
-      key: max_tokens
+      key: max_completion_tokens
       maxValue: 128000
       minValue: 1
     - defaultValue: null
@@ -51,6 +51,7 @@ params:
 provisioning: serverless
 removeParams:
     - parallel_tool_calls
+    - max_tokens
 retirementDate: "2027-09-07"
 status: active
 supportedModes:

--- a/providers/azure-open-ai/gpt-5.4-pro.yaml
+++ b/providers/azure-open-ai/gpt-5.4-pro.yaml
@@ -35,6 +35,10 @@ modalities:
 mode: responses
 model: gpt-5.4-pro
 params:
+    - defaultValue: 128
+      key: max_completion_tokens
+      maxValue: 128000
+      minValue: 1
     - defaultValue: medium
       key: reasoning_effort
       supportedValues:
@@ -45,6 +49,8 @@ params:
           - xhigh
       type: string
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2027-09-07"
 status: active
 supportedModes:

--- a/providers/azure-open-ai/gpt-5.4.yaml
+++ b/providers/azure-open-ai/gpt-5.4.yaml
@@ -44,10 +44,12 @@ mode: chat
 model: gpt-5.4
 params:
     - defaultValue: 128
-      key: max_tokens
+      key: max_completion_tokens
       maxValue: 128000
       minValue: 1
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2027-09-02"
 status: active
 supportedModes:

--- a/providers/azure-open-ai/gpt-5.5-2026-04-24.yaml
+++ b/providers/azure-open-ai/gpt-5.5-2026-04-24.yaml
@@ -66,6 +66,10 @@ modalities:
 mode: chat
 model: gpt-5.5-2026-04-24
 params:
+    - defaultValue: 128
+      key: max_completion_tokens
+      maxValue: 128000
+      minValue: 1
     - defaultValue: medium
       key: reasoning_effort
       supportedValues:
@@ -76,6 +80,8 @@ params:
           - xhigh
       type: string
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2027-10-26"
 status: active
 supportedModes:

--- a/providers/azure-open-ai/gpt-5.5.yaml
+++ b/providers/azure-open-ai/gpt-5.5.yaml
@@ -66,6 +66,10 @@ modalities:
 mode: chat
 model: gpt-5.5
 params:
+    - defaultValue: 128
+      key: max_completion_tokens
+      maxValue: 128000
+      minValue: 1
     - defaultValue: medium
       key: reasoning_effort
       supportedValues:
@@ -76,6 +80,8 @@ params:
           - xhigh
       type: string
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2027-10-26"
 status: active
 supportedModes:

--- a/providers/azure-open-ai/gpt-5.6-luna-2026-07-09.yaml
+++ b/providers/azure-open-ai/gpt-5.6-luna-2026-07-09.yaml
@@ -67,6 +67,10 @@ modalities:
 mode: chat
 model: gpt-5.6-luna-2026-07-09
 params:
+    - defaultValue: 128
+      key: max_completion_tokens
+      maxValue: 128000
+      minValue: 1
     - defaultValue: medium
       key: reasoning_effort
       supportedValues:
@@ -78,6 +82,8 @@ params:
           - max
       type: string
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2028-01-11"
 status: active
 supportedModes:

--- a/providers/azure-open-ai/gpt-5.6-sol-2026-07-09.yaml
+++ b/providers/azure-open-ai/gpt-5.6-sol-2026-07-09.yaml
@@ -66,6 +66,10 @@ modalities:
 mode: chat
 model: gpt-5.6-sol-2026-07-09
 params:
+    - defaultValue: 128
+      key: max_completion_tokens
+      maxValue: 128000
+      minValue: 1
     - defaultValue: medium
       key: reasoning_effort
       supportedValues:
@@ -76,6 +80,8 @@ params:
           - xhigh
       type: string
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2028-01-11"
 status: active
 supportedModes:

--- a/providers/azure-open-ai/gpt-5.6-sol.yaml
+++ b/providers/azure-open-ai/gpt-5.6-sol.yaml
@@ -65,6 +65,10 @@ modalities:
 mode: chat
 model: gpt-5.6-sol
 params:
+    - defaultValue: 128
+      key: max_completion_tokens
+      maxValue: 128000
+      minValue: 1
     - defaultValue: medium
       key: reasoning_effort
       supportedValues:
@@ -75,6 +79,8 @@ params:
           - xhigh
       type: string
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2028-01-11"
 status: active
 supportedModes:

--- a/providers/azure-open-ai/gpt-5.6-terra-2026-07-09.yaml
+++ b/providers/azure-open-ai/gpt-5.6-terra-2026-07-09.yaml
@@ -65,6 +65,10 @@ modalities:
 mode: chat
 model: gpt-5.6-terra-2026-07-09
 params:
+    - defaultValue: 128
+      key: max_completion_tokens
+      maxValue: 128000
+      minValue: 1
     - defaultValue: medium
       key: reasoning_effort
       supportedValues:
@@ -75,6 +79,8 @@ params:
           - xhigh
       type: string
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2028-01-11"
 status: active
 supportedModes:

--- a/providers/azure-open-ai/gpt-5.6-terra.yaml
+++ b/providers/azure-open-ai/gpt-5.6-terra.yaml
@@ -65,6 +65,10 @@ modalities:
 mode: chat
 model: gpt-5.6-terra
 params:
+    - defaultValue: 128
+      key: max_completion_tokens
+      maxValue: 128000
+      minValue: 1
     - defaultValue: medium
       key: reasoning_effort
       supportedValues:
@@ -75,6 +79,8 @@ params:
           - xhigh
       type: string
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2028-01-11"
 status: active
 supportedModes:


### PR DESCRIPTION
* Updated parameter names from max_tokens to max_completion_tokens for consistency.
* Removed deprecated max_tokens parameter from various model YAML files.
* Ensured all models reflect the latest naming conventions and parameter structures.

This change enhances clarity and aligns with the updated API specifications.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Model catalog changes that alter which token-limit parameter is sent to Azure OpenAI. Incorrect mapping could cause API errors or ignored output-length settings for many GPT-5 models.
> 
> **Overview**
> Aligns Azure OpenAI GPT-5 family model configs with the Chat Completions API by exposing `max_completion_tokens` instead of `max_tokens`.
> 
> Across GPT-5 through GPT-5.6 YAML definitions, the request param key is renamed (or added where missing), and `max_tokens` is listed under `removeParams` so the deprecated field is stripped from requests. Limits still keep `max_tokens` as a catalog limit field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbcc844daa099e912dd15f160f71c1fcaf30f6d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->