### PR TITLE
fix(aws-bedrock-mantle/openai): add chat to gpt-5.6-sol and -terra supportedModes

### DIFF
--- a/providers/aws-bedrock-mantle/openai.gpt-5.6-sol.yaml
+++ b/providers/aws-bedrock-mantle/openai.gpt-5.6-sol.yaml
@@ -69,4 +69,5 @@ sources:
 status: active
 supportedModes:
     - responses
+    - chat
 thinking: true

--- a/providers/aws-bedrock-mantle/openai.gpt-5.6-terra.yaml
+++ b/providers/aws-bedrock-mantle/openai.gpt-5.6-terra.yaml
@@ -94,4 +94,5 @@ sources:
 status: active
 supportedModes:
     - responses
+    - chat
 thinking: true


### PR DESCRIPTION


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only provider YAML updates with no runtime logic or security impact.
> 
> **Overview**
> Adds **`chat`** to `supportedModes` for **`openai.gpt-5.6-sol`** and **`openai.gpt-5.6-terra`** in the AWS Bedrock Mantle provider, alongside the existing **`responses`** entry.
> 
> This declares that both models can be routed through chat-style APIs, consistent with other Bedrock Mantle model cards that list multiple modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32e253a08c7dedd8a95d691303c1a0d5f9a526d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->