### PR TITLE
Create gpt-6-astra.yaml

### DIFF
--- a/providers/openai/gpt-6-astra.yaml
+++ b/providers/openai/gpt-6-astra.yaml
@@ -24,7 +24,7 @@ costs:
           output:
               - cost_per_token: 0.000075
                 from: 272000
-          pricing_mode: marginal
+          pricing_mode: cumulative
 features:
     - function_calling
     - structured_output

--- a/providers/openai/gpt-6-astra.yaml
+++ b/providers/openai/gpt-6-astra.yaml
@@ -1,72 +1,72 @@
 costs:
-  - cache_creation_input_token_cost: 0.0000125
-    cache_read_input_token_cost: 0.000001
-    input_cost_per_token: 0.000010
-    input_cost_per_token_batches: 0.000005
-    output_cost_per_token: 0.000050
-    output_cost_per_token_batches: 0.000025
-    priority_pricing:
-      cache_creation_input_token_cost: 0.000025
-      cache_read_input_token_cost: 0.000002
-      input_cost_per_token: 0.000020
-      output_cost_per_token: 0.000100
-    region: "*"
-    tiered_pricing:
-      cache_read:
-        - cost_per_token: 0.000002
-          from: 272000
-      cache_write:
-        - cost_per_token: 0.000025
-          from: 272000
-      input:
-        - cost_per_token: 0.000020
-          from: 272000
-      output:
-        - cost_per_token: 0.000075
-          from: 272000
-      pricing_mode: cumulative
+    - cache_creation_input_token_cost: 0.0000125
+      cache_read_input_token_cost: 0.000001
+      input_cost_per_token: 0.000010
+      input_cost_per_token_batches: 0.000005
+      output_cost_per_token: 0.000050
+      output_cost_per_token_batches: 0.000025
+      priority_pricing:
+          cache_creation_input_token_cost: 0.000025
+          cache_read_input_token_cost: 0.000002
+          input_cost_per_token: 0.000020
+          output_cost_per_token: 0.000100
+      region: "*"
+      tiered_pricing:
+          cache_read:
+              - cost_per_token: 0.000002
+                from: 272000
+          cache_write:
+              - cost_per_token: 0.000025
+                from: 272000
+          input:
+              - cost_per_token: 0.000020
+                from: 272000
+          output:
+              - cost_per_token: 0.000075
+                from: 272000
+          pricing_mode: marginal
 features:
-  - function_calling
-  - structured_output
-  - prompt_caching
-  - system_messages
-  - tool_choice
-  - parallel_function_calling
-  - json_output
+    - function_calling
+    - structured_output
+    - prompt_caching
+    - system_messages
+    - tool_choice
+    - parallel_function_calling
+    - json_output
 limits:
-  context_window: 1050000
-  max_input_tokens: 922000
-  max_output_tokens: 128000
-  max_tokens: 128000
+    context_window: 1050000
+    max_input_tokens: 922000
+    max_output_tokens: 128000
+    max_tokens: 128000
 modalities:
-  input:
-    - text
-    - image
-  output:
-    - text
+    input:
+        - text
+        - image
+    output:
+        - text
 mode: chat
 model: gpt-6-astra
 params:
-  - defaultValue: 128
-    key: max_completion_tokens
-    maxValue: 128000
-    minValue: 1
-  - defaultValue: medium
-    key: reasoning_effort
-    supportedValues:
-      - low
-      - medium
-      - high
-      - xhigh
-      - max
-    type: string
+    - defaultValue: 128
+      key: max_completion_tokens
+      maxValue: 128000
+      minValue: 1
+    - defaultValue: medium
+      key: reasoning_effort
+      supportedValues:
+          - low
+          - medium
+          - high
+          - xhigh
+          - max
+      type: string
 provisioning: serverless
 removeParams:
-  - max_tokens
+    - max_tokens
 sources:
-  - https://developers.openai.com/api/docs/models/gpt-6-astra
+    - https://developers.openai.com/api/docs/models/gpt-6-astra
 status: active
 supportedModes:
-  - chat
-  - responses
+    - chat
+    - responses
 thinking: true

--- a/providers/openai/gpt-6-astra.yaml
+++ b/providers/openai/gpt-6-astra.yaml
@@ -1,0 +1,72 @@
+costs:
+  - cache_creation_input_token_cost: 0.0000125
+    cache_read_input_token_cost: 0.000001
+    input_cost_per_token: 0.000010
+    input_cost_per_token_batches: 0.000005
+    output_cost_per_token: 0.000050
+    output_cost_per_token_batches: 0.000025
+    priority_pricing:
+      cache_creation_input_token_cost: 0.000025
+      cache_read_input_token_cost: 0.000002
+      input_cost_per_token: 0.000020
+      output_cost_per_token: 0.000100
+    region: "*"
+    tiered_pricing:
+      cache_read:
+        - cost_per_token: 0.000002
+          from: 272000
+      cache_write:
+        - cost_per_token: 0.000025
+          from: 272000
+      input:
+        - cost_per_token: 0.000020
+          from: 272000
+      output:
+        - cost_per_token: 0.000075
+          from: 272000
+      pricing_mode: cumulative
+features:
+  - function_calling
+  - structured_output
+  - prompt_caching
+  - system_messages
+  - tool_choice
+  - parallel_function_calling
+  - json_output
+limits:
+  context_window: 1050000
+  max_input_tokens: 922000
+  max_output_tokens: 128000
+  max_tokens: 128000
+modalities:
+  input:
+    - text
+    - image
+  output:
+    - text
+mode: chat
+model: gpt-6-astra
+params:
+  - defaultValue: 128
+    key: max_completion_tokens
+    maxValue: 128000
+    minValue: 1
+  - defaultValue: medium
+    key: reasoning_effort
+    supportedValues:
+      - low
+      - medium
+      - high
+      - xhigh
+      - max
+    type: string
+provisioning: serverless
+removeParams:
+  - max_tokens
+sources:
+  - https://developers.openai.com/api/docs/models/gpt-6-astra
+status: active
+supportedModes:
+  - chat
+  - responses
+thinking: true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Adds a new static model metadata file only; no runtime logic or security-sensitive code paths change.
> 
> **Overview**
> Registers **gpt-6-astra** as a new active OpenAI chat model in `providers/openai/gpt-6-astra.yaml`, wired for **chat** and **responses** with `thinking: true`.
> 
> The definition adds large-context limits (~1.05M window, 922k max input, 128k max output), text+image input, standard tool/JSON/caching features, and pricing that includes batch rates, priority pricing, and **cumulative tiered pricing** above 272k tokens for input/output/cache read/write.
> 
> Request shaping differs from nearby GPT-5 configs: it uses **`max_completion_tokens`** (default 128) and drops **`max_tokens`**, and exposes **`reasoning_effort`** with `low` through **`max`** (including `xhigh`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e955714339c4a9ef6b65788cadff9ee95cbd8c04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->