### PR TITLE
GATEWAY-2646: Adding Video to Gemini and Vertex

### DIFF
--- a/.github/test/model.cue
+++ b/.github/test/model.cue
@@ -168,8 +168,9 @@ package model
 
 	// Resolution-based image pricing: matches fields like output_cost_per_image_1k, output_cost_per_image_4k, etc.
 	[=~"^output_cost_per_image_\\d+[pk]$"]: number & >= 0
-	// Resolution-based video pricing: matches fields like output_cost_per_second_480p, output_cost_per_second_4k, etc.
-	[=~"^output_cost_per_second_\\d+[pk]$"]: number & >= 0
+	// Resolution-based video pricing: matches fields like output_cost_per_second_480p, output_cost_per_second_4k,
+	// and their video-only counterparts output_cost_per_second_480p_noaudio, etc. (no suffix = with audio, the default).
+	[=~"^output_cost_per_second_\\d+[pk](_noaudio)?$"]: number & >= 0
 }
 
 // Pricing entry; "*" applies to all regions

--- a/providers/google-gemini/veo-3.1-fast-generate-preview.yaml
+++ b/providers/google-gemini/veo-3.1-fast-generate-preview.yaml
@@ -1,5 +1,6 @@
 costs:
-    - output_cost_per_second_1080p: 0.12
+    - output_cost_per_second: 0.1
+      output_cost_per_second_1080p: 0.12
       output_cost_per_second_4k: 0.3
       output_cost_per_second_720p: 0.1
       region: "*"

--- a/providers/google-gemini/veo-3.1-generate-preview.yaml
+++ b/providers/google-gemini/veo-3.1-generate-preview.yaml
@@ -1,5 +1,6 @@
 costs:
-    - output_cost_per_second_1080p: 0.4
+    - output_cost_per_second: 0.4
+      output_cost_per_second_1080p: 0.4
       output_cost_per_second_4k: 0.6
       output_cost_per_second_720p: 0.4
       region: "*"

--- a/providers/google-gemini/veo-3.1-lite-generate-preview.yaml
+++ b/providers/google-gemini/veo-3.1-lite-generate-preview.yaml
@@ -1,5 +1,6 @@
 costs:
-    - output_cost_per_second_1080p: 0.08
+    - output_cost_per_second: 0.05
+      output_cost_per_second_1080p: 0.08
       output_cost_per_second_720p: 0.05
       region: "*"
 limits:

--- a/providers/google-vertex/google/veo-3.1-fast-generate-001.yaml
+++ b/providers/google-vertex/google/veo-3.1-fast-generate-001.yaml
@@ -1,119 +1,235 @@
 costs:
-    - output_cost_per_second_1080p: 0.10
-      output_cost_per_second_4k: 0.25
-      output_cost_per_second_720p: 0.08
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_1080p_noaudio: 0.10
+      output_cost_per_second_4k: 0.30
+      output_cost_per_second_4k_noaudio: 0.25
+      output_cost_per_second_720p: 0.10
+      output_cost_per_second_720p_noaudio: 0.08
+      output_cost_per_second: 0.10
       region: us-west4
-    - output_cost_per_second_1080p: 0.10
-      output_cost_per_second_4k: 0.25
-      output_cost_per_second_720p: 0.08
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_1080p_noaudio: 0.10
+      output_cost_per_second_4k: 0.30
+      output_cost_per_second_4k_noaudio: 0.25
+      output_cost_per_second_720p: 0.10
+      output_cost_per_second_720p_noaudio: 0.08
+      output_cost_per_second: 0.10
       region: us-west1
-    - output_cost_per_second_1080p: 0.10
-      output_cost_per_second_4k: 0.25
-      output_cost_per_second_720p: 0.08
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_1080p_noaudio: 0.10
+      output_cost_per_second_4k: 0.30
+      output_cost_per_second_4k_noaudio: 0.25
+      output_cost_per_second_720p: 0.10
+      output_cost_per_second_720p_noaudio: 0.08
+      output_cost_per_second: 0.10
       region: us-south1
-    - output_cost_per_second_1080p: 0.10
-      output_cost_per_second_4k: 0.25
-      output_cost_per_second_720p: 0.08
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_1080p_noaudio: 0.10
+      output_cost_per_second_4k: 0.30
+      output_cost_per_second_4k_noaudio: 0.25
+      output_cost_per_second_720p: 0.10
+      output_cost_per_second_720p_noaudio: 0.08
+      output_cost_per_second: 0.10
       region: us-east5
-    - output_cost_per_second_1080p: 0.10
-      output_cost_per_second_4k: 0.25
-      output_cost_per_second_720p: 0.08
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_1080p_noaudio: 0.10
+      output_cost_per_second_4k: 0.30
+      output_cost_per_second_4k_noaudio: 0.25
+      output_cost_per_second_720p: 0.10
+      output_cost_per_second_720p_noaudio: 0.08
+      output_cost_per_second: 0.10
       region: us-east4
-    - output_cost_per_second_1080p: 0.10
-      output_cost_per_second_4k: 0.25
-      output_cost_per_second_720p: 0.08
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_1080p_noaudio: 0.10
+      output_cost_per_second_4k: 0.30
+      output_cost_per_second_4k_noaudio: 0.25
+      output_cost_per_second_720p: 0.10
+      output_cost_per_second_720p_noaudio: 0.08
+      output_cost_per_second: 0.10
       region: us-east1
-    - output_cost_per_second_1080p: 0.10
-      output_cost_per_second_4k: 0.25
-      output_cost_per_second_720p: 0.08
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_1080p_noaudio: 0.10
+      output_cost_per_second_4k: 0.30
+      output_cost_per_second_4k_noaudio: 0.25
+      output_cost_per_second_720p: 0.10
+      output_cost_per_second_720p_noaudio: 0.08
+      output_cost_per_second: 0.10
       region: us-central1
-    - output_cost_per_second_1080p: 0.10
-      output_cost_per_second_4k: 0.25
-      output_cost_per_second_720p: 0.08
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_1080p_noaudio: 0.10
+      output_cost_per_second_4k: 0.30
+      output_cost_per_second_4k_noaudio: 0.25
+      output_cost_per_second_720p: 0.10
+      output_cost_per_second_720p_noaudio: 0.08
+      output_cost_per_second: 0.10
       region: southamerica-east1
-    - output_cost_per_second_1080p: 0.10
-      output_cost_per_second_4k: 0.25
-      output_cost_per_second_720p: 0.08
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_1080p_noaudio: 0.10
+      output_cost_per_second_4k: 0.30
+      output_cost_per_second_4k_noaudio: 0.25
+      output_cost_per_second_720p: 0.10
+      output_cost_per_second_720p_noaudio: 0.08
+      output_cost_per_second: 0.10
       region: northamerica-northeast1
-    - output_cost_per_second_1080p: 0.10
-      output_cost_per_second_4k: 0.25
-      output_cost_per_second_720p: 0.08
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_1080p_noaudio: 0.10
+      output_cost_per_second_4k: 0.30
+      output_cost_per_second_4k_noaudio: 0.25
+      output_cost_per_second_720p: 0.10
+      output_cost_per_second_720p_noaudio: 0.08
+      output_cost_per_second: 0.10
       region: me-west1
-    - output_cost_per_second_1080p: 0.10
-      output_cost_per_second_4k: 0.25
-      output_cost_per_second_720p: 0.08
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_1080p_noaudio: 0.10
+      output_cost_per_second_4k: 0.30
+      output_cost_per_second_4k_noaudio: 0.25
+      output_cost_per_second_720p: 0.10
+      output_cost_per_second_720p_noaudio: 0.08
+      output_cost_per_second: 0.10
       region: me-central2
-    - output_cost_per_second_1080p: 0.10
-      output_cost_per_second_4k: 0.25
-      output_cost_per_second_720p: 0.08
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_1080p_noaudio: 0.10
+      output_cost_per_second_4k: 0.30
+      output_cost_per_second_4k_noaudio: 0.25
+      output_cost_per_second_720p: 0.10
+      output_cost_per_second_720p_noaudio: 0.08
+      output_cost_per_second: 0.10
       region: me-central1
-    - output_cost_per_second_1080p: 0.10
-      output_cost_per_second_4k: 0.25
-      output_cost_per_second_720p: 0.08
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_1080p_noaudio: 0.10
+      output_cost_per_second_4k: 0.30
+      output_cost_per_second_4k_noaudio: 0.25
+      output_cost_per_second_720p: 0.10
+      output_cost_per_second_720p_noaudio: 0.08
+      output_cost_per_second: 0.10
       region: europe-west9
-    - output_cost_per_second_1080p: 0.10
-      output_cost_per_second_4k: 0.25
-      output_cost_per_second_720p: 0.08
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_1080p_noaudio: 0.10
+      output_cost_per_second_4k: 0.30
+      output_cost_per_second_4k_noaudio: 0.25
+      output_cost_per_second_720p: 0.10
+      output_cost_per_second_720p_noaudio: 0.08
+      output_cost_per_second: 0.10
       region: europe-west8
-    - output_cost_per_second_1080p: 0.10
-      output_cost_per_second_4k: 0.25
-      output_cost_per_second_720p: 0.08
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_1080p_noaudio: 0.10
+      output_cost_per_second_4k: 0.30
+      output_cost_per_second_4k_noaudio: 0.25
+      output_cost_per_second_720p: 0.10
+      output_cost_per_second_720p_noaudio: 0.08
+      output_cost_per_second: 0.10
       region: europe-west6
-    - output_cost_per_second_1080p: 0.10
-      output_cost_per_second_4k: 0.25
-      output_cost_per_second_720p: 0.08
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_1080p_noaudio: 0.10
+      output_cost_per_second_4k: 0.30
+      output_cost_per_second_4k_noaudio: 0.25
+      output_cost_per_second_720p: 0.10
+      output_cost_per_second_720p_noaudio: 0.08
+      output_cost_per_second: 0.10
       region: europe-west4
-    - output_cost_per_second_1080p: 0.10
-      output_cost_per_second_4k: 0.25
-      output_cost_per_second_720p: 0.08
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_1080p_noaudio: 0.10
+      output_cost_per_second_4k: 0.30
+      output_cost_per_second_4k_noaudio: 0.25
+      output_cost_per_second_720p: 0.10
+      output_cost_per_second_720p_noaudio: 0.08
+      output_cost_per_second: 0.10
       region: europe-west3
-    - output_cost_per_second_1080p: 0.10
-      output_cost_per_second_4k: 0.25
-      output_cost_per_second_720p: 0.08
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_1080p_noaudio: 0.10
+      output_cost_per_second_4k: 0.30
+      output_cost_per_second_4k_noaudio: 0.25
+      output_cost_per_second_720p: 0.10
+      output_cost_per_second_720p_noaudio: 0.08
+      output_cost_per_second: 0.10
       region: europe-west2
-    - output_cost_per_second_1080p: 0.10
-      output_cost_per_second_4k: 0.25
-      output_cost_per_second_720p: 0.08
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_1080p_noaudio: 0.10
+      output_cost_per_second_4k: 0.30
+      output_cost_per_second_4k_noaudio: 0.25
+      output_cost_per_second_720p: 0.10
+      output_cost_per_second_720p_noaudio: 0.08
+      output_cost_per_second: 0.10
       region: europe-west1
-    - output_cost_per_second_1080p: 0.10
-      output_cost_per_second_4k: 0.25
-      output_cost_per_second_720p: 0.08
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_1080p_noaudio: 0.10
+      output_cost_per_second_4k: 0.30
+      output_cost_per_second_4k_noaudio: 0.25
+      output_cost_per_second_720p: 0.10
+      output_cost_per_second_720p_noaudio: 0.08
+      output_cost_per_second: 0.10
       region: europe-southwest1
-    - output_cost_per_second_1080p: 0.10
-      output_cost_per_second_4k: 0.25
-      output_cost_per_second_720p: 0.08
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_1080p_noaudio: 0.10
+      output_cost_per_second_4k: 0.30
+      output_cost_per_second_4k_noaudio: 0.25
+      output_cost_per_second_720p: 0.10
+      output_cost_per_second_720p_noaudio: 0.08
+      output_cost_per_second: 0.10
       region: europe-north1
-    - output_cost_per_second_1080p: 0.10
-      output_cost_per_second_4k: 0.25
-      output_cost_per_second_720p: 0.08
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_1080p_noaudio: 0.10
+      output_cost_per_second_4k: 0.30
+      output_cost_per_second_4k_noaudio: 0.25
+      output_cost_per_second_720p: 0.10
+      output_cost_per_second_720p_noaudio: 0.08
+      output_cost_per_second: 0.10
       region: europe-central2
-    - output_cost_per_second_1080p: 0.10
-      output_cost_per_second_4k: 0.25
-      output_cost_per_second_720p: 0.08
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_1080p_noaudio: 0.10
+      output_cost_per_second_4k: 0.30
+      output_cost_per_second_4k_noaudio: 0.25
+      output_cost_per_second_720p: 0.10
+      output_cost_per_second_720p_noaudio: 0.08
+      output_cost_per_second: 0.10
       region: australia-southeast1
-    - output_cost_per_second_1080p: 0.10
-      output_cost_per_second_4k: 0.25
-      output_cost_per_second_720p: 0.08
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_1080p_noaudio: 0.10
+      output_cost_per_second_4k: 0.30
+      output_cost_per_second_4k_noaudio: 0.25
+      output_cost_per_second_720p: 0.10
+      output_cost_per_second_720p_noaudio: 0.08
+      output_cost_per_second: 0.10
       region: asia-southeast1
-    - output_cost_per_second_1080p: 0.10
-      output_cost_per_second_4k: 0.25
-      output_cost_per_second_720p: 0.08
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_1080p_noaudio: 0.10
+      output_cost_per_second_4k: 0.30
+      output_cost_per_second_4k_noaudio: 0.25
+      output_cost_per_second_720p: 0.10
+      output_cost_per_second_720p_noaudio: 0.08
+      output_cost_per_second: 0.10
       region: asia-south1
-    - output_cost_per_second_1080p: 0.10
-      output_cost_per_second_4k: 0.25
-      output_cost_per_second_720p: 0.08
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_1080p_noaudio: 0.10
+      output_cost_per_second_4k: 0.30
+      output_cost_per_second_4k_noaudio: 0.25
+      output_cost_per_second_720p: 0.10
+      output_cost_per_second_720p_noaudio: 0.08
+      output_cost_per_second: 0.10
       region: asia-northeast3
-    - output_cost_per_second_1080p: 0.10
-      output_cost_per_second_4k: 0.25
-      output_cost_per_second_720p: 0.08
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_1080p_noaudio: 0.10
+      output_cost_per_second_4k: 0.30
+      output_cost_per_second_4k_noaudio: 0.25
+      output_cost_per_second_720p: 0.10
+      output_cost_per_second_720p_noaudio: 0.08
+      output_cost_per_second: 0.10
       region: asia-northeast1
-    - output_cost_per_second_1080p: 0.10
-      output_cost_per_second_4k: 0.25
-      output_cost_per_second_720p: 0.08
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_1080p_noaudio: 0.10
+      output_cost_per_second_4k: 0.30
+      output_cost_per_second_4k_noaudio: 0.25
+      output_cost_per_second_720p: 0.10
+      output_cost_per_second_720p_noaudio: 0.08
+      output_cost_per_second: 0.10
       region: asia-east2
-    - output_cost_per_second_1080p: 0.10
-      output_cost_per_second_4k: 0.25
-      output_cost_per_second_720p: 0.08
+    - output_cost_per_second_1080p: 0.12
+      output_cost_per_second_1080p_noaudio: 0.10
+      output_cost_per_second_4k: 0.30
+      output_cost_per_second_4k_noaudio: 0.25
+      output_cost_per_second_720p: 0.10
+      output_cost_per_second_720p_noaudio: 0.08
+      output_cost_per_second: 0.10
       region: asia-east1
 messages:
     options:

--- a/providers/google-vertex/google/veo-3.1-fast-generate-001.yaml
+++ b/providers/google-vertex/google/veo-3.1-fast-generate-001.yaml
@@ -1,235 +1,235 @@
 costs:
-    - output_cost_per_second_1080p: 0.12
+    - output_cost_per_second: 0.10
+      output_cost_per_second_1080p: 0.12
       output_cost_per_second_1080p_noaudio: 0.10
       output_cost_per_second_4k: 0.30
       output_cost_per_second_4k_noaudio: 0.25
       output_cost_per_second_720p: 0.10
       output_cost_per_second_720p_noaudio: 0.08
-      output_cost_per_second: 0.10
       region: us-west4
-    - output_cost_per_second_1080p: 0.12
+    - output_cost_per_second: 0.10
+      output_cost_per_second_1080p: 0.12
       output_cost_per_second_1080p_noaudio: 0.10
       output_cost_per_second_4k: 0.30
       output_cost_per_second_4k_noaudio: 0.25
       output_cost_per_second_720p: 0.10
       output_cost_per_second_720p_noaudio: 0.08
-      output_cost_per_second: 0.10
       region: us-west1
-    - output_cost_per_second_1080p: 0.12
+    - output_cost_per_second: 0.10
+      output_cost_per_second_1080p: 0.12
       output_cost_per_second_1080p_noaudio: 0.10
       output_cost_per_second_4k: 0.30
       output_cost_per_second_4k_noaudio: 0.25
       output_cost_per_second_720p: 0.10
       output_cost_per_second_720p_noaudio: 0.08
-      output_cost_per_second: 0.10
       region: us-south1
-    - output_cost_per_second_1080p: 0.12
+    - output_cost_per_second: 0.10
+      output_cost_per_second_1080p: 0.12
       output_cost_per_second_1080p_noaudio: 0.10
       output_cost_per_second_4k: 0.30
       output_cost_per_second_4k_noaudio: 0.25
       output_cost_per_second_720p: 0.10
       output_cost_per_second_720p_noaudio: 0.08
-      output_cost_per_second: 0.10
       region: us-east5
-    - output_cost_per_second_1080p: 0.12
+    - output_cost_per_second: 0.10
+      output_cost_per_second_1080p: 0.12
       output_cost_per_second_1080p_noaudio: 0.10
       output_cost_per_second_4k: 0.30
       output_cost_per_second_4k_noaudio: 0.25
       output_cost_per_second_720p: 0.10
       output_cost_per_second_720p_noaudio: 0.08
-      output_cost_per_second: 0.10
       region: us-east4
-    - output_cost_per_second_1080p: 0.12
+    - output_cost_per_second: 0.10
+      output_cost_per_second_1080p: 0.12
       output_cost_per_second_1080p_noaudio: 0.10
       output_cost_per_second_4k: 0.30
       output_cost_per_second_4k_noaudio: 0.25
       output_cost_per_second_720p: 0.10
       output_cost_per_second_720p_noaudio: 0.08
-      output_cost_per_second: 0.10
       region: us-east1
-    - output_cost_per_second_1080p: 0.12
+    - output_cost_per_second: 0.10
+      output_cost_per_second_1080p: 0.12
       output_cost_per_second_1080p_noaudio: 0.10
       output_cost_per_second_4k: 0.30
       output_cost_per_second_4k_noaudio: 0.25
       output_cost_per_second_720p: 0.10
       output_cost_per_second_720p_noaudio: 0.08
-      output_cost_per_second: 0.10
       region: us-central1
-    - output_cost_per_second_1080p: 0.12
+    - output_cost_per_second: 0.10
+      output_cost_per_second_1080p: 0.12
       output_cost_per_second_1080p_noaudio: 0.10
       output_cost_per_second_4k: 0.30
       output_cost_per_second_4k_noaudio: 0.25
       output_cost_per_second_720p: 0.10
       output_cost_per_second_720p_noaudio: 0.08
-      output_cost_per_second: 0.10
       region: southamerica-east1
-    - output_cost_per_second_1080p: 0.12
+    - output_cost_per_second: 0.10
+      output_cost_per_second_1080p: 0.12
       output_cost_per_second_1080p_noaudio: 0.10
       output_cost_per_second_4k: 0.30
       output_cost_per_second_4k_noaudio: 0.25
       output_cost_per_second_720p: 0.10
       output_cost_per_second_720p_noaudio: 0.08
-      output_cost_per_second: 0.10
       region: northamerica-northeast1
-    - output_cost_per_second_1080p: 0.12
+    - output_cost_per_second: 0.10
+      output_cost_per_second_1080p: 0.12
       output_cost_per_second_1080p_noaudio: 0.10
       output_cost_per_second_4k: 0.30
       output_cost_per_second_4k_noaudio: 0.25
       output_cost_per_second_720p: 0.10
       output_cost_per_second_720p_noaudio: 0.08
-      output_cost_per_second: 0.10
       region: me-west1
-    - output_cost_per_second_1080p: 0.12
+    - output_cost_per_second: 0.10
+      output_cost_per_second_1080p: 0.12
       output_cost_per_second_1080p_noaudio: 0.10
       output_cost_per_second_4k: 0.30
       output_cost_per_second_4k_noaudio: 0.25
       output_cost_per_second_720p: 0.10
       output_cost_per_second_720p_noaudio: 0.08
-      output_cost_per_second: 0.10
       region: me-central2
-    - output_cost_per_second_1080p: 0.12
+    - output_cost_per_second: 0.10
+      output_cost_per_second_1080p: 0.12
       output_cost_per_second_1080p_noaudio: 0.10
       output_cost_per_second_4k: 0.30
       output_cost_per_second_4k_noaudio: 0.25
       output_cost_per_second_720p: 0.10
       output_cost_per_second_720p_noaudio: 0.08
-      output_cost_per_second: 0.10
       region: me-central1
-    - output_cost_per_second_1080p: 0.12
+    - output_cost_per_second: 0.10
+      output_cost_per_second_1080p: 0.12
       output_cost_per_second_1080p_noaudio: 0.10
       output_cost_per_second_4k: 0.30
       output_cost_per_second_4k_noaudio: 0.25
       output_cost_per_second_720p: 0.10
       output_cost_per_second_720p_noaudio: 0.08
-      output_cost_per_second: 0.10
       region: europe-west9
-    - output_cost_per_second_1080p: 0.12
+    - output_cost_per_second: 0.10
+      output_cost_per_second_1080p: 0.12
       output_cost_per_second_1080p_noaudio: 0.10
       output_cost_per_second_4k: 0.30
       output_cost_per_second_4k_noaudio: 0.25
       output_cost_per_second_720p: 0.10
       output_cost_per_second_720p_noaudio: 0.08
-      output_cost_per_second: 0.10
       region: europe-west8
-    - output_cost_per_second_1080p: 0.12
+    - output_cost_per_second: 0.10
+      output_cost_per_second_1080p: 0.12
       output_cost_per_second_1080p_noaudio: 0.10
       output_cost_per_second_4k: 0.30
       output_cost_per_second_4k_noaudio: 0.25
       output_cost_per_second_720p: 0.10
       output_cost_per_second_720p_noaudio: 0.08
-      output_cost_per_second: 0.10
       region: europe-west6
-    - output_cost_per_second_1080p: 0.12
+    - output_cost_per_second: 0.10
+      output_cost_per_second_1080p: 0.12
       output_cost_per_second_1080p_noaudio: 0.10
       output_cost_per_second_4k: 0.30
       output_cost_per_second_4k_noaudio: 0.25
       output_cost_per_second_720p: 0.10
       output_cost_per_second_720p_noaudio: 0.08
-      output_cost_per_second: 0.10
       region: europe-west4
-    - output_cost_per_second_1080p: 0.12
+    - output_cost_per_second: 0.10
+      output_cost_per_second_1080p: 0.12
       output_cost_per_second_1080p_noaudio: 0.10
       output_cost_per_second_4k: 0.30
       output_cost_per_second_4k_noaudio: 0.25
       output_cost_per_second_720p: 0.10
       output_cost_per_second_720p_noaudio: 0.08
-      output_cost_per_second: 0.10
       region: europe-west3
-    - output_cost_per_second_1080p: 0.12
+    - output_cost_per_second: 0.10
+      output_cost_per_second_1080p: 0.12
       output_cost_per_second_1080p_noaudio: 0.10
       output_cost_per_second_4k: 0.30
       output_cost_per_second_4k_noaudio: 0.25
       output_cost_per_second_720p: 0.10
       output_cost_per_second_720p_noaudio: 0.08
-      output_cost_per_second: 0.10
       region: europe-west2
-    - output_cost_per_second_1080p: 0.12
+    - output_cost_per_second: 0.10
+      output_cost_per_second_1080p: 0.12
       output_cost_per_second_1080p_noaudio: 0.10
       output_cost_per_second_4k: 0.30
       output_cost_per_second_4k_noaudio: 0.25
       output_cost_per_second_720p: 0.10
       output_cost_per_second_720p_noaudio: 0.08
-      output_cost_per_second: 0.10
       region: europe-west1
-    - output_cost_per_second_1080p: 0.12
+    - output_cost_per_second: 0.10
+      output_cost_per_second_1080p: 0.12
       output_cost_per_second_1080p_noaudio: 0.10
       output_cost_per_second_4k: 0.30
       output_cost_per_second_4k_noaudio: 0.25
       output_cost_per_second_720p: 0.10
       output_cost_per_second_720p_noaudio: 0.08
-      output_cost_per_second: 0.10
       region: europe-southwest1
-    - output_cost_per_second_1080p: 0.12
+    - output_cost_per_second: 0.10
+      output_cost_per_second_1080p: 0.12
       output_cost_per_second_1080p_noaudio: 0.10
       output_cost_per_second_4k: 0.30
       output_cost_per_second_4k_noaudio: 0.25
       output_cost_per_second_720p: 0.10
       output_cost_per_second_720p_noaudio: 0.08
-      output_cost_per_second: 0.10
       region: europe-north1
-    - output_cost_per_second_1080p: 0.12
+    - output_cost_per_second: 0.10
+      output_cost_per_second_1080p: 0.12
       output_cost_per_second_1080p_noaudio: 0.10
       output_cost_per_second_4k: 0.30
       output_cost_per_second_4k_noaudio: 0.25
       output_cost_per_second_720p: 0.10
       output_cost_per_second_720p_noaudio: 0.08
-      output_cost_per_second: 0.10
       region: europe-central2
-    - output_cost_per_second_1080p: 0.12
+    - output_cost_per_second: 0.10
+      output_cost_per_second_1080p: 0.12
       output_cost_per_second_1080p_noaudio: 0.10
       output_cost_per_second_4k: 0.30
       output_cost_per_second_4k_noaudio: 0.25
       output_cost_per_second_720p: 0.10
       output_cost_per_second_720p_noaudio: 0.08
-      output_cost_per_second: 0.10
       region: australia-southeast1
-    - output_cost_per_second_1080p: 0.12
+    - output_cost_per_second: 0.10
+      output_cost_per_second_1080p: 0.12
       output_cost_per_second_1080p_noaudio: 0.10
       output_cost_per_second_4k: 0.30
       output_cost_per_second_4k_noaudio: 0.25
       output_cost_per_second_720p: 0.10
       output_cost_per_second_720p_noaudio: 0.08
-      output_cost_per_second: 0.10
       region: asia-southeast1
-    - output_cost_per_second_1080p: 0.12
+    - output_cost_per_second: 0.10
+      output_cost_per_second_1080p: 0.12
       output_cost_per_second_1080p_noaudio: 0.10
       output_cost_per_second_4k: 0.30
       output_cost_per_second_4k_noaudio: 0.25
       output_cost_per_second_720p: 0.10
       output_cost_per_second_720p_noaudio: 0.08
-      output_cost_per_second: 0.10
       region: asia-south1
-    - output_cost_per_second_1080p: 0.12
+    - output_cost_per_second: 0.10
+      output_cost_per_second_1080p: 0.12
       output_cost_per_second_1080p_noaudio: 0.10
       output_cost_per_second_4k: 0.30
       output_cost_per_second_4k_noaudio: 0.25
       output_cost_per_second_720p: 0.10
       output_cost_per_second_720p_noaudio: 0.08
-      output_cost_per_second: 0.10
       region: asia-northeast3
-    - output_cost_per_second_1080p: 0.12
+    - output_cost_per_second: 0.10
+      output_cost_per_second_1080p: 0.12
       output_cost_per_second_1080p_noaudio: 0.10
       output_cost_per_second_4k: 0.30
       output_cost_per_second_4k_noaudio: 0.25
       output_cost_per_second_720p: 0.10
       output_cost_per_second_720p_noaudio: 0.08
-      output_cost_per_second: 0.10
       region: asia-northeast1
-    - output_cost_per_second_1080p: 0.12
+    - output_cost_per_second: 0.10
+      output_cost_per_second_1080p: 0.12
       output_cost_per_second_1080p_noaudio: 0.10
       output_cost_per_second_4k: 0.30
       output_cost_per_second_4k_noaudio: 0.25
       output_cost_per_second_720p: 0.10
       output_cost_per_second_720p_noaudio: 0.08
-      output_cost_per_second: 0.10
       region: asia-east2
-    - output_cost_per_second_1080p: 0.12
+    - output_cost_per_second: 0.10
+      output_cost_per_second_1080p: 0.12
       output_cost_per_second_1080p_noaudio: 0.10
       output_cost_per_second_4k: 0.30
       output_cost_per_second_4k_noaudio: 0.25
       output_cost_per_second_720p: 0.10
       output_cost_per_second_720p_noaudio: 0.08
-      output_cost_per_second: 0.10
       region: asia-east1
 messages:
     options:
@@ -240,6 +240,7 @@ modalities:
         - image
     output:
         - video
+        - audio
 mode: video
 model: veo-3.1-fast-generate-001
 provisioning: serverless

--- a/providers/google-vertex/google/veo-3.1-generate-001.yaml
+++ b/providers/google-vertex/google/veo-3.1-generate-001.yaml
@@ -1,7 +1,11 @@
 costs:
-    - output_cost_per_second_1080p: 0.4
+    - output_cost_per_second: 0.4
+      output_cost_per_second_1080p: 0.4
+      output_cost_per_second_1080p_noaudio: 0.2
       output_cost_per_second_4k: 0.6
+      output_cost_per_second_4k_noaudio: 0.4
       output_cost_per_second_720p: 0.4
+      output_cost_per_second_720p_noaudio: 0.2
       region: us-central1
 messages:
     options: []

--- a/providers/google-vertex/google/veo-3.1-lite-generate-001.yaml
+++ b/providers/google-vertex/google/veo-3.1-lite-generate-001.yaml
@@ -1,183 +1,183 @@
 costs:
-    - output_cost_per_second_1080p: 0.08
+    - output_cost_per_second: 0.05
+      output_cost_per_second_1080p: 0.08
       output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
       output_cost_per_second_720p_noaudio: 0.03
-      output_cost_per_second: 0.05
       region: us-west4
-    - output_cost_per_second_1080p: 0.08
+    - output_cost_per_second: 0.05
+      output_cost_per_second_1080p: 0.08
       output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
       output_cost_per_second_720p_noaudio: 0.03
-      output_cost_per_second: 0.05
       region: us-west1
-    - output_cost_per_second_1080p: 0.08
+    - output_cost_per_second: 0.05
+      output_cost_per_second_1080p: 0.08
       output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
       output_cost_per_second_720p_noaudio: 0.03
-      output_cost_per_second: 0.05
       region: us-south1
-    - output_cost_per_second_1080p: 0.08
+    - output_cost_per_second: 0.05
+      output_cost_per_second_1080p: 0.08
       output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
       output_cost_per_second_720p_noaudio: 0.03
-      output_cost_per_second: 0.05
       region: us-east5
-    - output_cost_per_second_1080p: 0.08
+    - output_cost_per_second: 0.05
+      output_cost_per_second_1080p: 0.08
       output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
       output_cost_per_second_720p_noaudio: 0.03
-      output_cost_per_second: 0.05
       region: us-east4
-    - output_cost_per_second_1080p: 0.08
+    - output_cost_per_second: 0.05
+      output_cost_per_second_1080p: 0.08
       output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
       output_cost_per_second_720p_noaudio: 0.03
-      output_cost_per_second: 0.05
       region: us-east1
-    - output_cost_per_second_1080p: 0.08
+    - output_cost_per_second: 0.05
+      output_cost_per_second_1080p: 0.08
       output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
       output_cost_per_second_720p_noaudio: 0.03
-      output_cost_per_second: 0.05
       region: us-central1
-    - output_cost_per_second_1080p: 0.08
+    - output_cost_per_second: 0.05
+      output_cost_per_second_1080p: 0.08
       output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
       output_cost_per_second_720p_noaudio: 0.03
-      output_cost_per_second: 0.05
       region: southamerica-east1
-    - output_cost_per_second_1080p: 0.08
+    - output_cost_per_second: 0.05
+      output_cost_per_second_1080p: 0.08
       output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
       output_cost_per_second_720p_noaudio: 0.03
-      output_cost_per_second: 0.05
       region: northamerica-northeast1
-    - output_cost_per_second_1080p: 0.08
+    - output_cost_per_second: 0.05
+      output_cost_per_second_1080p: 0.08
       output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
       output_cost_per_second_720p_noaudio: 0.03
-      output_cost_per_second: 0.05
       region: me-west1
-    - output_cost_per_second_1080p: 0.08
+    - output_cost_per_second: 0.05
+      output_cost_per_second_1080p: 0.08
       output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
       output_cost_per_second_720p_noaudio: 0.03
-      output_cost_per_second: 0.05
       region: me-central2
-    - output_cost_per_second_1080p: 0.08
+    - output_cost_per_second: 0.05
+      output_cost_per_second_1080p: 0.08
       output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
       output_cost_per_second_720p_noaudio: 0.03
-      output_cost_per_second: 0.05
       region: me-central1
-    - output_cost_per_second_1080p: 0.08
+    - output_cost_per_second: 0.05
+      output_cost_per_second_1080p: 0.08
       output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
       output_cost_per_second_720p_noaudio: 0.03
-      output_cost_per_second: 0.05
       region: global
-    - output_cost_per_second_1080p: 0.08
+    - output_cost_per_second: 0.05
+      output_cost_per_second_1080p: 0.08
       output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
       output_cost_per_second_720p_noaudio: 0.03
-      output_cost_per_second: 0.05
       region: europe-west9
-    - output_cost_per_second_1080p: 0.08
+    - output_cost_per_second: 0.05
+      output_cost_per_second_1080p: 0.08
       output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
       output_cost_per_second_720p_noaudio: 0.03
-      output_cost_per_second: 0.05
       region: europe-west8
-    - output_cost_per_second_1080p: 0.08
+    - output_cost_per_second: 0.05
+      output_cost_per_second_1080p: 0.08
       output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
       output_cost_per_second_720p_noaudio: 0.03
-      output_cost_per_second: 0.05
       region: europe-west6
-    - output_cost_per_second_1080p: 0.08
+    - output_cost_per_second: 0.05
+      output_cost_per_second_1080p: 0.08
       output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
       output_cost_per_second_720p_noaudio: 0.03
-      output_cost_per_second: 0.05
       region: europe-west4
-    - output_cost_per_second_1080p: 0.08
+    - output_cost_per_second: 0.05
+      output_cost_per_second_1080p: 0.08
       output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
       output_cost_per_second_720p_noaudio: 0.03
-      output_cost_per_second: 0.05
       region: europe-west3
-    - output_cost_per_second_1080p: 0.08
+    - output_cost_per_second: 0.05
+      output_cost_per_second_1080p: 0.08
       output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
       output_cost_per_second_720p_noaudio: 0.03
-      output_cost_per_second: 0.05
       region: europe-west2
-    - output_cost_per_second_1080p: 0.08
+    - output_cost_per_second: 0.05
+      output_cost_per_second_1080p: 0.08
       output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
       output_cost_per_second_720p_noaudio: 0.03
-      output_cost_per_second: 0.05
       region: europe-west1
-    - output_cost_per_second_1080p: 0.08
+    - output_cost_per_second: 0.05
+      output_cost_per_second_1080p: 0.08
       output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
       output_cost_per_second_720p_noaudio: 0.03
-      output_cost_per_second: 0.05
       region: europe-southwest1
-    - output_cost_per_second_1080p: 0.08
+    - output_cost_per_second: 0.05
+      output_cost_per_second_1080p: 0.08
       output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
       output_cost_per_second_720p_noaudio: 0.03
-      output_cost_per_second: 0.05
       region: europe-north1
-    - output_cost_per_second_1080p: 0.08
+    - output_cost_per_second: 0.05
+      output_cost_per_second_1080p: 0.08
       output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
       output_cost_per_second_720p_noaudio: 0.03
-      output_cost_per_second: 0.05
       region: europe-central2
-    - output_cost_per_second_1080p: 0.08
+    - output_cost_per_second: 0.05
+      output_cost_per_second_1080p: 0.08
       output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
       output_cost_per_second_720p_noaudio: 0.03
-      output_cost_per_second: 0.05
       region: australia-southeast1
-    - output_cost_per_second_1080p: 0.08
+    - output_cost_per_second: 0.05
+      output_cost_per_second_1080p: 0.08
       output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
       output_cost_per_second_720p_noaudio: 0.03
-      output_cost_per_second: 0.05
       region: asia-southeast1
-    - output_cost_per_second_1080p: 0.08
+    - output_cost_per_second: 0.05
+      output_cost_per_second_1080p: 0.08
       output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
       output_cost_per_second_720p_noaudio: 0.03
-      output_cost_per_second: 0.05
       region: asia-south1
-    - output_cost_per_second_1080p: 0.08
+    - output_cost_per_second: 0.05
+      output_cost_per_second_1080p: 0.08
       output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
       output_cost_per_second_720p_noaudio: 0.03
-      output_cost_per_second: 0.05
       region: asia-northeast3
-    - output_cost_per_second_1080p: 0.08
+    - output_cost_per_second: 0.05
+      output_cost_per_second_1080p: 0.08
       output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
       output_cost_per_second_720p_noaudio: 0.03
-      output_cost_per_second: 0.05
       region: asia-northeast1
-    - output_cost_per_second_1080p: 0.08
+    - output_cost_per_second: 0.05
+      output_cost_per_second_1080p: 0.08
       output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
       output_cost_per_second_720p_noaudio: 0.03
-      output_cost_per_second: 0.05
       region: asia-east2
-    - output_cost_per_second_1080p: 0.08
+    - output_cost_per_second: 0.05
+      output_cost_per_second_1080p: 0.08
       output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
       output_cost_per_second_720p_noaudio: 0.03
-      output_cost_per_second: 0.05
       region: asia-east1
 messages:
     options: []
@@ -187,6 +187,7 @@ modalities:
         - image
     output:
         - video
+        - audio
 mode: video
 model: veo-3.1-lite-generate-001
 provisioning: serverless

--- a/providers/google-vertex/google/veo-3.1-lite-generate-001.yaml
+++ b/providers/google-vertex/google/veo-3.1-lite-generate-001.yaml
@@ -1,93 +1,183 @@
 costs:
     - output_cost_per_second_1080p: 0.08
+      output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
+      output_cost_per_second_720p_noaudio: 0.03
+      output_cost_per_second: 0.05
       region: us-west4
     - output_cost_per_second_1080p: 0.08
+      output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
+      output_cost_per_second_720p_noaudio: 0.03
+      output_cost_per_second: 0.05
       region: us-west1
     - output_cost_per_second_1080p: 0.08
+      output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
+      output_cost_per_second_720p_noaudio: 0.03
+      output_cost_per_second: 0.05
       region: us-south1
     - output_cost_per_second_1080p: 0.08
+      output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
+      output_cost_per_second_720p_noaudio: 0.03
+      output_cost_per_second: 0.05
       region: us-east5
     - output_cost_per_second_1080p: 0.08
+      output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
+      output_cost_per_second_720p_noaudio: 0.03
+      output_cost_per_second: 0.05
       region: us-east4
     - output_cost_per_second_1080p: 0.08
+      output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
+      output_cost_per_second_720p_noaudio: 0.03
+      output_cost_per_second: 0.05
       region: us-east1
     - output_cost_per_second_1080p: 0.08
+      output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
+      output_cost_per_second_720p_noaudio: 0.03
+      output_cost_per_second: 0.05
       region: us-central1
     - output_cost_per_second_1080p: 0.08
+      output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
+      output_cost_per_second_720p_noaudio: 0.03
+      output_cost_per_second: 0.05
       region: southamerica-east1
     - output_cost_per_second_1080p: 0.08
+      output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
+      output_cost_per_second_720p_noaudio: 0.03
+      output_cost_per_second: 0.05
       region: northamerica-northeast1
     - output_cost_per_second_1080p: 0.08
+      output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
+      output_cost_per_second_720p_noaudio: 0.03
+      output_cost_per_second: 0.05
       region: me-west1
     - output_cost_per_second_1080p: 0.08
+      output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
+      output_cost_per_second_720p_noaudio: 0.03
+      output_cost_per_second: 0.05
       region: me-central2
     - output_cost_per_second_1080p: 0.08
+      output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
+      output_cost_per_second_720p_noaudio: 0.03
+      output_cost_per_second: 0.05
       region: me-central1
     - output_cost_per_second_1080p: 0.08
+      output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
+      output_cost_per_second_720p_noaudio: 0.03
+      output_cost_per_second: 0.05
       region: global
     - output_cost_per_second_1080p: 0.08
+      output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
+      output_cost_per_second_720p_noaudio: 0.03
+      output_cost_per_second: 0.05
       region: europe-west9
     - output_cost_per_second_1080p: 0.08
+      output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
+      output_cost_per_second_720p_noaudio: 0.03
+      output_cost_per_second: 0.05
       region: europe-west8
     - output_cost_per_second_1080p: 0.08
+      output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
+      output_cost_per_second_720p_noaudio: 0.03
+      output_cost_per_second: 0.05
       region: europe-west6
     - output_cost_per_second_1080p: 0.08
+      output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
+      output_cost_per_second_720p_noaudio: 0.03
+      output_cost_per_second: 0.05
       region: europe-west4
     - output_cost_per_second_1080p: 0.08
+      output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
+      output_cost_per_second_720p_noaudio: 0.03
+      output_cost_per_second: 0.05
       region: europe-west3
     - output_cost_per_second_1080p: 0.08
+      output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
+      output_cost_per_second_720p_noaudio: 0.03
+      output_cost_per_second: 0.05
       region: europe-west2
     - output_cost_per_second_1080p: 0.08
+      output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
+      output_cost_per_second_720p_noaudio: 0.03
+      output_cost_per_second: 0.05
       region: europe-west1
     - output_cost_per_second_1080p: 0.08
+      output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
+      output_cost_per_second_720p_noaudio: 0.03
+      output_cost_per_second: 0.05
       region: europe-southwest1
     - output_cost_per_second_1080p: 0.08
+      output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
+      output_cost_per_second_720p_noaudio: 0.03
+      output_cost_per_second: 0.05
       region: europe-north1
     - output_cost_per_second_1080p: 0.08
+      output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
+      output_cost_per_second_720p_noaudio: 0.03
+      output_cost_per_second: 0.05
       region: europe-central2
     - output_cost_per_second_1080p: 0.08
+      output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
+      output_cost_per_second_720p_noaudio: 0.03
+      output_cost_per_second: 0.05
       region: australia-southeast1
     - output_cost_per_second_1080p: 0.08
+      output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
+      output_cost_per_second_720p_noaudio: 0.03
+      output_cost_per_second: 0.05
       region: asia-southeast1
     - output_cost_per_second_1080p: 0.08
+      output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
+      output_cost_per_second_720p_noaudio: 0.03
+      output_cost_per_second: 0.05
       region: asia-south1
     - output_cost_per_second_1080p: 0.08
+      output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
+      output_cost_per_second_720p_noaudio: 0.03
+      output_cost_per_second: 0.05
       region: asia-northeast3
     - output_cost_per_second_1080p: 0.08
+      output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
+      output_cost_per_second_720p_noaudio: 0.03
+      output_cost_per_second: 0.05
       region: asia-northeast1
     - output_cost_per_second_1080p: 0.08
+      output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
+      output_cost_per_second_720p_noaudio: 0.03
+      output_cost_per_second: 0.05
       region: asia-east2
     - output_cost_per_second_1080p: 0.08
+      output_cost_per_second_1080p_noaudio: 0.05
       output_cost_per_second_720p: 0.05
+      output_cost_per_second_720p_noaudio: 0.03
+      output_cost_per_second: 0.05
       region: asia-east1
 messages:
     options: []


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes published billing rates and new cost field shapes for video models; incorrect values would misquote customer usage.
> 
> **Overview**
> Extends the model cost schema so resolution-based **video** per-second fields can include an optional `_noaudio` suffix (with-audio rates remain the unsuffixed keys).
> 
> **Gemini** Veo 3.1 preview configs add a base `output_cost_per_second` alongside existing 720p/1080p/4k rates.
> 
> **Vertex** Veo 3.1 fast/lite/generate configs are refreshed: per-region entries now include base per-second pricing, separate with-audio vs `_noaudio` rates per resolution (e.g. 1080p/4k bumps on fast), and **audio** is listed under output modalities where the diff adds it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9835ba0706af5904643acc65baef883c8b760683. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->