### PR TITLE
fix(aws-bedrock-mantle/openai): declare max_completion_tokens for gpt-5.6 models

### DIFF
--- a/providers/aws-bedrock-mantle/openai.gpt-5.6-luna.yaml
+++ b/providers/aws-bedrock-mantle/openai.gpt-5.6-luna.yaml
@@ -90,7 +90,13 @@ params:
           - xhigh
           - max
       type: string
+    - key: max_completion_tokens
+      maxValue: 128000
+      minValue: 1
+      type: number
 provisioning: serverless
+removeParams:
+    - max_tokens
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-luna.html
     - https://developers.openai.com/api/docs/models/gpt-5.6-luna

--- a/providers/aws-bedrock-mantle/openai.gpt-5.6-sol.yaml
+++ b/providers/aws-bedrock-mantle/openai.gpt-5.6-sol.yaml
@@ -55,7 +55,14 @@ modalities:
         - text
 mode: responses
 model: openai.gpt-5.6-sol
+params:
+    - key: max_completion_tokens
+      maxValue: 128000
+      minValue: 1
+      type: number
 provisioning: serverless
+removeParams:
+    - max_tokens
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-sol.html
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-cards-openai.html

--- a/providers/aws-bedrock-mantle/openai.gpt-5.6-terra.yaml
+++ b/providers/aws-bedrock-mantle/openai.gpt-5.6-terra.yaml
@@ -80,7 +80,14 @@ modalities:
         - text
 mode: responses
 model: openai.gpt-5.6-terra
+params:
+    - key: max_completion_tokens
+      maxValue: 128000
+      minValue: 1
+      type: number
 provisioning: serverless
+removeParams:
+    - max_tokens
 sources:
     - https://developers.openai.com/api/docs/models/gpt-5.6-terra
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-terra.html


### PR DESCRIPTION


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Provider YAML metadata only; no runtime or security-sensitive logic, with a small risk of mis-routed token limits if consumers still send max_tokens.
> 
> **Overview**
> Updates the **aws-bedrock-mantle** catalog entries for **openai.gpt-5.6-luna**, **openai.gpt-5.6-sol**, and **openai.gpt-5.6-terra** so callers use the Responses-style output limit parameter instead of legacy chat **`max_tokens`**.
> 
> Each model now declares **`max_completion_tokens`** (numeric, 1–128000). **Luna** adds it alongside existing **`reasoning_effort`**; **sol** and **terra** gain a new **`params`** block with only this field. All three list **`removeParams: max_tokens`** so routing strips the old parameter in favor of **`max_completion_tokens`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aba9244aeb88fdc7b1678e07da3a727ba1252f7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->