### PR TITLE
fix(aws-bedrock-mantle/openai): align gpt-5.6 key ordering with repo convention

### DIFF
--- a/providers/aws-bedrock-mantle/openai.gpt-5.6-luna.yaml
+++ b/providers/aws-bedrock-mantle/openai.gpt-5.6-luna.yaml
@@ -80,6 +80,10 @@ modalities:
 mode: responses
 model: openai.gpt-5.6-luna
 params:
+    - key: max_completion_tokens
+      maxValue: 128000
+      minValue: 1
+      type: number
     - defaultValue: medium
       key: reasoning_effort
       supportedValues:
@@ -90,10 +94,6 @@ params:
           - xhigh
           - max
       type: string
-    - key: max_completion_tokens
-      maxValue: 128000
-      minValue: 1
-      type: number
 provisioning: serverless
 removeParams:
     - max_tokens
@@ -102,6 +102,6 @@ sources:
     - https://developers.openai.com/api/docs/models/gpt-5.6-luna
 status: active
 supportedModes:
-    - responses
     - chat
+    - responses
 thinking: true

--- a/providers/aws-bedrock-mantle/openai.gpt-5.6-sol.yaml
+++ b/providers/aws-bedrock-mantle/openai.gpt-5.6-sol.yaml
@@ -68,6 +68,6 @@ sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-cards-openai.html
 status: active
 supportedModes:
-    - responses
     - chat
+    - responses
 thinking: true

--- a/providers/aws-bedrock-mantle/openai.gpt-5.6-terra.yaml
+++ b/providers/aws-bedrock-mantle/openai.gpt-5.6-terra.yaml
@@ -93,6 +93,6 @@ sources:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-terra.html
 status: active
 supportedModes:
-    - responses
     - chat
+    - responses
 thinking: true


### PR DESCRIPTION


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> YAML-only ordering in model metadata; behavior and declared modes/params are unchanged.
> 
> **Overview**
> Reorders fields in the **gpt-5.6-luna**, **gpt-5.6-sol**, and **gpt-5.6-terra** Bedrock Mantle model YAMLs so they match how other provider configs are written—no capability or limit changes.
> 
> For **luna**, `max_completion_tokens` is listed before `reasoning_effort` under `params`. On all three models, `supportedModes` is now **`chat` then `responses`** instead of `responses` first.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 479a1579d0665cfbbc0f1687cb91ea41d6e3de3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->