### PR TITLE
fix(openai/gpt-5): keep alias active, only the dated snapshot is deprecated

### DIFF
--- a/providers/openai/gpt-5.yaml
+++ b/providers/openai/gpt-5.yaml
@@ -5,7 +5,6 @@ costs:
       output_cost_per_token: 1e-5
       output_cost_per_token_batches: 5e-6
       region: "*"
-deprecationDate: "2026-06-11"
 features:
     - function_calling
     - parallel_function_calling
@@ -14,7 +13,6 @@ features:
     - prompt_caching
     - structured_output
     - json_output
-isDeprecated: true
 limits:
     context_window: 400000
     max_output_tokens: 128000
@@ -53,10 +51,9 @@ removeParams:
     - top_p
     - n
     - max_tokens
-retirementDate: "2026-12-11"
 sources:
     - https://developers.openai.com/api/docs/models/gpt-5
-status: deprecated
+status: active
 supportedModes:
     - chat
     - responses


### PR DESCRIPTION
## Summary

`providers/openai/gpt-5.yaml` marks the floating `gpt-5` alias as deprecated. OpenAI's [deprecations page](https://developers.openai.com/api/docs/deprecations) does not list the alias — the 2026-06-11 notice covers the **dated snapshots** only:

| OpenAI entry | Shutdown | Replacement |
|---|---|---|
| `gpt-5-2025-08-07` | 2026-12-11 | `gpt-5.6-sol` |
| `gpt-5-mini-2025-08-07` | 2026-12-11 | `gpt-5.6-terra` |
| `gpt-5-nano-2025-08-07` | 2026-12-11 | `gpt-5.6-luna` |
| `gpt-5-pro-2025-10-06` | 2026-12-11 | `gpt-5.6-sol` (reasoning.mode: pro) |

The [`gpt-5` model page](https://developers.openai.com/api/docs/models/gpt-5) calls it "our previous model" and recommends GPT-5.6, but carries no deprecation or shutdown date.

The registry was also self-inconsistent: the sibling aliases were already handled the right way.

| File | Before | After |
|---|---|---|
| `gpt-5.yaml` | `deprecated` | **`active`** |
| `gpt-5-mini.yaml` | `active` | `active` (unchanged) |
| `gpt-5-nano.yaml` | `active` | `active` (unchanged) |
| `gpt-5-pro.yaml` | `active` | `active` (unchanged) |
| `gpt-5-2025-08-07.yaml` | `deprecated` | `deprecated` (unchanged) |

## Changes

`providers/openai/gpt-5.yaml` — drop `deprecationDate`, `isDeprecated` and `retirementDate`, set `status: active`. This matches the shape of the active sibling aliases. The dated snapshot keeps its deprecation.

## Why this matters

Deprecation state drives the "Fix Deprecated Models" panel in the dashboard, which tells customers the listed models are "deprecated and no longer supported by the provider" and will be removed from their provider account. `gpt-5` still serves traffic, so that notice is wrong today. Reported by a customer.

## Checked but deliberately left alone

- `gpt-audio` / `gpt-audio-mini` — correct. OpenAI announced these **aliases** on 2026-07-20 with shutdown 2027-01-20, replacement `gpt-audio-1.5`. Dates in the registry match exactly.
- `gpt-audio-2025-08-28` — not separately announced by OpenAI, but it is the default snapshot behind the now-deprecated `gpt-audio` alias, so inheriting the alias dates is reasonable.
- `gpt-audio-mini-2025-10-06` — matches OpenAI's 2026-04-22 notice, shutdown 2026-07-23.

## Residual risk

If OpenAI never repoints the `gpt-5` alias away from `gpt-5-2025-08-07`, the alias will stop working on 2026-12-11 along with the snapshot. That is a judgement call: this change follows the provider's published list and the repo's existing convention for `gpt-5-mini`/`-nano`/`-pro`. Worth revisiting closer to the shutdown date if OpenAI has not published alias guidance by then.

## Testing

- `yamllint -c .yamllint.yml providers/openai/gpt-5.yaml` — clean
- `./.github/test/validate.sh providers/openai/gpt-5.yaml` — passes (all three removed fields are optional in `model.cue`; `active` is a valid `#Status`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry metadata only; no runtime routing logic. Residual product risk if OpenAI shuts down the alias with the dated snapshot on 2026-12-11 without separate notice.
> 
> **Overview**
> Corrects the registry so the floating **`gpt-5`** alias is **active** again, matching OpenAI’s deprecations list (dated snapshots like `gpt-5-2025-08-07` are deprecated, not the alias) and the other **`gpt-5-*`** sibling aliases.
> 
> In **`providers/openai/gpt-5.yaml`**, removes **`deprecationDate`**, **`isDeprecated`**, and **`retirementDate`**, and sets **`status: active`**. That stops the dashboard “Fix Deprecated Models” flow from treating still-serving **`gpt-5`** traffic as provider-deprecated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cbd7826c6f16a826b26215cd4c11e75ff794be3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->