### PR TITLE
Add: mid_conversation_system feature flag for Claude models that support it

### DIFF
--- a/.github/scripts/autogen/types.ts
+++ b/.github/scripts/autogen/types.ts
@@ -88,7 +88,7 @@ export interface components {
          * @description Supported feature flags a model can declare
          * @enum {string}
          */
-        Feature: "assistant_prefill" | "cache_control" | "code_execution" | "function_calling" | "json_output" | "mid_conversation_system" | "parallel_function_calling" | "prompt_caching" | "structured_output" | "system_messages" | "tool_choice";
+        Feature: "assistant_prefill" | "cache_control" | "code_execution" | "function_calling" | "json_output" | "mid_conversation_system_messages" | "parallel_function_calling" | "prompt_caching" | "structured_output" | "system_messages" | "tool_choice";
         /**
          * @description GCP region identifiers
          * @enum {string}

--- a/.github/scripts/autogen/types.ts
+++ b/.github/scripts/autogen/types.ts
@@ -88,7 +88,7 @@ export interface components {
          * @description Supported feature flags a model can declare
          * @enum {string}
          */
-        Feature: "assistant_prefill" | "cache_control" | "code_execution" | "function_calling" | "json_output" | "parallel_function_calling" | "prompt_caching" | "structured_output" | "system_messages" | "tool_choice";
+        Feature: "assistant_prefill" | "cache_control" | "code_execution" | "function_calling" | "json_output" | "mid_conversation_system" | "parallel_function_calling" | "prompt_caching" | "structured_output" | "system_messages" | "tool_choice";
         /**
          * @description GCP region identifiers
          * @enum {string}

--- a/.github/test/model.cue
+++ b/.github/test/model.cue
@@ -198,7 +198,7 @@ package model
 	"code_execution" |             // Model can execute code natively as part of its response
 	"function_calling" |           // Model supports tool/function calling
 	"json_output" |				   // Model can return output in JSON format
-	"mid_conversation_system" |    // Model accepts a role:"system" message inside `messages`, not just the top-level system prompt
+	"mid_conversation_system_messages" |  // Model accepts a role:"system" message inside `messages`, not just the top-level system prompt
 	"parallel_function_calling" |  // Model can invoke multiple tools in a single turn
 	"prompt_caching" |			   // Provider caches repeated prompt prefixes to reduce cost and latency
 	"structured_output" |          // Model can return output conforming to a JSON schema

--- a/.github/test/model.cue
+++ b/.github/test/model.cue
@@ -198,6 +198,7 @@ package model
 	"code_execution" |             // Model can execute code natively as part of its response
 	"function_calling" |           // Model supports tool/function calling
 	"json_output" |				   // Model can return output in JSON format
+	"mid_conversation_system" |    // Model accepts a role:"system" message inside `messages`, not just the top-level system prompt
 	"parallel_function_calling" |  // Model can invoke multiple tools in a single turn
 	"prompt_caching" |			   // Provider caches repeated prompt prefixes to reduce cost and latency
 	"structured_output" |          // Model can return output conforming to a JSON schema

--- a/providers/anthropic/claude-fable-5-1.yaml
+++ b/providers/anthropic/claude-fable-5-1.yaml
@@ -13,6 +13,7 @@ features:
     - cache_control
     - system_messages
     - prompt_caching
+    - mid_conversation_system
 limits:
     context_window: 1000000
     max_output_tokens: 128000

--- a/providers/anthropic/claude-fable-5-1.yaml
+++ b/providers/anthropic/claude-fable-5-1.yaml
@@ -13,7 +13,7 @@ features:
     - cache_control
     - system_messages
     - prompt_caching
-    - mid_conversation_system
+    - mid_conversation_system_messages
 limits:
     context_window: 1000000
     max_output_tokens: 128000

--- a/providers/anthropic/claude-fable-5.yaml
+++ b/providers/anthropic/claude-fable-5.yaml
@@ -16,6 +16,7 @@ features:
     - prompt_caching
     - assistant_prefill
     - code_execution
+    - mid_conversation_system
 limits:
     context_window: 1000000
     max_output_tokens: 128000

--- a/providers/anthropic/claude-fable-5.yaml
+++ b/providers/anthropic/claude-fable-5.yaml
@@ -16,7 +16,7 @@ features:
     - prompt_caching
     - assistant_prefill
     - code_execution
-    - mid_conversation_system
+    - mid_conversation_system_messages
 limits:
     context_window: 1000000
     max_output_tokens: 128000

--- a/providers/anthropic/claude-opus-4-8.yaml
+++ b/providers/anthropic/claude-opus-4-8.yaml
@@ -16,6 +16,7 @@ features:
     - prompt_caching
     - assistant_prefill
     - code_execution
+    - mid_conversation_system
 limits:
     context_window: 1000000
     max_output_tokens: 128000

--- a/providers/anthropic/claude-opus-4-8.yaml
+++ b/providers/anthropic/claude-opus-4-8.yaml
@@ -16,7 +16,7 @@ features:
     - prompt_caching
     - assistant_prefill
     - code_execution
-    - mid_conversation_system
+    - mid_conversation_system_messages
 limits:
     context_window: 1000000
     max_output_tokens: 128000

--- a/providers/anthropic/claude-opus-5.yaml
+++ b/providers/anthropic/claude-opus-5.yaml
@@ -17,6 +17,7 @@ features:
     - structured_output
     - assistant_prefill
     - code_execution
+    - mid_conversation_system
 limits:
     context_window: 1000000
     max_input_tokens: 1000000

--- a/providers/anthropic/claude-opus-5.yaml
+++ b/providers/anthropic/claude-opus-5.yaml
@@ -17,7 +17,7 @@ features:
     - structured_output
     - assistant_prefill
     - code_execution
-    - mid_conversation_system
+    - mid_conversation_system_messages
 limits:
     context_window: 1000000
     max_input_tokens: 1000000

--- a/providers/anthropic/claude-sonnet-5.yaml
+++ b/providers/anthropic/claude-sonnet-5.yaml
@@ -20,7 +20,7 @@ features:
     - structured_output
     - json_output
     - code_execution
-    - mid_conversation_system
+    - mid_conversation_system_messages
 limits:
     context_window: 1000000
     max_input_tokens: 1000000

--- a/providers/anthropic/claude-sonnet-5.yaml
+++ b/providers/anthropic/claude-sonnet-5.yaml
@@ -20,6 +20,7 @@ features:
     - structured_output
     - json_output
     - code_execution
+    - mid_conversation_system
 limits:
     context_window: 1000000
     max_input_tokens: 1000000

--- a/providers/anthropic/default.yaml
+++ b/providers/anthropic/default.yaml
@@ -4,6 +4,7 @@ documentation:
     - https://platform.claude.com/docs/en/about-claude/models/overview
     - https://platform.claude.com/docs/en/about-claude/model-deprecations
     - https://platform.claude.com/docs/en/build-with-claude/effort
+    - https://platform.claude.com/docs/en/build-with-claude/mid-conversation-system-messages
 messages:
     options:
         - system

--- a/providers/aws-bedrock-mantle/anthropic.claude-opus-4-8.yaml
+++ b/providers/aws-bedrock-mantle/anthropic.claude-opus-4-8.yaml
@@ -33,7 +33,7 @@ features:
     - tool_choice
     - prompt_caching
     - assistant_prefill
-    - mid_conversation_system
+    - mid_conversation_system_messages
 limits:
     context_window: 1000000
     max_output_tokens: 128000

--- a/providers/aws-bedrock-mantle/anthropic.claude-opus-4-8.yaml
+++ b/providers/aws-bedrock-mantle/anthropic.claude-opus-4-8.yaml
@@ -33,6 +33,7 @@ features:
     - tool_choice
     - prompt_caching
     - assistant_prefill
+    - mid_conversation_system
 limits:
     context_window: 1000000
     max_output_tokens: 128000

--- a/providers/aws-bedrock-mantle/anthropic.claude-opus-5.yaml
+++ b/providers/aws-bedrock-mantle/anthropic.claude-opus-5.yaml
@@ -13,6 +13,7 @@ features:
     - prompt_caching
     - cache_control
     - assistant_prefill
+    - mid_conversation_system
 limits:
     context_window: 1000000
     max_input_tokens: 1000000

--- a/providers/aws-bedrock-mantle/anthropic.claude-opus-5.yaml
+++ b/providers/aws-bedrock-mantle/anthropic.claude-opus-5.yaml
@@ -13,7 +13,7 @@ features:
     - prompt_caching
     - cache_control
     - assistant_prefill
-    - mid_conversation_system
+    - mid_conversation_system_messages
 limits:
     context_window: 1000000
     max_input_tokens: 1000000

--- a/providers/aws-bedrock-mantle/anthropic.claude-sonnet-5.yaml
+++ b/providers/aws-bedrock-mantle/anthropic.claude-sonnet-5.yaml
@@ -41,6 +41,7 @@ features:
     - cache_control
     - system_messages
     - assistant_prefill
+    - mid_conversation_system
 limits:
     context_window: 1000000
     max_input_tokens: 1000000

--- a/providers/aws-bedrock-mantle/anthropic.claude-sonnet-5.yaml
+++ b/providers/aws-bedrock-mantle/anthropic.claude-sonnet-5.yaml
@@ -41,7 +41,7 @@ features:
     - cache_control
     - system_messages
     - assistant_prefill
-    - mid_conversation_system
+    - mid_conversation_system_messages
 limits:
     context_window: 1000000
     max_input_tokens: 1000000

--- a/providers/aws-bedrock-mantle/default.yaml
+++ b/providers/aws-bedrock-mantle/default.yaml
@@ -3,6 +3,7 @@ documentation:
     - https://aws.amazon.com/bedrock/pricing/
     - https://docs.aws.amazon.com/bedrock/latest/userguide/model-cards.html
     - https://docs.aws.amazon.com/bedrock/latest/userguide/structured-output.html#structured-output-supported-apis
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/claude-messages-mid-conversation-system.html
 tool_pricing:
     web_search:
         per_thousand_requests: 12

--- a/providers/aws-bedrock/au.anthropic.claude-fable-5.yaml
+++ b/providers/aws-bedrock/au.anthropic.claude-fable-5.yaml
@@ -9,7 +9,7 @@ features:
     - prompt_caching
     - cache_control
     - assistant_prefill
-    - mid_conversation_system
+    - mid_conversation_system_messages
 limits:
     context_window: 1000000
     max_output_tokens: 128000

--- a/providers/aws-bedrock/au.anthropic.claude-fable-5.yaml
+++ b/providers/aws-bedrock/au.anthropic.claude-fable-5.yaml
@@ -9,6 +9,7 @@ features:
     - prompt_caching
     - cache_control
     - assistant_prefill
+    - mid_conversation_system
 limits:
     context_window: 1000000
     max_output_tokens: 128000

--- a/providers/aws-bedrock/au.anthropic.claude-opus-4-8.yaml
+++ b/providers/aws-bedrock/au.anthropic.claude-opus-4-8.yaml
@@ -18,6 +18,7 @@ features:
     - system_messages
     - tool_choice
     - prompt_caching
+    - mid_conversation_system
     # - structured_output is not supported in bedrock-converse
     - assistant_prefill
 limits:

--- a/providers/aws-bedrock/au.anthropic.claude-opus-4-8.yaml
+++ b/providers/aws-bedrock/au.anthropic.claude-opus-4-8.yaml
@@ -18,7 +18,7 @@ features:
     - system_messages
     - tool_choice
     - prompt_caching
-    - mid_conversation_system
+    - mid_conversation_system_messages
     # - structured_output is not supported in bedrock-converse
     - assistant_prefill
 limits:

--- a/providers/aws-bedrock/au.anthropic.claude-opus-5.yaml
+++ b/providers/aws-bedrock/au.anthropic.claude-opus-5.yaml
@@ -23,6 +23,7 @@ features:
     - prompt_caching
     - cache_control
     - assistant_prefill
+    - mid_conversation_system
 limits:
     context_window: 1000000
     max_input_tokens: 1000000

--- a/providers/aws-bedrock/au.anthropic.claude-opus-5.yaml
+++ b/providers/aws-bedrock/au.anthropic.claude-opus-5.yaml
@@ -23,7 +23,7 @@ features:
     - prompt_caching
     - cache_control
     - assistant_prefill
-    - mid_conversation_system
+    - mid_conversation_system_messages
 limits:
     context_window: 1000000
     max_input_tokens: 1000000

--- a/providers/aws-bedrock/au.anthropic.claude-sonnet-5.yaml
+++ b/providers/aws-bedrock/au.anthropic.claude-sonnet-5.yaml
@@ -20,7 +20,7 @@ features:
     - cache_control
     - assistant_prefill
     - json_output
-    - mid_conversation_system
+    - mid_conversation_system_messages
 limits:
     context_window: 1000000
     max_output_tokens: 128000

--- a/providers/aws-bedrock/au.anthropic.claude-sonnet-5.yaml
+++ b/providers/aws-bedrock/au.anthropic.claude-sonnet-5.yaml
@@ -20,6 +20,7 @@ features:
     - cache_control
     - assistant_prefill
     - json_output
+    - mid_conversation_system
 limits:
     context_window: 1000000
     max_output_tokens: 128000

--- a/providers/aws-bedrock/default.yaml
+++ b/providers/aws-bedrock/default.yaml
@@ -6,6 +6,7 @@ documentation:
     - https://docs.aws.amazon.com/bedrock/latest/userguide/structured-output.html
     - https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html
     - https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference-supported-models-features.html
+    - https://docs.aws.amazon.com/bedrock/latest/userguide/claude-messages-mid-conversation-system.html
     - https://docs.aws.amazon.com/nova/latest/nova2-userguide/extended-thinking.html
 messages:
     options:

--- a/providers/aws-bedrock/eu.anthropic.claude-opus-4-8.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-opus-4-8.yaml
@@ -70,7 +70,7 @@ features:
     - system_messages
     - tool_choice
     - prompt_caching
-    - mid_conversation_system
+    - mid_conversation_system_messages
     # - structured_output is not supported in bedrock-converse
     - assistant_prefill
 limits:

--- a/providers/aws-bedrock/eu.anthropic.claude-opus-4-8.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-opus-4-8.yaml
@@ -70,6 +70,7 @@ features:
     - system_messages
     - tool_choice
     - prompt_caching
+    - mid_conversation_system
     # - structured_output is not supported in bedrock-converse
     - assistant_prefill
 limits:

--- a/providers/aws-bedrock/eu.anthropic.claude-opus-5.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-opus-5.yaml
@@ -71,7 +71,7 @@ features:
     - system_messages
     - tool_choice
     - assistant_prefill
-    - mid_conversation_system
+    - mid_conversation_system_messages
 limits:
     context_window: 1000000
     max_input_tokens: 1000000

--- a/providers/aws-bedrock/eu.anthropic.claude-opus-5.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-opus-5.yaml
@@ -71,6 +71,7 @@ features:
     - system_messages
     - tool_choice
     - assistant_prefill
+    - mid_conversation_system
 limits:
     context_window: 1000000
     max_input_tokens: 1000000

--- a/providers/aws-bedrock/eu.anthropic.claude-sonnet-5.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-sonnet-5.yaml
@@ -32,7 +32,7 @@ features:
     - cache_control
     - assistant_prefill
     - json_output
-    - mid_conversation_system
+    - mid_conversation_system_messages
 limits:
     context_window: 1000000
     max_output_tokens: 128000

--- a/providers/aws-bedrock/eu.anthropic.claude-sonnet-5.yaml
+++ b/providers/aws-bedrock/eu.anthropic.claude-sonnet-5.yaml
@@ -32,6 +32,7 @@ features:
     - cache_control
     - assistant_prefill
     - json_output
+    - mid_conversation_system
 limits:
     context_window: 1000000
     max_output_tokens: 128000

--- a/providers/aws-bedrock/global.anthropic.claude-fable-5-1.yaml
+++ b/providers/aws-bedrock/global.anthropic.claude-fable-5-1.yaml
@@ -269,7 +269,7 @@ features:
     - cache_control
     - system_messages
     - structured_output
-    - mid_conversation_system
+    - mid_conversation_system_messages
 limits:
     context_window: 1000000
     max_input_tokens: 1000000

--- a/providers/aws-bedrock/global.anthropic.claude-fable-5-1.yaml
+++ b/providers/aws-bedrock/global.anthropic.claude-fable-5-1.yaml
@@ -269,6 +269,7 @@ features:
     - cache_control
     - system_messages
     - structured_output
+    - mid_conversation_system
 limits:
     context_window: 1000000
     max_input_tokens: 1000000

--- a/providers/aws-bedrock/global.anthropic.claude-fable-5.yaml
+++ b/providers/aws-bedrock/global.anthropic.claude-fable-5.yaml
@@ -271,7 +271,7 @@ features:
     - prompt_caching
     - cache_control
     - assistant_prefill
-    - mid_conversation_system
+    - mid_conversation_system_messages
 limits:
     context_window: 1000000
     max_input_tokens: 1000000

--- a/providers/aws-bedrock/global.anthropic.claude-fable-5.yaml
+++ b/providers/aws-bedrock/global.anthropic.claude-fable-5.yaml
@@ -271,6 +271,7 @@ features:
     - prompt_caching
     - cache_control
     - assistant_prefill
+    - mid_conversation_system
 limits:
     context_window: 1000000
     max_input_tokens: 1000000

--- a/providers/aws-bedrock/global.anthropic.claude-opus-4-8.yaml
+++ b/providers/aws-bedrock/global.anthropic.claude-opus-4-8.yaml
@@ -271,7 +271,7 @@ features:
     - prompt_caching
     - cache_control
     - assistant_prefill
-    - mid_conversation_system
+    - mid_conversation_system_messages
 limits:
     context_window: 1000000
     max_output_tokens: 128000

--- a/providers/aws-bedrock/global.anthropic.claude-opus-4-8.yaml
+++ b/providers/aws-bedrock/global.anthropic.claude-opus-4-8.yaml
@@ -271,6 +271,7 @@ features:
     - prompt_caching
     - cache_control
     - assistant_prefill
+    - mid_conversation_system
 limits:
     context_window: 1000000
     max_output_tokens: 128000

--- a/providers/aws-bedrock/global.anthropic.claude-opus-5.yaml
+++ b/providers/aws-bedrock/global.anthropic.claude-opus-5.yaml
@@ -255,7 +255,7 @@ features:
     - prompt_caching
     - cache_control
     - assistant_prefill
-    - mid_conversation_system
+    - mid_conversation_system_messages
 limits:
     context_window: 1000000
     max_output_tokens: 128000

--- a/providers/aws-bedrock/global.anthropic.claude-opus-5.yaml
+++ b/providers/aws-bedrock/global.anthropic.claude-opus-5.yaml
@@ -255,6 +255,7 @@ features:
     - prompt_caching
     - cache_control
     - assistant_prefill
+    - mid_conversation_system
 limits:
     context_window: 1000000
     max_output_tokens: 128000

--- a/providers/aws-bedrock/global.anthropic.claude-sonnet-5.yaml
+++ b/providers/aws-bedrock/global.anthropic.claude-sonnet-5.yaml
@@ -274,6 +274,7 @@ features:
     - tool_choice
     - prompt_caching
     - assistant_prefill
+    - mid_conversation_system
 limits:
     context_window: 1000000
     max_input_tokens: 1000000

--- a/providers/aws-bedrock/global.anthropic.claude-sonnet-5.yaml
+++ b/providers/aws-bedrock/global.anthropic.claude-sonnet-5.yaml
@@ -274,7 +274,7 @@ features:
     - tool_choice
     - prompt_caching
     - assistant_prefill
-    - mid_conversation_system
+    - mid_conversation_system_messages
 limits:
     context_window: 1000000
     max_input_tokens: 1000000

--- a/providers/aws-bedrock/jp.anthropic.claude-opus-4-8.yaml
+++ b/providers/aws-bedrock/jp.anthropic.claude-opus-4-8.yaml
@@ -22,7 +22,7 @@ features:
     - system_messages
     - tool_choice
     - prompt_caching
-    - mid_conversation_system
+    - mid_conversation_system_messages
     # - structured_output is not supported in bedrock-converse
     - assistant_prefill
 limits:

--- a/providers/aws-bedrock/jp.anthropic.claude-opus-4-8.yaml
+++ b/providers/aws-bedrock/jp.anthropic.claude-opus-4-8.yaml
@@ -22,6 +22,7 @@ features:
     - system_messages
     - tool_choice
     - prompt_caching
+    - mid_conversation_system
     # - structured_output is not supported in bedrock-converse
     - assistant_prefill
 limits:

--- a/providers/aws-bedrock/us.anthropic.claude-fable-5-1.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-fable-5-1.yaml
@@ -53,6 +53,7 @@ features:
     - system_messages
     - prompt_caching
     - cache_control
+    - mid_conversation_system
 limits:
     context_window: 1000000
     max_output_tokens: 128000

--- a/providers/aws-bedrock/us.anthropic.claude-fable-5-1.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-fable-5-1.yaml
@@ -53,7 +53,7 @@ features:
     - system_messages
     - prompt_caching
     - cache_control
-    - mid_conversation_system
+    - mid_conversation_system_messages
 limits:
     context_window: 1000000
     max_output_tokens: 128000

--- a/providers/aws-bedrock/us.anthropic.claude-fable-5.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-fable-5.yaml
@@ -43,7 +43,7 @@ features:
     - tool_choice
     - prompt_caching
     - assistant_prefill
-    - mid_conversation_system
+    - mid_conversation_system_messages
 limits:
     context_window: 1000000
     max_input_tokens: 1000000

--- a/providers/aws-bedrock/us.anthropic.claude-fable-5.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-fable-5.yaml
@@ -43,6 +43,7 @@ features:
     - tool_choice
     - prompt_caching
     - assistant_prefill
+    - mid_conversation_system
 limits:
     context_window: 1000000
     max_input_tokens: 1000000

--- a/providers/aws-bedrock/us.anthropic.claude-opus-4-8.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-opus-4-8.yaml
@@ -54,6 +54,7 @@ features:
     - system_messages
     - prompt_caching
     - cache_control
+    - mid_conversation_system
     # - structured_output is not supported in bedrock-converse
     - assistant_prefill
 limits:

--- a/providers/aws-bedrock/us.anthropic.claude-opus-4-8.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-opus-4-8.yaml
@@ -54,7 +54,7 @@ features:
     - system_messages
     - prompt_caching
     - cache_control
-    - mid_conversation_system
+    - mid_conversation_system_messages
     # - structured_output is not supported in bedrock-converse
     - assistant_prefill
 limits:

--- a/providers/aws-bedrock/us.anthropic.claude-opus-5.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-opus-5.yaml
@@ -44,6 +44,7 @@ features:
     - cache_control
     - assistant_prefill
     - json_output
+    - mid_conversation_system
 limits:
     context_window: 1000000
     max_output_tokens: 128000

--- a/providers/aws-bedrock/us.anthropic.claude-opus-5.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-opus-5.yaml
@@ -44,7 +44,7 @@ features:
     - cache_control
     - assistant_prefill
     - json_output
-    - mid_conversation_system
+    - mid_conversation_system_messages
 limits:
     context_window: 1000000
     max_output_tokens: 128000

--- a/providers/aws-bedrock/us.anthropic.claude-sonnet-5.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-sonnet-5.yaml
@@ -54,7 +54,7 @@ features:
     - system_messages
     - prompt_caching
     - cache_control
-    - mid_conversation_system
+    - mid_conversation_system_messages
 limits:
     context_window: 1000000
     max_output_tokens: 128000

--- a/providers/aws-bedrock/us.anthropic.claude-sonnet-5.yaml
+++ b/providers/aws-bedrock/us.anthropic.claude-sonnet-5.yaml
@@ -54,6 +54,7 @@ features:
     - system_messages
     - prompt_caching
     - cache_control
+    - mid_conversation_system
 limits:
     context_window: 1000000
     max_output_tokens: 128000

--- a/providers/azure-ai-foundry/claude-fable-5-1.yaml
+++ b/providers/azure-ai-foundry/claude-fable-5-1.yaml
@@ -16,7 +16,7 @@ features:
     - structured_output
     - json_output
     - code_execution
-    - mid_conversation_system
+    - mid_conversation_system_messages
 limits:
     context_window: 1000000
     max_input_tokens: 1000000

--- a/providers/azure-ai-foundry/claude-fable-5-1.yaml
+++ b/providers/azure-ai-foundry/claude-fable-5-1.yaml
@@ -16,6 +16,7 @@ features:
     - structured_output
     - json_output
     - code_execution
+    - mid_conversation_system
 limits:
     context_window: 1000000
     max_input_tokens: 1000000

--- a/providers/azure-ai-foundry/claude-fable-5.yaml
+++ b/providers/azure-ai-foundry/claude-fable-5.yaml
@@ -16,6 +16,7 @@ features:
     - structured_output
     - system_messages
     - json_output
+    - mid_conversation_system
 limits:
     context_window: 1000000
     max_output_tokens: 128000

--- a/providers/azure-ai-foundry/claude-fable-5.yaml
+++ b/providers/azure-ai-foundry/claude-fable-5.yaml
@@ -16,7 +16,7 @@ features:
     - structured_output
     - system_messages
     - json_output
-    - mid_conversation_system
+    - mid_conversation_system_messages
 limits:
     context_window: 1000000
     max_output_tokens: 128000

--- a/providers/azure-ai-foundry/claude-opus-4-8.yaml
+++ b/providers/azure-ai-foundry/claude-opus-4-8.yaml
@@ -21,7 +21,7 @@ features:
     - structured_output
     - assistant_prefill
     - json_output
-    - mid_conversation_system
+    - mid_conversation_system_messages
 limits:
     context_window: 1000000
     max_input_tokens: 1000000

--- a/providers/azure-ai-foundry/claude-opus-4-8.yaml
+++ b/providers/azure-ai-foundry/claude-opus-4-8.yaml
@@ -21,6 +21,7 @@ features:
     - structured_output
     - assistant_prefill
     - json_output
+    - mid_conversation_system
 limits:
     context_window: 1000000
     max_input_tokens: 1000000

--- a/providers/azure-ai-foundry/claude-opus-5.yaml
+++ b/providers/azure-ai-foundry/claude-opus-5.yaml
@@ -21,7 +21,7 @@ features:
     - structured_output
     - json_output
     - assistant_prefill
-    - mid_conversation_system
+    - mid_conversation_system_messages
 limits:
     context_window: 1000000
     max_input_tokens: 1000000

--- a/providers/azure-ai-foundry/claude-opus-5.yaml
+++ b/providers/azure-ai-foundry/claude-opus-5.yaml
@@ -21,6 +21,7 @@ features:
     - structured_output
     - json_output
     - assistant_prefill
+    - mid_conversation_system
 limits:
     context_window: 1000000
     max_input_tokens: 1000000

--- a/providers/azure-ai-foundry/claude-sonnet-5.yaml
+++ b/providers/azure-ai-foundry/claude-sonnet-5.yaml
@@ -20,7 +20,7 @@ features:
     - cache_control
     - structured_output
     - assistant_prefill
-    - mid_conversation_system
+    - mid_conversation_system_messages
 limits:
     context_window: 1000000
     max_input_tokens: 1000000

--- a/providers/azure-ai-foundry/claude-sonnet-5.yaml
+++ b/providers/azure-ai-foundry/claude-sonnet-5.yaml
@@ -20,6 +20,7 @@ features:
     - cache_control
     - structured_output
     - assistant_prefill
+    - mid_conversation_system
 limits:
     context_window: 1000000
     max_input_tokens: 1000000

--- a/providers/databricks/databricks-claude-sonnet-5.yaml
+++ b/providers/databricks/databricks-claude-sonnet-5.yaml
@@ -13,6 +13,7 @@ features:
     - cache_control
     - structured_output
     - assistant_prefill
+    - mid_conversation_system
 limits:
     context_window: 1000000
     max_output_tokens: 128000

--- a/providers/databricks/databricks-claude-sonnet-5.yaml
+++ b/providers/databricks/databricks-claude-sonnet-5.yaml
@@ -13,7 +13,7 @@ features:
     - cache_control
     - structured_output
     - assistant_prefill
-    - mid_conversation_system
+    - mid_conversation_system_messages
 limits:
     context_window: 1000000
     max_output_tokens: 128000

--- a/providers/google-vertex/anthropic/claude-fable-5-1.yaml
+++ b/providers/google-vertex/anthropic/claude-fable-5-1.yaml
@@ -24,6 +24,7 @@ features:
     - cache_control
     - system_messages
     - structured_output
+    - mid_conversation_system
 limits:
     context_window: 1000000
     max_output_tokens: 128000

--- a/providers/google-vertex/anthropic/claude-fable-5-1.yaml
+++ b/providers/google-vertex/anthropic/claude-fable-5-1.yaml
@@ -24,7 +24,7 @@ features:
     - cache_control
     - system_messages
     - structured_output
-    - mid_conversation_system
+    - mid_conversation_system_messages
 limits:
     context_window: 1000000
     max_output_tokens: 128000

--- a/providers/google-vertex/anthropic/claude-fable-5.yaml
+++ b/providers/google-vertex/anthropic/claude-fable-5.yaml
@@ -26,6 +26,7 @@ features:
     - system_messages
     - assistant_prefill
     - structured_output
+    - mid_conversation_system
 limits:
     context_window: 1000000
     max_input_tokens: 1000000

--- a/providers/google-vertex/anthropic/claude-fable-5.yaml
+++ b/providers/google-vertex/anthropic/claude-fable-5.yaml
@@ -26,7 +26,7 @@ features:
     - system_messages
     - assistant_prefill
     - structured_output
-    - mid_conversation_system
+    - mid_conversation_system_messages
 limits:
     context_window: 1000000
     max_input_tokens: 1000000

--- a/providers/google-vertex/anthropic/claude-opus-4-8.yaml
+++ b/providers/google-vertex/anthropic/claude-opus-4-8.yaml
@@ -26,6 +26,7 @@ features:
     - system_messages
     - structured_output
     - assistant_prefill
+    - mid_conversation_system
 limits:
     context_window: 1000000
     max_input_tokens: 1000000

--- a/providers/google-vertex/anthropic/claude-opus-4-8.yaml
+++ b/providers/google-vertex/anthropic/claude-opus-4-8.yaml
@@ -26,7 +26,7 @@ features:
     - system_messages
     - structured_output
     - assistant_prefill
-    - mid_conversation_system
+    - mid_conversation_system_messages
 limits:
     context_window: 1000000
     max_input_tokens: 1000000

--- a/providers/google-vertex/anthropic/claude-opus-5.yaml
+++ b/providers/google-vertex/anthropic/claude-opus-5.yaml
@@ -26,6 +26,7 @@ features:
     - prompt_caching
     - structured_output
     - assistant_prefill
+    - mid_conversation_system
 limits:
     context_window: 1000000
     max_input_tokens: 1000000

--- a/providers/google-vertex/anthropic/claude-opus-5.yaml
+++ b/providers/google-vertex/anthropic/claude-opus-5.yaml
@@ -26,7 +26,7 @@ features:
     - prompt_caching
     - structured_output
     - assistant_prefill
-    - mid_conversation_system
+    - mid_conversation_system_messages
 limits:
     context_window: 1000000
     max_input_tokens: 1000000

--- a/providers/google-vertex/anthropic/claude-sonnet-5.yaml
+++ b/providers/google-vertex/anthropic/claude-sonnet-5.yaml
@@ -26,6 +26,7 @@ features:
     - system_messages
     - structured_output
     - assistant_prefill
+    - mid_conversation_system
 limits:
     context_window: 1000000
     max_input_tokens: 1000000

--- a/providers/google-vertex/anthropic/claude-sonnet-5.yaml
+++ b/providers/google-vertex/anthropic/claude-sonnet-5.yaml
@@ -26,7 +26,7 @@ features:
     - system_messages
     - structured_output
     - assistant_prefill
-    - mid_conversation_system
+    - mid_conversation_system_messages
 limits:
     context_window: 1000000
     max_input_tokens: 1000000

--- a/providers/microsoft-foundry/claude-opus-4-8.yaml
+++ b/providers/microsoft-foundry/claude-opus-4-8.yaml
@@ -21,7 +21,7 @@ features:
     - structured_output
     - assistant_prefill
     - json_output
-    - mid_conversation_system
+    - mid_conversation_system_messages
 limits:
     context_window: 1000000
     max_input_tokens: 1000000

--- a/providers/microsoft-foundry/claude-opus-4-8.yaml
+++ b/providers/microsoft-foundry/claude-opus-4-8.yaml
@@ -21,6 +21,7 @@ features:
     - structured_output
     - assistant_prefill
     - json_output
+    - mid_conversation_system
 limits:
     context_window: 1000000
     max_input_tokens: 1000000

--- a/providers/microsoft-foundry/claude-opus-5.yaml
+++ b/providers/microsoft-foundry/claude-opus-5.yaml
@@ -21,7 +21,7 @@ features:
     - structured_output
     - assistant_prefill
     - json_output
-    - mid_conversation_system
+    - mid_conversation_system_messages
 limits:
     context_window: 1000000
     max_input_tokens: 1000000

--- a/providers/microsoft-foundry/claude-opus-5.yaml
+++ b/providers/microsoft-foundry/claude-opus-5.yaml
@@ -21,6 +21,7 @@ features:
     - structured_output
     - assistant_prefill
     - json_output
+    - mid_conversation_system
 limits:
     context_window: 1000000
     max_input_tokens: 1000000

--- a/providers/microsoft-foundry/claude-sonnet-5.yaml
+++ b/providers/microsoft-foundry/claude-sonnet-5.yaml
@@ -24,7 +24,7 @@ features:
     - json_output
     - system_messages
     - tool_choice
-    - mid_conversation_system
+    - mid_conversation_system_messages
 limits:
     context_window: 1000000
     max_input_tokens: 1000000

--- a/providers/microsoft-foundry/claude-sonnet-5.yaml
+++ b/providers/microsoft-foundry/claude-sonnet-5.yaml
@@ -24,6 +24,7 @@ features:
     - json_output
     - system_messages
     - tool_choice
+    - mid_conversation_system
 limits:
     context_window: 1000000
     max_input_tokens: 1000000


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Catalog and schema metadata only; no runtime gateway logic in this diff, so impact is limited to how capabilities are advertised to consumers.
> 
> **Overview**
> Introduces a new model capability flag **`mid_conversation_system_messages`**, distinct from **`system_messages`**, for accepting `role: "system"` entries inside the `messages` array rather than only a top-level system prompt.
> 
> The flag is wired into the shared schema (**`#Feature`** in `model.cue` and the generated **`Feature`** type in `types.ts`), then enabled on supported Claude Fable/Opus/Sonnet variants across Anthropic, AWS Bedrock (regional and global profiles), Bedrock Mantle, Azure AI Foundry, Microsoft Foundry, Google Vertex, and Databricks. Provider **`default.yaml`** docs gain links to Anthropic and AWS mid-conversation system message guides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 787046766641177ad63e6da45dd5f355159a1f10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->