### PR TITLE
docs: scope the registry to gateway-supported providers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,12 +4,32 @@ Thank you for your interest in contributing to the TrueFoundry Models Registry! 
 
 ## Table of Contents
 
+- [What Belongs Here](#what-belongs-here)
 - [Code of Conduct](#code-of-conduct)
 - [How to Contribute](#how-to-contribute)
 - [Adding a New Model](#adding-a-new-model)
+- [Requesting a New Provider](#requesting-a-new-provider)
 - [Updating an Existing Model](#updating-an-existing-model)
 - [Pull Request Process](#pull-request-process)
 - [Style Guide](#style-guide)
+
+## What Belongs Here
+
+This registry holds **metadata for providers the TrueFoundry LLM Gateway already integrates with**. The directories under `providers/` are that list, and the [Supported Providers table](README.md#supported-providers) in the README renders it.
+
+In scope:
+
+- Adding a model under an existing provider
+- Correcting pricing, limits, features, modalities, or `sources`
+- Marking a model deprecated or retired
+
+Out of scope:
+
+- **A new `providers/<name>/` directory.** The gateway can only route to providers it has an integration for, so registry YAML for an unsupported provider is inert. See [Requesting a New Provider](#requesting-a-new-provider).
+- Gateway routing, authentication, or request/response transformation. None of that is configured from this repo.
+- Edits to the README's Supported Providers table. It's generated from `providers/` by [`update-readme-counts.ts`](.github/scripts/update-readme-counts.ts).
+
+PRs that add an unsupported provider will be closed with a pointer to this section. It isn't a judgement on the provider, there's just nothing on the gateway side for the files to attach to yet.
 
 ## Code of Conduct
 
@@ -41,6 +61,8 @@ To add a new model, create a YAML file in the appropriate provider directory:
 ```
 providers/<provider-name>/<model-name>.yaml
 ```
+
+`<provider-name>` must be a directory that already exists. If it doesn't, see [Requesting a New Provider](#requesting-a-new-provider) rather than creating one.
 
 ### 2. Required Fields
 
@@ -187,6 +209,19 @@ A minimal model definition (e.g., audio transcription or TTS):
 model: nova-3-general
 mode: audio_transcription
 ```
+
+## Requesting a New Provider
+
+Support for a provider that isn't in the [Supported Providers table](README.md#supported-providers) starts in the gateway, not in this repo. [Open an issue](../../issues) with:
+
+- The provider and a link to its API reference
+- Which endpoints you need (chat, embeddings, transcription, text-to-speech, images, rerank)
+- Whether the API is OpenAI-compatible, and on which routes
+- The use case and rough volume
+
+Note that OpenAI compatibility on `/chat/completions` doesn't cover everything. Endpoints outside chat, embeddings, and responses need explicit work in the gateway even when the provider mirrors OpenAI's shape.
+
+Once the integration lands, the provider directory gets created and model YAML is welcome.
 
 ## Updating an Existing Model
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,17 @@
 
 A comprehensive, community-maintained registry of AI/LLM model configurations. This repository provides standardized model metadata including pricing, features, and token limits across all major AI providers.
 
+## Scope
+
+This registry is **metadata only**, for providers the TrueFoundry LLM Gateway already integrates with. Every directory under `providers/` corresponds to an existing gateway integration, and the list of those integrations lives in the gateway, not here.
+
+That means:
+
+- **Adding or updating a model** under an existing provider is exactly what this repo is for. Pricing, limits, features, modalities, deprecations — open a PR.
+- **Adding a new provider** is not. A new `providers/<name>/` directory has no effect on its own: without a gateway integration behind it, nothing reads those files at runtime. New provider support is gateway work, so [open an issue](../../issues) describing the provider and the use case instead of sending registry YAML.
+
+See [Supported Providers](#supported-providers) below for the current list.
+
 ## Why Use This?
 
 LLM model configs change often — prices drop, features expand, limits shift. This repository provides up-to-date information across providers and makes updating stale data easy.
@@ -15,6 +26,8 @@ LLM model configs change often — prices drop, features expand, limits shift. T
 - **Open Source** — Community-driven updates ensure accuracy and coverage
 
 ## Supported Providers
+
+This is the complete set of providers the gateway supports. If a provider isn't listed here, the registry has no place to put its models yet. The table is generated from `providers/` by [`update-readme-counts.ts`](.github/scripts/update-readme-counts.ts), so don't edit it by hand.
 
 | Provider | Models | Description |
 |----------|--------|-------------|
@@ -118,7 +131,7 @@ providers/
 
 ## Contributing
 
-We welcome contributions! Whether it's adding a new model, updating pricing, or fixing outdated information — see the [Contributing Guide](CONTRIBUTING.md) for details on the schema, examples, and PR process.
+We welcome contributions! Whether it's adding a model under one of the [supported providers](#supported-providers), updating pricing, or fixing outdated information — see the [Contributing Guide](CONTRIBUTING.md) for details on the schema, examples, and PR process. For a provider that isn't on that list, read [Scope](#scope) first.
 
 ## License
 


### PR DESCRIPTION
## Why

Neither the README nor `CONTRIBUTING.md` states what this repository is scoped to. Because of that, contributors reasonably read "community-maintained registry of AI/LLM model configurations" as an invitation to add a provider, send a well-formed `providers/<new-provider>/` directory, and get the PR closed with no written rule to point at. #2551 is the latest instance: 19 valid, schema-conformant, lint-passing YAML files for a provider the gateway has no integration for, so nothing would have read them at runtime.

This adds the missing rule so the expectation is set before someone does the work.

## Changes

**README.md**
- New `## Scope` section near the top: the registry is metadata only, every directory under `providers/` corresponds to an existing gateway integration, and new provider support is gateway work that starts with an issue.
- A line under `## Supported Providers` noting the table is the complete supported set and is generated, not hand-edited.
- The `## Contributing` blurb now points at `Scope` for providers that aren't on the list.

**CONTRIBUTING.md**
- New `## What Belongs Here` with explicit in-scope / out-of-scope lists, and a plain statement that PRs adding an unsupported provider will be closed with a pointer to that section.
- New `## Requesting a New Provider` describing what an issue should contain (API reference, endpoints needed, whether the API is OpenAI-compatible and on which routes, use case and volume), plus the caveat that OpenAI compatibility on `/chat/completions` does not extend to transcription or text-to-speech.
- A note under `### 1. File Location` that the provider directory must already exist.

No YAML or schema changes.

## Notes for review

- Checked against `.github/scripts/update-readme-counts.ts`: its table regex and its `across N providers` regex each still match exactly once after the edits, so the generated README table is unaffected.
- The `Requesting a New Provider` caveat about OpenAI compatibility reflects `openai-like` in the gateway, which exposes `chatComplete`, `embed`, and `createModelResponse` only. Worth a second pair of eyes on the wording if that changes.
- Not addressed here: `## Pull Request Process` documents titles like `Add: provider/model-name`, but `auto-test-on-add.yml` and `auto-test-on-update.yml` trigger on `[Community] Add model:` / `[Community] Update model:`. Contributors following the guide today do not get the automated model tests. Happy to fix in this PR or a follow-up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to README and CONTRIBUTING; no runtime, schema, or CI behavior changes.
> 
> **Overview**
> **Documents that this repo is metadata-only for providers the TrueFoundry LLM Gateway already integrates with**, so contributors know before opening a PR that new `providers/<name>/` trees are out of scope without a gateway integration.
> 
> The **README** gains a **Scope** section (models under existing providers vs. new providers via issues), clarifies that **Supported Providers** is the full supported set and is **generated** by `update-readme-counts.ts`, and tightens the **Contributing** blurb to point at scope for unsupported providers.
> 
> **CONTRIBUTING** adds **What Belongs Here** (in/out of scope, policy to close unsupported-provider PRs), **Requesting a New Provider** (issue checklist and OpenAI-compat limits), TOC links, and a rule that **File Location** must use an existing provider directory.
> 
> No schema, YAML, or automation changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77e290327fffda7a1a256305d95a7730727ae14f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->