### PR TITLE
feat(elevenlabs): add provider default.yaml with documentation URLs

### DIFF
--- a/providers/elevenlabs/default.yaml
+++ b/providers/elevenlabs/default.yaml
@@ -8,9 +8,4 @@ documentation:
     - https://elevenlabs.io/docs/api-reference/text-to-speech/convert
     - https://elevenlabs.io/docs/api-reference/speech-to-text/convert
     - https://elevenlabs.io/docs/changelog
-params:
-    - defaultValue: null
-      key: seed
-      maxValue: 4294967295
-      minValue: 0
-      type: number
+

--- a/providers/elevenlabs/default.yaml
+++ b/providers/elevenlabs/default.yaml
@@ -8,4 +8,3 @@ documentation:
     - https://elevenlabs.io/docs/api-reference/text-to-speech/convert
     - https://elevenlabs.io/docs/api-reference/speech-to-text/convert
     - https://elevenlabs.io/docs/changelog
-

--- a/providers/elevenlabs/default.yaml
+++ b/providers/elevenlabs/default.yaml
@@ -2,7 +2,15 @@ documentation:
     - https://elevenlabs.io/docs
     - https://elevenlabs.io/pricing/api
     - https://elevenlabs.io/docs/models
-    - https://elevenlabs.io/docs/models#model-deprecation
+    - https://elevenlabs.io/docs/models#deprecated-models
     - https://elevenlabs.io/docs/capabilities/text-to-speech
     - https://elevenlabs.io/docs/capabilities/speech-to-text
+    - https://elevenlabs.io/docs/api-reference/text-to-speech/convert
+    - https://elevenlabs.io/docs/api-reference/speech-to-text/convert
     - https://elevenlabs.io/docs/changelog
+params:
+    - defaultValue: null
+      key: seed
+      maxValue: 4294967295
+      minValue: 0
+      type: number

--- a/providers/elevenlabs/default.yaml
+++ b/providers/elevenlabs/default.yaml
@@ -1,0 +1,8 @@
+documentation:
+    - https://elevenlabs.io/docs
+    - https://elevenlabs.io/pricing/api
+    - https://elevenlabs.io/docs/models
+    - https://elevenlabs.io/docs/models#model-deprecation
+    - https://elevenlabs.io/docs/capabilities/text-to-speech
+    - https://elevenlabs.io/docs/capabilities/speech-to-text
+    - https://elevenlabs.io/docs/changelog


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only provider metadata with no runtime, auth, or API behavior changes.
> 
> **Overview**
> Adds **`providers/elevenlabs/default.yaml`** so the ElevenLabs provider has the same kind of provider defaults file as other integrations.
> 
> The file only defines a **`documentation`** list: main docs, API pricing, models (including deprecated), TTS/STT capability pages, the convert API references for both modalities, and the changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dff2dc2aaed3c96324b6aec5a05024df195cb10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->