### PR TITLE
fix(sambanova/MiniMax-M3): unquote cost values so they validate as numbers

### DIFF
--- a/providers/sambanova/MiniMax-M3.yaml
+++ b/providers/sambanova/MiniMax-M3.yaml
@@ -1,6 +1,6 @@
 costs:
-    - input_cost_per_token: "0.00000060"
-      output_cost_per_token: "0.00000240"
+    - input_cost_per_token: 0.0000006
+      output_cost_per_token: 0.0000024
       region: "*"
 limits:
     context_window: 1048576


### PR DESCRIPTION


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change to cost literal types with no runtime logic impact.
> 
> **Overview**
> Updates **MiniMax-M3** provider pricing so `input_cost_per_token` and `output_cost_per_token` are YAML numbers instead of quoted strings, matching other SambaNova model configs and satisfying numeric validation for those fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0338a20d79c775facd7dc8e662b84ba95ffe9db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->