### PR TITLE
Revert "fix(aws-bedrock-mantle/openai): declare max_completion_tokens for gpt-5.6 models"

### DIFF
--- a/providers/aws-bedrock-mantle/openai.gpt-5.6-luna.yaml
+++ b/providers/aws-bedrock-mantle/openai.gpt-5.6-luna.yaml
@@ -90,13 +90,7 @@ params:
           - xhigh
           - max
       type: string
-    - key: max_completion_tokens
-      maxValue: 128000
-      minValue: 1
-      type: number
 provisioning: serverless
-removeParams:
-    - max_tokens
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-luna.html
     - https://developers.openai.com/api/docs/models/gpt-5.6-luna

--- a/providers/aws-bedrock-mantle/openai.gpt-5.6-sol.yaml
+++ b/providers/aws-bedrock-mantle/openai.gpt-5.6-sol.yaml
@@ -55,14 +55,7 @@ modalities:
         - text
 mode: responses
 model: openai.gpt-5.6-sol
-params:
-    - key: max_completion_tokens
-      maxValue: 128000
-      minValue: 1
-      type: number
 provisioning: serverless
-removeParams:
-    - max_tokens
 sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-sol.html
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-cards-openai.html

--- a/providers/aws-bedrock-mantle/openai.gpt-5.6-terra.yaml
+++ b/providers/aws-bedrock-mantle/openai.gpt-5.6-terra.yaml
@@ -80,14 +80,7 @@ modalities:
         - text
 mode: responses
 model: openai.gpt-5.6-terra
-params:
-    - key: max_completion_tokens
-      maxValue: 128000
-      minValue: 1
-      type: number
 provisioning: serverless
-removeParams:
-    - max_tokens
 sources:
     - https://developers.openai.com/api/docs/models/gpt-5.6-terra
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-terra.html


### PR DESCRIPTION
Reverts truefoundry/models#2545

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> YAML-only catalog metadata revert with no auth or runtime code changes; main effect is how completion token params are advertised for three models.
> 
> **Overview**
> Reverts the prior model-catalog change that exposed **`max_completion_tokens`** (1–128000) and **`removeParams: max_tokens`** on three AWS Bedrock Mantle OpenAI GPT-5.6 entries: **luna**, **sol**, and **terra**.
> 
> After this change, **luna** keeps only **`reasoning_effort`** under `params`; **sol** and **terra** have no `params` block. None of the three declare `removeParams` anymore, so catalog-driven token-parameter handling for these models goes back to whatever the platform default is instead of explicitly mapping completion length and stripping `max_tokens`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9df448a3a014064f6ad4b11afca69a237be4a2ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->