### PR TITLE
GATEWAY-2910: Add tool-search provider configuration

### DIFF
--- a/.github/scripts/autogen/types.ts
+++ b/.github/scripts/autogen/types.ts
@@ -7,6 +7,15 @@ export type paths = Record<string, never>;
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        /** @description One Anthropic server-tool column: client tool type -> provider mapping */
+        AnthropicServerToolColumn: {
+            [key: string]: components["schemas"]["AnthropicServerToolMapping"];
+        };
+        /** @description One Anthropic server-tool mapping. A null type drops the tool; betas are added when it survives. */
+        AnthropicServerToolMapping: {
+            betas?: string[];
+            type: string | null;
+        };
         /**
          * @description AWS region identifiers
          * @enum {string}
@@ -182,9 +191,9 @@ export interface components {
             anthropic_betas?: {
                 [key: string]: components["schemas"]["BetaColumn"];
             };
-            /** @description server-tool translation keyed by provider flavor (e.g. invoke/converse, or default) */
-            server_tools?: {
-                [key: string]: components["schemas"]["ServerToolColumn"];
+            /** @description Anthropic server-tool translation keyed by provider flavor (e.g. invoke/converse, or default) */
+            anthropic_server_tools?: {
+                [key: string]: components["schemas"]["AnthropicServerToolColumn"];
             };
         };
         /**
@@ -192,15 +201,6 @@ export interface components {
          * @enum {string}
          */
         Provisioning: "serverless" | "provisioned";
-        /** @description One server-tool column: client tool type -> provider mapping */
-        ServerToolColumn: {
-            [key: string]: components["schemas"]["ServerToolMapping"];
-        };
-        /** @description One server-tool mapping. A null type drops the tool; betas are added when it survives. */
-        ServerToolMapping: {
-            betas?: string[];
-            type: string | null;
-        };
         /**
          * @description Lifecycle status of a model
          * @enum {string}
@@ -239,6 +239,8 @@ export type $defs = Record<string, never>;
 export type operations = Record<string, never>;
 
 export type AWSRegion = components['schemas']['AWSRegion'];
+export type AnthropicServerToolColumn = components['schemas']['AnthropicServerToolColumn'];
+export type AnthropicServerToolMapping = components['schemas']['AnthropicServerToolMapping'];
 export type AzureRegion = components['schemas']['AzureRegion'];
 export type BetaColumn = components['schemas']['BetaColumn'];
 export type Cost = components['schemas']['Cost'];
@@ -261,8 +263,6 @@ export type PricingMode = components['schemas']['PricingMode'];
 export type PricingTier = components['schemas']['PricingTier'];
 export type ProviderConfig = components['schemas']['ProviderConfig'];
 export type Provisioning = components['schemas']['Provisioning'];
-export type ServerToolColumn = components['schemas']['ServerToolColumn'];
-export type ServerToolMapping = components['schemas']['ServerToolMapping'];
 export type Status = components['schemas']['Status'];
 export type TieredPricing = components['schemas']['TieredPricing'];
 export type ToolCost = components['schemas']['ToolCost'];

--- a/.github/scripts/autogen/types.ts
+++ b/.github/scripts/autogen/types.ts
@@ -182,12 +182,25 @@ export interface components {
             anthropic_betas?: {
                 [key: string]: components["schemas"]["BetaColumn"];
             };
+            /** @description server-tool translation keyed by provider flavor (e.g. invoke/converse, or default) */
+            server_tools?: {
+                [key: string]: components["schemas"]["ServerToolColumn"];
+            };
         };
         /**
          * @description How the model is made available to callers
          * @enum {string}
          */
         Provisioning: "serverless" | "provisioned";
+        /** @description One server-tool column: client tool type -> provider mapping */
+        ServerToolColumn: {
+            [key: string]: components["schemas"]["ServerToolMapping"];
+        };
+        /** @description One server-tool mapping. A null type drops the tool; betas are added when it survives. */
+        ServerToolMapping: {
+            betas?: string[];
+            type: string | null;
+        };
         /**
          * @description Lifecycle status of a model
          * @enum {string}
@@ -248,6 +261,8 @@ export type PricingMode = components['schemas']['PricingMode'];
 export type PricingTier = components['schemas']['PricingTier'];
 export type ProviderConfig = components['schemas']['ProviderConfig'];
 export type Provisioning = components['schemas']['Provisioning'];
+export type ServerToolColumn = components['schemas']['ServerToolColumn'];
+export type ServerToolMapping = components['schemas']['ServerToolMapping'];
 export type Status = components['schemas']['Status'];
 export type TieredPricing = components['schemas']['TieredPricing'];
 export type ToolCost = components['schemas']['ToolCost'];

--- a/.github/test/model.cue
+++ b/.github/test/model.cue
@@ -71,22 +71,22 @@ package model
 // One anthropic-beta column: clientToken -> providerToken, or null to drop
 #BetaColumn: {[string]: string | null}
 
-// One server-tool mapping. A null type drops the tool; betas are added when it survives.
-#ServerToolMapping: {
+// One Anthropic server-tool mapping. A null type drops the tool; betas are added when it survives.
+#AnthropicServerToolMapping: {
 	type:   string | null
 	betas?: [...string]
 }
 
-// One server-tool column: client tool type -> provider mapping
-#ServerToolColumn: {[string]: #ServerToolMapping}
+// One Anthropic server-tool column: client tool type -> provider mapping
+#AnthropicServerToolColumn: {[string]: #AnthropicServerToolMapping}
 
 // Schema for provider-config.yaml files (provider-scoped, not per-model).
 // Every field is optional so future provider-scoped settings can slot in.
 #ProviderConfig: {
 	// anthropic-beta translation keyed by provider flavor (e.g. invoke/converse, or default)
 	anthropic_betas?: {[string]: #BetaColumn}
-	// server-tool translation keyed by provider flavor (e.g. invoke/converse, or default)
-	server_tools?: {[string]: #ServerToolColumn}
+	// Anthropic server-tool translation keyed by provider flavor (e.g. invoke/converse, or default)
+	anthropic_server_tools?: {[string]: #AnthropicServerToolColumn}
 }
 
 // ============================================================

--- a/.github/test/model.cue
+++ b/.github/test/model.cue
@@ -71,11 +71,22 @@ package model
 // One anthropic-beta column: clientToken -> providerToken, or null to drop
 #BetaColumn: {[string]: string | null}
 
+// One server-tool mapping. A null type drops the tool; betas are added when it survives.
+#ServerToolMapping: {
+	type:   string | null
+	betas?: [...string]
+}
+
+// One server-tool column: client tool type -> provider mapping
+#ServerToolColumn: {[string]: #ServerToolMapping}
+
 // Schema for provider-config.yaml files (provider-scoped, not per-model).
 // Every field is optional so future provider-scoped settings can slot in.
 #ProviderConfig: {
 	// anthropic-beta translation keyed by provider flavor (e.g. invoke/converse, or default)
 	anthropic_betas?: {[string]: #BetaColumn}
+	// server-tool translation keyed by provider flavor (e.g. invoke/converse, or default)
+	server_tools?: {[string]: #ServerToolColumn}
 }
 
 // ============================================================

--- a/providers/aws-bedrock/provider-config.yaml
+++ b/providers/aws-bedrock/provider-config.yaml
@@ -43,3 +43,19 @@ anthropic_betas:
         token-efficient-tools-2025-02-19: token-efficient-tools-2025-02-19
         tool-examples-2025-10-29: tool-examples-2025-10-29
         tool-search-tool-2025-10-19: tool-search-tool-2025-10-19
+server_tools:
+    # Converse does not support Anthropic server-side tool search.
+    converse:
+        tool_search_tool_bm25_20251119:
+            type: null
+        tool_search_tool_regex_20251119:
+            type: null
+    # InvokeModel expects the unversioned regex type and does not support BM25.
+    invoke:
+        tool_search_tool_bm25_20251119:
+            type: null
+        tool_search_tool_regex_20251119:
+            betas:
+                - tool-examples-2025-10-29
+                - tool-search-tool-2025-10-19
+            type: tool_search_tool_regex

--- a/providers/aws-bedrock/provider-config.yaml
+++ b/providers/aws-bedrock/provider-config.yaml
@@ -43,17 +43,28 @@ anthropic_betas:
         token-efficient-tools-2025-02-19: token-efficient-tools-2025-02-19
         tool-examples-2025-10-29: tool-examples-2025-10-29
         tool-search-tool-2025-10-19: tool-search-tool-2025-10-19
-server_tools:
+anthropic_server_tools:
     # Converse does not support Anthropic server-side tool search.
     converse:
+        tool_search_tool_bm25:
+            type: null
         tool_search_tool_bm25_20251119:
+            type: null
+        tool_search_tool_regex:
             type: null
         tool_search_tool_regex_20251119:
             type: null
     # InvokeModel expects the unversioned regex type and does not support BM25.
     invoke:
+        tool_search_tool_bm25:
+            type: null
         tool_search_tool_bm25_20251119:
             type: null
+        tool_search_tool_regex:
+            betas:
+                - tool-examples-2025-10-29
+                - tool-search-tool-2025-10-19
+            type: tool_search_tool_regex
         tool_search_tool_regex_20251119:
             betas:
                 - tool-examples-2025-10-29


### PR DESCRIPTION
## Summary
- add a provider-scoped `anthropic_server_tools` schema keyed by API flavor
- move Bedrock Invoke and Converse tool-search rewrite/drop mappings into provider config
- cover both dated tool-search types and Anthropic’s undated aliases
- generate the updated TypeScript schema types
- leave web-search behavior unchanged

## Validation
- `npm run validate` (3742 passed)
- `npm run validate -- providers/aws-bedrock/provider-config.yaml`
- `npm run generate:types`
- `npm run build:provider-configs`

## Rollout
Publish and sync this provider config before deploying the corresponding gateway change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Declarative Bedrock tool-search rewrite/drop rules affect request shaping for Anthropic server tools; misconfiguration could break or silently strip tool-search on Invoke vs Converse until gateway and published config stay in sync.
> 
> **Overview**
> Introduces provider-scoped **`anthropic_server_tools`** configuration (mirroring **`anthropic_betas`**) so the gateway can translate or drop Anthropic server-side tools per API flavor.
> 
> The Cue **`#ProviderConfig`** schema and regenerated TypeScript types add **`AnthropicServerToolMapping`** (`type` nullable to drop, optional **`betas`** when the tool is kept) and flavor-keyed columns. **AWS Bedrock** **`provider-config.yaml`** now encodes tool-search behavior: **Converse** drops all BM25/regex tool-search types; **Invoke** drops BM25 variants and maps dated/undated regex types to **`tool_search_tool_regex`** while attaching **`tool-examples-2025-10-29`** and **`tool-search-tool-2025-10-19`** betas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cc43e020e8a282cd917b5f16e67762a61565a83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->