### PR TITLE
GATEWAY-3026: Add max_completion_token to GPT models in Microsoft Foundry

### DIFF
--- a/providers/microsoft-foundry/gpt-5-2025-08-07.yaml
+++ b/providers/microsoft-foundry/gpt-5-2025-08-07.yaml
@@ -33,7 +33,7 @@ modalities:
 mode: chat
 model: gpt-5-2025-08-07
 params:
-    - key: max_tokens
+    - key: max_completion_tokens
       maxValue: 128000
     - defaultValue: medium
       key: reasoning_effort
@@ -52,3 +52,6 @@ supportedModes:
     - chat
     - responses
 thinking: true
+
+removeParams:
+    - max_tokens

--- a/providers/microsoft-foundry/gpt-5-2025-08-07.yaml
+++ b/providers/microsoft-foundry/gpt-5-2025-08-07.yaml
@@ -44,6 +44,8 @@ params:
           - high
       type: string
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2027-02-09"
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
@@ -52,6 +54,3 @@ supportedModes:
     - chat
     - responses
 thinking: true
-
-removeParams:
-    - max_tokens

--- a/providers/microsoft-foundry/gpt-5-codex-2025-09-15.yaml
+++ b/providers/microsoft-foundry/gpt-5-codex-2025-09-15.yaml
@@ -37,6 +37,8 @@ params:
           - high
       type: string
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2027-03-17"
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
@@ -44,6 +46,3 @@ status: active
 supportedModes:
     - responses
 thinking: true
-
-removeParams:
-    - max_tokens

--- a/providers/microsoft-foundry/gpt-5-codex-2025-09-15.yaml
+++ b/providers/microsoft-foundry/gpt-5-codex-2025-09-15.yaml
@@ -26,7 +26,7 @@ mode: responses
 model: gpt-5-codex-2025-09-15
 params:
     - defaultValue: 128
-      key: max_tokens
+      key: max_completion_tokens
       maxValue: 128000
       minValue: 1
     - defaultValue: medium
@@ -44,3 +44,6 @@ status: active
 supportedModes:
     - responses
 thinking: true
+
+removeParams:
+    - max_tokens

--- a/providers/microsoft-foundry/gpt-5-mini-2025-08-07-lite.yaml
+++ b/providers/microsoft-foundry/gpt-5-mini-2025-08-07-lite.yaml
@@ -34,13 +34,13 @@ mode: chat
 model: gpt-5-mini-2025-08-07-lite
 params:
     - key: max_completion_tokens
+      maxValue: 128000
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2027-02-09"
 status: active
 supportedModes:
     - chat
     - responses
 thinking: true
-
-removeParams:
-    - max_tokens

--- a/providers/microsoft-foundry/gpt-5-mini-2025-08-07-lite.yaml
+++ b/providers/microsoft-foundry/gpt-5-mini-2025-08-07-lite.yaml
@@ -32,6 +32,8 @@ modalities:
         - text
 mode: chat
 model: gpt-5-mini-2025-08-07-lite
+params:
+    - key: max_completion_tokens
 provisioning: serverless
 retirementDate: "2027-02-09"
 status: active
@@ -39,3 +41,6 @@ supportedModes:
     - chat
     - responses
 thinking: true
+
+removeParams:
+    - max_tokens

--- a/providers/microsoft-foundry/gpt-5-mini-2025-08-07.yaml
+++ b/providers/microsoft-foundry/gpt-5-mini-2025-08-07.yaml
@@ -50,6 +50,8 @@ params:
           - high
       type: string
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2027-02-09"
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
@@ -58,6 +60,3 @@ supportedModes:
     - chat
     - responses
 thinking: true
-
-removeParams:
-    - max_tokens

--- a/providers/microsoft-foundry/gpt-5-mini-2025-08-07.yaml
+++ b/providers/microsoft-foundry/gpt-5-mini-2025-08-07.yaml
@@ -38,7 +38,7 @@ mode: chat
 model: gpt-5-mini-2025-08-07
 params:
     - defaultValue: 128
-      key: max_tokens
+      key: max_completion_tokens
       maxValue: 128000
       minValue: 1
     - defaultValue: medium
@@ -58,3 +58,6 @@ supportedModes:
     - chat
     - responses
 thinking: true
+
+removeParams:
+    - max_tokens

--- a/providers/microsoft-foundry/gpt-5-nano-2025-08-07.yaml
+++ b/providers/microsoft-foundry/gpt-5-nano-2025-08-07.yaml
@@ -34,7 +34,7 @@ mode: chat
 model: gpt-5-nano-2025-08-07
 params:
     - defaultValue: 128
-      key: max_tokens
+      key: max_completion_tokens
       maxValue: 128000
       minValue: 1
     - defaultValue: medium
@@ -52,3 +52,6 @@ supportedModes:
     - chat
     - responses
 thinking: true
+
+removeParams:
+    - max_tokens

--- a/providers/microsoft-foundry/gpt-5-nano-2025-08-07.yaml
+++ b/providers/microsoft-foundry/gpt-5-nano-2025-08-07.yaml
@@ -46,12 +46,11 @@ params:
           - high
       type: string
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2027-02-09"
 status: active
 supportedModes:
     - chat
     - responses
 thinking: true
-
-removeParams:
-    - max_tokens

--- a/providers/microsoft-foundry/gpt-5-pro-2025-10-06.yaml
+++ b/providers/microsoft-foundry/gpt-5-pro-2025-10-06.yaml
@@ -34,11 +34,10 @@ params:
           - high
       type: string
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2027-04-07"
 status: active
 supportedModes:
     - responses
 thinking: true
-
-removeParams:
-    - max_tokens

--- a/providers/microsoft-foundry/gpt-5-pro-2025-10-06.yaml
+++ b/providers/microsoft-foundry/gpt-5-pro-2025-10-06.yaml
@@ -25,7 +25,7 @@ mode: responses
 model: gpt-5-pro-2025-10-06
 params:
     - defaultValue: 128000
-      key: max_tokens
+      key: max_completion_tokens
       maxValue: 128000
       minValue: 1
     - defaultValue: high
@@ -39,3 +39,6 @@ status: active
 supportedModes:
     - responses
 thinking: true
+
+removeParams:
+    - max_tokens

--- a/providers/microsoft-foundry/gpt-5.1-codex-2025-11-13.yaml
+++ b/providers/microsoft-foundry/gpt-5.1-codex-2025-11-13.yaml
@@ -44,6 +44,8 @@ params:
     - key: max_completion_tokens
       maxValue: 128000
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2027-05-15"
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
@@ -52,6 +54,3 @@ status: active
 supportedModes:
     - responses
 thinking: true
-
-removeParams:
-    - max_tokens

--- a/providers/microsoft-foundry/gpt-5.1-codex-2025-11-13.yaml
+++ b/providers/microsoft-foundry/gpt-5.1-codex-2025-11-13.yaml
@@ -41,7 +41,7 @@ modalities:
 mode: responses
 model: gpt-5.1-codex-2025-11-13
 params:
-    - key: max_tokens
+    - key: max_completion_tokens
       maxValue: 128000
 provisioning: serverless
 retirementDate: "2027-05-15"
@@ -52,3 +52,6 @@ status: active
 supportedModes:
     - responses
 thinking: true
+
+removeParams:
+    - max_tokens

--- a/providers/microsoft-foundry/gpt-5.1-codex-max-2025-12-04.yaml
+++ b/providers/microsoft-foundry/gpt-5.1-codex-max-2025-12-04.yaml
@@ -43,6 +43,8 @@ params:
           - xhigh
       type: string
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2027-05-18"
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
@@ -50,6 +52,3 @@ status: active
 supportedModes:
     - responses
 thinking: true
-
-removeParams:
-    - max_tokens

--- a/providers/microsoft-foundry/gpt-5.1-codex-max-2025-12-04.yaml
+++ b/providers/microsoft-foundry/gpt-5.1-codex-max-2025-12-04.yaml
@@ -30,7 +30,7 @@ mode: responses
 model: gpt-5.1-codex-max-2025-12-04
 params:
     - defaultValue: 128000
-      key: max_tokens
+      key: max_completion_tokens
       maxValue: 128000
       minValue: 1
     - defaultValue: medium
@@ -50,3 +50,6 @@ status: active
 supportedModes:
     - responses
 thinking: true
+
+removeParams:
+    - max_tokens

--- a/providers/microsoft-foundry/gpt-5.1-codex-max.yaml
+++ b/providers/microsoft-foundry/gpt-5.1-codex-max.yaml
@@ -25,6 +25,7 @@ mode: responses
 model: gpt-5.1-codex-max
 params:
     - key: max_completion_tokens
+      maxValue: 128000
     - defaultValue: medium
       key: reasoning_effort
       supportedValues:
@@ -35,11 +36,10 @@ params:
           - xhigh
       type: string
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2027-05-18"
 status: active
 supportedModes:
     - responses
 thinking: true
-
-removeParams:
-    - max_tokens

--- a/providers/microsoft-foundry/gpt-5.1-codex-max.yaml
+++ b/providers/microsoft-foundry/gpt-5.1-codex-max.yaml
@@ -24,6 +24,7 @@ modalities:
 mode: responses
 model: gpt-5.1-codex-max
 params:
+    - key: max_completion_tokens
     - defaultValue: medium
       key: reasoning_effort
       supportedValues:
@@ -39,3 +40,6 @@ status: active
 supportedModes:
     - responses
 thinking: true
+
+removeParams:
+    - max_tokens

--- a/providers/microsoft-foundry/gpt-5.1-codex-mini-2025-11-13.yaml
+++ b/providers/microsoft-foundry/gpt-5.1-codex-mini-2025-11-13.yaml
@@ -42,7 +42,7 @@ mode: responses
 model: gpt-5.1-codex-mini-2025-11-13
 params:
     - defaultValue: 128
-      key: max_tokens
+      key: max_completion_tokens
       maxValue: 128000
       minValue: 1
     - defaultValue: medium
@@ -55,6 +55,7 @@ params:
       type: string
 provisioning: serverless
 removeParams:
+    - max_tokens
     - "n"
 retirementDate: "2027-05-15"
 status: active

--- a/providers/microsoft-foundry/gpt-5.2-codex-2026-01-14.yaml
+++ b/providers/microsoft-foundry/gpt-5.2-codex-2026-01-14.yaml
@@ -30,11 +30,10 @@ params:
       maxValue: 128000
       minValue: 1
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2027-07-13"
 status: active
 supportedModes:
     - responses
 thinking: true
-
-removeParams:
-    - max_tokens

--- a/providers/microsoft-foundry/gpt-5.2-codex-2026-01-14.yaml
+++ b/providers/microsoft-foundry/gpt-5.2-codex-2026-01-14.yaml
@@ -26,7 +26,7 @@ mode: responses
 model: gpt-5.2-codex-2026-01-14
 params:
     - defaultValue: 128
-      key: max_tokens
+      key: max_completion_tokens
       maxValue: 128000
       minValue: 1
 provisioning: serverless
@@ -35,3 +35,6 @@ status: active
 supportedModes:
     - responses
 thinking: true
+
+removeParams:
+    - max_tokens

--- a/providers/microsoft-foundry/gpt-5.2-codex.yaml
+++ b/providers/microsoft-foundry/gpt-5.2-codex.yaml
@@ -26,12 +26,12 @@ mode: responses
 model: gpt-5.2-codex
 params:
     - key: max_completion_tokens
+      maxValue: 128000
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2027-07-13"
 status: active
 supportedModes:
     - responses
 thinking: true
-
-removeParams:
-    - max_tokens

--- a/providers/microsoft-foundry/gpt-5.2-codex.yaml
+++ b/providers/microsoft-foundry/gpt-5.2-codex.yaml
@@ -24,9 +24,14 @@ modalities:
         - text
 mode: responses
 model: gpt-5.2-codex
+params:
+    - key: max_completion_tokens
 provisioning: serverless
 retirementDate: "2027-07-13"
 status: active
 supportedModes:
     - responses
 thinking: true
+
+removeParams:
+    - max_tokens

--- a/providers/microsoft-foundry/gpt-5.3-codex-2026-02-20.yaml
+++ b/providers/microsoft-foundry/gpt-5.3-codex-2026-02-20.yaml
@@ -26,7 +26,7 @@ mode: responses
 model: gpt-5.3-codex-2026-02-20
 params:
     - defaultValue: 128
-      key: max_tokens
+      key: max_completion_tokens
       maxValue: 128000
       minValue: 1
     - defaultValue: medium
@@ -42,3 +42,6 @@ status: active
 supportedModes:
     - responses
 thinking: true
+
+removeParams:
+    - max_tokens

--- a/providers/microsoft-foundry/gpt-5.3-codex-2026-02-20.yaml
+++ b/providers/microsoft-foundry/gpt-5.3-codex-2026-02-20.yaml
@@ -37,11 +37,10 @@ params:
           - high
       type: string
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2027-08-24"
 status: active
 supportedModes:
     - responses
 thinking: true
-
-removeParams:
-    - max_tokens

--- a/providers/microsoft-foundry/gpt-5.3-codex-2026-02-24.yaml
+++ b/providers/microsoft-foundry/gpt-5.3-codex-2026-02-24.yaml
@@ -26,7 +26,7 @@ mode: responses
 model: gpt-5.3-codex-2026-02-24
 params:
     - defaultValue: 128
-      key: max_tokens
+      key: max_completion_tokens
       maxValue: 128000
       minValue: 1
     - defaultValue: medium
@@ -40,3 +40,6 @@ status: active
 supportedModes:
     - responses
 thinking: true
+
+removeParams:
+    - max_tokens

--- a/providers/microsoft-foundry/gpt-5.3-codex-2026-02-24.yaml
+++ b/providers/microsoft-foundry/gpt-5.3-codex-2026-02-24.yaml
@@ -33,6 +33,8 @@ params:
       key: reasoning_effort
       type: string
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2027-08-24"
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
@@ -40,6 +42,3 @@ status: active
 supportedModes:
     - responses
 thinking: true
-
-removeParams:
-    - max_tokens

--- a/providers/microsoft-foundry/gpt-5.3-codex.yaml
+++ b/providers/microsoft-foundry/gpt-5.3-codex.yaml
@@ -26,12 +26,12 @@ mode: responses
 model: gpt-5.3-codex
 params:
     - key: max_completion_tokens
+      maxValue: 128000
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2027-08-24"
 status: active
 supportedModes:
     - responses
 thinking: true
-
-removeParams:
-    - max_tokens

--- a/providers/microsoft-foundry/gpt-5.3-codex.yaml
+++ b/providers/microsoft-foundry/gpt-5.3-codex.yaml
@@ -24,9 +24,14 @@ modalities:
         - text
 mode: responses
 model: gpt-5.3-codex
+params:
+    - key: max_completion_tokens
 provisioning: serverless
 retirementDate: "2027-08-24"
 status: active
 supportedModes:
     - responses
 thinking: true
+
+removeParams:
+    - max_tokens

--- a/providers/microsoft-foundry/gpt-5.4-mini-2026-03-17.yaml
+++ b/providers/microsoft-foundry/gpt-5.4-mini-2026-03-17.yaml
@@ -27,7 +27,7 @@ mode: chat
 model: gpt-5.4-mini-2026-03-17
 params:
     - defaultValue: 128
-      key: max_tokens
+      key: max_completion_tokens
       maxValue: 128000
       minValue: 1
     - defaultValue: none
@@ -48,3 +48,6 @@ supportedModes:
     - chat
     - responses
 thinking: true
+
+removeParams:
+    - max_tokens

--- a/providers/microsoft-foundry/gpt-5.4-mini-2026-03-17.yaml
+++ b/providers/microsoft-foundry/gpt-5.4-mini-2026-03-17.yaml
@@ -40,6 +40,8 @@ params:
           - xhigh
       type: string
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2027-09-21"
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
@@ -48,6 +50,3 @@ supportedModes:
     - chat
     - responses
 thinking: true
-
-removeParams:
-    - max_tokens

--- a/providers/microsoft-foundry/gpt-5.4-mini.yaml
+++ b/providers/microsoft-foundry/gpt-5.4-mini.yaml
@@ -26,6 +26,7 @@ mode: chat
 model: gpt-5.4-mini
 params:
     - key: max_completion_tokens
+      maxValue: 128000
     - defaultValue: none
       key: reasoning_effort
       supportedValues:
@@ -36,12 +37,11 @@ params:
           - xhigh
       type: string
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2027-09-21"
 status: active
 supportedModes:
     - chat
     - responses
 thinking: true
-
-removeParams:
-    - max_tokens

--- a/providers/microsoft-foundry/gpt-5.4-mini.yaml
+++ b/providers/microsoft-foundry/gpt-5.4-mini.yaml
@@ -25,6 +25,7 @@ modalities:
 mode: chat
 model: gpt-5.4-mini
 params:
+    - key: max_completion_tokens
     - defaultValue: none
       key: reasoning_effort
       supportedValues:
@@ -41,3 +42,6 @@ supportedModes:
     - chat
     - responses
 thinking: true
+
+removeParams:
+    - max_tokens

--- a/providers/microsoft-foundry/gpt-5.4-nano-2026-03-17.yaml
+++ b/providers/microsoft-foundry/gpt-5.4-nano-2026-03-17.yaml
@@ -38,6 +38,8 @@ params:
           - xhigh
       type: string
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2027-09-21"
 sources:
     - https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models
@@ -46,6 +48,3 @@ supportedModes:
     - chat
     - responses
 thinking: true
-
-removeParams:
-    - max_tokens

--- a/providers/microsoft-foundry/gpt-5.4-nano-2026-03-17.yaml
+++ b/providers/microsoft-foundry/gpt-5.4-nano-2026-03-17.yaml
@@ -26,7 +26,7 @@ modalities:
 mode: chat
 model: gpt-5.4-nano-2026-03-17
 params:
-    - key: max_tokens
+    - key: max_completion_tokens
       maxValue: 128000
     - defaultValue: none
       key: reasoning_effort
@@ -46,3 +46,6 @@ supportedModes:
     - chat
     - responses
 thinking: true
+
+removeParams:
+    - max_tokens

--- a/providers/microsoft-foundry/gpt-5.4-nano.yaml
+++ b/providers/microsoft-foundry/gpt-5.4-nano.yaml
@@ -25,6 +25,7 @@ mode: chat
 model: gpt-5.4-nano
 params:
     - key: max_completion_tokens
+      maxValue: 128000
     - defaultValue: none
       key: reasoning_effort
       supportedValues:
@@ -35,12 +36,11 @@ params:
           - xhigh
       type: string
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2027-09-21"
 status: active
 supportedModes:
     - chat
     - responses
 thinking: true
-
-removeParams:
-    - max_tokens

--- a/providers/microsoft-foundry/gpt-5.4-nano.yaml
+++ b/providers/microsoft-foundry/gpt-5.4-nano.yaml
@@ -24,6 +24,7 @@ modalities:
 mode: chat
 model: gpt-5.4-nano
 params:
+    - key: max_completion_tokens
     - defaultValue: none
       key: reasoning_effort
       supportedValues:
@@ -40,3 +41,6 @@ supportedModes:
     - chat
     - responses
 thinking: true
+
+removeParams:
+    - max_tokens

--- a/providers/microsoft-foundry/gpt-5.4-pro-2026-03-05.yaml
+++ b/providers/microsoft-foundry/gpt-5.4-pro-2026-03-05.yaml
@@ -36,7 +36,7 @@ mode: responses
 model: gpt-5.4-pro-2026-03-05
 params:
     - defaultValue: 128
-      key: max_tokens
+      key: max_completion_tokens
       maxValue: 128000
       minValue: 1
     - defaultValue: null
@@ -50,6 +50,7 @@ params:
       type: string
 provisioning: serverless
 removeParams:
+    - max_tokens
     - parallel_tool_calls
 retirementDate: "2027-09-07"
 status: active

--- a/providers/microsoft-foundry/gpt-5.4-pro.yaml
+++ b/providers/microsoft-foundry/gpt-5.4-pro.yaml
@@ -35,6 +35,7 @@ modalities:
 mode: responses
 model: gpt-5.4-pro
 params:
+    - key: max_completion_tokens
     - defaultValue: medium
       key: reasoning_effort
       supportedValues:
@@ -50,3 +51,6 @@ status: active
 supportedModes:
     - responses
 thinking: true
+
+removeParams:
+    - max_tokens

--- a/providers/microsoft-foundry/gpt-5.4-pro.yaml
+++ b/providers/microsoft-foundry/gpt-5.4-pro.yaml
@@ -36,6 +36,7 @@ mode: responses
 model: gpt-5.4-pro
 params:
     - key: max_completion_tokens
+      maxValue: 128000
     - defaultValue: medium
       key: reasoning_effort
       supportedValues:
@@ -46,11 +47,10 @@ params:
           - xhigh
       type: string
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2027-09-07"
 status: active
 supportedModes:
     - responses
 thinking: true
-
-removeParams:
-    - max_tokens

--- a/providers/microsoft-foundry/gpt-5.4.yaml
+++ b/providers/microsoft-foundry/gpt-5.4.yaml
@@ -44,7 +44,7 @@ mode: chat
 model: gpt-5.4
 params:
     - defaultValue: 128
-      key: max_tokens
+      key: max_completion_tokens
       maxValue: 128000
       minValue: 1
 provisioning: serverless
@@ -54,3 +54,6 @@ supportedModes:
     - chat
     - responses
 thinking: true
+
+removeParams:
+    - max_tokens

--- a/providers/microsoft-foundry/gpt-5.4.yaml
+++ b/providers/microsoft-foundry/gpt-5.4.yaml
@@ -48,12 +48,11 @@ params:
       maxValue: 128000
       minValue: 1
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2027-09-02"
 status: active
 supportedModes:
     - chat
     - responses
 thinking: true
-
-removeParams:
-    - max_tokens

--- a/providers/microsoft-foundry/gpt-5.5-2026-04-24.yaml
+++ b/providers/microsoft-foundry/gpt-5.5-2026-04-24.yaml
@@ -66,6 +66,7 @@ modalities:
 mode: chat
 model: gpt-5.5-2026-04-24
 params:
+    - key: max_completion_tokens
     - defaultValue: medium
       key: reasoning_effort
       supportedValues:
@@ -82,3 +83,6 @@ supportedModes:
     - chat
     - responses
 thinking: true
+
+removeParams:
+    - max_tokens

--- a/providers/microsoft-foundry/gpt-5.5-2026-04-24.yaml
+++ b/providers/microsoft-foundry/gpt-5.5-2026-04-24.yaml
@@ -67,6 +67,7 @@ mode: chat
 model: gpt-5.5-2026-04-24
 params:
     - key: max_completion_tokens
+      maxValue: 128000
     - defaultValue: medium
       key: reasoning_effort
       supportedValues:
@@ -77,12 +78,11 @@ params:
           - xhigh
       type: string
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2027-10-26"
 status: active
 supportedModes:
     - chat
     - responses
 thinking: true
-
-removeParams:
-    - max_tokens

--- a/providers/microsoft-foundry/gpt-5.5.yaml
+++ b/providers/microsoft-foundry/gpt-5.5.yaml
@@ -67,6 +67,7 @@ mode: chat
 model: gpt-5.5
 params:
     - key: max_completion_tokens
+      maxValue: 128000
     - defaultValue: medium
       key: reasoning_effort
       supportedValues:
@@ -77,12 +78,11 @@ params:
           - xhigh
       type: string
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2027-10-26"
 status: active
 supportedModes:
     - chat
     - responses
 thinking: true
-
-removeParams:
-    - max_tokens

--- a/providers/microsoft-foundry/gpt-5.5.yaml
+++ b/providers/microsoft-foundry/gpt-5.5.yaml
@@ -66,6 +66,7 @@ modalities:
 mode: chat
 model: gpt-5.5
 params:
+    - key: max_completion_tokens
     - defaultValue: medium
       key: reasoning_effort
       supportedValues:
@@ -82,3 +83,6 @@ supportedModes:
     - chat
     - responses
 thinking: true
+
+removeParams:
+    - max_tokens

--- a/providers/microsoft-foundry/gpt-5.6-luna-2026-07-09.yaml
+++ b/providers/microsoft-foundry/gpt-5.6-luna-2026-07-09.yaml
@@ -67,6 +67,7 @@ modalities:
 mode: chat
 model: gpt-5.6-luna-2026-07-09
 params:
+    - key: max_completion_tokens
     - defaultValue: medium
       key: reasoning_effort
       supportedValues:
@@ -84,3 +85,6 @@ supportedModes:
     - chat
     - responses
 thinking: true
+
+removeParams:
+    - max_tokens

--- a/providers/microsoft-foundry/gpt-5.6-luna-2026-07-09.yaml
+++ b/providers/microsoft-foundry/gpt-5.6-luna-2026-07-09.yaml
@@ -68,6 +68,7 @@ mode: chat
 model: gpt-5.6-luna-2026-07-09
 params:
     - key: max_completion_tokens
+      maxValue: 128000
     - defaultValue: medium
       key: reasoning_effort
       supportedValues:
@@ -79,12 +80,11 @@ params:
           - max
       type: string
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2028-01-11"
 status: active
 supportedModes:
     - chat
     - responses
 thinking: true
-
-removeParams:
-    - max_tokens

--- a/providers/microsoft-foundry/gpt-5.6-sol-2026-07-09.yaml
+++ b/providers/microsoft-foundry/gpt-5.6-sol-2026-07-09.yaml
@@ -66,6 +66,7 @@ modalities:
 mode: chat
 model: gpt-5.6-sol-2026-07-09
 params:
+    - key: max_completion_tokens
     - defaultValue: medium
       key: reasoning_effort
       supportedValues:
@@ -82,3 +83,6 @@ supportedModes:
     - chat
     - responses
 thinking: true
+
+removeParams:
+    - max_tokens

--- a/providers/microsoft-foundry/gpt-5.6-sol-2026-07-09.yaml
+++ b/providers/microsoft-foundry/gpt-5.6-sol-2026-07-09.yaml
@@ -67,6 +67,7 @@ mode: chat
 model: gpt-5.6-sol-2026-07-09
 params:
     - key: max_completion_tokens
+      maxValue: 128000
     - defaultValue: medium
       key: reasoning_effort
       supportedValues:
@@ -77,12 +78,11 @@ params:
           - xhigh
       type: string
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2028-01-11"
 status: active
 supportedModes:
     - chat
     - responses
 thinking: true
-
-removeParams:
-    - max_tokens

--- a/providers/microsoft-foundry/gpt-5.6-sol.yaml
+++ b/providers/microsoft-foundry/gpt-5.6-sol.yaml
@@ -65,6 +65,7 @@ modalities:
 mode: chat
 model: gpt-5.6-sol
 params:
+    - key: max_completion_tokens
     - defaultValue: medium
       key: reasoning_effort
       supportedValues:
@@ -81,3 +82,6 @@ supportedModes:
     - chat
     - responses
 thinking: true
+
+removeParams:
+    - max_tokens

--- a/providers/microsoft-foundry/gpt-5.6-sol.yaml
+++ b/providers/microsoft-foundry/gpt-5.6-sol.yaml
@@ -66,6 +66,7 @@ mode: chat
 model: gpt-5.6-sol
 params:
     - key: max_completion_tokens
+      maxValue: 128000
     - defaultValue: medium
       key: reasoning_effort
       supportedValues:
@@ -76,12 +77,11 @@ params:
           - xhigh
       type: string
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2028-01-11"
 status: active
 supportedModes:
     - chat
     - responses
 thinking: true
-
-removeParams:
-    - max_tokens

--- a/providers/microsoft-foundry/gpt-5.6-terra-2026-07-09.yaml
+++ b/providers/microsoft-foundry/gpt-5.6-terra-2026-07-09.yaml
@@ -66,6 +66,7 @@ mode: chat
 model: gpt-5.6-terra-2026-07-09
 params:
     - key: max_completion_tokens
+      maxValue: 128000
     - defaultValue: medium
       key: reasoning_effort
       supportedValues:
@@ -76,12 +77,11 @@ params:
           - xhigh
       type: string
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2028-01-11"
 status: active
 supportedModes:
     - chat
     - responses
 thinking: true
-
-removeParams:
-    - max_tokens

--- a/providers/microsoft-foundry/gpt-5.6-terra-2026-07-09.yaml
+++ b/providers/microsoft-foundry/gpt-5.6-terra-2026-07-09.yaml
@@ -65,6 +65,7 @@ modalities:
 mode: chat
 model: gpt-5.6-terra-2026-07-09
 params:
+    - key: max_completion_tokens
     - defaultValue: medium
       key: reasoning_effort
       supportedValues:
@@ -81,3 +82,6 @@ supportedModes:
     - chat
     - responses
 thinking: true
+
+removeParams:
+    - max_tokens

--- a/providers/microsoft-foundry/gpt-5.6-terra.yaml
+++ b/providers/microsoft-foundry/gpt-5.6-terra.yaml
@@ -66,6 +66,7 @@ mode: chat
 model: gpt-5.6-terra
 params:
     - key: max_completion_tokens
+      maxValue: 128000
     - defaultValue: medium
       key: reasoning_effort
       supportedValues:
@@ -76,12 +77,11 @@ params:
           - xhigh
       type: string
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2028-01-11"
 status: active
 supportedModes:
     - chat
     - responses
 thinking: true
-
-removeParams:
-    - max_tokens

--- a/providers/microsoft-foundry/gpt-5.6-terra.yaml
+++ b/providers/microsoft-foundry/gpt-5.6-terra.yaml
@@ -65,6 +65,7 @@ modalities:
 mode: chat
 model: gpt-5.6-terra
 params:
+    - key: max_completion_tokens
     - defaultValue: medium
       key: reasoning_effort
       supportedValues:
@@ -81,3 +82,6 @@ supportedModes:
     - chat
     - responses
 thinking: true
+
+removeParams:
+    - max_tokens

--- a/providers/microsoft-foundry/gpt-6-astra-2026-09-03-private.yaml
+++ b/providers/microsoft-foundry/gpt-6-astra-2026-09-03-private.yaml
@@ -75,6 +75,8 @@ params:
       maxValue: 128000
       minValue: 1
 provisioning: serverless
+removeParams:
+    - max_tokens
 sources:
     - https://azure.microsoft.com/en-us/blog/gpt-6-astra-frontier-intelligence-for-work-now-available-in-microsoft-foundry/
 status: preview
@@ -82,6 +84,3 @@ supportedModes:
     - chat
     - responses
 thinking: true
-
-removeParams:
-    - max_tokens

--- a/providers/microsoft-foundry/gpt-6-astra-2026-09-03-private.yaml
+++ b/providers/microsoft-foundry/gpt-6-astra-2026-09-03-private.yaml
@@ -71,7 +71,7 @@ params:
           - max
       type: string
     - defaultValue: 128
-      key: max_tokens
+      key: max_completion_tokens
       maxValue: 128000
       minValue: 1
 provisioning: serverless
@@ -82,3 +82,6 @@ supportedModes:
     - chat
     - responses
 thinking: true
+
+removeParams:
+    - max_tokens

--- a/providers/microsoft-foundry/gpt-chat-latest-2026-05-28.yaml
+++ b/providers/microsoft-foundry/gpt-chat-latest-2026-05-28.yaml
@@ -26,13 +26,13 @@ mode: chat
 model: gpt-chat-latest-2026-05-28
 params:
     - key: max_completion_tokens
+      maxValue: 16384
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2026-08-28"
 status: preview
 supportedModes:
     - chat
     - responses
 thinking: true
-
-removeParams:
-    - max_tokens

--- a/providers/microsoft-foundry/gpt-chat-latest-2026-05-28.yaml
+++ b/providers/microsoft-foundry/gpt-chat-latest-2026-05-28.yaml
@@ -24,6 +24,8 @@ modalities:
         - text
 mode: chat
 model: gpt-chat-latest-2026-05-28
+params:
+    - key: max_completion_tokens
 provisioning: serverless
 retirementDate: "2026-08-28"
 status: preview
@@ -31,3 +33,6 @@ supportedModes:
     - chat
     - responses
 thinking: true
+
+removeParams:
+    - max_tokens

--- a/providers/microsoft-foundry/gpt-chat-latest-2026-06-24.yaml
+++ b/providers/microsoft-foundry/gpt-chat-latest-2026-06-24.yaml
@@ -26,13 +26,13 @@ mode: chat
 model: gpt-chat-latest-2026-06-24
 params:
     - key: max_completion_tokens
+      maxValue: 16384
 provisioning: serverless
+removeParams:
+    - max_tokens
 retirementDate: "2026-09-24"
 status: preview
 supportedModes:
     - chat
     - responses
 thinking: true
-
-removeParams:
-    - max_tokens

--- a/providers/microsoft-foundry/gpt-chat-latest-2026-06-24.yaml
+++ b/providers/microsoft-foundry/gpt-chat-latest-2026-06-24.yaml
@@ -24,6 +24,8 @@ modalities:
         - text
 mode: chat
 model: gpt-chat-latest-2026-06-24
+params:
+    - key: max_completion_tokens
 provisioning: serverless
 retirementDate: "2026-09-24"
 status: preview
@@ -31,3 +33,6 @@ supportedModes:
     - chat
     - responses
 thinking: true
+
+removeParams:
+    - max_tokens

--- a/providers/microsoft-foundry/gpt-chat-latest.yaml
+++ b/providers/microsoft-foundry/gpt-chat-latest.yaml
@@ -24,8 +24,11 @@ modalities:
         - text
 mode: chat
 model: gpt-chat-latest
+params:
+    - key: max_completion_tokens
 provisioning: serverless
 removeParams:
+    - max_tokens
     - reasoning_effort
 retirementDate: "2026-12-02"
 sources:

--- a/providers/microsoft-foundry/gpt-chat-latest.yaml
+++ b/providers/microsoft-foundry/gpt-chat-latest.yaml
@@ -26,6 +26,7 @@ mode: chat
 model: gpt-chat-latest
 params:
     - key: max_completion_tokens
+      maxValue: 128000
 provisioning: serverless
 removeParams:
     - max_tokens


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Bulk request-parameter mapping for many active Foundry models; misconfiguration could break or silently change output limits for callers still sending `max_tokens`.
> 
> **Overview**
> Updates **Microsoft Foundry** GPT-family model definitions (GPT-5 through GPT-6, Codex variants, `gpt-chat-latest`, etc.) so the gateway advertises and validates **`max_completion_tokens`** instead of **`max_tokens`** in each file’s `params` block, including where entries only had limits before and now declare an explicit param with the same caps (e.g. 128000, or 16384 for chat-latest previews).
> 
> Every touched model also gets **`removeParams: max_tokens`** (or adds `max_tokens` to an existing `removeParams` list) so client-supplied `max_tokens` is dropped on the way to Foundry while the supported knob is `max_completion_tokens`. Existing defaults, min/max, and `reasoning_effort` entries are unchanged aside from the param rename.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e72c2cedf588c5c30e191dbddad849a83a9ebb56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->